### PR TITLE
(#3241) Wayland wrapper generator now generates a virtual stub function for destructors

### DIFF
--- a/src/wayland/generator/request.cpp
+++ b/src/wayland/generator/request.cpp
@@ -26,7 +26,7 @@ Emitter Request::virtual_mir_prototype() const
 {
     if (is_destroy())
     {
-        return nullptr;
+        return {"virtual void ", name, "(", mir_args(), ") {}"};
     }
     else
     {
@@ -43,7 +43,11 @@ Emitter Request::thunk_impl() const
             "try",
             Block{
                 (is_destroy() ?
-                    Emitter{"wl_resource_destroy(resource);"}
+                     Lines{
+                         {"auto me = static_cast<", class_name, "*>(wl_resource_get_user_data(resource));"},
+                         {"me->", name, "(", mir_call_args(), ");"},
+                         {"wl_resource_destroy(resource);"}
+                     }
                 :
                     Lines{
                         {"auto me = static_cast<", class_name, "*>(wl_resource_get_user_data(resource));"},

--- a/tests/acceptance-tests/wayland-generator/expected.cpp
+++ b/tests/acceptance-tests/wayland-generator/expected.cpp
@@ -305,6 +305,8 @@ struct mw::ShmPool::Thunks
     {
         try
         {
+            auto me = static_cast<ShmPool*>(wl_resource_get_user_data(resource));
+            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -602,6 +604,8 @@ struct mw::Buffer::Thunks
     {
         try
         {
+            auto me = static_cast<Buffer*>(wl_resource_get_user_data(resource));
+            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -719,6 +723,8 @@ struct mw::DataOffer::Thunks
     {
         try
         {
+            auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
+            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -916,6 +922,8 @@ struct mw::DataSource::Thunks
     {
         try
         {
+            auto me = static_cast<DataSource*>(wl_resource_get_user_data(resource));
+            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -1163,6 +1171,8 @@ struct mw::DataDevice::Thunks
     {
         try
         {
+            auto me = static_cast<DataDevice*>(wl_resource_get_user_data(resource));
+            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -1936,6 +1946,8 @@ struct mw::Surface::Thunks
     {
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
+            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -2313,6 +2325,8 @@ struct mw::Seat::Thunks
     {
         try
         {
+            auto me = static_cast<Seat*>(wl_resource_get_user_data(resource));
+            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -2502,6 +2516,8 @@ struct mw::Pointer::Thunks
     {
         try
         {
+            auto me = static_cast<Pointer*>(wl_resource_get_user_data(resource));
+            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -2769,6 +2785,8 @@ struct mw::Keyboard::Thunks
     {
         try
         {
+            auto me = static_cast<Keyboard*>(wl_resource_get_user_data(resource));
+            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -2913,6 +2931,8 @@ struct mw::Touch::Thunks
     {
         try
         {
+            auto me = static_cast<Touch*>(wl_resource_get_user_data(resource));
+            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -3085,6 +3105,8 @@ struct mw::Output::Thunks
     {
         try
         {
+            auto me = static_cast<Output*>(wl_resource_get_user_data(resource));
+            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -3345,6 +3367,8 @@ struct mw::Region::Thunks
     {
         try
         {
+            auto me = static_cast<Region*>(wl_resource_get_user_data(resource));
+            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -3451,6 +3475,8 @@ struct mw::Subcompositor::Thunks
     {
         try
         {
+            auto me = static_cast<Subcompositor*>(wl_resource_get_user_data(resource));
+            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -3592,6 +3618,8 @@ struct mw::Subsurface::Thunks
     {
         try
         {
+            auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
+            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)

--- a/tests/acceptance-tests/wayland-generator/expected.h
+++ b/tests/acceptance-tests/wayland-generator/expected.h
@@ -116,6 +116,7 @@ public:
 
 private:
     virtual void create_buffer(struct wl_resource* id, int32_t offset, int32_t width, int32_t height, int32_t stride, uint32_t format) = 0;
+    virtual void destroy() {}
     virtual void resize(int32_t size) = 0;
 };
 
@@ -249,6 +250,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
+    virtual void destroy() {}
 };
 
 class DataOffer : public Resource
@@ -291,6 +293,7 @@ public:
 private:
     virtual void accept(uint32_t serial, std::optional<std::string> const& mime_type) = 0;
     virtual void receive(std::string const& mime_type, mir::Fd fd) = 0;
+    virtual void destroy() {}
     virtual void finish() = 0;
     virtual void set_actions(uint32_t dnd_actions, uint32_t preferred_action) = 0;
 };
@@ -340,6 +343,7 @@ public:
 
 private:
     virtual void offer(std::string const& mime_type) = 0;
+    virtual void destroy() {}
     virtual void set_actions(uint32_t dnd_actions) = 0;
 };
 
@@ -382,6 +386,7 @@ public:
 private:
     virtual void start_drag(std::optional<struct wl_resource*> const& source, struct wl_resource* origin, std::optional<struct wl_resource*> const& icon, uint32_t serial) = 0;
     virtual void set_selection(std::optional<struct wl_resource*> const& source, uint32_t serial) = 0;
+    virtual void release() {}
 };
 
 class DataDeviceManager : public Resource
@@ -558,6 +563,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
+    virtual void destroy() {}
     virtual void attach(std::optional<struct wl_resource*> const& buffer, int32_t x, int32_t y) = 0;
     virtual void damage(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void frame(struct wl_resource* callback) = 0;
@@ -622,6 +628,7 @@ private:
     virtual void get_pointer(struct wl_resource* id) = 0;
     virtual void get_keyboard(struct wl_resource* id) = 0;
     virtual void get_touch(struct wl_resource* id) = 0;
+    virtual void release() {}
 };
 
 class Pointer : public Resource
@@ -700,6 +707,7 @@ public:
 
 private:
     virtual void set_cursor(uint32_t serial, std::optional<struct wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) = 0;
+    virtual void release() {}
 };
 
 class Keyboard : public Resource
@@ -748,6 +756,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
+    virtual void release() {}
 };
 
 class Touch : public Resource
@@ -788,6 +797,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
+    virtual void release() {}
 };
 
 class Output : public Resource
@@ -870,6 +880,7 @@ public:
     };
 
 private:
+    virtual void release() {}
 };
 
 class Region : public Resource
@@ -887,6 +898,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
+    virtual void destroy() {}
     virtual void add(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void subtract(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
 };
@@ -923,6 +935,7 @@ public:
     };
 
 private:
+    virtual void destroy() {}
     virtual void get_subsurface(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* parent) = 0;
 };
 
@@ -946,6 +959,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
+    virtual void destroy() {}
     virtual void set_position(int32_t x, int32_t y) = 0;
     virtual void place_above(struct wl_resource* sibling) = 0;
     virtual void place_below(struct wl_resource* sibling) = 0;


### PR DESCRIPTION
fixes https://github.com/canonical/mir/issues/3241

## What's new?
- We now generate a virtual stub method with destructors so that you can do something like this:

```c++
void mf::SessionLockV1::unlock_and_destroy()
{
    printf("Being unlocked and destroyed\n");
}
```

This is called right before destruction happens. By default, the method is a stub.