### PR TITLE
Fatal errors when XKB context fails to build

### DIFF
--- a/src/common/input/xkb_mapper.cpp
+++ b/src/common/input/xkb_mapper.cpp
@@ -23,8 +23,6 @@
 #include "mir/events/event_private.h"
 #include "mir/events/event_builders.h"
 
-#include <boost/throw_exception.hpp>
-
 #include <linux/input-event-codes.h>
 
 #include <sstream>
@@ -126,7 +124,7 @@ mi::XKBContextPtr mi::make_unique_context()
     auto context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (!context)
     {
-        BOOST_THROW_EXCEPTION(std::runtime_error("Failed to create XKB context"));
+        fatal_error("Failed to create XKB context");
     }
     return {context, &xkb_context_unref};
 }

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -421,7 +421,7 @@ mgw::DisplayClient::DisplayClient(
 {
     if (!keyboard_context_)
     {
-        BOOST_THROW_EXCEPTION(std::runtime_error("Failed to create XKB context"));
+        fatal_error("Failed to create XKB context");
     }
 
     registry = {wl_display_get_registry(display), &wl_registry_destroy};

--- a/src/server/frontend_wayland/keyboard_helper.cpp
+++ b/src/server/frontend_wayland/keyboard_helper.cpp
@@ -22,6 +22,7 @@
 #include "mir/input/keymap.h"
 #include "mir/events/keyboard_event.h"
 #include "mir/input/seat.h"
+#include "mir/fatal.h"
 
 #include <xkbcommon/xkbcommon.h>
 #include <cstring> // memcpy
@@ -45,7 +46,7 @@ mf::KeyboardHelper::KeyboardHelper(
 {
     if (!context)
     {
-        BOOST_THROW_EXCEPTION(std::runtime_error("Failed to create XKB context"));
+        fatal_error("Failed to create XKB context");
     }
 
     /* The wayland::Keyboard constructor has already run, creating the keyboard


### PR DESCRIPTION
`xkb_context_new()` may return null, see https://github.com/MirServer/ubuntu-frame/issues/33