### PR TITLE
graphics/MultiplexingDisplay: Add HW cursor support.

### DIFF
--- a/src/server/graphics/CMakeLists.txt
+++ b/src/server/graphics/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(
   platform_probe.h
   multiplexing_display.h
   multiplexing_display.cpp
+  multiplexing_hw_cursor.h
+  multiplexing_hw_cursor.cpp
 )
 
 target_link_libraries(mirgraphics

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -15,11 +15,14 @@
  */
 
 #include "multiplexing_display.h"
+#include "multiplexing_hw_cursor.h"
 #include "mir/graphics/display_configuration.h"
 #include "mir/renderer/gl/context.h"
 #include "mir/output_type_names.h"
+#include "mir/log.h"
 
 #include <boost/throw_exception.hpp>
+#include <exception>
 #include <stdexcept>
 #include <sstream>
 #include <functional>
@@ -319,5 +322,21 @@ void mg::MultiplexingDisplay::resume()
 
 auto mg::MultiplexingDisplay::create_hardware_cursor() -> std::shared_ptr<Cursor>
 {
-    return {};
+    std::vector<Display*> platform_displays;
+    for (auto& display : displays)
+    {
+        platform_displays.push_back(display.get());
+    }
+    try
+    {
+        return std::make_shared<MultiplexingCursor>(platform_displays);
+    }
+    catch (std::exception const&)
+    {
+        mir::log(
+            mir::logging::Severity::informational,
+            "display",
+            "Failed to create hardware cursor");
+        return nullptr;
+    }
 }

--- a/src/server/graphics/multiplexing_hw_cursor.cpp
+++ b/src/server/graphics/multiplexing_hw_cursor.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "multiplexing_hw_cursor.h"
+
+#include "mir/graphics/display.h"
+#include <boost/throw_exception.hpp>
+
+namespace mg = mir::graphics;
+
+namespace
+{
+auto construct_platform_cursors(std::span<mg::Display*> platform_displays) -> std::vector<std::shared_ptr<mg::Cursor>>
+{
+    std::vector<std::shared_ptr<mg::Cursor>> cursors;
+    for (auto display : platform_displays)
+    {
+        cursors.push_back(display->create_hardware_cursor());
+        if (cursors.back() == nullptr)
+        {
+            BOOST_THROW_EXCEPTION((std::runtime_error{"Platform failed to create hardware cursor"}));
+        }
+    }
+    return cursors;
+}
+}
+
+mg::MultiplexingCursor::MultiplexingCursor(std::span<Display*> platform_displays)
+    : platform_cursors{construct_platform_cursors(platform_displays)}
+{
+}
+
+void mg::MultiplexingCursor::show(CursorImage const& image)
+{
+    for (auto& cursor : platform_cursors)
+    {
+        cursor->show(image);
+    }
+}
+
+void mg::MultiplexingCursor::hide()
+{
+    for (auto& cursor: platform_cursors)
+    {
+        cursor->hide();
+    }
+}
+
+void mg::MultiplexingCursor::move_to(geometry::Point position)
+{
+    for (auto& cursor : platform_cursors)
+    {
+        cursor->move_to(position);
+    }
+}

--- a/src/server/graphics/multiplexing_hw_cursor.h
+++ b/src/server/graphics/multiplexing_hw_cursor.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <vector>
+#include <span>
+
+#include "mir/graphics/cursor.h"
+
+namespace mir::graphics
+{
+class Display;
+
+class MultiplexingCursor : public Cursor
+{
+public:
+    explicit MultiplexingCursor(std::span<Display*> platform_displays);
+
+    void show(CursorImage const& image) override;
+    void hide() override;
+    void move_to(geometry::Point position) override;
+
+private:
+    std::vector<std::shared_ptr<Cursor>> const platform_cursors;
+};
+}


### PR DESCRIPTION
Create a HW cursor on each `Display`; if any `Display` cannot support a HW cursor, bail.

Our existing HW cursor implementations already handle setting the position outside of their display area, so we can just directly delegate to all multiplexed `Cursor` implementations without needing to track which platform(s) should actually be handling the event.

Fixes: #3198
