### PR TITLE
(#3259) buffer size should be the possibly-inverted extents size so that the final image is correct

### DIFF
--- a/src/server/frontend_wayland/wlr_screencopy_v1.cpp
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.cpp
@@ -378,8 +378,7 @@ void mf::WlrScreencopyManagerV1::capture_output(
     (void)overlay_cursor;
     auto const& output_config = OutputGlobal::from_or_throw(output).current_config();
     auto const extents = output_config.extents();
-    auto const buffer_size = output_config.modes[output_config.current_mode_index].size;
-    new WlrScreencopyFrameV1{frame, this, ctx, {output, extents, buffer_size}};
+    new WlrScreencopyFrameV1{frame, this, ctx, {output, extents, extents.size}};
 }
 
 void mf::WlrScreencopyManagerV1::capture_output_region(
@@ -393,8 +392,7 @@ void mf::WlrScreencopyManagerV1::capture_output_region(
     auto const& output_config = OutputGlobal::from_or_throw(output).current_config();
     auto const extents = output_config.extents();
     auto const intersection = intersection_of({{x, y}, {width, height}}, extents);
-    auto const output_size = output_config.modes[output_config.current_mode_index].size;
-    auto const buffer_size = translate_and_scale(intersection, extents, {{}, output_size}).size;
+    auto const buffer_size = translate_and_scale(intersection, extents, {{}, extents.size}).size;
     new WlrScreencopyFrameV1{frame, this, ctx, {output, intersection, buffer_size}};
 }
 


### PR DESCRIPTION
fixes #3259 

# Screenshots
## Left
![20240318_15h54m23s_grim](https://github.com/canonical/mir/assets/25062299/7815dfb9-ed03-491f-8422-e417d5d39d3b)

## Right
![20240318_15h54m44s_grim](https://github.com/canonical/mir/assets/25062299/412bd5a8-4935-4c4f-8c9a-6c710bf232b4)

## Inverted (Scaled)
![20240318_15h55m27s_grim](https://github.com/canonical/mir/assets/25062299/4bd4a102-c666-431f-86f8-ec005d3c457a)


## Normal
![20240318_15h56m07s_grim](https://github.com/canonical/mir/assets/25062299/f50be354-d664-4589-a75a-63e818d8597f)
