### PR TITLE
Ensure the_console_services() is constructed only once.

### DIFF
--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -450,7 +450,7 @@ protected:
     CachedPtr<scene::ApplicationNotRespondingDetector> application_not_responding_detector;
     CachedPtr<cookie::Authority> cookie_authority;
     CachedPtr<input::KeyMapper> key_mapper;
-    CachedPtr<ConsoleServices> console_services;
+    std::shared_ptr<ConsoleServices> console_services;
 
 private:
     std::shared_ptr<options::Configuration> const configuration_options;

--- a/src/server/console/default_configuration.cpp
+++ b/src/server/console/default_configuration.cpp
@@ -96,7 +96,7 @@ struct RealPosixProcessOperations : public mir::PosixProcessOperations
 
 std::shared_ptr<mir::ConsoleServices> mir::DefaultServerConfiguration::the_console_services()
 {
-    return console_services(
+    auto const make_console_services =
         [this]() -> std::shared_ptr<ConsoleServices>
         {
             auto const provider = the_options()->get<std::string>(options::console_provider);
@@ -200,5 +200,13 @@ std::shared_ptr<mir::ConsoleServices> mir::DefaultServerConfiguration::the_conso
             BOOST_THROW_EXCEPTION((
                 std::runtime_error{
                     std::string{"Unknown console provider: "} + provider}));
-        });
+        };
+
+    // TODO: this is clearly not threadsafe, but then neither is CachedPtr
+    if (!console_services)
+    {
+        console_services = make_console_services();
+    }
+
+    return console_services;
 }


### PR DESCRIPTION
We need to pass the_console_services() through to a number of components, some of which (like platform probing) don't have anywhere to stash an owning reference. This means we construct and destroy the_console_services() multiple times during server startup.

So, use a shared_ptr<> rather than a CachedPtr<> for console_services, leaving DefaultServerConfiguration to have an owning ref and guaranteeing single-construction.