### PR TITLE
common/Signal: New worker-thread synchronisaton primitive.

### DIFF
--- a/include/common/mir/signal.h
+++ b/include/common/mir/signal.h
@@ -68,7 +68,7 @@ public:
      */
     void wait();
 private:
-    std::atomic<bool> flag;
+    std::atomic<bool> raised;
 };
 }
 

--- a/include/common/mir/signal.h
+++ b/include/common/mir/signal.h
@@ -63,7 +63,7 @@ public:
     /**
      * Wait for the signal to be raised
      *
-     * This synchronises-wtih a previous call to `raise()`, and
+     * This synchronises-with a previous call to `raise()`, and
      * then resets the signal.
      */
     void wait();

--- a/include/common/mir/signal.h
+++ b/include/common/mir/signal.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_SIGNAL_H_
+#define MIR_SIGNAL_H_
+
+#include <atomic>
+
+namespace mir
+{
+/**
+ * A thread-synchronisation barrier.
+ *
+ * The expected usage is that one thread sits in `wait()` until
+ * signalled from another thread with `raise()`.
+ *
+ * This mechanism does not attempt to ensure that only one thread
+ * is released per `raise()` or that each `raise()` unblocks only
+ * one `wait()`. The only guarantees are that:
+ * 1) At least one call to `raise()` strongly-happens-before 
+ *    a call to `wait()` returns, and
+ * 2) `wait()` will block until a call to `raise()` that 
+ *    happens-after the most recent return from `wait()`.
+ *
+ * The primary use-case for such a barrier is to signal a
+ * worker thread to run the next iteration of work.
+ *
+ * This is very similar to a `std::binary_semaphore` but
+ * without the precondition that `raise()` is not called
+ * if the Signal is already raised.
+ */
+class Signal
+{
+public:
+    Signal();
+
+    /**
+     * Raise the signal, releasing any thread in `wait()`
+     *
+     * This does not synchronise with any other call to `raise()`
+     * This synchronises-with a subsequent call to `wait()`, but does
+     * not guarantee that each call to `raise()` releases at least one
+     * `wait()`.
+     *
+     * Two unsynchronised calls to `raise()` may result in either one
+     * or two calls to `wait()` being unblocked, depending on timing.
+     */
+    void raise();
+
+    /**
+     * Wait for the signal to be raised
+     *
+     * This synchronises-wtih a previous call to `raise()`, and
+     * then resets the signal.
+     */
+    void wait();
+private:
+    std::atomic<bool> flag;
+};
+}
+
+#endif // MIR_SIGNAL_H_

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -34,6 +34,8 @@ list(APPEND MIR_COMMON_SOURCES
   thread_pool_executor.cpp
   linearising_executor.cpp
   immediate_executor.cpp
+  ${PROJECT_SOURCE_DIR}/include/common/mir/signal.h
+  signal.cpp
 )
 
 set(

--- a/src/common/signal.cpp
+++ b/src/common/signal.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/signal.h"
+
+mir::Signal::Signal()
+  : flag{false}
+{
+}
+
+void mir::Signal::raise()
+{
+    flag = true;
+    flag.notify_all();
+}
+
+void mir::Signal::wait()
+{
+    flag.wait(false);
+    flag = false;
+}

--- a/src/common/signal.cpp
+++ b/src/common/signal.cpp
@@ -17,18 +17,18 @@
 #include "mir/signal.h"
 
 mir::Signal::Signal()
-  : flag{false}
+  : raised{false}
 {
 }
 
 void mir::Signal::raise()
 {
-    flag = true;
-    flag.notify_all();
+    raised = true;
+    raised.notify_all();
 }
 
 void mir::Signal::wait()
 {
-    flag.wait(false);
-    flag = false;
+    raised.wait(false);
+    raised = false;
 }

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -336,6 +336,10 @@ MIR_COMMON_2.17 {
     mir::SharedLibraryProberReport::?SharedLibraryProberReport*;
     mir::SharedLibraryProberReport::SharedLibraryProberReport*;
     mir::SharedLibraryProberReport::operator*;
+    mir::Signal::Signal*;
+    mir::Signal::?Signal*;
+    mir::Signal::raise*;
+    mir::Signal::wait*;
     mir::SignalBlocker::?SignalBlocker*;
     mir::SignalBlocker::SignalBlocker*;
     mir::detail::RefCountedLibrary::?RefCountedLibrary*;

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(
   test_thread_pool_executor.cpp
   test_linearising_executor.cpp
   test_shm_backing.cpp
+  test_signal.cpp
 )
 
 if (HAVE_PTHREAD_GETNAME_NP)

--- a/tests/unit-tests/test_signal.cpp
+++ b/tests/unit-tests/test_signal.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/signal.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <thread>
+#include <latch>
+
+#include "mir/test/auto_unblock_thread.h"
+
+namespace mt = mir::test;
+
+TEST(Signal, waits_until_raised)
+{
+    mir::Signal signal;
+
+    std::atomic<bool> event_hit{false};
+    std::latch thread_spawned{2};
+
+    std::thread waiter_thread{
+        [&]()
+        {
+            thread_spawned.arrive_and_wait();
+            EXPECT_FALSE(event_hit);
+            signal.wait();
+            EXPECT_TRUE(event_hit);
+        }
+    };
+
+    thread_spawned.arrive_and_wait();
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+    event_hit = true;
+    signal.raise();
+
+    waiter_thread.join();
+}
+
+TEST(Signal, racing_raises_release_at_least_one_waiter)
+{
+    mir::Signal signal;
+
+    int const thread_count{10};
+    std::latch threads_spawned{thread_count + 1};
+    std::vector<mt::AutoJoinThread> racing_releasers;
+
+    for(auto i = 0; i < thread_count; ++i)
+    {
+        racing_releasers.emplace_back(
+            mt::AutoJoinThread{
+                [&]()
+                {
+                    threads_spawned.arrive_and_wait();
+                    signal.raise();
+                }
+        });
+    }
+
+    threads_spawned.arrive_and_wait();
+    signal.wait();
+}
+
+TEST(Signal, pre_raised_signal_releases_immediately)
+{
+    mir::Signal signal;
+
+    signal.raise();
+    signal.wait();
+}
+
+TEST(Signal, release_from_wait_resets_signal)
+{
+    mir::Signal signal;
+
+    std::chrono::milliseconds const delay{500};
+
+    mt::AutoJoinThread releaser{
+        [&]()
+        {
+            signal.raise();
+            std::this_thread::sleep_for(delay * 2);
+            signal.raise();            
+        }
+    };
+
+    signal.wait();
+    auto now = std::chrono::steady_clock::now();
+    signal.wait();
+    EXPECT_THAT(std::chrono::steady_clock::now(), testing::Gt(now + delay));
+}


### PR DESCRIPTION
This is *very* much like `std::binary_semaphore`, but doesn't have the preconditon that the signal must not be raised before attempting to raise it.

Use it to fix the UB (on shutdown) in `mir::ThreadPoolExecutor`