### PR TITLE
Add floating point options

### DIFF
--- a/src/include/server/mir/server.h
+++ b/src/include/server/mir/server.h
@@ -78,7 +78,8 @@ enum class OptionType
     integer,
     string,
     boolean,
-    strings
+    strings,
+    real
 };
 
 /// Customise and run a Mir server.

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -741,5 +741,19 @@ void mir::Server::add_configuration_option(
             self->set_add_configuration_options(option_adder);
         }
         break;
+
+        case OptionType::real:
+        {
+            auto const option_adder = [=](options::DefaultConfiguration& config)
+            {
+                existing(config);
+
+                config.add_options()
+                        (option.c_str(), po::value<double>(), description.c_str());
+            };
+
+            self->set_add_configuration_options(option_adder);
+        }
+        break;
     }
 }


### PR DESCRIPTION
We already have some floating point "input configuration" options in our examples. This provides a little more support internally that I used in hacking that code about.