### PR TITLE
Compositor & Scene: Simplify buffering

### DIFF
--- a/debian/libmiroil5.symbols
+++ b/debian/libmiroil5.symbols
@@ -82,7 +82,6 @@ libmiroil.so.5 libmiroil5 #MINVER#
  (c++)"miroil::SetCompositor::operator()(mir::Server&)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::Surface(std::shared_ptr<mir::scene::Surface>)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::add_observer(std::shared_ptr<miroil::SurfaceObserver> const&)@MIROIL_5.0" 2.17.0
- (c++)"miroil::Surface::buffers_ready_for_compositor(void const*) const@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::configure(MirWindowAttrib, int)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::generate_renderables(void const*) const@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::get_wrapped() const@MIROIL_5.0" 2.17.0

--- a/debian/libmiroil5.symbols.armhf
+++ b/debian/libmiroil5.symbols.armhf
@@ -82,7 +82,6 @@ libmiroil.so.5 libmiroil5 #MINVER#
  (c++)"miroil::SetCompositor::operator()(mir::Server&)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::Surface(std::shared_ptr<mir::scene::Surface>)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::add_observer(std::shared_ptr<miroil::SurfaceObserver> const&)@MIROIL_5.0" 2.17.0
- (c++)"miroil::Surface::buffers_ready_for_compositor(void const*) const@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::configure(MirWindowAttrib, int)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::generate_renderables(void const*) const@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::get_wrapped() const@MIROIL_5.0" 2.17.0

--- a/include/miroil/miroil/surface.h
+++ b/include/miroil/miroil/surface.h
@@ -44,7 +44,6 @@ public:
     void add_observer(std::shared_ptr<miroil::SurfaceObserver> const& observer);    
     void remove_observer(std::shared_ptr<miroil::SurfaceObserver> const& observer);
     
-    int  buffers_ready_for_compositor(void const* compositor_id) const;
     mir::graphics::RenderableList generate_renderables(miroil::CompositorID id) const; 
 
     

--- a/src/include/server/mir/compositor/buffer_stream.h
+++ b/src/include/server/mir/compositor/buffer_stream.h
@@ -42,7 +42,6 @@ public:
     virtual auto lock_compositor_buffer(void const* user_id) -> std::shared_ptr<graphics::Buffer> = 0;
     /// Logical size of the stream (may be different than buffer sizes if scaled)
     virtual auto stream_size() -> geometry::Size = 0;
-    virtual auto buffers_ready_for_compositor(void const* user_id) const -> int = 0;
     virtual auto has_submitted_buffer() const -> bool = 0;
 };
 

--- a/src/include/server/mir/compositor/scene.h
+++ b/src/include/server/mir/compositor/scene.h
@@ -52,16 +52,6 @@ public:
      */
     virtual SceneElementSequence scene_elements_for(CompositorID id) = 0;
 
-    /**
-     * Return the number of additional frames that you need to render to get
-     * fully up to date with the latest data in the scene. For a generic
-     * "scene change" this will be just 1. For surfaces that have multiple
-     * frames queued up however, it could be greater than 1. When the result
-     * reaches zero, you know you have consumed all the latest data from the
-     * scene.
-     */
-    virtual int frames_pending(CompositorID id) const = 0;
-
     virtual void register_compositor(CompositorID id) = 0;
     virtual void unregister_compositor(CompositorID id) = 0;
 

--- a/src/include/server/mir/scene/null_surface_observer.h
+++ b/src/include/server/mir/scene/null_surface_observer.h
@@ -34,7 +34,7 @@ public:
     void content_resized_to(Surface const* surf, geometry::Size const& content_size) override;
     void moved_to(Surface const* surf, geometry::Point const& top_left) override;
     void hidden_set_to(Surface const* surf, bool hide) override;
-    void frame_posted(Surface const* surf, int frames_available, geometry::Rectangle const& damage) override;
+    void frame_posted(Surface const* surf, geometry::Rectangle const& damage) override;
     void alpha_set_to(Surface const* surf, float alpha) override;
     void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
     void transformation_set_to(Surface const* surf, glm::mat4 const& t) override;

--- a/src/include/server/mir/scene/scene_change_notification.h
+++ b/src/include/server/mir/scene/scene_change_notification.h
@@ -38,7 +38,7 @@ class SceneChangeNotification : public Observer
 public:
     SceneChangeNotification(
         std::function<void()> const& scene_notify_change,
-        std::function<void(int frames, mir::geometry::Rectangle const& damage)> const& damage_notify_change);
+        std::function<void(mir::geometry::Rectangle const& damage)> const& damage_notify_change);
 
     ~SceneChangeNotification();
 
@@ -53,7 +53,7 @@ public:
 
 private:
     std::function<void()> const scene_notify_change;
-    std::function<void(int frames, mir::geometry::Rectangle const& damage)> const damage_notify_change;
+    std::function<void(mir::geometry::Rectangle const& damage)> const damage_notify_change;
 
     std::mutex surface_observers_guard;
     std::map<Surface*, std::shared_ptr<SurfaceObserver>> surface_observers;

--- a/src/include/server/mir/scene/surface.h
+++ b/src/include/server/mir/scene/surface.h
@@ -64,7 +64,6 @@ public:
     virtual geometry::Size window_size() const = 0;
 
     virtual graphics::RenderableList generate_renderables(compositor::CompositorID id) const = 0; 
-    virtual int buffers_ready_for_compositor(void const* compositor_id) const = 0;
 
     virtual MirWindowType type() const = 0;
     virtual MirWindowState state() const = 0;

--- a/src/include/server/mir/scene/surface_observer.h
+++ b/src/include/server/mir/scene/surface_observer.h
@@ -49,7 +49,7 @@ public:
     virtual void moved_to(Surface const* surf, geometry::Point const& top_left) = 0;
     virtual void hidden_set_to(Surface const* surf, bool hide) = 0;
     /// damage is given in surface-local logical coordinates
-    virtual void frame_posted(Surface const* surf, int frames_available, geometry::Rectangle const& damage) = 0;
+    virtual void frame_posted(Surface const* surf, geometry::Rectangle const& damage) = 0;
     virtual void alpha_set_to(Surface const* surf, float alpha) = 0;
     virtual void orientation_set_to(Surface const* surf, MirOrientation orientation) = 0;
     virtual void transformation_set_to(Surface const* surf, glm::mat4 const& t) = 0;

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -207,11 +207,6 @@ auto miroil::Surface::get_wrapped() const -> mir::scene::Surface*
     return wrapped.get();
 }
 
-int miroil::Surface::buffers_ready_for_compositor(void const* compositor_id) const
-{
-    return wrapped->buffers_ready_for_compositor(compositor_id);
-}
-
 mir::graphics::RenderableList miroil::Surface::generate_renderables(miroil::CompositorID id) const
 {
     return wrapped->generate_renderables(id);

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -39,8 +39,7 @@ public:
                            std::weak_ptr<mir::graphics::CursorImage> const& image) override;
   void depth_layer_set_to(mir::scene::Surface const *surf,
                           MirDepthLayer depth_layer) override;
-  void frame_posted(mir::scene::Surface const *surf, int frames_available,
-                    mir::geometry::Rectangle const& area) override;
+  void frame_posted(mir::scene::Surface const *surf, mir::geometry::Rectangle const& area) override;
   void hidden_set_to(mir::scene::Surface const *surf, bool hide) override;
   void input_consumed(mir::scene::Surface const *surf,
                       std::shared_ptr<MirEvent const> const& event) override;
@@ -115,9 +114,9 @@ void miroil::SurfaceObserverImpl::depth_layer_set_to(mir::scene::Surface const* 
     listener->depth_layer_set_to(surf, depth_layer);
 }
 
-void miroil::SurfaceObserverImpl::frame_posted(mir::scene::Surface const* surf, int frames_available, mir::geometry::Rectangle const& area)
+void miroil::SurfaceObserverImpl::frame_posted(mir::scene::Surface const* surf, mir::geometry::Rectangle const& area)
 {
-    listener->frame_posted(surf, frames_available, area.size);
+    listener->frame_posted(surf, 1, area.size);
 }
 
 void miroil::SurfaceObserverImpl::hidden_set_to(mir::scene::Surface const* surf, bool hide)

--- a/src/miroil/symbols.map
+++ b/src/miroil/symbols.map
@@ -79,7 +79,6 @@ global:
     miroil::Surface::?Surface*;
     miroil::Surface::Surface*;
     miroil::Surface::add_observer*;
-    miroil::Surface::buffers_ready_for_compositor*;
     miroil::Surface::configure*;
     miroil::Surface::generate_renderables*;
     miroil::Surface::get_wrapped*;

--- a/src/server/compositor/multi_threaded_compositor.cpp
+++ b/src/server/compositor/multi_threaded_compositor.cpp
@@ -293,9 +293,9 @@ mc::MultiThreadedCompositor::MultiThreadedCompositor(
     {
         schedule_compositing(1);
     },
-    [this](int num, geometry::Rectangle const& damage)
+    [this](geometry::Rectangle const& damage)
     {
-        schedule_compositing(num, damage);
+        schedule_compositing(1, damage);
     });
 }
 

--- a/src/server/compositor/multi_threaded_compositor.cpp
+++ b/src/server/compositor/multi_threaded_compositor.cpp
@@ -29,6 +29,7 @@
 #include "mir/thread_name.h"
 #include "mir/executor.h"
 
+#include <atomic>
 #include <thread>
 #include <chrono>
 #include <future>
@@ -211,7 +212,7 @@ private:
     mg::DisplaySyncGroup& group;
     std::shared_ptr<mc::Scene> const scene;
     std::binary_semaphore wakeup;
-    bool running;
+    std::atomic<bool> running;
     std::chrono::milliseconds force_sleep{-1};
     std::shared_ptr<DisplayListener> const display_listener;
     std::shared_ptr<CompositorReport> const report;

--- a/src/server/compositor/multi_threaded_compositor.cpp
+++ b/src/server/compositor/multi_threaded_compositor.cpp
@@ -23,8 +23,6 @@
 #include "mir/compositor/scene.h"
 #include "mir/compositor/compositor_report.h"
 #include "mir/scene/scene_change_notification.h"
-#include "mir/scene/surface_observer.h"
-#include "mir/scene/surface.h"
 #include "mir/terminate_with_current_exception.h"
 #include "mir/raii.h"
 #include "mir/unwind_helpers.h"
@@ -33,7 +31,8 @@
 
 #include <thread>
 #include <chrono>
-#include <condition_variable>
+#include <future>
+#include <semaphore>
 #include <boost/throw_exception.hpp>
 
 using namespace std::literals::chrono_literals;
@@ -60,8 +59,8 @@ public:
         compositor_factory{db_compositor_factory},
         group(group),
         scene(scene),
+        wakeup{0},
         running{true},
-        frames_scheduled{0},
         force_sleep{fixed_composite_delay},
         display_listener{display_listener},
         report{report},
@@ -118,11 +117,10 @@ public:
 
         try
         {
-            std::unique_lock lock{run_mutex};
             while (running)
             {
                 /* Wait until compositing has been scheduled or we are stopped */
-                run_cv.wait(lock, [&]{ return (frames_scheduled > 0) || !running; });
+                wakeup.acquire();
 
                 /*
                  * Check if we are running before compositing, since we may have
@@ -130,17 +128,6 @@ public:
                  */
                 if (running)
                 {
-                    /*
-                     * Each surface could have a number of frames ready in its buffer
-                     * queue. And we need to ensure that we render all of them so that
-                     * none linger in the queue indefinitely (seen as input lag).
-                     * frames_scheduled indicates the number of frames that are scheduled
-                     * to ensure all surfaces' queues are fully drained.
-                     */
-                    frames_scheduled--;
-                    not_posted_yet = false;
-                    lock.unlock();
-
                     bool needs_post = false;
                     for (auto& tuple : compositors)
                     {
@@ -163,26 +150,6 @@ public:
                     auto delay = force_sleep >= std::chrono::milliseconds::zero() ?
                                  force_sleep : group.recommended_sleep();
                     std::this_thread::sleep_for(delay);
-
-                    lock.lock();
-
-                    /*
-                     * Note the compositor may have chosen to ignore any number
-                     * of renderables and not consumed buffers from them. So it's
-                     * important to re-count number of frames pending, separately
-                     * to the initial scene_elements_for()...
-                     */
-                    int pending = 0;
-                    for (auto& compositor : compositors)
-                    {
-                        auto const comp_id = std::get<1>(compositor).get();
-                        int pend = scene->frames_pending(comp_id);
-                        if (pend > pending)
-                            pending = pend;
-                    }
-
-                    if (pending > frames_scheduled)
-                        frames_scheduled = pending;
                 }
             }
         }
@@ -196,41 +163,30 @@ public:
         started.set_exception(std::current_exception());
     }
 
-    void schedule_compositing(int num_frames)
+    void schedule_compositing()
     {
-        std::unique_lock lock{run_mutex};
-
-        if (num_frames > frames_scheduled)
-        {
-            frames_scheduled = num_frames;
-            lock.unlock();
-            run_cv.notify_one();
-        }
+        wakeup.try_acquire();
+        wakeup.release();
     }
 
-    void schedule_compositing(int num_frames, geometry::Rectangle const& damage)
+    void schedule_compositing(geometry::Rectangle const& damage)
     {
-        std::unique_lock lock{run_mutex};
-        bool took_damage = not_posted_yet;
-
+        bool took_damage = false;
         group.for_each_display_sink([&](mg::DisplaySink& sink)
             { if (damage.overlaps(sink.view_area())) took_damage = true; });
 
-        if (took_damage && num_frames > frames_scheduled)
+        if (took_damage)
         {
-            frames_scheduled = num_frames;
-            lock.unlock();
-            run_cv.notify_one();
+            wakeup.try_acquire();
+            wakeup.release();
         }
     }
 
     void stop()
     {
-        {
-            std::lock_guard lock{run_mutex};
-            running = false;
-        }
-        run_cv.notify_one();
+        running = false;
+        wakeup.try_acquire();
+        wakeup.release();
     }
 
     void wait_until_started()
@@ -254,18 +210,15 @@ private:
     std::shared_ptr<mc::DisplayBufferCompositorFactory> const compositor_factory;
     mg::DisplaySyncGroup& group;
     std::shared_ptr<mc::Scene> const scene;
+    std::binary_semaphore wakeup;
     bool running;
-    int frames_scheduled;
     std::chrono::milliseconds force_sleep{-1};
-    std::mutex run_mutex;
-    std::condition_variable run_cv;
     std::shared_ptr<DisplayListener> const display_listener;
     std::shared_ptr<CompositorReport> const report;
     std::promise<void> started;
     std::future<void> started_future;
     std::promise<void> stopped;
     std::future<void> stopped_future;
-    bool not_posted_yet = true;
 };
 
 }
@@ -291,11 +244,11 @@ mc::MultiThreadedCompositor::MultiThreadedCompositor(
     observer = std::make_shared<ms::SceneChangeNotification>(
     [this]()
     {
-        schedule_compositing(1);
+        schedule_compositing();
     },
     [this](geometry::Rectangle const& damage)
     {
-        schedule_compositing(1, damage);
+        schedule_compositing(damage);
     });
 }
 
@@ -304,18 +257,18 @@ mc::MultiThreadedCompositor::~MultiThreadedCompositor()
     stop();
 }
 
-void mc::MultiThreadedCompositor::schedule_compositing(int num)
+void mc::MultiThreadedCompositor::schedule_compositing()
 {
     report->scheduled();
     for (auto& f : thread_functors)
-        f->schedule_compositing(num);
+        f->schedule_compositing();
 }
 
-void mc::MultiThreadedCompositor::schedule_compositing(int num, geometry::Rectangle const& damage) const
+void mc::MultiThreadedCompositor::schedule_compositing(geometry::Rectangle const& damage) const
 {
     report->scheduled();
     for (auto& f : thread_functors)
-        f->schedule_compositing(num, damage);
+        f->schedule_compositing(damage);
 }
 
 void mc::MultiThreadedCompositor::start()
@@ -341,7 +294,7 @@ void mc::MultiThreadedCompositor::start()
 
     /* Optional first render */
     if (compose_on_start)
-        schedule_compositing(1);
+        schedule_compositing();
 
     state = CompositorState::started;
 }

--- a/src/server/compositor/multi_threaded_compositor.h
+++ b/src/server/compositor/multi_threaded_compositor.h
@@ -20,10 +20,8 @@
 #include "mir/compositor/compositor.h"
 #include "mir/geometry/forward.h"
 
-#include <mutex>
 #include <memory>
 #include <vector>
-#include <future>
 #include <chrono>
 #include <atomic>
 
@@ -87,8 +85,8 @@ private:
     std::chrono::milliseconds fixed_composite_delay;
     bool compose_on_start;
 
-    void schedule_compositing(int number_composites);
-    void schedule_compositing(int number_composites, geometry::Rectangle const& damage) const;
+    void schedule_compositing();
+    void schedule_compositing(geometry::Rectangle const& damage) const;
 
     std::shared_ptr<mir::scene::Observer> observer;
 };

--- a/src/server/compositor/stream.cpp
+++ b/src/server/compositor/stream.cpp
@@ -83,13 +83,6 @@ geom::Size mc::Stream::stream_size()
         roundf(state->latest_buffer_size.height.as_int() / state->scale_)};
 }
 
-int mc::Stream::buffers_ready_for_compositor(void const* id) const
-{
-    if (arbiter->buffer_ready_for(id))
-        return 1;
-    return 0;
-}
-
 bool mc::Stream::has_submitted_buffer() const
 {
     // Don't need to lock mutex because first_frame_posted is atomic

--- a/src/server/compositor/stream.h
+++ b/src/server/compositor/stream.h
@@ -44,7 +44,6 @@ public:
     std::shared_ptr<graphics::Buffer>
         lock_compositor_buffer(void const* user_id) override;
     geometry::Size stream_size() override;
-    int buffers_ready_for_compositor(void const* user_id) const override;
     bool has_submitted_buffer() const override;
     void set_scale(float scale) override;
 

--- a/src/server/frontend_wayland/wlr_screencopy_v1.cpp
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.cpp
@@ -257,7 +257,7 @@ void mf::WlrScreencopyV1DamageTracker::create_change_notifier()
         };
     change_notifier = std::make_shared<ms::SceneChangeNotification>(
         [callback](){ callback(std::nullopt); },
-        [callback=std::move(callback)](int, geom::Rectangle const& damage){ callback(damage); });
+        callback);
     surface_stack.add_observer(change_notifier);
 }
 

--- a/src/server/frontend_xwayland/scaled_buffer_stream.cpp
+++ b/src/server/frontend_xwayland/scaled_buffer_stream.cpp
@@ -57,11 +57,6 @@ auto mf::ScaledBufferStream::stream_size() -> geometry::Size
     return inner->stream_size() * inv_scale;
 }
 
-auto mf::ScaledBufferStream::buffers_ready_for_compositor(void const* user_id) const -> int
-{
-    return inner->buffers_ready_for_compositor(user_id);
-}
-
 auto mf::ScaledBufferStream::has_submitted_buffer() const -> bool
 {
     return inner->has_submitted_buffer();

--- a/src/server/frontend_xwayland/scaled_buffer_stream.h
+++ b/src/server/frontend_xwayland/scaled_buffer_stream.h
@@ -45,7 +45,6 @@ public:
     /// @{
     auto lock_compositor_buffer(void const* user_id) -> std::shared_ptr<graphics::Buffer>;
     auto stream_size() -> geometry::Size;
-    auto buffers_ready_for_compositor(void const* user_id) const -> int;
     auto has_submitted_buffer() const -> bool;
     /// @}
 

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -58,7 +58,7 @@ struct UpdateCursorOnSurfaceChanges : ms::NullSurfaceObserver
     {
         cursor_controller->update_cursor_image();
     }
-    void frame_posted(ms::Surface const*, int, geom::Rectangle const&) override
+    void frame_posted(ms::Surface const*, geom::Rectangle const&) override
     {
         // The first frame posted will trigger a cursor update, since it
         // changes the visibility status of the surface, and can thus affect

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -96,9 +96,9 @@ public:
         for_each_observer(&SurfaceObserver::hidden_set_to, surf, hide);
     }
 
-    void frame_posted(Surface const* surf, int frames_available, geometry::Rectangle const& damage) override
+    void frame_posted(Surface const* surf, geometry::Rectangle const& damage) override
     {
-        for_each_observer(&SurfaceObserver::frame_posted, surf, frames_available, damage);
+        for_each_observer(&SurfaceObserver::frame_posted, surf, damage);
     }
 
     void alpha_set_to(Surface const* surf, float alpha) override
@@ -975,7 +975,7 @@ void mir::scene::BasicSurface::update_frame_posted_callbacks(State& state)
                 auto const logical_size = explicit_size ? explicit_size.value() : stream->stream_size();
                 if (auto const o = observers.lock())
                 {
-                    o->frame_posted(this, 1, geom::Rectangle{position, logical_size});
+                    o->frame_posted(this, geom::Rectangle{position, logical_size});
                 }
             });
     }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -748,15 +748,6 @@ private:
 };
 }
 
-int ms::BasicSurface::buffers_ready_for_compositor(void const* id) const
-{
-    auto state = synchronised_state.lock();
-    auto max_buf = 0;
-    for (auto const& info : state->layers)
-        max_buf = std::max(max_buf, info.stream->buffers_ready_for_compositor(id));
-    return max_buf;
-}
-
 void ms::BasicSurface::consume(std::shared_ptr<MirEvent const> const& event)
 {
     observers->input_consumed(this, event);

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -118,7 +118,6 @@ public:
     bool visible() const override;
 
     graphics::RenderableList generate_renderables(compositor::CompositorID id) const override;
-    int buffers_ready_for_compositor(void const* compositor_id) const override;
 
     MirWindowType type() const override;
     MirWindowState state() const override;

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -24,12 +24,12 @@ void ms::NullSurfaceObserver::window_resized_to(Surface const*, geometry::Size c
 void ms::NullSurfaceObserver::content_resized_to(Surface const*, geometry::Size const&) {}
 void ms::NullSurfaceObserver::moved_to(Surface const*, geometry::Point const&) {}
 void ms::NullSurfaceObserver::hidden_set_to(Surface const*, bool) {}
-void ms::NullSurfaceObserver::frame_posted(Surface const*, int, geometry::Rectangle const&) {}
+void ms::NullSurfaceObserver::frame_posted(Surface const*, geometry::Rectangle const&) {}
 void ms::NullSurfaceObserver::alpha_set_to(Surface const*, float) {}
 void ms::NullSurfaceObserver::orientation_set_to(Surface const*, MirOrientation) {}
 void ms::NullSurfaceObserver::transformation_set_to(Surface const*, glm::mat4 const&) {}
 void ms::NullSurfaceObserver::reception_mode_set_to(Surface const*, input::InputReceptionMode) {}
-void ms::NullSurfaceObserver::cursor_image_set_to(Surface const*, std::weak_ptr<mir::graphics::CursorImage> const&) {}
+void ms::NullSurfaceObserver::cursor_image_set_to(Surface const*, std::weak_ptr<mg::CursorImage> const&) {}
 void ms::NullSurfaceObserver::client_surface_close_requested(Surface const*) {}
 void ms::NullSurfaceObserver::renamed(Surface const*, std::string const&) {}
 void ms::NullSurfaceObserver::cursor_image_removed(Surface const*) {}

--- a/src/server/scene/scene_change_notification.cpp
+++ b/src/server/scene/scene_change_notification.cpp
@@ -27,7 +27,7 @@ namespace geom = mir::geometry;
 
 ms::SceneChangeNotification::SceneChangeNotification(
     std::function<void()> const& scene_notify_change,
-    std::function<void(int frames, geom::Rectangle const& damage)> const& damage_notify_change) :
+    std::function<void(geom::Rectangle const& damage)> const& damage_notify_change) :
     scene_notify_change(scene_notify_change),
     damage_notify_change(damage_notify_change)
 {

--- a/src/server/scene/surface_change_notification.cpp
+++ b/src/server/scene/surface_change_notification.cpp
@@ -19,8 +19,6 @@
 #include "mir/scene/surface.h"
 
 namespace ms = mir::scene;
-namespace mg = mir::graphics;
-namespace mi = mir::input;
 namespace geom = mir::geometry;
 
 ms::SurfaceChangeNotification::SurfaceChangeNotification(

--- a/src/server/scene/surface_change_notification.cpp
+++ b/src/server/scene/surface_change_notification.cpp
@@ -54,13 +54,12 @@ void ms::SurfaceChangeNotification::hidden_set_to(Surface const*, bool)
 
 void ms::SurfaceChangeNotification::frame_posted(
     Surface const*,
-    int frames_available,
     geometry::Rectangle const& damage)
 {
     std::unique_lock lock{mutex};
     geom::Rectangle global_damage{top_left + as_displacement(damage.top_left), damage.size};
     lock.unlock();
-    notify_buffer_change(frames_available, global_damage);
+    notify_buffer_change(1, global_damage);
 }
 
 void ms::SurfaceChangeNotification::alpha_set_to(Surface const*, float)

--- a/src/server/scene/surface_change_notification.cpp
+++ b/src/server/scene/surface_change_notification.cpp
@@ -26,7 +26,7 @@ namespace geom = mir::geometry;
 ms::SurfaceChangeNotification::SurfaceChangeNotification(
     ms::Surface* surface,
     std::function<void()> const& notify_scene_change,
-    std::function<void(int, geom::Rectangle const&)> const& notify_buffer_change) :
+    std::function<void(geom::Rectangle const&)> const& notify_buffer_change) :
     notify_scene_change(notify_scene_change),
     notify_buffer_change(notify_buffer_change)
 {
@@ -59,7 +59,7 @@ void ms::SurfaceChangeNotification::frame_posted(
     std::unique_lock lock{mutex};
     geom::Rectangle global_damage{top_left + as_displacement(damage.top_left), damage.size};
     lock.unlock();
-    notify_buffer_change(1, global_damage);
+    notify_buffer_change(global_damage);
 }
 
 void ms::SurfaceChangeNotification::alpha_set_to(Surface const*, float)

--- a/src/server/scene/surface_change_notification.h
+++ b/src/server/scene/surface_change_notification.h
@@ -32,7 +32,7 @@ public:
     SurfaceChangeNotification(
         scene::Surface* surface,
         std::function<void()> const& notify_scene_change,
-        std::function<void(int, geometry::Rectangle const&)> const& notify_buffer_change);
+        std::function<void(geometry::Rectangle const&)> const& notify_buffer_change);
 
     void content_resized_to(Surface const* surf, geometry::Size const&) override;
     void moved_to(Surface const* surf, geometry::Point const& new_top_left) override;
@@ -45,7 +45,7 @@ public:
 
 private:
     std::function<void()> const notify_scene_change;
-    std::function<void(int, geometry::Rectangle const&)> const notify_buffer_change;
+    std::function<void(geometry::Rectangle const&)> const notify_buffer_change;
 
     std::mutex mutex;
     geometry::Point top_left;

--- a/src/server/scene/surface_change_notification.h
+++ b/src/server/scene/surface_change_notification.h
@@ -37,7 +37,7 @@ public:
     void content_resized_to(Surface const* surf, geometry::Size const&) override;
     void moved_to(Surface const* surf, geometry::Point const& new_top_left) override;
     void hidden_set_to(Surface const* surf, bool) override;
-    void frame_posted(Surface const* surf, int frames_available, geometry::Rectangle const& damage) override;
+    void frame_posted(Surface const* surf, geometry::Rectangle const& damage) override;
     void alpha_set_to(Surface const* surf, float) override;
     void transformation_set_to(Surface const* surf, glm::mat4 const&) override;
     void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -180,33 +180,6 @@ mc::SceneElementSequence ms::SurfaceStack::scene_elements_for(mc::CompositorID i
     return elements;
 }
 
-int ms::SurfaceStack::frames_pending(mc::CompositorID id) const
-{
-    RecursiveReadLock lg(guard);
-
-    int result = scene_changed ? 1 : 0;
-    for (auto const& layer : surface_layers)
-    {
-        for (auto const& surface : layer)
-        {
-            if (surface_can_be_shown(surface) && surface->visible())
-            {
-                auto const tracker = rendering_trackers.find(surface.get());
-                if (tracker != rendering_trackers.end() && tracker->second->is_exposed_in(id))
-                {
-                    // Note that we ask the surface and not a Renderable.
-                    // This is because we don't want to waste time and resources
-                    // on a snapshot till we're sure we need it...
-                    int ready = surface->buffers_ready_for_compositor(id);
-                    if (ready > result)
-                        result = ready;
-                }
-            }
-        }
-    }
-    return result;
-}
-
 void ms::SurfaceStack::register_compositor(mc::CompositorID cid)
 {
     RecursiveWriteLock lg(guard);

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -33,7 +33,6 @@
 #include <atomic>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <set>
 #include <vector>
 
@@ -89,7 +88,6 @@ public:
 
     // From Scene
     compositor::SceneElementSequence scene_elements_for(compositor::CompositorID id) override;
-    int frames_pending(compositor::CompositorID) const override;
     void register_compositor(compositor::CompositorID id) override;
     void unregister_compositor(compositor::CompositorID id) override;
 

--- a/tests/include/mir/test/doubles/mock_buffer_stream.h
+++ b/tests/include/mir/test/doubles/mock_buffer_stream.h
@@ -40,8 +40,6 @@ struct MockBufferStream : public compositor::BufferStream
 
     MockBufferStream()
     {
-        ON_CALL(*this, buffers_ready_for_compositor(::testing::_))
-            .WillByDefault(testing::Invoke(this, &MockBufferStream::buffers_ready));
         ON_CALL(*this, has_submitted_buffer())
             .WillByDefault(testing::Return(true));
         ON_CALL(*this, pixel_format())
@@ -57,7 +55,6 @@ struct MockBufferStream : public compositor::BufferStream
     MOCK_METHOD(void, set_frame_posted_callback, (std::function<void(geometry::Size const&)> const&), (override));
 
     MOCK_METHOD(geometry::Size, stream_size, (), (override));
-    MOCK_METHOD(int, buffers_ready_for_compositor, (void const*), (const override));
 
     MOCK_METHOD(void, submit_buffer, (std::shared_ptr<graphics::Buffer> const&), (override));
     MOCK_METHOD(MirPixelFormat, pixel_format, (), (const override));

--- a/tests/include/mir/test/doubles/stub_buffer_stream.h
+++ b/tests/include/mir/test/doubles/stub_buffer_stream.h
@@ -47,8 +47,6 @@ public:
         return geometry::Size();
     }
 
-    int buffers_ready_for_compositor(void const*) const override { return nready; }
-
     void submit_buffer(std::shared_ptr<graphics::Buffer> const& b) override
     {
         if (b) ++nready;

--- a/tests/include/mir/test/doubles/stub_scene.h
+++ b/tests/include/mir/test/doubles/stub_scene.h
@@ -34,10 +34,6 @@ public:
     {
         return {};
     }
-    int frames_pending(compositor::CompositorID) const override
-    {
-        return 0;
-    }
     void register_compositor(compositor::CompositorID) override
     {
     }

--- a/tests/include/mir/test/doubles/stub_surface.h
+++ b/tests/include/mir/test/doubles/stub_surface.h
@@ -49,7 +49,6 @@ struct StubSurface : scene::Surface
     void set_transformation(glm::mat4 const&) override {}
     bool visible() const override { return false; }
     graphics::RenderableList generate_renderables(compositor::CompositorID) const override { return {}; }
-    int buffers_ready_for_compositor(void const*) const override { return 0; }
     MirWindowType type() const override { return mir_window_type_normal; }
     auto state_tracker() const -> scene::SurfaceStateTracker override
     {

--- a/tests/unit-tests/compositor/test_multi_threaded_compositor.cpp
+++ b/tests/unit-tests/compositor/test_multi_threaded_compositor.cpp
@@ -684,6 +684,30 @@ TEST(MultiThreadedCompositor, when_no_initial_composite_is_needed_there_is_none)
     compositor.stop();
 }
 
+TEST(MultiThreadedCompositor, initial_composite_is_requested_we_composite_exactly_once_on_start)
+{
+    using namespace testing;
+    using namespace std::literals::chrono_literals;
+
+    unsigned int const nbuffers = 3;
+
+    auto display = std::make_shared<mtd::StubDisplay>(nbuffers);
+    auto scene = std::make_shared<StubScene>();
+    auto db_compositor_factory = std::make_shared<RecordingDisplayBufferCompositorFactory>();
+    mc::MultiThreadedCompositor compositor{display, scene, db_compositor_factory, null_display_listener, null_report, default_delay, true};
+
+    // Verify we're actually starting at zero frames
+    ASSERT_TRUE(db_compositor_factory->check_record_count_for_each_buffer(nbuffers, 0, 0));
+
+    compositor.start();
+    std::this_thread::sleep_for(100ms);
+
+    // Verify we've composited exactly once
+    EXPECT_TRUE(db_compositor_factory->check_record_count_for_each_buffer(nbuffers, 1, 1));
+
+    compositor.stop();
+}
+
 TEST(MultiThreadedCompositor, when_no_initial_composite_is_needed_we_still_composite_on_restart)
 {
     using namespace testing;

--- a/tests/unit-tests/compositor/test_multi_threaded_compositor.cpp
+++ b/tests/unit-tests/compositor/test_multi_threaded_compositor.cpp
@@ -94,7 +94,7 @@ class StubScene : public mtd::StubScene
 {
 public:
     StubScene()
-        : pending{0}, throw_on_add_observer_{false}
+        : throw_on_add_observer_{false}
     {
     }
 
@@ -133,19 +133,7 @@ public:
         throw_on_add_observer_ = flag;
     }
 
-    int frames_pending(mc::CompositorID) const override
-    {
-        return pending;
-    }
-
-    void set_pending(int n)
-    {
-        pending = n;
-        observer->scene_changed();
-    }
-
-private:
-    std::atomic<int> pending;
+    private:
     std::mutex observer_mutex;
     std::shared_ptr<ms::Observer> observer;
     bool throw_on_add_observer_;
@@ -532,79 +520,6 @@ TEST(MultiThreadedCompositor, composites_only_on_demand)
 
     // Verify we never triggered more than 9 compositions
     EXPECT_TRUE(db_compositor_factory->check_record_count_for_each_buffer(nbuffers, 3*composites_per_update, 3*composites_per_update));
-
-    compositor.stop();
-}
-
-TEST(MultiThreadedCompositor, schedules_enough_frames)
-{
-    using namespace testing;
-
-    unsigned int const nbuffers = 3;
-
-    auto display = std::make_shared<mtd::StubDisplay>(nbuffers);
-    auto scene = std::make_shared<StubScene>();
-    auto factory = std::make_shared<RecordingDisplayBufferCompositorFactory>();
-    mc::MultiThreadedCompositor compositor{display, scene, factory,
-                                           null_display_listener, null_report, default_delay, true};
-
-    EXPECT_TRUE(factory->check_record_count_for_each_buffer(nbuffers, 0, 0));
-
-    compositor.start();
-
-    int const max_retries = 100;
-    int retry = 0;
-    while (retry < max_retries &&
-           !factory->check_record_count_for_each_buffer(nbuffers, 1))
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        ++retry;
-    }
-
-    ASSERT_LT(retry, max_retries);
-
-    // Now we have the initial frame wait a bit
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    // ... and make sure the number is still only 1
-    ASSERT_TRUE(factory->check_record_count_for_each_buffer(nbuffers, 1, 1));
-
-    // Trigger scene changes. Only need one frame to cover them all...
-    scene->emit_change_event();
-    scene->emit_change_event();
-    scene->emit_change_event();
-
-    // Display buffers should be forced to render another 1, so that's 2
-    retry = 0;
-    while (retry < max_retries &&
-           !factory->check_record_count_for_each_buffer(nbuffers, 2))
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        ++retry;
-    }
-    ASSERT_LT(retry, max_retries);
-
-    // Scene unchanged. Expect no new frames:
-    retry = 0;
-    while (retry < max_retries &&
-           !factory->check_record_count_for_each_buffer(nbuffers, 2))
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        ++retry;
-    }
-    ASSERT_LT(retry, max_retries);
-
-    // Some surface queues up multiple frames
-    scene->set_pending(3);
-
-    // Make sure they all get composited separately (2 + 3 more)
-    retry = 0;
-    while (retry < max_retries &&
-           !factory->check_record_count_for_each_buffer(nbuffers, 5))
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        ++retry;
-    }
-    ASSERT_LT(retry, max_retries);
 
     compositor.stop();
 }

--- a/tests/unit-tests/compositor/test_stream.cpp
+++ b/tests/unit-tests/compositor/test_stream.cpp
@@ -50,16 +50,6 @@ struct Stream : Test
 };
 }
 
-TEST_F(Stream, indicates_buffers_ready_when_dropping)
-{
-    for(auto& buffer : buffers)
-        stream.submit_buffer(buffer);
-
-    EXPECT_THAT(stream.buffers_ready_for_compositor(this), Eq(1));
-    stream.lock_compositor_buffer(this);
-    EXPECT_THAT(stream.buffers_ready_for_compositor(this), Eq(0));
-}
-
 TEST_F(Stream, tracks_has_buffer)
 {
     EXPECT_FALSE(stream.has_submitted_buffer());
@@ -82,7 +72,6 @@ TEST_F(Stream, frame_callback_is_called_without_scheduling_lock)
     stream.set_frame_posted_callback(
         [this](auto)
         {
-            EXPECT_THAT(stream.buffers_ready_for_compositor(this), Eq(1));
             EXPECT_TRUE(stream.has_submitted_buffer());
         });
     stream.submit_buffer(buffers[0]);

--- a/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
+++ b/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
@@ -106,7 +106,7 @@ struct DamageTrackerV1 : Test
     {
         auto const locked = surface_observer.lock();
         ASSERT_THAT(locked, NotNull());
-        locked->frame_posted(&surface, 1, damage);
+        locked->frame_posted(&surface, damage);
     }
 };
 }

--- a/tests/unit-tests/input/test_cursor_controller.cpp
+++ b/tests/unit-tests/input/test_cursor_controller.cpp
@@ -174,7 +174,7 @@ struct StubInputSurface : public mtd::StubSurface
     {
         for (auto observer : observers)
         {
-            observer->frame_posted(this, 1, {});
+            observer->frame_posted(this, {});
         }
     }
 

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -67,7 +67,7 @@ public:
     MOCK_METHOD(void, attrib_changed, (ms::Surface const*, MirWindowAttrib, int), (override));
     MOCK_METHOD(void, window_resized_to, (ms::Surface const*, geom::Size const&), (override));
     MOCK_METHOD(void, content_resized_to, (ms::Surface const*, geom::Size const&), (override));
-    MOCK_METHOD(void, frame_posted, (ms::Surface const*, int, geom::Rectangle const&), (override));
+    MOCK_METHOD(void, frame_posted, (ms::Surface const*, geom::Rectangle const&), (override));
     MOCK_METHOD(void, hidden_set_to, (ms::Surface const*, bool), (override));
     MOCK_METHOD(void, renamed, (ms::Surface const*, std::string const&), (override));
     MOCK_METHOD(void, client_surface_close_requested, (ms::Surface const*), (override));
@@ -1019,7 +1019,7 @@ TEST_F(BasicSurfaceTest, when_frame_is_posted_an_observer_is_notified_of_frame_w
     ON_CALL(*buffer_stream, stream_size())
         .WillByDefault(Return(rect.size));
 
-    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(rect.size)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, mt::RectSizeEq(rect.size)));
     buffer_stream->frame_posted_callback(rect.size);
 }
 
@@ -1036,7 +1036,7 @@ TEST_F(BasicSurfaceTest, when_stream_size_differs_from_buffer_size_an_observer_i
     surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
 
-    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(stream_size)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, mt::RectSizeEq(stream_size)));
     buffer_stream->frame_posted_callback(stream_size * 2);
 }
 
@@ -1054,7 +1054,7 @@ TEST_F(BasicSurfaceTest, when_stream_info_has_explicit_size_an_observer_is_notif
     surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, stream_info_size}});
 
-    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(stream_info_size)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, mt::RectSizeEq(stream_info_size)));
     buffer_stream->frame_posted_callback(stream_size);
 }
 
@@ -1066,7 +1066,7 @@ TEST_F(BasicSurfaceTest, when_frame_is_posted_an_observer_is_notified_of_frame_a
     surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
 
-    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{})));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, mt::RectTopLeftEq(geom::Point{})));
     buffer_stream->frame_posted_callback(rect.size);
 }
 
@@ -1081,7 +1081,7 @@ TEST_F(BasicSurfaceTest, when_stream_info_has_offset_an_observer_is_notified_of_
     surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, stream_info_offset, {}}});
 
-    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{} + stream_info_offset)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, mt::RectTopLeftEq(geom::Point{} + stream_info_offset)));
     buffer_stream->frame_posted_callback(rect.size);
 }
 
@@ -1097,7 +1097,7 @@ TEST_F(BasicSurfaceTest, when_surface_has_margins_an_observer_is_notified_of_fra
     surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
 
-    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{} + margin_top + margin_left)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, mt::RectTopLeftEq(geom::Point{} + margin_top + margin_left)));
     surface.set_window_margins(margin_top, margin_left, margin_bottom, margin_right);
     buffer_stream->frame_posted_callback({20, 30});
 }

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -1511,35 +1511,6 @@ TEST_F(BasicSurfaceTest, visibility_matches_produced_list)
     EXPECT_THAT(renderables.size(), Eq(2));
 }
 
-TEST_F(BasicSurfaceTest, buffers_ready_correctly_reported)
-{
-    using namespace testing;
-    auto buffer_stream0 = std::make_shared<NiceMock<mtd::MockBufferStream>>();
-    auto buffer_stream1 = std::make_shared<NiceMock<mtd::MockBufferStream>>();
-    EXPECT_CALL(*mock_buffer_stream, buffers_ready_for_compositor(_))
-        .WillOnce(Return(0))
-        .WillOnce(Return(0))
-        .WillOnce(Return(2));
-    EXPECT_CALL(*buffer_stream0, buffers_ready_for_compositor(_))
-        .WillOnce(Return(1))
-        .WillOnce(Return(0))
-        .WillOnce(Return(1));
-    EXPECT_CALL(*buffer_stream1, buffers_ready_for_compositor(_))
-        .WillOnce(Return(3))
-        .WillOnce(Return(0))
-        .WillOnce(Return(1));
-
-    std::list<ms::StreamInfo> streams = {
-        { mock_buffer_stream, {0,0}, {} },
-        { buffer_stream0, {0,0}, {} },
-        { buffer_stream1, {0,0}, {} },
-    };
-    surface.set_streams(streams);
-    EXPECT_THAT(surface.buffers_ready_for_compositor(this), Eq(3));
-    EXPECT_THAT(surface.buffers_ready_for_compositor(this), Eq(0));
-    EXPECT_THAT(surface.buffers_ready_for_compositor(this), Eq(2));
-}
-
 TEST_F(BasicSurfaceTest, buffer_streams_produce_correctly_sized_renderables)
 {
     using namespace testing;

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -112,7 +112,7 @@ struct BasicSurfaceTest : public testing::Test
         std::make_shared<ms::SurfaceChangeNotification>(
             &surface,
             mock_change_cb,
-            [this](int, geom::Rectangle const&){mock_change_cb();});
+            [this](geom::Rectangle const&){mock_change_cb();});
 
     BasicSurfaceTest()
     {

--- a/tests/unit-tests/scene/test_scene_change_notification.cpp
+++ b/tests/unit-tests/scene/test_scene_change_notification.cpp
@@ -17,7 +17,6 @@
 #include "mir/scene/scene_change_notification.h"
 #include "mir/scene/surface_observer.h"
 
-#include "mir/test/fake_shared.h"
 #include "mir/test/doubles/mock_surface.h"
 
 #include <gtest/gtest.h>
@@ -91,13 +90,13 @@ TEST_F(SceneChangeNotificationTest, observes_surface_changes)
     EXPECT_CALL(*surface, register_interest(_)).Times(1)
         .WillOnce(SaveArg<0>(&surface_observer));
    
-    int buffer_num{3}; 
+    int buffer_num{1};
     EXPECT_CALL(scene_callback, invoke()).Times(1);
     EXPECT_CALL(buffer_callback, invoke(buffer_num, _)).Times(1);
 
     ms::SceneChangeNotification observer(scene_change_callback, buffer_change_callback);
     observer.surface_added(surface);
-    surface_observer.lock()->frame_posted(surface.get(), buffer_num, {});
+    surface_observer.lock()->frame_posted(surface.get(), {});
 }
 
 TEST_F(SceneChangeNotificationTest, redraws_on_rename)

--- a/tests/unit-tests/scene/test_scene_change_notification.cpp
+++ b/tests/unit-tests/scene/test_scene_change_notification.cpp
@@ -30,11 +30,11 @@ namespace
 {
 struct MockSceneCallback
 {
-    MOCK_METHOD0(invoke, void());
+    MOCK_METHOD(void, invoke, (), ());
 };
 struct MockBufferCallback
 {
-    MOCK_METHOD2(invoke, void(int, mir::geometry::Rectangle const&));
+    MOCK_METHOD(void, invoke, (mir::geometry::Rectangle const&), ());
 };
 
 struct SceneChangeNotificationTest : public testing::Test
@@ -46,9 +46,9 @@ struct SceneChangeNotificationTest : public testing::Test
     }
     testing::NiceMock<MockSceneCallback> scene_callback;
     testing::NiceMock<MockBufferCallback> buffer_callback;
-    std::function<void(int, mir::geometry::Rectangle const&)> buffer_change_callback{[this](int arg, mir::geometry::Rectangle const& damage)
+    std::function<void(mir::geometry::Rectangle const&)> buffer_change_callback{[this](mir::geometry::Rectangle const& damage)
         {
-            buffer_callback.invoke(arg, damage);
+            buffer_callback.invoke(damage);
         }};
     std::function<void()> scene_change_callback{[this](){scene_callback.invoke();}};
     std::shared_ptr<testing::NiceMock<mtd::MockSurface>> surface;
@@ -90,9 +90,8 @@ TEST_F(SceneChangeNotificationTest, observes_surface_changes)
     EXPECT_CALL(*surface, register_interest(_)).Times(1)
         .WillOnce(SaveArg<0>(&surface_observer));
    
-    int buffer_num{1};
     EXPECT_CALL(scene_callback, invoke()).Times(1);
-    EXPECT_CALL(buffer_callback, invoke(buffer_num, _)).Times(1);
+    EXPECT_CALL(buffer_callback, invoke(_)).Times(1);
 
     ms::SceneChangeNotification observer(scene_change_callback, buffer_change_callback);
     observer.surface_added(surface);


### PR DESCRIPTION
In various places we notify observers of how many buffers have changed when events happen.

Since we don't have any queues anymore, we only ever supply `1` as the number of buffers.

Remove some of the buffer counts and simplify `MultiThreadedCompositor` appropriately.