### PR TITLE
(#3274) When a window is fullscreen AND it is not a background AND it is focused, then we don't render any layer above it

### DIFF
--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -155,12 +155,21 @@ mc::SceneElementSequence ms::SurfaceStack::scene_elements_for(mc::CompositorID i
 
     scene_changed = false;
     mc::SceneElementSequence elements;
+    bool encountered_fullscreen = false;
     for (auto const& layer : surface_layers)
     {
         for (auto const& surface : layer)
         {
             if (surface_can_be_shown(surface) && surface->visible())
             {
+                if (!encountered_fullscreen)
+                {
+                    encountered_fullscreen = surface->state() == mir_window_state_fullscreen
+                        && surface->depth_layer() > mir_depth_layer_background
+                        && (surface->focus_state() == mir_window_focus_state_focused
+                            || surface->focus_state() == mir_window_focus_state_active);
+                }
+
                 for (auto& renderable : surface->generate_renderables(id))
                 {
                     elements.emplace_back(
@@ -172,6 +181,9 @@ mc::SceneElementSequence ms::SurfaceStack::scene_elements_for(mc::CompositorID i
                 }
             }
         }
+
+        if (encountered_fullscreen)
+            break;
     }
     for (auto const& renderable : overlays)
     {


### PR DESCRIPTION
fixes #3274 

## What's new?
- If a window is fullscreen AND it is not a background AND it is focused, then we don't render any layer above it.

## Question
While this is somewhat of a natural place to put this, I'm wondering if a better solution would be to move it between layers. But that would be kind of tricky in my opinion.