### PR TITLE
feature: support for `zwlr_layer_surface_v1::set_exclusive_zone(-1)`

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -210,6 +210,7 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::WindowInfo::focus_mode() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowInfo::has_output_id() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowInfo::height_inc() const@MIRAL_5.0" 5.0.0
+ (c++)"miral::WindowInfo::ignore_exclusion_zones() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowInfo::is_visible() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowInfo::max_aspect() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowInfo::max_height() const@MIRAL_5.0" 5.0.0
@@ -318,6 +319,8 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::WindowSpecification::focus_mode()@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowSpecification::height_inc() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowSpecification::height_inc()@MIRAL_5.0" 5.0.0
+ (c++)"miral::WindowSpecification::ignore_exclusion_zones() const@MIRAL_5.0" 5.0.0
+ (c++)"miral::WindowSpecification::ignore_exclusion_zones()@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowSpecification::input_mode() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowSpecification::input_mode()@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowSpecification::input_shape() const@MIRAL_5.0" 5.0.0

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -116,6 +116,10 @@ struct WindowInfo
     /// (only meaningful when the window is attached to an edge)
     auto exclusive_rect() const -> mir::optional_value<mir::geometry::Rectangle>;
 
+    /// Mir will ignore the exclusive_rects of other windows when this is set to true.
+    /// (only meaningful when the window is attached to an edge)
+    auto ignore_exclusion_zones() const -> bool;
+
     /// Mir will not render anything outside this rectangle
     auto clip_area() const -> mir::optional_value<mir::geometry::Rectangle>;
     void clip_area(mir::optional_value<mir::geometry::Rectangle> const& area);

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -147,6 +147,13 @@ public:
     auto exclusive_rect() -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&;
     ///@}
 
+    /// Decides whether or not this window should ignore the exclusion zones set by other windows.
+    /// Only meaningful for windows attached to an edge
+    ///@{
+    auto ignore_exclusion_zones() const -> mir::optional_value<bool> const&;
+    auto ignore_exclusion_zones() -> mir::optional_value<bool>&;
+    ///@}
+
     /// The D-bus service name and basename of the app's .desktop file
     /// See http://standards.freedesktop.org/desktop-entry-spec/
     ///@{

--- a/src/include/server/mir/shell/surface_specification.h
+++ b/src/include/server/mir/shell/surface_specification.h
@@ -103,6 +103,7 @@ struct SurfaceSpecification
 
     optional_value<MirPlacementGravity> attached_edges;
     optional_value<optional_value<geometry::Rectangle>> exclusive_rect;
+    optional_value<bool> ignore_exclusion_zones;
     optional_value<std::string> application_id;
 
     /// If to enable server-side decorations for this surface

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -183,6 +183,7 @@ global:
     miral::WindowInfo::constrain_resize*;
     miral::WindowInfo::depth_layer*;
     miral::WindowInfo::exclusive_rect*;
+    miral::WindowInfo::ignore_exclusion_zones*;
     miral::WindowInfo::focus_mode*;
     miral::WindowInfo::has_output_id*;
     miral::WindowInfo::height_inc*;
@@ -279,6 +280,7 @@ global:
     miral::WindowSpecification::confine_pointer*;
     miral::WindowSpecification::depth_layer*;
     miral::WindowSpecification::exclusive_rect*;
+    miral::WindowSpecification::ignore_exclusion_zones*;
     miral::WindowSpecification::focus_mode*;
     miral::WindowSpecification::height_inc*;
     miral::WindowSpecification::input_mode*;

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -439,6 +439,11 @@ auto miral::WindowInfo::exclusive_rect() const -> mir::optional_value<mir::geome
     return self->exclusive_rect;
 }
 
+auto miral::WindowInfo::ignore_exclusion_zones() const -> bool
+{
+    return self->ignore_exclusion_zones;
+}
+
 auto miral::WindowInfo::clip_area() const -> mir::optional_value<mir::geometry::Rectangle>
 {
     std::shared_ptr<mir::scene::Surface> const surface = self->window;

--- a/src/miral/window_info_internal.cpp
+++ b/src/miral/window_info_internal.cpp
@@ -87,7 +87,8 @@ miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) 
     max_aspect(optional_value_or_default(params.max_aspect(), default_max_aspect_ratio)),
     shell_chrome(optional_value_or_default(params.shell_chrome(), mir_shell_chrome_normal)),
     depth_layer(optional_value_or_default(params.depth_layer(), mir_depth_layer_application)),
-    attached_edges(optional_value_or_default(params.attached_edges(), mir_placement_gravity_center))
+    attached_edges(optional_value_or_default(params.attached_edges(), mir_placement_gravity_center)),
+    ignore_exclusion_zones{optional_value_or_default(params.ignore_exclusion_zones(), false)}
 {
     if (params.output_id().is_set())
         output_id = params.output_id().value();

--- a/src/miral/window_info_internal.h
+++ b/src/miral/window_info_internal.h
@@ -49,6 +49,7 @@ struct miral::WindowInfo::Self
     MirDepthLayer depth_layer;
     MirPlacementGravity attached_edges;
     mir::optional_value<mir::geometry::Rectangle> exclusive_rect;
+    bool ignore_exclusion_zones;
     std::shared_ptr<void> userdata;
 };
 

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -52,6 +52,7 @@ miral::WindowSpecification::Self::Self(mir::shell::SurfaceSpecification const& s
     depth_layer(spec.depth_layer),
     attached_edges(spec.attached_edges),
     exclusive_rect(spec.exclusive_rect),
+    ignore_exclusion_zones(spec.ignore_exclusion_zones),
     application_id(spec.application_id),
     server_side_decorated(spec.server_side_decorated),
     focus_mode(spec.focus_mode),
@@ -264,6 +265,12 @@ auto miral::WindowSpecification::exclusive_rect() const
     return self->exclusive_rect;
 }
 
+auto miral::WindowSpecification::ignore_exclusion_zones() const
+    -> mir::optional_value<bool> const&
+{
+    return self->ignore_exclusion_zones;
+}
+
 auto miral::WindowSpecification::userdata() const -> mir::optional_value<std::shared_ptr<void>> const&
 {
     return self->userdata;
@@ -408,6 +415,12 @@ auto miral::WindowSpecification::exclusive_rect()
     -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&
 {
     return self->exclusive_rect;
+}
+
+auto miral::WindowSpecification::ignore_exclusion_zones()
+    -> mir::optional_value<bool>&
+{
+    return self->ignore_exclusion_zones;
 }
 
 auto miral::WindowSpecification::application_id() const -> mir::optional_value<std::string> const&

--- a/src/miral/window_specification_internal.h
+++ b/src/miral/window_specification_internal.h
@@ -69,6 +69,7 @@ struct WindowSpecification::Self
     mir::optional_value<MirDepthLayer> depth_layer;
     mir::optional_value<MirPlacementGravity> attached_edges;
     mir::optional_value<mir::optional_value<mir::geometry::Rectangle>> exclusive_rect;
+    mir::optional_value<bool> ignore_exclusion_zones;
     mir::optional_value<std::string> application_id;
     mir::optional_value<bool> server_side_decorated;
     mir::optional_value<MirFocusMode> focus_mode;

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -196,7 +196,7 @@ private:
         wl_resource_destroy(resource);
     }
 
-    DoubleBuffered<uint32_t> exclusive_zone{0};
+    DoubleBuffered<int32_t> exclusive_zone{0};
     DoubleBuffered<Anchors> anchors;
     DoubleBuffered<Margin> margin;
     bool width_set_by_client{false}; ///< If the client gave a width on the last .set_size() request
@@ -434,6 +434,13 @@ auto mf::LayerSurfaceV1::inform_window_role_of_pending_placement()
     spec.exclusive_rect = exclusive_rect ?
         mir::optional_value<geom::Rectangle>(exclusive_rect.value()) :
         mir::optional_value<geom::Rectangle>();
+
+    // Per the spec: https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:request:set_exclusive_zone
+    // If the zone is -1, it indicates that the surface will not be moved to respect the exclusion zones of other
+    // surfaces.
+    auto zone = exclusive_zone.pending();
+    if (zone == -1)
+        spec.ignore_exclusion_zones = true;
 
     apply_spec(spec);
 }

--- a/src/server/frontend_wayland/session_lock_v1.cpp
+++ b/src/server/frontend_wayland/session_lock_v1.cpp
@@ -282,11 +282,12 @@ mf::SessionLockSurfaceV1::SessionLockSurfaceV1(
 {
     shell::SurfaceSpecification spec;
     spec.state = mir_window_state_attached;
-    spec.depth_layer = mir_depth_layer_background;
+    spec.depth_layer = mir_depth_layer_overlay;
     spec.focus_mode = mir_focus_mode_grabbing;
     spec.output_id = output_id;
     spec.attached_edges = MirPlacementGravity(mir_placement_gravity_northwest | mir_placement_gravity_southeast);
     spec.visible_on_lock_screen = true;
+    spec.ignore_exclusion_zones = true;
     apply_spec(spec);
     auto const serial = Resource::client->next_serial(nullptr);
     send_configure_event(serial, 100, 100);

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -146,6 +146,8 @@ void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
         attached_edges = that.attached_edges;
     if (that.exclusive_rect.is_set())
         exclusive_rect = that.exclusive_rect;
+    if (that.ignore_exclusion_zones.is_set())
+        ignore_exclusion_zones = that.ignore_exclusion_zones;
     if (that.application_id.is_set())
         application_id = that.application_id;
     if (that.server_side_decorated.is_set())
@@ -200,6 +202,7 @@ bool msh::operator==(
         lhs.depth_layer == rhs.depth_layer &&
         lhs.attached_edges == rhs.attached_edges &&
         lhs.exclusive_rect == rhs.exclusive_rect &&
+        lhs.ignore_exclusion_zones == rhs.ignore_exclusion_zones &&
         lhs.application_id == rhs.application_id &&
         lhs.server_side_decorated == rhs.server_side_decorated &&
         lhs.focus_mode == rhs.focus_mode &&

--- a/tests/miral/window_placement_attached.cpp
+++ b/tests/miral/window_placement_attached.cpp
@@ -808,6 +808,38 @@ TEST_P(WindowPlacementAttached, attaching_to_any_output_in_logical_group_attache
     EXPECT_THAT(window.size(), Eq(placement.size));
 }
 
+TEST_P(WindowPlacementAttached, windows_that_ignore_exclusion_zones_are_not_placed_relative_to_windows_that_define_exclusive_rects)
+{
+    AttachedEdges edges = GetParam();
+    Size window_size{120, 80};
+    Rectangle exclusive_rect{{0, 0}, window_size};
+
+    {
+        mir::shell::SurfaceSpecification params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = edges;
+        params.set_size(window_size);
+        params.exclusive_rect = exclusive_rect;
+        create_window(params);
+    }
+
+    Window attached;
+    {
+        mir::shell::SurfaceSpecification params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = (MirPlacementGravity)(
+            mir_placement_gravity_north |
+            mir_placement_gravity_south |
+            mir_placement_gravity_east |
+            mir_placement_gravity_west);
+        params.ignore_exclusion_zones = true;
+        attached = create_window(params);
+    }
+
+    EXPECT_THAT(attached.top_left(), Eq(display_area.top_left));
+    EXPECT_THAT(attached.size(), Eq(display_area.size));
+}
+
 INSTANTIATE_TEST_SUITE_P(WindowPlacementAttached, WindowPlacementAttached, ::testing::Values(
     mir_placement_gravity_center,
     mir_placement_gravity_west,


### PR DESCRIPTION
fixes #1992 (and maybe #3125?)

## What's new
- If we have an attached window with `ignore_exclusion_zones` set to `true`, then the surface will attach to its edges without regard for other exclusion zones
- When we're locked, we shouldn't calculate exclusion zones that are _not_ visible on the lockscreen

## To Test
- Run `waybar`
- Run `swaybg -i /path/to/jpg`
- Note that `swaybg` will appear _underneath_ `waybar`, as it should!