### PR TITLE
When running tests, log the test client

### DIFF
--- a/examples/mir_demo_server/server_example_test_client.cpp
+++ b/examples/mir_demo_server/server_example_test_client.cpp
@@ -139,6 +139,7 @@ void me::TestClientRunner::operator()(mir::Server& server)
                 setenv("SDL_VIDEODRIVER", "wayland", true);         // configure SDL to use Wayland
 
                 auto const client = options1->get<std::string>(test_client_opt);
+                log(logging::Severity::informational, "mir::examples", "Starting test client: %s", client.c_str());
                 execlp(client.c_str(), client.c_str(), static_cast<char const*>(nullptr));
                 // If execl() returns then something is badly wrong
                 log(logging::Severity::critical, "mir::examples",


### PR DESCRIPTION
This makes it clear in the logs which client is being used for the test.