### PR TITLE
mf::BufferStream: Remove with_most_recent_buffer_do

### DIFF
--- a/src/include/server/mir/frontend/buffer_stream.h
+++ b/src/include/server/mir/frontend/buffer_stream.h
@@ -44,9 +44,6 @@ public:
     virtual void set_frame_posted_callback(
         std::function<void(geometry::Size const&)> const& callback) = 0;
 
-    virtual void with_most_recent_buffer_do(
-        std::function<void(graphics::Buffer&)> const& exec) = 0;
-
     virtual MirPixelFormat pixel_format() const = 0;
 
     virtual void set_scale(float scale) = 0;

--- a/src/server/compositor/stream.cpp
+++ b/src/server/compositor/stream.cpp
@@ -59,11 +59,6 @@ void mc::Stream::submit_buffer(std::shared_ptr<mg::Buffer> const& buffer)
     }
 }
 
-void mc::Stream::with_most_recent_buffer_do(std::function<void(mg::Buffer&)> const& fn)
-{
-    fn(*arbiter->snapshot_acquire());
-}
-
 MirPixelFormat mc::Stream::pixel_format() const
 {
     return latest_state.lock()->pf;

--- a/src/server/compositor/stream.h
+++ b/src/server/compositor/stream.h
@@ -38,7 +38,6 @@ public:
     ~Stream();
 
     void submit_buffer(std::shared_ptr<graphics::Buffer> const& buffer) override;
-    void with_most_recent_buffer_do(std::function<void(graphics::Buffer&)> const& exec) override;
     MirPixelFormat pixel_format() const override;
     void set_frame_posted_callback(
         std::function<void(geometry::Size const&)> const& callback) override;

--- a/src/server/frontend_xwayland/scaled_buffer_stream.cpp
+++ b/src/server/frontend_xwayland/scaled_buffer_stream.cpp
@@ -35,11 +35,6 @@ void mf::ScaledBufferStream::set_frame_posted_callback(std::function<void(geomet
     inner->set_frame_posted_callback(callback);
 }
 
-void mf::ScaledBufferStream::with_most_recent_buffer_do(std::function<void(graphics::Buffer&)> const& exec)
-{
-    inner->with_most_recent_buffer_do(exec);
-}
-
 MirPixelFormat mf::ScaledBufferStream::pixel_format() const
 {
     return inner->pixel_format();

--- a/src/server/frontend_xwayland/scaled_buffer_stream.h
+++ b/src/server/frontend_xwayland/scaled_buffer_stream.h
@@ -37,7 +37,6 @@ public:
     /// @{
     void submit_buffer(std::shared_ptr<graphics::Buffer> const& buffer);
     void set_frame_posted_callback(std::function<void(geometry::Size const&)> const& callback);
-    void with_most_recent_buffer_do(std::function<void(graphics::Buffer&)> const& exec);
     MirPixelFormat pixel_format() const;
     void set_scale(float scale);
     /// @}

--- a/tests/include/mir/test/doubles/mock_buffer_stream.h
+++ b/tests/include/mir/test/doubles/mock_buffer_stream.h
@@ -42,8 +42,6 @@ struct MockBufferStream : public compositor::BufferStream
     {
         ON_CALL(*this, buffers_ready_for_compositor(::testing::_))
             .WillByDefault(testing::Invoke(this, &MockBufferStream::buffers_ready));
-        ON_CALL(*this, with_most_recent_buffer_do(testing::_))
-            .WillByDefault(testing::InvokeArgument<0>(testing::ByRef(*buffer)));
         ON_CALL(*this, acquire_client_buffer(testing::_))
             .WillByDefault(testing::InvokeArgument<0>(nullptr));
         ON_CALL(*this, has_submitted_buffer())
@@ -69,13 +67,10 @@ struct MockBufferStream : public compositor::BufferStream
     MOCK_CONST_METHOD1(buffers_ready_for_compositor, int(void const*));
     MOCK_METHOD0(drop_client_requests, void());
 
-    MOCK_METHOD1(submit_buffer, void(std::shared_ptr<graphics::Buffer> const&));
-    MOCK_METHOD1(with_most_recent_buffer_do, void(std::function<void(graphics::Buffer&)> const&));
-    MOCK_CONST_METHOD0(pixel_format, MirPixelFormat());
-    MOCK_CONST_METHOD0(has_submitted_buffer, bool());
-    MOCK_METHOD1(disassociate_buffer, void(graphics::BufferID));
-    MOCK_METHOD1(associate_buffer, void(graphics::BufferID));
-    MOCK_METHOD1(set_scale, void(float));
+    MOCK_METHOD(void, submit_buffer, (std::shared_ptr<graphics::Buffer> const&), (override));
+    MOCK_METHOD(MirPixelFormat, pixel_format, (), (const override));
+    MOCK_METHOD(bool, has_submitted_buffer, (), (const override));
+    MOCK_METHOD(void, set_scale, (float), (override));
 
 };
 }

--- a/tests/include/mir/test/doubles/stub_buffer_stream.h
+++ b/tests/include/mir/test/doubles/stub_buffer_stream.h
@@ -53,10 +53,6 @@ public:
     {
         if (b) ++nready;
     }
-    void with_most_recent_buffer_do(std::function<void(graphics::Buffer&)> const& fn) override
-    {
-        fn(*stub_compositor_buffer);
-    }
     MirPixelFormat pixel_format() const override { return mir_pixel_format_abgr_8888; }
     void set_frame_posted_callback(std::function<void(geometry::Size const&)> const&) override {}
     bool has_submitted_buffer() const override { return true; }


### PR DESCRIPTION
This is unused (and untested!)