### PR TITLE
platform/graphics: Renderables don't have a swap_interval.

### DIFF
--- a/include/platform/mir/graphics/renderable.h
+++ b/include/platform/mir/graphics/renderable.h
@@ -71,8 +71,6 @@ public:
     virtual glm::mat4 transformation() const = 0;
 
     virtual bool shaped() const = 0;  // meaning the pixel format has alpha
-
-    virtual unsigned int swap_interval() const = 0;
 protected:
     Renderable() = default;
     Renderable(Renderable const&) = delete;

--- a/src/server/graphics/software_cursor.cpp
+++ b/src/server/graphics/software_cursor.cpp
@@ -67,11 +67,6 @@ public:
     {
     }
 
-    unsigned int swap_interval() const override
-    {
-        return 1;
-    }
-
     mg::Renderable::ID id() const override
     {
         return this;

--- a/src/server/input/touchspot_controller.cpp
+++ b/src/server/input/touchspot_controller.cpp
@@ -54,11 +54,6 @@ public:
 
 // mg::Renderable
 
-    unsigned int swap_interval() const override
-    {
-        return 1;
-    }
-
     mg::Renderable::ID id() const override
     {
         return this;

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -829,11 +829,6 @@ public:
     {
     }
 
-    unsigned int swap_interval() const override
-    {
-        return underlying_buffer_stream->framedropping() ? 0 : 1;
-    }
-
     std::shared_ptr<mg::Buffer> buffer() const override
     {
         if (!compositor_buffer)

--- a/tests/include/mir/test/doubles/fake_renderable.h
+++ b/tests/include/mir/test/doubles/fake_renderable.h
@@ -100,11 +100,6 @@ public:
         return std::experimental::optional<geometry::Rectangle>();
     }
 
-    unsigned int swap_interval() const override
-    {
-        return 1u;
-    }
-
 private:
     std::shared_ptr<graphics::Buffer> buf;
     mir::geometry::Rectangle rect;

--- a/tests/include/mir/test/doubles/mock_renderable.h
+++ b/tests/include/mir/test/doubles/mock_renderable.h
@@ -55,7 +55,6 @@ struct MockRenderable : public graphics::Renderable
     MOCK_CONST_METHOD0(transformation, glm::mat4());
     MOCK_CONST_METHOD0(visible, bool());
     MOCK_CONST_METHOD0(shaped, bool());
-    MOCK_CONST_METHOD0(swap_interval, unsigned int());
 };
 }
 }

--- a/tests/include/mir/test/doubles/stub_renderable.h
+++ b/tests/include/mir/test/doubles/stub_renderable.h
@@ -90,11 +90,6 @@ public:
     {
         return false;
     }
-    unsigned int swap_interval() const override
-    {
-        return 1;
-    }
-
 private:
     std::shared_ptr<graphics::Buffer> make_stub_buffer(geometry::Rectangle const& rect)
     {
@@ -163,11 +158,6 @@ struct IntervalZeroRenderable : StubRenderable
         std::shared_ptr<graphics::Buffer> const& buffer, geometry::Rectangle const& rect) :
         StubRenderable(buffer, rect)
     {
-    }
-
-    unsigned int swap_interval() const override
-    {
-        return 0;
     }
 };
 

--- a/tests/platform_test_harness/graphics_platform_test_harness.cpp
+++ b/tests/platform_test_harness/graphics_platform_test_harness.cpp
@@ -488,11 +488,6 @@ void basic_software_buffer_drawing(
             return std::experimental::optional<mir::geometry::Rectangle>{};
         }
 
-        unsigned int swap_interval() const override
-        {
-            return 0;
-        }
-
         void set_position(mir::geometry::Point top_left)
         {
             this->top_left = top_left;


### PR DESCRIPTION
It doesn't make sense to ask what the swap interval of a Renderable is;
a Renderable is something that you draw *from*, not draw to.

And indeed, the fact that the method is unused suggests its lack of utility.