### PR TITLE
(#3236) `CPUCopyOutputSurface` now used a GL output layout

### DIFF
--- a/src/platforms/common/server/cpu_copy_output_surface.cpp
+++ b/src/platforms/common/server/cpu_copy_output_surface.cpp
@@ -296,5 +296,5 @@ auto mgc::CPUCopyOutputSurface::Impl::size() const -> geom::Size
 
 auto mgc::CPUCopyOutputSurface::Impl::layout() const -> Layout
 {
-    return Layout::GL;
+    return Layout::TopRowFirst;
 }

--- a/src/platforms/common/server/cpu_copy_output_surface.cpp
+++ b/src/platforms/common/server/cpu_copy_output_surface.cpp
@@ -296,5 +296,5 @@ auto mgc::CPUCopyOutputSurface::Impl::size() const -> geom::Size
 
 auto mgc::CPUCopyOutputSurface::Impl::layout() const -> Layout
 {
-    return Layout::TopRowFirst;
+    return Layout::GL;
 }


### PR DESCRIPTION
fixes https://github.com/canonical/mir/issues/3236

Am I right to think this @RAOF ? It looks like `CPUCopyOutputSurface`  is trying to have a `GL` layout. I could be wrong, but this makes my screenshots work.

## Before
![2024-02-21T17:01:19,606591722-05:00](https://github.com/canonical/mir/assets/25062299/1835506f-6725-47d4-920a-f2fdcec4ce91)


## After
![2024-02-21T17:06:29,424484886-05:00](https://github.com/canonical/mir/assets/25062299/6dfbc1e2-8fcf-40e2-8913-7a610b9a5743)
