### PR TITLE
Fix positioning of satellite windows

### DIFF
--- a/examples/example-server-lib/floating_window_manager.cpp
+++ b/examples/example-server-lib/floating_window_manager.cpp
@@ -32,8 +32,6 @@ using namespace miral::toolkit;
 
 namespace
 {
-DeltaY const title_bar_height{12};
-
 struct PolicyData
 {
     bool in_hidden_workspace{false};
@@ -344,9 +342,7 @@ bool FloatingWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* 
             case KEY_LEFT:
                 modifications.state() = mir_window_state_vertmaximized;
                 tools.place_and_size_for_state(modifications, window_info);
-                modifications.top_left() = window_info.needs_titlebar(window_info.type()) ?
-                                               active_zone.top_left + title_bar_height :
-                                               active_zone.top_left;
+                modifications.top_left() = active_zone.top_left;
                 break;
 
             case KEY_RIGHT:
@@ -357,18 +353,14 @@ bool FloatingWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* 
                 auto const new_width =
                     (modifications.size().is_set() ? modifications.size().value() : active_window.size()).width;
 
-                modifications.top_left() = window_info.needs_titlebar(window_info.type()) ?
-                        active_zone.top_right() - Displacement{as_delta(new_width), 0} + title_bar_height :
-                        active_zone.top_right() - Displacement{as_delta(new_width), 0};
+                modifications.top_left() = active_zone.top_right() - Displacement{as_delta(new_width), 0};
                 break;
             }
 
             case KEY_UP:
                 modifications.state() = mir_window_state_horizmaximized;
                 tools.place_and_size_for_state(modifications, window_info);
-                modifications.top_left() = window_info.needs_titlebar(window_info.type()) ?
-                                               active_zone.top_left + title_bar_height :
-                                               active_zone.top_left;
+                modifications.top_left() = active_zone.top_left;
                 break;
 
             case KEY_DOWN:
@@ -476,11 +468,6 @@ WindowSpecification FloatingWindowManagerPolicy::place_new_window(
         parameters.depth_layer() = mir_depth_layer_background;
     }
 
-    bool const needs_titlebar = WindowInfo::needs_titlebar(parameters.type().value());
-
-    if (parameters.state().value() != mir_window_state_fullscreen && needs_titlebar)
-        parameters.top_left() = Point{parameters.top_left().value().x, parameters.top_left().value().y + title_bar_height};
-
     parameters.userdata() = std::make_shared<PolicyData>();
     return parameters;
 }
@@ -505,25 +492,10 @@ void FloatingWindowManagerPolicy::advise_adding_to_workspace(
 }
 
 auto FloatingWindowManagerPolicy::confirm_placement_on_display(
-    miral::WindowInfo const& window_info, MirWindowState new_state, Rectangle const& new_placement) -> Rectangle
+    miral::WindowInfo const& /*window_info*/, MirWindowState /*new_state*/, Rectangle const& new_placement)
+    -> Rectangle
 {
-    switch (new_state)
-    {
-    case mir_window_state_maximized:
-    case mir_window_state_vertmaximized:
-        if (window_info.needs_titlebar(window_info.type()))
-        {
-            auto result = new_placement;
-
-            result.top_left.y = result.top_left.y  + title_bar_height;
-            result.size.height = result.size.height - title_bar_height;
-            return result;
-        }
-        // else
-        //     Falls through.
-    default:
-        return new_placement;
-    }
+    return new_placement;
 }
 
 void FloatingWindowManagerPolicy::switch_workspace_to(

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -47,10 +47,9 @@ struct WindowInfo
 
     bool is_visible() const;
 
-    /// \remark Since MirAL 5.0
-    /// \deprecated Use Surface::content_size()/Surface::window_size() instead
+    /// \deprecated Obsolete: Window::size() includes decorations
     /// @{
-    [[deprecated("use Surface::content_size()/Surface::window_size() instead")]]
+    [[deprecated("Obsolete: Window::size() includes decorations")]]
     static bool needs_titlebar(MirWindowType type);
     /// @}
 

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -47,7 +47,12 @@ struct WindowInfo
 
     bool is_visible() const;
 
+    /// \remark Since MirAL 5.0
+    /// \deprecated Use Surface::content_size()/Surface::window_size() instead
+    /// @{
+    [[deprecated("use Surface::content_size()/Surface::window_size() instead")]]
     static bool needs_titlebar(MirWindowType type);
+    /// @}
 
     void constrain_resize(mir::geometry::Point& requested_pos, mir::geometry::Size& requested_size) const;
 

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -261,6 +261,7 @@ bool miral::WindowInfo::needs_titlebar(MirWindowType type)
     case mir_window_type_gloss:
     case mir_window_type_tip:
     case mir_window_type_decoration:
+    case mir_window_type_satellite:
         // No decorations for these surface types
         return false;
     default:

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -261,7 +261,6 @@ bool miral::WindowInfo::needs_titlebar(MirWindowType type)
     case mir_window_type_gloss:
     case mir_window_type_tip:
     case mir_window_type_decoration:
-    case mir_window_type_satellite:
         // No decorations for these surface types
         return false;
     default:


### PR DESCRIPTION
When a satellite window is positioned, an extra vertical offset is added to its top-left position, making the vertical anchoring incorrect. The offset is added because `WindowInfo::needs_titlebar()` returns `true` when called from the floating window policy manager. This PR fixes that.