### PR TITLE
SPIKE: expose existing input configuration options

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -1,5 +1,6 @@
 libmiral.so.7 libmiral7 #MINVER#
  MIRAL_5.0@MIRAL_5.0 5.0.0
+ (c++)"miral::add_input_device_configuration(mir::Server&)@MIRAL_5.0" 5.0.0
  (c++)"miral::AddInitCallback::AddInitCallback(std::function<void ()> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::AddInitCallback::operator()(mir::Server&) const@MIRAL_5.0" 5.0.0
  (c++)"miral::AddInitCallback::~AddInitCallback()@MIRAL_5.0" 5.0.0

--- a/examples/mir_demo_server/CMakeLists.txt
+++ b/examples/mir_demo_server/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_library(exampleserverconfig STATIC
-  server_example_input_device_config.cpp
   server_example_input_event_filter.cpp
   server_example_input_filter.cpp
 )

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -17,7 +17,7 @@
 #include "server_example_input_event_filter.h"
 #include "server_example_input_filter.h"
 #include "server_example_test_client.h"
-#include "server_example_input_device_config.h"
+#include "miral/input_device_config.h"
 
 #include <miral/cursor_theme.h>
 #include <miral/display_configuration_option.h>
@@ -130,18 +130,20 @@ try
     for (auto const& ext : wayland_extensions.all_supported())
         wayland_extensions.enable(ext);
 
-    auto const server_exit_status = runner.run_with({
-        // example options for display layout, logging and timeout
-        miral::display_configuration_options,
-        miral::X11Support{},
-        wayland_extensions,
-        miral::set_window_management_policy<miral::MinimalWindowManager>(),
-        me::add_input_device_configuration_options_to,
-        add_timeout_option_to,
-        miral::CursorTheme{"default:DMZ-White"},
-        input_filters,
-        test_runner
-    });
+    auto const server_exit_status = runner.run_with(
+        {
+            // example options for display layout, logging and timeout
+            miral::display_configuration_options,
+
+            miral::X11Support{},
+            wayland_extensions,
+            miral::set_window_management_policy<miral::MinimalWindowManager>(),
+            miral::add_input_device_configuration,
+            add_timeout_option_to,
+            miral::CursorTheme{"default:DMZ-White"},
+            input_filters,
+            test_runner
+        });
 
     // Propagate any test failure
     if (test_runner.test_failed())

--- a/examples/mir_demo_server/server_example_input_device_config.cpp
+++ b/examples/mir_demo_server/server_example_input_device_config.cpp
@@ -152,8 +152,7 @@ void me::InputDeviceConfig::device_added(std::shared_ptr<mi::Device> const& devi
 {
     if (contains(device->capabilities(), mi::DeviceCapability::touchpad))
     {
-	auto optional_pointer_config = device->pointer_configuration();
-        if (optional_pointer_config.is_set())
+	    if (auto const optional_pointer_config = device->pointer_configuration(); optional_pointer_config.is_set())
         {
             MirPointerConfig pointer_config( optional_pointer_config.value() );
             pointer_config.cursor_acceleration_bias(touchpad_cursor_acceleration_bias);
@@ -162,8 +161,7 @@ void me::InputDeviceConfig::device_added(std::shared_ptr<mi::Device> const& devi
             device->apply_pointer_configuration(pointer_config);
         }
 
-	auto optional_touchpad_config = device->touchpad_configuration();
-        if (optional_touchpad_config.is_set())
+	    if (auto const optional_touchpad_config = device->touchpad_configuration(); optional_touchpad_config.is_set())
         {
             MirTouchpadConfig touch_config( optional_touchpad_config.value() );
             touch_config.disable_while_typing(disable_while_typing);
@@ -174,8 +172,7 @@ void me::InputDeviceConfig::device_added(std::shared_ptr<mi::Device> const& devi
     }
     else if (contains(device->capabilities(), mi::DeviceCapability::pointer))
     {
-	auto optional_pointer_config = device->pointer_configuration();
-        if (optional_pointer_config.is_set())
+	    if (auto optional_pointer_config = device->pointer_configuration(); optional_pointer_config.is_set())
         {
             MirPointerConfig pointer_config( optional_pointer_config.value() );
             pointer_config.acceleration(mouse_profile);

--- a/examples/mir_demo_server/server_example_input_device_config.cpp
+++ b/examples/mir_demo_server/server_example_input_device_config.cpp
@@ -32,6 +32,7 @@ namespace mi = mir::input;
 namespace
 {
 char const* const disable_while_typing_opt = "disable-while-typing";
+char const* const tap_to_click_opt = "tap-to-click";
 char const* const mouse_acceleration_opt = "mouse-acceleration";
 char const* const acceleration_none = "none";
 char const* const acceleration_adaptive = "adaptive";
@@ -55,6 +56,10 @@ void me::add_input_device_configuration_options_to(mir::Server& server)
     // Add choice of monitor configuration
     server.add_configuration_option(disable_while_typing_opt,
                                     "Disable touchpad while typing on keyboard configuration [true, false]",
+                                    false);
+    server.add_configuration_option(tap_to_click_opt,
+                                    "Enable or disable tap-to-click on this device, with a default mapping of"
+                                    " 1, 2, 3 finger tap mapping to left, right, middle click, respectively [true, false]",
                                     false);
     server.add_configuration_option(mouse_acceleration_opt,
                                     "Select acceleration profile for mice and trackballs [none, adaptive]",
@@ -120,6 +125,7 @@ void me::add_input_device_configuration_options_to(mir::Server& server)
             auto const options = server.get_options();
             auto const input_config = std::make_shared<me::InputDeviceConfig>(
                 options->get<bool>(disable_while_typing_opt),
+                options->get<bool>(tap_to_click_opt),
                 to_profile(options->get<std::string>(mouse_acceleration_opt)),
                 clamp_to_range(options->get<double>(mouse_cursor_acceleration_bias_opt)),
                 options->get<double>(mouse_scroll_speed_scale_opt),
@@ -133,6 +139,7 @@ void me::add_input_device_configuration_options_to(mir::Server& server)
 }
 
 me::InputDeviceConfig::InputDeviceConfig(bool disable_while_typing,
+                                         bool tap_to_click,
                                          MirPointerAcceleration mouse_profile,
                                          double mouse_cursor_acceleration_bias,
                                          double mouse_scroll_speed_scale,
@@ -140,11 +147,12 @@ me::InputDeviceConfig::InputDeviceConfig(bool disable_while_typing,
                                          double touchpad_scroll_speed_scale,
                                          MirTouchpadClickModes click_mode,
                                          MirTouchpadClickModes scroll_mode)
-    : disable_while_typing(disable_while_typing), mouse_profile{mouse_profile},
-      mouse_cursor_acceleration_bias(mouse_cursor_acceleration_bias),
-      mouse_scroll_speed_scale(mouse_scroll_speed_scale),
-      touchpad_cursor_acceleration_bias(touchpad_cursor_acceleration_bias),
-      touchpad_scroll_speed_scale(touchpad_scroll_speed_scale), click_mode(click_mode), scroll_mode(scroll_mode)
+    : disable_while_typing{disable_while_typing}, mouse_profile{mouse_profile},
+      mouse_cursor_acceleration_bias{mouse_cursor_acceleration_bias},
+      mouse_scroll_speed_scale{mouse_scroll_speed_scale},
+      touchpad_cursor_acceleration_bias{touchpad_cursor_acceleration_bias},
+      touchpad_scroll_speed_scale{touchpad_scroll_speed_scale}, click_mode{click_mode}, scroll_mode{scroll_mode},
+      tap_to_click{tap_to_click}
 {
 }
 
@@ -167,6 +175,7 @@ void me::InputDeviceConfig::device_added(std::shared_ptr<mi::Device> const& devi
             touch_config.disable_while_typing(disable_while_typing);
             touch_config.click_mode(click_mode);
             touch_config.scroll_mode(scroll_mode);
+            touch_config.tap_to_click(tap_to_click);
             device->apply_touchpad_configuration(touch_config);
         }
     }

--- a/examples/mir_demo_server/server_example_input_device_config.h
+++ b/examples/mir_demo_server/server_example_input_device_config.h
@@ -45,18 +45,18 @@ public:
                       MirTouchpadClickModes click_mode,
                       MirTouchpadScrollModes scroll_mode);
     void device_added(std::shared_ptr<input::Device> const& device) override;
-    void device_changed(std::shared_ptr<input::Device> const&) override {};
-    void device_removed(std::shared_ptr<input::Device> const&) override {};
+    void device_changed(std::shared_ptr<input::Device> const&) override {}
+    void device_removed(std::shared_ptr<input::Device> const&) override {}
     void changes_complete() override {}
 private:
-    bool disable_while_typing;
-    MirPointerAcceleration mouse_profile;
-    double mouse_cursor_acceleration_bias;
-    double mouse_scroll_speed_scale;
-    double touchpad_cursor_acceleration_bias;
-    double touchpad_scroll_speed_scale;
-    MirTouchpadClickModes click_mode;
-    MirTouchpadScrollModes scroll_mode;
+    bool const disable_while_typing;
+    MirPointerAcceleration const mouse_profile;
+    double const mouse_cursor_acceleration_bias;
+    double const mouse_scroll_speed_scale;
+    double const touchpad_cursor_acceleration_bias;
+    double const touchpad_scroll_speed_scale;
+    MirTouchpadClickModes const click_mode;
+    MirTouchpadScrollModes const scroll_mode;
 };
 
 }

--- a/examples/mir_demo_server/server_example_input_device_config.h
+++ b/examples/mir_demo_server/server_example_input_device_config.h
@@ -37,6 +37,7 @@ class InputDeviceConfig : public mir::input::InputDeviceObserver
 {
 public:
     InputDeviceConfig(bool disable_while_typing,
+                      bool tap_to_click,
                       MirPointerAcceleration mouse_profile,
                       double mouse_cursor_acceleration_bias,
                       double mouse_scroll_speed_scale,
@@ -57,6 +58,7 @@ private:
     double const touchpad_scroll_speed_scale;
     MirTouchpadClickModes const click_mode;
     MirTouchpadScrollModes const scroll_mode;
+    bool const tap_to_click;
 };
 
 }

--- a/include/common/mir/input/mir_touchpad_config.h
+++ b/include/common/mir/input/mir_touchpad_config.h
@@ -30,8 +30,8 @@ struct MirTouchpadConfig
     MirTouchpadConfig(MirTouchpadConfig const& other);
     MirTouchpadConfig& operator=(MirTouchpadConfig const& other);
     ~MirTouchpadConfig();
-    MirTouchpadConfig(MirTouchpadClickModes click_mode,
-                          MirTouchpadScrollModes scroll_mode,
+    MirTouchpadConfig(MirTouchpadClickMode click_mode,
+                          MirTouchpadScrollMode scroll_mode,
                           int button_down_scroll_button,
                           bool tap_to_click,
                           bool disable_while_typing,
@@ -41,13 +41,13 @@ struct MirTouchpadConfig
     /*!
      * The click mode defines when the touchpad generates software emulated button events.
      */
-    MirTouchpadClickModes click_mode() const;
-    void click_mode(MirTouchpadClickModes) ;
+    MirTouchpadClickMode click_mode() const;
+    void click_mode(MirTouchpadClickMode modes) ;
     /*!
      * The scroll mode defines when the touchpad generates scroll events instead of pointer motion events.
      */
-    MirTouchpadScrollModes scroll_mode() const;
-    void scroll_mode(MirTouchpadScrollModes);
+    MirTouchpadScrollMode scroll_mode() const;
+    void scroll_mode(MirTouchpadScrollMode mode);
 
     /*!
      * Configures the button used for the on-button-down scroll mode

--- a/include/core/mir_toolkit/mir_input_device_types.h
+++ b/include/core/mir_toolkit/mir_input_device_types.h
@@ -63,7 +63,6 @@ typedef enum MirTouchpadClickMode
     mir_touchpad_click_mode_area_to_click = 1 << 0,
     mir_touchpad_click_mode_finger_count  = 1 << 1
 } MirTouchpadClickMode;
-typedef unsigned int MirTouchpadClickModes;
 
 /**
  * MirTouchpadScrollMode configures how the touchpad should generate scroll
@@ -83,7 +82,6 @@ typedef enum MirTouchpadScrollMode
     mir_touchpad_scroll_mode_edge_scroll        = 1 << 1,
     mir_touchpad_scroll_mode_button_down_scroll = 1 << 2
 } MirTouchpadScrollMode;
-typedef unsigned int MirTouchpadScrollModes;
 
 /**
  * Mapping modes for touchscreen devices. The mode defines how coordinates

--- a/include/miral/miral/input_device_config.h
+++ b/include/miral/miral/input_device_config.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_INPUT_DEVICE_CONFIG_H_
+#define MIRAL_INPUT_DEVICE_CONFIG_H_
+
+namespace mir
+{
+class Server;
+}
+
+namespace miral
+{
+void add_input_device_configuration(::mir::Server& server);
+}
+
+#endif

--- a/include/miral/miral/input_device_config.h
+++ b/include/miral/miral/input_device_config.h
@@ -24,7 +24,7 @@ class Server;
 
 namespace miral
 {
-void add_input_device_configuration(::mir::Server& server);
+void add_input_device_configuration(::mir::Server& opt_val);
 }
 
 #endif

--- a/include/platform/mir/input/pointer_settings.h
+++ b/include/platform/mir/input/pointer_settings.h
@@ -50,15 +50,10 @@ struct PointerSettings
      * Scale vertical scrolling linearly
      */
     double vertical_scroll_scale{1.0};
+
+    bool operator==(PointerSettings const& rhs) const = default;
+    bool operator!=(PointerSettings const& rhs) const = default;
 };
-
-inline bool operator==(PointerSettings const& lhs, PointerSettings const& rhs)
-{
-    return lhs.handedness == rhs.handedness && lhs.cursor_acceleration_bias == rhs.cursor_acceleration_bias &&
-           lhs.acceleration == rhs.acceleration && lhs.horizontal_scroll_scale == rhs.horizontal_scroll_scale &&
-           lhs.vertical_scroll_scale == rhs.vertical_scroll_scale;
-}
-
 }
 }
 

--- a/include/platform/mir/input/touchpad_settings.h
+++ b/include/platform/mir/input/touchpad_settings.h
@@ -28,23 +28,18 @@ int const no_scroll_button = 0;
 struct TouchpadSettings
 {
     TouchpadSettings() {}
-    MirTouchpadClickModes click_mode{mir_touchpad_click_mode_finger_count};
-    MirTouchpadScrollModes scroll_mode{mir_touchpad_scroll_mode_two_finger_scroll};
+
+    bool operator==(TouchpadSettings const& rhs) const = default;
+    bool operator!=(TouchpadSettings const& rhs) const = default;
+
+    MirTouchpadClickMode click_mode{mir_touchpad_click_mode_finger_count};
+    MirTouchpadScrollMode scroll_mode{mir_touchpad_scroll_mode_two_finger_scroll};
     int button_down_scroll_button{no_scroll_button};
     bool tap_to_click{true};
     bool disable_while_typing{false};
     bool disable_with_mouse{false};
     bool middle_mouse_button_emulation{true};
 };
-
-inline bool operator==(TouchpadSettings const& lhs, TouchpadSettings const& rhs)
-{
-    return lhs.click_mode == rhs.click_mode && lhs.scroll_mode == rhs.scroll_mode &&
-           lhs.button_down_scroll_button == rhs.button_down_scroll_button && lhs.tap_to_click == rhs.tap_to_click &&
-           lhs.disable_while_typing == rhs.disable_while_typing && lhs.disable_with_mouse == rhs.disable_with_mouse &&
-           lhs.middle_mouse_button_emulation == rhs.middle_mouse_button_emulation;
-}
-
 }
 }
 

--- a/src/common/input/mir_touchpad_config.cpp
+++ b/src/common/input/mir_touchpad_config.cpp
@@ -20,8 +20,8 @@
 struct MirTouchpadConfig::Implementation
 {
     Implementation() = default;
-    Implementation(MirTouchpadClickModes click_mode,
-                   MirTouchpadScrollModes scroll_mode,
+    Implementation(MirTouchpadClickMode click_mode,
+                   MirTouchpadScrollMode scroll_mode,
                    int button_down_scroll_button,
                    bool tap_to_click,
                    bool middle_mouse_button_emulation,
@@ -36,8 +36,8 @@ struct MirTouchpadConfig::Implementation
           disable_while_typing{disable_while_typing}
     {
     }
-    MirTouchpadClickModes click_mode{mir_touchpad_click_mode_finger_count};
-    MirTouchpadScrollModes scroll_mode{mir_touchpad_scroll_mode_two_finger_scroll};
+    MirTouchpadClickMode click_mode{mir_touchpad_click_mode_finger_count};
+    MirTouchpadScrollMode scroll_mode{mir_touchpad_scroll_mode_two_finger_scroll};
     int button_down_scroll_button{0};
     bool tap_to_click{true};
     bool middle_mouse_button_emulation{true};
@@ -68,13 +68,14 @@ MirTouchpadConfig& MirTouchpadConfig::operator=(MirTouchpadConfig const& other)
 
 MirTouchpadConfig::~MirTouchpadConfig() = default;
 
-MirTouchpadConfig::MirTouchpadConfig(MirTouchpadClickModes click_mode,
-                                                 MirTouchpadScrollModes scroll_mode,
-                                                 int button_down_scroll_button,
-                                                 bool tap_to_click,
-                                                 bool disable_while_typing,
-                                                 bool disable_with_mouse,
-                                                 bool middle_mouse_button_emulation)
+MirTouchpadConfig::MirTouchpadConfig(
+    MirTouchpadClickMode click_mode,
+    MirTouchpadScrollMode scroll_mode,
+    int button_down_scroll_button,
+    bool tap_to_click,
+    bool disable_while_typing,
+    bool disable_with_mouse,
+    bool middle_mouse_button_emulation)
     : impl{std::make_unique<Implementation>(
             click_mode,
             scroll_mode,
@@ -87,24 +88,24 @@ MirTouchpadConfig::MirTouchpadConfig(MirTouchpadClickModes click_mode,
 {
 }
 
-MirTouchpadClickModes MirTouchpadConfig::click_mode() const
+MirTouchpadClickMode MirTouchpadConfig::click_mode() const
 {
     return impl->click_mode;
 }
 
-void MirTouchpadConfig::click_mode(MirTouchpadClickModes modes)
+void MirTouchpadConfig::click_mode(MirTouchpadClickMode modes)
 {
     impl->click_mode = modes;
 }
 
-MirTouchpadScrollModes MirTouchpadConfig::scroll_mode() const
+MirTouchpadScrollMode MirTouchpadConfig::scroll_mode() const
 {
     return impl->scroll_mode;
 }
 
-void MirTouchpadConfig::scroll_mode(MirTouchpadScrollModes modes)
+void MirTouchpadConfig::scroll_mode(MirTouchpadScrollMode mode)
 {
-    impl->scroll_mode = modes;
+    impl->scroll_mode = mode;
 }
 
 int MirTouchpadConfig::button_down_scroll_button() const

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(miral SHARED
     custom_renderer.cpp                 ${miral_include}/miral/custom_renderer.h
     display_configuration.cpp           ${miral_include}/miral/display_configuration.h
     external_client.cpp                 ${miral_include}/miral/external_client.h
+    input_device_config.cpp             ${miral_include}/miral/input_device_config.h
     keymap.cpp                          ${miral_include}/miral/keymap.h
     minimal_window_manager.cpp          ${miral_include}/miral/minimal_window_manager.h
     runner.cpp                          ${miral_include}/miral/runner.h

--- a/src/miral/input_device_config.cpp
+++ b/src/miral/input_device_config.cpp
@@ -25,6 +25,7 @@
 #include "mir/options/option.h"
 #include "mir/server.h"
 #include "mir_toolkit/mir_input_device_types.h"
+#include "mir/log.h"
 
 namespace mi = mir::input;
 
@@ -187,6 +188,7 @@ void InputDeviceConfig::device_added(std::shared_ptr<mi::Device> const& device)
 {
     if (contains(device->capabilities(), mi::DeviceCapability::touchpad))
     {
+        mir::log_debug("Configuring touchpad: '%s'", device->name().c_str());
 	    if (auto const optional_pointer_config = device->pointer_configuration(); optional_pointer_config.is_set())
         {
             MirPointerConfig pointer_config( optional_pointer_config.value() );
@@ -208,7 +210,8 @@ void InputDeviceConfig::device_added(std::shared_ptr<mi::Device> const& device)
     }
     else if (contains(device->capabilities(), mi::DeviceCapability::pointer))
     {
-	    if (auto optional_pointer_config = device->pointer_configuration(); optional_pointer_config.is_set())
+        mir::log_debug("Configuring pointer: '%s'", device->name().c_str());
+        if (auto optional_pointer_config = device->pointer_configuration(); optional_pointer_config.is_set())
         {
             MirPointerConfig pointer_config( optional_pointer_config.value() );
             pointer_config.acceleration(mouse_profile);

--- a/src/miral/input_device_config.cpp
+++ b/src/miral/input_device_config.cpp
@@ -81,7 +81,9 @@ char const* const touchpad_scroll_speed_scale_opt = "touchpad-scroll-speed-scale
 char const* const touchpad_scroll_mode_opt = "touchpad-scroll-mode";
 
 char const* const touchpad_scroll_mode_two_finger = "two-finger";
+char const* const touchpad_scroll_mode_button_down_scroll = "button-down";
 char const* const touchpad_scroll_mode_edge = "edge";
+char const* const touchpad_scroll_mode_none = "none";
 
 char const* const touchpad_click_mode_opt= "touchpad-click-mode";
 
@@ -116,7 +118,10 @@ void miral::add_input_device_configuration(::mir::Server& server)
                                     mir::OptionType::real);
 
     server.add_configuration_option(touchpad_scroll_mode_opt,
-                                    "Select scroll mode for touchpads: [{two-finger, edge}]",
+                                    std::format("Select scroll mode for touchpads: [{}, {}, {}]",
+                                                touchpad_scroll_mode_edge,
+                                                touchpad_scroll_mode_two_finger,
+                                                touchpad_scroll_mode_button_down_scroll),
                                     mir::OptionType::string);
 
     server.add_configuration_option(touchpad_click_mode_opt,
@@ -140,19 +145,26 @@ void miral::add_input_device_configuration(::mir::Server& server)
         }
     };
 
-    // TODO options should not be exclusive
     auto convert_to_scroll_mode = [](std::optional<std::string> const& opt_val)
     -> std::optional<MirTouchpadScrollMode>
     {
         if (opt_val)
         {
-            if (*opt_val == touchpad_scroll_mode_edge)
+            if (*opt_val == touchpad_scroll_mode_none)
+            {
+                return mir_touchpad_scroll_mode_none;
+            }
+            else if (*opt_val == touchpad_scroll_mode_edge)
             {
                 return mir_touchpad_scroll_mode_edge_scroll;
             }
             else if (*opt_val == touchpad_scroll_mode_two_finger)
             {
                 return mir_touchpad_scroll_mode_two_finger_scroll;
+            }
+            else if (*opt_val == touchpad_scroll_mode_button_down_scroll)
+            {
+                return mir_touchpad_scroll_mode_button_down_scroll;
             }
             else
             {

--- a/src/miral/input_device_config.cpp
+++ b/src/miral/input_device_config.cpp
@@ -16,6 +16,7 @@
 
 #include "miral/input_device_config.h"
 
+#include "mir/abnormal_exit.h"
 #include "mir/input/device.h"
 #include "mir/input/device_capability.h"
 #include "mir/input/input_device_hub.h"
@@ -27,6 +28,7 @@
 #include "mir_toolkit/mir_input_device_types.h"
 #include "mir/log.h"
 
+#include <format>
 #include <optional>
 
 namespace mi = mir::input;
@@ -138,18 +140,29 @@ void miral::add_input_device_configuration(::mir::Server& server)
         }
     };
 
-    // TODO options are not exclusive
+    // TODO options should not be exclusive
     auto convert_to_scroll_mode = [](std::optional<std::string> const& opt_val)
     -> std::optional<MirTouchpadScrollMode>
     {
         if (opt_val)
         {
             if (*opt_val == touchpad_scroll_mode_edge)
+            {
                 return mir_touchpad_scroll_mode_edge_scroll;
-            if (*opt_val == touchpad_scroll_mode_two_finger)
+            }
+            else if (*opt_val == touchpad_scroll_mode_two_finger)
+            {
                 return mir_touchpad_scroll_mode_two_finger_scroll;
+            }
+            else
+            {
+                throw mir::AbnormalExit{std::format("Unrecognised option for {}: {}", touchpad_scroll_mode_opt, *opt_val)};
+            }
         }
-        return std::nullopt;
+        else
+        {
+            return std::nullopt;
+        }
     };
 
     auto to_acceleration_profile = [](std::optional<std::string> const& opt_val)-> std::optional<MirPointerAcceleration>
@@ -157,11 +170,22 @@ void miral::add_input_device_configuration(::mir::Server& server)
         if (opt_val)
         {
             if (*opt_val == acceleration_none)
+            {
                 return mir_pointer_acceleration_none;
-            if (*opt_val == acceleration_adaptive)
+            }
+            else if (*opt_val == acceleration_adaptive)
+            {
                 return mir_pointer_acceleration_adaptive;
+            }
+            else
+            {
+                throw mir::AbnormalExit{std::format("Unrecognised option for {}: {}", mouse_acceleration_opt, *opt_val)};
+            }
         }
-        return std::nullopt;
+        else
+        {
+            return std::nullopt;
+        }
     };
 
     // TODO options are not exclusive
@@ -172,11 +196,22 @@ void miral::add_input_device_configuration(::mir::Server& server)
         {
             auto val = *opt_val;
             if (val == touchpad_click_mode_finger_count)
+            {
                 return mir_touchpad_click_mode_finger_count;
+            }
             if (val == touchpad_click_mode_area)
+            {
                 return mir_touchpad_click_mode_area_to_click;
+            }
+            else
+            {
+                throw mir::AbnormalExit{std::format("Unrecognised option for {}: {}", touchpad_click_mode_opt, *opt_val)};
+            }
         }
-        return std::nullopt;
+        else
+        {
+            return std::nullopt;
+        }
     };
 
     server.add_init_callback([&]()

--- a/src/miral/input_device_config.cpp
+++ b/src/miral/input_device_config.cpp
@@ -51,8 +51,8 @@ public:
                       std::optional<double> mouse_scroll_speed_scale,
                       std::optional<double> touchpad_cursor_acceleration_bias,
                       std::optional<double> touchpad_scroll_speed_scale,
-                      std::optional<MirTouchpadClickModes> click_mode,
-                      std::optional<MirTouchpadScrollModes> scroll_mode);
+                      std::optional<MirTouchpadClickMode> click_mode,
+                      std::optional<MirTouchpadScrollMode> scroll_mode);
     void device_added(std::shared_ptr<mi::Device> const& device) override;
     void device_changed(std::shared_ptr<mi::Device> const&) override {}
     void device_removed(std::shared_ptr<mi::Device> const&) override {}
@@ -64,8 +64,8 @@ private:
     std::optional<double> const mouse_scroll_speed_scale;
     std::optional<double> const touchpad_cursor_acceleration_bias;
     std::optional<double> const touchpad_scroll_speed_scale;
-    std::optional<MirTouchpadClickModes> const click_mode;
-    std::optional<MirTouchpadScrollModes> const scroll_mode;
+    std::optional<MirTouchpadClickMode> const click_mode;
+    std::optional<MirTouchpadScrollMode> const scroll_mode;
     std::optional<bool> const tap_to_click;
 };
 
@@ -87,6 +87,7 @@ char const* const touchpad_scroll_mode_none = "none";
 
 char const* const touchpad_click_mode_opt= "touchpad-click-mode";
 
+char const* const touchpad_click_mode_none = "none";
 char const* const touchpad_click_mode_area = "area";
 char const* const touchpad_click_mode_finger_count = "finger-count";
 }
@@ -200,18 +201,21 @@ void miral::add_input_device_configuration(::mir::Server& server)
         }
     };
 
-    // TODO options are not exclusive
     auto convert_to_click_mode = [](std::optional<std::string> const& opt_val)
     -> std::optional<MirTouchpadClickMode>
     {
         if (opt_val)
         {
             auto val = *opt_val;
-            if (val == touchpad_click_mode_finger_count)
+            if (val == touchpad_click_mode_none)
+            {
+                return mir_touchpad_click_mode_none;
+            }
+            else if (val == touchpad_click_mode_finger_count)
             {
                 return mir_touchpad_click_mode_finger_count;
             }
-            if (val == touchpad_click_mode_area)
+            else if (val == touchpad_click_mode_area)
             {
                 return mir_touchpad_click_mode_area_to_click;
             }
@@ -251,8 +255,8 @@ InputDeviceConfig::InputDeviceConfig(std::optional<bool> disable_while_typing,
                                      std::optional<double> mouse_scroll_speed_scale,
                                      std::optional<double> touchpad_cursor_acceleration_bias,
                                      std::optional<double> touchpad_scroll_speed_scale,
-                                     std::optional<MirTouchpadClickModes> click_mode,
-                                     std::optional<MirTouchpadClickModes> scroll_mode)
+                                     std::optional<MirTouchpadClickMode> click_mode,
+                                     std::optional<MirTouchpadScrollMode> scroll_mode)
     : disable_while_typing{disable_while_typing}, mouse_profile{mouse_profile},
       mouse_cursor_acceleration_bias{mouse_cursor_acceleration_bias},
       mouse_scroll_speed_scale{mouse_scroll_speed_scale},

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -321,6 +321,7 @@ global:
     miral::Zone::id*;
     miral::Zone::is_same_zone*;
     miral::Zone::operator*;
+    miral::add_input_device_configuration*;
     miral::application_for*;
     miral::apply_lifecycle_state_to*;
     miral::display_configuration_options*;
@@ -456,4 +457,3 @@ global:
   };
 local: *;
 };
-

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -71,6 +71,20 @@ std::string describe(libinput_device* dev)
     }
 #endif
 
+#ifdef ARG_DEBUGGING
+    for (auto entry = udev_device_get_properties_list_entry(udev_dev.get()); entry; entry = udev_list_entry_get_next(entry))
+    {
+        mir::log_debug("{arg} property '%s=%s'", udev_list_entry_get_name(entry), udev_list_entry_get_value(entry));
+    }
+    for (auto entry = udev_device_get_tags_list_entry(udev_dev.get()); entry; entry = udev_list_entry_get_next(entry))
+    {
+        mir::log_debug("{arg} tag '%s=%s'", udev_list_entry_get_name(entry), udev_list_entry_get_value(entry));
+    }
+    for (auto entry = udev_device_get_sysattr_list_entry(udev_dev.get()); entry; entry = udev_list_entry_get_next(entry))
+    {
+        mir::log_debug("{arg} sysattr '%s=%s'", udev_list_entry_get_name(entry), udev_list_entry_get_value(entry));
+    }
+#endif
     auto const vendor = libinput_device_get_id_vendor(dev);
     auto const product = libinput_device_get_id_product(dev);
     desc += std::format(" [{:0>4x}:{:0>4x}]", vendor, product);
@@ -80,6 +94,7 @@ std::string describe(libinput_device* dev)
         desc += ": " + std::string(name);
     }
 
+#ifdef ARG_DEBUGGING
     for (auto const key : {/*"ID_MODEL", "ID_VENDOR_ID", "ID_MODEL_ID",*/ "ID_PATH"})
     {
         if (char const *const value = udev_device_get_property_value(udev_dev.get(), key))
@@ -87,6 +102,7 @@ std::string describe(libinput_device* dev)
             desc += ": " + std::string(key) + "=" + value;
         }
     }
+#endif
 
     return desc;
 }

--- a/src/server/input/default_device.cpp
+++ b/src/server/input/default_device.cpp
@@ -167,10 +167,6 @@ void mi::DefaultDevice::apply_touchpad_configuration(MirTouchpadConfig const& co
             BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot apply a touchpad configuration"));
     }
 
-    if (conf.scroll_mode() & mir_touchpad_scroll_mode_button_down_scroll &&
-        conf.button_down_scroll_button() == mi::no_scroll_button)
-        BOOST_THROW_EXCEPTION(std::invalid_argument("No scroll button configured"));
-
     set_touchpad_configuration(conf);
     device_changed_callback(this);
 }


### PR DESCRIPTION
I don't intend to land this in its current form. But it allows me to experiment with the input configuration