### PR TITLE
feature: provide surface access via the Renderable

### DIFF
--- a/include/platform/mir/graphics/renderable.h
+++ b/include/platform/mir/graphics/renderable.h
@@ -25,6 +25,9 @@
 
 namespace mir
 {
+
+namespace scene { class Surface; }
+
 namespace graphics
 {
 
@@ -69,6 +72,9 @@ public:
     virtual glm::mat4 transformation() const = 0;
 
     virtual bool shaped() const = 0;  // meaning the pixel format has alpha
+
+    virtual auto surface_if_any() const
+        -> std::optional<mir::scene::Surface const*> = 0;
 protected:
     Renderable() = default;
     Renderable(Renderable const&) = delete;

--- a/src/server/graphics/software_cursor.cpp
+++ b/src/server/graphics/software_cursor.cpp
@@ -100,6 +100,12 @@ public:
         return true;
     }
 
+    auto surface_if_any() const
+        -> std::optional<mir::scene::Surface const*> override
+    {
+        return std::nullopt;
+    }
+
     void move_to(geom::Point new_position)
     {
         std::lock_guard lock{position_mutex};

--- a/src/server/input/touchspot_controller.cpp
+++ b/src/server/input/touchspot_controller.cpp
@@ -83,7 +83,13 @@ public:
         return true;
     }
 
-// TouchspotRenderable    
+    auto surface_if_any() const
+        -> std::optional<mir::scene::Surface const*> override
+    {
+        return std::nullopt;
+    }
+
+    // TouchspotRenderable
     void move_center_to(geom::Point pos)
     {
         std::lock_guard lg(guard);

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -697,14 +697,16 @@ public:
         std::optional<geom::Rectangle> const& clip_area,
         glm::mat4 const& transform,
         float alpha,
-        mg::Renderable::ID id)
+        mg::Renderable::ID id,
+        ms::Surface const* surface)
     : underlying_buffer_stream{stream},
       compositor_id{compositor_id},
       alpha_{alpha},
       screen_position_(position),
       clip_area_(clip_area),
       transformation_(transform),
-      id_(id)
+      id_(id),
+      surface{surface}
     {
     }
 
@@ -736,6 +738,11 @@ public:
 
     mg::Renderable::ID id() const override
     { return id_; }
+
+    auto surface_if_any() const -> std::optional<mir::scene::Surface const*> override
+    {
+        return surface;
+    }
 private:
     std::shared_ptr<mc::BufferStream> const underlying_buffer_stream;
     std::shared_ptr<mg::Buffer> mutable compositor_buffer;
@@ -745,6 +752,7 @@ private:
     std::optional<geom::Rectangle> const clip_area_;
     glm::mat4 const transformation_;
     mg::Renderable::ID const id_;
+    ms::Surface const* surface;
 };
 }
 
@@ -806,7 +814,7 @@ mg::RenderableList ms::BasicSurface::generate_renderables(mc::CompositorID id) c
                 info.stream, id,
                 geom::Rectangle{content_top_left_ + info.displacement, std::move(size)},
                 state->clip_area,
-                state->transformation_matrix, state->surface_alpha, info.stream.get()));
+                state->transformation_matrix, state->surface_alpha, info.stream.get(), this));
         }
     }
     return list;

--- a/src/server/shell/basic_idle_handler.cpp
+++ b/src/server/shell/basic_idle_handler.cpp
@@ -85,6 +85,12 @@ public:
         return false;
     }
 
+    auto surface_if_any() const
+        -> std::optional<mir::scene::Surface const*> override
+    {
+        return std::nullopt;
+    }
+
 private:
     std::shared_ptr<mg::Buffer> const buffer_;
 };

--- a/tests/include/mir/test/doubles/fake_renderable.h
+++ b/tests/include/mir/test/doubles/fake_renderable.h
@@ -98,6 +98,12 @@ public:
         return std::optional<geometry::Rectangle>();
     }
 
+    auto surface_if_any() const
+        -> std::optional<mir::scene::Surface const*> override
+    {
+        return std::nullopt;
+    }
+
 private:
     std::shared_ptr<graphics::Buffer> buf;
     mir::geometry::Rectangle rect;

--- a/tests/include/mir/test/doubles/mock_renderable.h
+++ b/tests/include/mir/test/doubles/mock_renderable.h
@@ -53,6 +53,7 @@ struct MockRenderable : public graphics::Renderable
     MOCK_CONST_METHOD0(transformation, glm::mat4());
     MOCK_CONST_METHOD0(visible, bool());
     MOCK_CONST_METHOD0(shaped, bool());
+    MOCK_CONST_METHOD0(surface_if_any, std::optional<mir::scene::Surface const*>());
 };
 }
 }

--- a/tests/include/mir/test/doubles/stub_renderable.h
+++ b/tests/include/mir/test/doubles/stub_renderable.h
@@ -88,6 +88,12 @@ public:
     {
         return false;
     }
+
+    auto surface_if_any() const
+        -> std::optional<mir::scene::Surface const*> override
+    {
+        return std::nullopt;
+    }
 private:
     std::shared_ptr<graphics::Buffer> make_stub_buffer(geometry::Rectangle const& rect)
     {

--- a/tests/platform_test_harness/graphics_platform_test_harness.cpp
+++ b/tests/platform_test_harness/graphics_platform_test_harness.cpp
@@ -450,6 +450,12 @@ void basic_software_buffer_drawing(
         {
             this->top_left = top_left;
         }
+
+        auto surface_if_any() const
+            -> std::optional<mir::scene::Surface const*> override
+        {
+            return std::nullopt;
+        }
     private:
         std::shared_ptr<mg::Buffer> const buffer_;
         mir::geometry::Point top_left;


### PR DESCRIPTION
Alternative to https://github.com/canonical/mir/pull/3349

## What's new?
- Now you can access the `Surface` via the `Renderable`