### PR TITLE
platform/linux-dmabuf: Be more lenient with EGL implementations

### DIFF
--- a/include/platform/mir/graphics/drm_formats.h
+++ b/include/platform/mir/graphics/drm_formats.h
@@ -58,6 +58,7 @@ private:
 };
 
 auto drm_modifier_to_string(uint64_t modifier) -> std::string;
+auto drm_format_to_string(uint32_t format) -> char const*;
 }
 
 #endif //MIR_PLATFORM_GRAPHICS_DRM_FORMATS_H_

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -30,9 +30,7 @@
 
 namespace mg = mir::graphics;
 
-namespace
-{
-constexpr auto drm_format_to_string(uint32_t format) -> char const*
+auto mg::drm_format_to_string(uint32_t format) -> char const*
 {
 #define STRINGIFY(val) \
     case val:          \
@@ -65,7 +63,6 @@ constexpr auto drm_format_to_string(uint32_t format) -> char const*
 #undef STRINGIFY_BIGENDIAN
 }
 
-}
 struct mg::DRMFormat::FormatInfo
 {
     uint32_t format;
@@ -456,7 +453,7 @@ constexpr auto info_for_format(uint32_t fourcc_format) -> mg::DRMFormat::FormatI
     }
     BOOST_THROW_EXCEPTION((
         std::runtime_error{
-            std::string{"Unsupported DRM format: "} + drm_format_to_string(fourcc_format)}));
+            std::string{"Unsupported DRM format: "} + mg::drm_format_to_string(fourcc_format)}));
 }
 
 }

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -87,7 +87,7 @@ public:
             resize(returned_formats);
         }
 
-        for (auto i = 0u; i < formats.size(); ++i)
+        for (auto i = 0u; i < formats.size();)
         {
             auto [format, modifiers, external_only] = (*this)[i];
 
@@ -109,9 +109,8 @@ public:
                 formats.erase(formats.begin() + i);
                 modifiers_for_format.erase(modifiers_for_format.begin() + i);
                 external_only_for_format.erase(external_only_for_format.begin() + i);
-                // formats[i] is now the format *after* the one we've just removed, so go back one
-                // and continue the loop.
-                --i;
+                // formats[i] is now the format *after* the one we've just removed,
+                // so we can can continue iterating through the formats from here.
                 continue;
             }
             modifiers.resize(num_modifiers);
@@ -149,6 +148,9 @@ public:
                 modifiers.push_back(DRM_FORMAT_MOD_INVALID);
                 external_only.push_back(false);
             }
+
+            // We've processed this format; move on to the next one
+            ++i;
         }
         if (this->num_formats() == 0)
         {

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -70,6 +70,7 @@ MIR_PLATFORM_2.17 {
     mir::graphics::common::EGLContextExecutor::spawn*;
     mir::graphics::contains_alpha*;
     mir::graphics::drm_modifier_to_string*;
+    mir::graphics::drm_format_to_string*;
     mir::graphics::egl_category*;
     mir::graphics::gl::Program::?Program*;
     mir::graphics::gl::ProgramFactory::?ProgramFactory*;


### PR DESCRIPTION
Some EGL implementations (*cough* NVIDIA) return formats from `eglQueryDmaBufFormatsEXT` that generate
`EGL_BAD_PARAMETER` errors when querying for the associated modifiers with `eglQueryDmaBufModifiersEXT`.

This doesn't need to be fatal, as long as there are *some* formats for which we can successfully query
the modifiers, so make it non-fatal.

Fixes: #3278