### PR TITLE
Use the compiler generated default comparison operators

### DIFF
--- a/include/core/mir/geometry/dimensions.h
+++ b/include/core/mir/geometry/dimensions.h
@@ -80,35 +80,7 @@ struct Value
     {
     }
 
-    inline constexpr auto operator == (Value<T, Tag> const& rhs) const -> bool
-    {
-        return value == rhs.as_value();
-    }
-
-    inline constexpr auto operator != (Value<T, Tag> const& rhs) const -> bool
-    {
-        return value != rhs.as_value();
-    }
-
-    inline constexpr auto operator <= (Value<T, Tag> const& rhs) const -> bool
-    {
-        return value <= rhs.as_value();
-    }
-
-    inline constexpr auto operator >= (Value<T, Tag> const& rhs) const -> bool
-    {
-        return value >= rhs.as_value();
-    }
-
-    inline constexpr auto operator < (Value<T, Tag> const& rhs) const -> bool
-    {
-        return value < rhs.as_value();
-    }
-
-    inline constexpr auto operator > (Value<T, Tag> const& rhs) const -> bool
-    {
-        return value > rhs.as_value();
-    }
+    friend auto operator <=> (Value const& lhs, Value const& rhs) = default;
 
 protected:
     T value;

--- a/include/core/mir/geometry/displacement.h
+++ b/include/core/mir/geometry/displacement.h
@@ -67,21 +67,12 @@ struct Displacement
         return x * x + y * y;
     }
 
+    friend bool operator== (Displacement const& lhs, Displacement const& rhs) = default;
+    friend bool operator!= (Displacement const& lhs, Displacement const& rhs) = default;
+
     DeltaX<T> dx;
     DeltaY<T> dy;
 };
-
-template<typename T>
-inline constexpr bool operator==(Displacement<T> const& lhs, Displacement<T> const& rhs)
-{
-    return lhs.dx == rhs.dx && lhs.dy == rhs.dy;
-}
-
-template<typename T>
-inline constexpr bool operator!=(Displacement<T> const& lhs, Displacement<T> const& rhs)
-{
-    return lhs.dx != rhs.dx || lhs.dy != rhs.dy;
-}
 
 template<typename T>
 std::ostream& operator<<(std::ostream& out, Displacement<T> const& value)

--- a/include/core/mir/geometry/point.h
+++ b/include/core/mir/geometry/point.h
@@ -51,21 +51,12 @@ struct Point
     template<typename XType, typename YType>
     constexpr Point(XType&& x, YType&& y) : x(x), y(y) {}
 
+    friend bool operator== (Point const& lhs, Point const& rhs) = default;
+    friend bool operator!= (Point const& lhs, Point const& rhs) = default;
+
     X<T> x;
     Y<T> y;
 };
-
-template<typename T>
-inline constexpr bool operator == (Point<T> const& lhs, Point<T> const& rhs)
-{
-    return lhs.x == rhs.x && lhs.y == rhs.y;
-}
-
-template<typename T>
-inline constexpr bool operator != (Point<T> const& lhs, Point<T> const& rhs)
-{
-    return lhs.x != rhs.x || lhs.y != rhs.y;
-}
 
 template<typename T>
 inline constexpr Point<T> operator+(Point<T> lhs, DeltaX<T> rhs) { return{lhs.x + rhs, lhs.y}; }

--- a/include/core/mir/geometry/rectangle.h
+++ b/include/core/mir/geometry/rectangle.h
@@ -103,6 +103,9 @@ struct Rectangle
     Y<T> top() const    { return top_left.y; }
     Y<T> bottom() const { return bottom_right().y; }
 
+    friend bool operator== (Rectangle const& lhs, Rectangle const& rhs) = default;
+    friend bool operator!= (Rectangle const& lhs, Rectangle const& rhs) = default;
+
     Point<T> top_left;
     Size<T> size;
 };
@@ -121,18 +124,6 @@ Rectangle<T> intersection_of(Rectangle<T> const& a, Rectangle<T> const& b)
                 (min_bottom - max_top).as_value()}};
     else
         return {};
-}
-
-template<typename T>
-inline constexpr bool operator == (Rectangle<T> const& lhs, Rectangle<T> const& rhs)
-{
-    return lhs.top_left == rhs.top_left && lhs.size == rhs.size;
-}
-
-template<typename T>
-inline constexpr bool operator != (Rectangle<T> const& lhs, Rectangle<T> const& rhs)
-{
-    return lhs.top_left != rhs.top_left || lhs.size != rhs.size;
 }
 
 template<typename T>

--- a/include/core/mir/geometry/size.h
+++ b/include/core/mir/geometry/size.h
@@ -51,21 +51,12 @@ struct Size
     template<typename WidthType, typename HeightType>
     constexpr Size(WidthType&& width, HeightType&& height) noexcept : width(width), height(height) {}
 
+    friend bool operator== (Size const& lhs, Size const& rhs) = default;
+    friend bool operator!= (Size const& lhs, Size const& rhs) = default;
+
     Width<T> width;
     Height<T> height;
 };
-
-template<typename T>
-inline constexpr bool operator == (Size<T> const& lhs, Size<T> const& rhs)
-{
-    return lhs.width == rhs.width && lhs.height == rhs.height;
-}
-
-template<typename T>
-inline constexpr bool operator != (Size<T> const& lhs, Size<T> const& rhs)
-{
-    return lhs.width != rhs.width || lhs.height != rhs.height;
-}
 
 template<typename T>
 std::ostream& operator<<(std::ostream& out, Size<T> const& value)

--- a/include/core/mir/int_wrapper.h
+++ b/include/core/mir/int_wrapper.h
@@ -29,7 +29,7 @@ public:
 
     explicit constexpr IntWrapper(ValueType value) : value(value) {}
     ValueType constexpr as_value() const { return value; }
-
+    friend auto operator <=> (IntWrapper const& lhs, IntWrapper const& rhs) = default;
 private:
     ValueType value;
 };
@@ -39,36 +39,6 @@ std::ostream& operator<<(std::ostream& out, IntWrapper<Tag,ValueType> const& val
 {
     out << value.as_value();
     return out;
-}
-
-template<typename Tag, typename ValueType>
-inline constexpr bool operator == (IntWrapper<Tag,ValueType> const& lhs, IntWrapper<Tag,ValueType> const& rhs)
-{
-    return lhs.as_value() == rhs.as_value();
-}
-
-template<typename Tag, typename ValueType>
-inline constexpr bool operator != (IntWrapper<Tag,ValueType> const& lhs, IntWrapper<Tag,ValueType> const& rhs)
-{
-    return lhs.as_value() != rhs.as_value();
-}
-
-template<typename Tag, typename ValueType>
-inline constexpr bool operator <= (IntWrapper<Tag,ValueType> const& lhs, IntWrapper<Tag,ValueType> const& rhs)
-{
-    return lhs.as_value() <= rhs.as_value();
-}
-
-template<typename Tag, typename ValueType>
-inline constexpr bool operator >= (IntWrapper<Tag,ValueType> const& lhs, IntWrapper<Tag,ValueType> const& rhs)
-{
-    return lhs.as_value() >= rhs.as_value();
-}
-
-template<typename Tag, typename ValueType>
-inline constexpr bool operator < (IntWrapper<Tag,ValueType> const& lhs, IntWrapper<Tag,ValueType> const& rhs)
-{
-    return lhs.as_value() < rhs.as_value();
 }
 }
 


### PR DESCRIPTION
Hand crafting leads to mistakes and/or omissions (as noticed by @hbatagelo in #3244)