### PR TITLE
Ignore zero length gamma curves

### DIFF
--- a/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
+++ b/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
@@ -360,6 +360,12 @@ void mgg::RealKMSOutput::set_power_mode(MirPowerMode mode)
 
 void mgg::RealKMSOutput::set_gamma(mg::GammaCurves const& gamma)
 {
+    if (!gamma.red.size())
+    {
+        mir::log_warning("Ignoring attempt to set zero length gamma");
+        return;
+    }
+
     if (!ensure_crtc())
     {
         mir::log_warning("Output %s has no associated CRTC to set gamma on",


### PR DESCRIPTION
After a wake we might see an invalid Gamma curve.  Ignore it.

Fixes: #3238

It fixes the problem because `ensure_crtc()` might allocate a new `current_crtc` but the `drmModeCrtcSetGamma()` will fail leaving it unused - but still associated with the output.