### PR TITLE
compositor/Stream: Remove `buffers_ready_for_compositor`

### DIFF
--- a/debian/libmiroil5.symbols
+++ b/debian/libmiroil5.symbols
@@ -82,7 +82,6 @@ libmiroil.so.5 libmiroil5 #MINVER#
  (c++)"miroil::SetCompositor::operator()(mir::Server&)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::Surface(std::shared_ptr<mir::scene::Surface>)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::add_observer(std::shared_ptr<miroil::SurfaceObserver> const&)@MIROIL_5.0" 2.17.0
- (c++)"miroil::Surface::buffers_ready_for_compositor(void const*) const@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::configure(MirWindowAttrib, int)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::generate_renderables(void const*) const@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::get_wrapped() const@MIROIL_5.0" 2.17.0

--- a/debian/libmiroil5.symbols.armhf
+++ b/debian/libmiroil5.symbols.armhf
@@ -82,7 +82,6 @@ libmiroil.so.5 libmiroil5 #MINVER#
  (c++)"miroil::SetCompositor::operator()(mir::Server&)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::Surface(std::shared_ptr<mir::scene::Surface>)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::add_observer(std::shared_ptr<miroil::SurfaceObserver> const&)@MIROIL_5.0" 2.17.0
- (c++)"miroil::Surface::buffers_ready_for_compositor(void const*) const@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::configure(MirWindowAttrib, int)@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::generate_renderables(void const*) const@MIROIL_5.0" 2.17.0
  (c++)"miroil::Surface::get_wrapped() const@MIROIL_5.0" 2.17.0

--- a/include/miroil/miroil/surface.h
+++ b/include/miroil/miroil/surface.h
@@ -44,7 +44,6 @@ public:
     void add_observer(std::shared_ptr<miroil::SurfaceObserver> const& observer);    
     void remove_observer(std::shared_ptr<miroil::SurfaceObserver> const& observer);
     
-    int  buffers_ready_for_compositor(void const* compositor_id) const;
     mir::graphics::RenderableList generate_renderables(miroil::CompositorID id) const; 
 
     

--- a/src/include/server/mir/compositor/buffer_stream.h
+++ b/src/include/server/mir/compositor/buffer_stream.h
@@ -42,7 +42,6 @@ public:
     virtual auto lock_compositor_buffer(void const* user_id) -> std::shared_ptr<graphics::Buffer> = 0;
     /// Logical size of the stream (may be different than buffer sizes if scaled)
     virtual auto stream_size() -> geometry::Size = 0;
-    virtual auto buffers_ready_for_compositor(void const* user_id) const -> int = 0;
     virtual auto has_submitted_buffer() const -> bool = 0;
 };
 

--- a/src/include/server/mir/scene/surface.h
+++ b/src/include/server/mir/scene/surface.h
@@ -64,7 +64,6 @@ public:
     virtual geometry::Size window_size() const = 0;
 
     virtual graphics::RenderableList generate_renderables(compositor::CompositorID id) const = 0; 
-    virtual int buffers_ready_for_compositor(void const* compositor_id) const = 0;
 
     virtual MirWindowType type() const = 0;
     virtual MirWindowState state() const = 0;

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -207,11 +207,6 @@ auto miroil::Surface::get_wrapped() const -> mir::scene::Surface*
     return wrapped.get();
 }
 
-int miroil::Surface::buffers_ready_for_compositor(void const* compositor_id) const
-{
-    return wrapped->buffers_ready_for_compositor(compositor_id);
-}
-
 mir::graphics::RenderableList miroil::Surface::generate_renderables(miroil::CompositorID id) const
 {
     return wrapped->generate_renderables(id);

--- a/src/miroil/symbols.map
+++ b/src/miroil/symbols.map
@@ -79,7 +79,6 @@ global:
     miroil::Surface::?Surface*;
     miroil::Surface::Surface*;
     miroil::Surface::add_observer*;
-    miroil::Surface::buffers_ready_for_compositor*;
     miroil::Surface::configure*;
     miroil::Surface::generate_renderables*;
     miroil::Surface::get_wrapped*;

--- a/src/server/compositor/stream.cpp
+++ b/src/server/compositor/stream.cpp
@@ -83,13 +83,6 @@ geom::Size mc::Stream::stream_size()
         roundf(state->latest_buffer_size.height.as_int() / state->scale_)};
 }
 
-int mc::Stream::buffers_ready_for_compositor(void const* id) const
-{
-    if (arbiter->buffer_ready_for(id))
-        return 1;
-    return 0;
-}
-
 bool mc::Stream::has_submitted_buffer() const
 {
     // Don't need to lock mutex because first_frame_posted is atomic

--- a/src/server/compositor/stream.h
+++ b/src/server/compositor/stream.h
@@ -44,7 +44,6 @@ public:
     std::shared_ptr<graphics::Buffer>
         lock_compositor_buffer(void const* user_id) override;
     geometry::Size stream_size() override;
-    int buffers_ready_for_compositor(void const* user_id) const override;
     bool has_submitted_buffer() const override;
     void set_scale(float scale) override;
 

--- a/src/server/frontend_xwayland/scaled_buffer_stream.cpp
+++ b/src/server/frontend_xwayland/scaled_buffer_stream.cpp
@@ -57,11 +57,6 @@ auto mf::ScaledBufferStream::stream_size() -> geometry::Size
     return inner->stream_size() * inv_scale;
 }
 
-auto mf::ScaledBufferStream::buffers_ready_for_compositor(void const* user_id) const -> int
-{
-    return inner->buffers_ready_for_compositor(user_id);
-}
-
 auto mf::ScaledBufferStream::has_submitted_buffer() const -> bool
 {
     return inner->has_submitted_buffer();

--- a/src/server/frontend_xwayland/scaled_buffer_stream.h
+++ b/src/server/frontend_xwayland/scaled_buffer_stream.h
@@ -45,7 +45,6 @@ public:
     /// @{
     auto lock_compositor_buffer(void const* user_id) -> std::shared_ptr<graphics::Buffer>;
     auto stream_size() -> geometry::Size;
-    auto buffers_ready_for_compositor(void const* user_id) const -> int;
     auto has_submitted_buffer() const -> bool;
     /// @}
 

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -748,15 +748,6 @@ private:
 };
 }
 
-int ms::BasicSurface::buffers_ready_for_compositor(void const* id) const
-{
-    auto state = synchronised_state.lock();
-    auto max_buf = 0;
-    for (auto const& info : state->layers)
-        max_buf = std::max(max_buf, info.stream->buffers_ready_for_compositor(id));
-    return max_buf;
-}
-
 void ms::BasicSurface::consume(std::shared_ptr<MirEvent const> const& event)
 {
     observers->input_consumed(this, event);

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -118,7 +118,6 @@ public:
     bool visible() const override;
 
     graphics::RenderableList generate_renderables(compositor::CompositorID id) const override;
-    int buffers_ready_for_compositor(void const* compositor_id) const override;
 
     MirWindowType type() const override;
     MirWindowState state() const override;

--- a/tests/include/mir/test/doubles/mock_buffer_stream.h
+++ b/tests/include/mir/test/doubles/mock_buffer_stream.h
@@ -40,8 +40,6 @@ struct MockBufferStream : public compositor::BufferStream
 
     MockBufferStream()
     {
-        ON_CALL(*this, buffers_ready_for_compositor(::testing::_))
-            .WillByDefault(testing::Invoke(this, &MockBufferStream::buffers_ready));
         ON_CALL(*this, has_submitted_buffer())
             .WillByDefault(testing::Return(true));
         ON_CALL(*this, pixel_format())
@@ -57,7 +55,6 @@ struct MockBufferStream : public compositor::BufferStream
     MOCK_METHOD(void, set_frame_posted_callback, (std::function<void(geometry::Size const&)> const&), (override));
 
     MOCK_METHOD(geometry::Size, stream_size, (), (override));
-    MOCK_METHOD(int, buffers_ready_for_compositor, (void const*), (const override));
 
     MOCK_METHOD(void, submit_buffer, (std::shared_ptr<graphics::Buffer> const&), (override));
     MOCK_METHOD(MirPixelFormat, pixel_format, (), (const override));

--- a/tests/include/mir/test/doubles/stub_buffer_stream.h
+++ b/tests/include/mir/test/doubles/stub_buffer_stream.h
@@ -47,8 +47,6 @@ public:
         return geometry::Size();
     }
 
-    int buffers_ready_for_compositor(void const*) const override { return nready; }
-
     void submit_buffer(std::shared_ptr<graphics::Buffer> const& b) override
     {
         if (b) ++nready;

--- a/tests/include/mir/test/doubles/stub_surface.h
+++ b/tests/include/mir/test/doubles/stub_surface.h
@@ -49,7 +49,6 @@ struct StubSurface : scene::Surface
     void set_transformation(glm::mat4 const&) override {}
     bool visible() const override { return false; }
     graphics::RenderableList generate_renderables(compositor::CompositorID) const override { return {}; }
-    int buffers_ready_for_compositor(void const*) const override { return 0; }
     MirWindowType type() const override { return mir_window_type_normal; }
     auto state_tracker() const -> scene::SurfaceStateTracker override
     {

--- a/tests/unit-tests/compositor/test_stream.cpp
+++ b/tests/unit-tests/compositor/test_stream.cpp
@@ -50,16 +50,6 @@ struct Stream : Test
 };
 }
 
-TEST_F(Stream, indicates_buffers_ready_when_dropping)
-{
-    for(auto& buffer : buffers)
-        stream.submit_buffer(buffer);
-
-    EXPECT_THAT(stream.buffers_ready_for_compositor(this), Eq(1));
-    stream.lock_compositor_buffer(this);
-    EXPECT_THAT(stream.buffers_ready_for_compositor(this), Eq(0));
-}
-
 TEST_F(Stream, tracks_has_buffer)
 {
     EXPECT_FALSE(stream.has_submitted_buffer());
@@ -82,7 +72,6 @@ TEST_F(Stream, frame_callback_is_called_without_scheduling_lock)
     stream.set_frame_posted_callback(
         [this](auto)
         {
-            EXPECT_THAT(stream.buffers_ready_for_compositor(this), Eq(1));
             EXPECT_TRUE(stream.has_submitted_buffer());
         });
     stream.submit_buffer(buffers[0]);

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -1511,35 +1511,6 @@ TEST_F(BasicSurfaceTest, visibility_matches_produced_list)
     EXPECT_THAT(renderables.size(), Eq(2));
 }
 
-TEST_F(BasicSurfaceTest, buffers_ready_correctly_reported)
-{
-    using namespace testing;
-    auto buffer_stream0 = std::make_shared<NiceMock<mtd::MockBufferStream>>();
-    auto buffer_stream1 = std::make_shared<NiceMock<mtd::MockBufferStream>>();
-    EXPECT_CALL(*mock_buffer_stream, buffers_ready_for_compositor(_))
-        .WillOnce(Return(0))
-        .WillOnce(Return(0))
-        .WillOnce(Return(2));
-    EXPECT_CALL(*buffer_stream0, buffers_ready_for_compositor(_))
-        .WillOnce(Return(1))
-        .WillOnce(Return(0))
-        .WillOnce(Return(1));
-    EXPECT_CALL(*buffer_stream1, buffers_ready_for_compositor(_))
-        .WillOnce(Return(3))
-        .WillOnce(Return(0))
-        .WillOnce(Return(1));
-
-    std::list<ms::StreamInfo> streams = {
-        { mock_buffer_stream, {0,0}, {} },
-        { buffer_stream0, {0,0}, {} },
-        { buffer_stream1, {0,0}, {} },
-    };
-    surface.set_streams(streams);
-    EXPECT_THAT(surface.buffers_ready_for_compositor(this), Eq(3));
-    EXPECT_THAT(surface.buffers_ready_for_compositor(this), Eq(0));
-    EXPECT_THAT(surface.buffers_ready_for_compositor(this), Eq(2));
-}
-
 TEST_F(BasicSurfaceTest, buffer_streams_produce_correctly_sized_renderables)
 {
     using namespace testing;


### PR DESCRIPTION
The only internal user of this has been removed. QtMir is an *external* user of this, but:
* Doesn't actually *need* this behaviour, and
* Needs significant work in this area anyway to update for 2.16's Platform changes