### PR TITLE
example-server: Fix a locale initialization crash on musl

### DIFF
--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -45,7 +45,7 @@ void null_window_callback(MirWindow*, void*) {}
 
 struct preferred_codecvt : std::codecvt_byname<wchar_t, char, std::mbstate_t>
 {
-    preferred_codecvt() : std::codecvt_byname<wchar_t, char, std::mbstate_t>("") {}
+    preferred_codecvt() : std::codecvt_byname<wchar_t, char, std::mbstate_t>("C") {}
     ~preferred_codecvt() = default;
 };
 


### PR DESCRIPTION
For std::locale() the C standard specifies that is valid to pass an empty
string as an argument for the locale name. This works as specified on musl.

On musl, passing an empty string for the locale name to
std::codecvt_byname() throws a runtime exception. It's uncertain whether
an empty string to std::codecvt_byname() should be valid or not for this
call.

Use the default locale "C" which works on musl too.
