### PR TITLE
Fix regenerate-miral-symbols-map

### DIFF
--- a/doc/sphinx/Doxyfile.in
+++ b/doc/sphinx/Doxyfile.in
@@ -1176,7 +1176,7 @@ CLANG_ADD_INC_PATHS    = YES
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          =
+CLANG_OPTIONS          = -std=c++23
 
 # If clang assisted parsing is enabled you can provide the clang parser with the
 # path to the directory containing a file called compile_commands.json. This


### PR DESCRIPTION
We started using C++23 features. Doxygen needs to tell clang