### PR TITLE
Revert "Merge pull request #3243 from canonical/feature/3241"

### DIFF
--- a/src/wayland/generator/request.cpp
+++ b/src/wayland/generator/request.cpp
@@ -26,7 +26,7 @@ Emitter Request::virtual_mir_prototype() const
 {
     if (is_destroy())
     {
-        return {"virtual void ", name, "(", mir_args(), ") {}"};
+        return nullptr;
     }
     else
     {
@@ -43,11 +43,7 @@ Emitter Request::thunk_impl() const
             "try",
             Block{
                 (is_destroy() ?
-                     Lines{
-                         {"auto me = static_cast<", class_name, "*>(wl_resource_get_user_data(resource));"},
-                         {"me->", name, "(", mir_call_args(), ");"},
-                         {"wl_resource_destroy(resource);"}
-                     }
+                    Emitter{"wl_resource_destroy(resource);"}
                 :
                     Lines{
                         {"auto me = static_cast<", class_name, "*>(wl_resource_get_user_data(resource));"},

--- a/tests/acceptance-tests/wayland-generator/expected.cpp
+++ b/tests/acceptance-tests/wayland-generator/expected.cpp
@@ -305,8 +305,6 @@ struct mw::ShmPool::Thunks
     {
         try
         {
-            auto me = static_cast<ShmPool*>(wl_resource_get_user_data(resource));
-            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -604,8 +602,6 @@ struct mw::Buffer::Thunks
     {
         try
         {
-            auto me = static_cast<Buffer*>(wl_resource_get_user_data(resource));
-            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -723,8 +719,6 @@ struct mw::DataOffer::Thunks
     {
         try
         {
-            auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
-            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -922,8 +916,6 @@ struct mw::DataSource::Thunks
     {
         try
         {
-            auto me = static_cast<DataSource*>(wl_resource_get_user_data(resource));
-            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -1171,8 +1163,6 @@ struct mw::DataDevice::Thunks
     {
         try
         {
-            auto me = static_cast<DataDevice*>(wl_resource_get_user_data(resource));
-            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -1946,8 +1936,6 @@ struct mw::Surface::Thunks
     {
         try
         {
-            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
-            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -2325,8 +2313,6 @@ struct mw::Seat::Thunks
     {
         try
         {
-            auto me = static_cast<Seat*>(wl_resource_get_user_data(resource));
-            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -2516,8 +2502,6 @@ struct mw::Pointer::Thunks
     {
         try
         {
-            auto me = static_cast<Pointer*>(wl_resource_get_user_data(resource));
-            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -2785,8 +2769,6 @@ struct mw::Keyboard::Thunks
     {
         try
         {
-            auto me = static_cast<Keyboard*>(wl_resource_get_user_data(resource));
-            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -2931,8 +2913,6 @@ struct mw::Touch::Thunks
     {
         try
         {
-            auto me = static_cast<Touch*>(wl_resource_get_user_data(resource));
-            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -3105,8 +3085,6 @@ struct mw::Output::Thunks
     {
         try
         {
-            auto me = static_cast<Output*>(wl_resource_get_user_data(resource));
-            me->release();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -3367,8 +3345,6 @@ struct mw::Region::Thunks
     {
         try
         {
-            auto me = static_cast<Region*>(wl_resource_get_user_data(resource));
-            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -3475,8 +3451,6 @@ struct mw::Subcompositor::Thunks
     {
         try
         {
-            auto me = static_cast<Subcompositor*>(wl_resource_get_user_data(resource));
-            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
@@ -3618,8 +3592,6 @@ struct mw::Subsurface::Thunks
     {
         try
         {
-            auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
-            me->destroy();
             wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)

--- a/tests/acceptance-tests/wayland-generator/expected.h
+++ b/tests/acceptance-tests/wayland-generator/expected.h
@@ -116,7 +116,6 @@ public:
 
 private:
     virtual void create_buffer(struct wl_resource* id, int32_t offset, int32_t width, int32_t height, int32_t stride, uint32_t format) = 0;
-    virtual void destroy() {}
     virtual void resize(int32_t size) = 0;
 };
 
@@ -250,7 +249,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() {}
 };
 
 class DataOffer : public Resource
@@ -293,7 +291,6 @@ public:
 private:
     virtual void accept(uint32_t serial, std::optional<std::string> const& mime_type) = 0;
     virtual void receive(std::string const& mime_type, mir::Fd fd) = 0;
-    virtual void destroy() {}
     virtual void finish() = 0;
     virtual void set_actions(uint32_t dnd_actions, uint32_t preferred_action) = 0;
 };
@@ -343,7 +340,6 @@ public:
 
 private:
     virtual void offer(std::string const& mime_type) = 0;
-    virtual void destroy() {}
     virtual void set_actions(uint32_t dnd_actions) = 0;
 };
 
@@ -386,7 +382,6 @@ public:
 private:
     virtual void start_drag(std::optional<struct wl_resource*> const& source, struct wl_resource* origin, std::optional<struct wl_resource*> const& icon, uint32_t serial) = 0;
     virtual void set_selection(std::optional<struct wl_resource*> const& source, uint32_t serial) = 0;
-    virtual void release() {}
 };
 
 class DataDeviceManager : public Resource
@@ -563,7 +558,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() {}
     virtual void attach(std::optional<struct wl_resource*> const& buffer, int32_t x, int32_t y) = 0;
     virtual void damage(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void frame(struct wl_resource* callback) = 0;
@@ -628,7 +622,6 @@ private:
     virtual void get_pointer(struct wl_resource* id) = 0;
     virtual void get_keyboard(struct wl_resource* id) = 0;
     virtual void get_touch(struct wl_resource* id) = 0;
-    virtual void release() {}
 };
 
 class Pointer : public Resource
@@ -707,7 +700,6 @@ public:
 
 private:
     virtual void set_cursor(uint32_t serial, std::optional<struct wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) = 0;
-    virtual void release() {}
 };
 
 class Keyboard : public Resource
@@ -756,7 +748,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void release() {}
 };
 
 class Touch : public Resource
@@ -797,7 +788,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void release() {}
 };
 
 class Output : public Resource
@@ -880,7 +870,6 @@ public:
     };
 
 private:
-    virtual void release() {}
 };
 
 class Region : public Resource
@@ -898,7 +887,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() {}
     virtual void add(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void subtract(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
 };
@@ -935,7 +923,6 @@ public:
     };
 
 private:
-    virtual void destroy() {}
     virtual void get_subsurface(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* parent) = 0;
 };
 
@@ -959,7 +946,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() {}
     virtual void set_position(int32_t x, int32_t y) = 0;
     virtual void place_above(struct wl_resource* sibling) = 0;
     virtual void place_below(struct wl_resource* sibling) = 0;


### PR DESCRIPTION
This reverts commit 8346ca9ac88341ef81fb0294f205504dd434368f, reversing changes made to 120d2ccfb744d6f43fd32df806936e6b92c4b3a8.

It turns out that sometimes the userdata is set to nullptr, leading `me->destroy()` to attempt to jump to null.