### PR TITLE
Revert spurious bump to mirserver soname

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -63,7 +63,7 @@ Vcs-Git: https://github.com/MirServer/mir
 
 #TODO: Packaging infrastructure for better dependency generation,
 #      ala pkg-xorg's xviddriver:Provides and ABI detection.
-Package: libmirserver61
+Package: libmirserver60
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -158,7 +158,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirserver61 (= ${binary:Version}),
+Depends: libmirserver60 (= ${binary:Version}),
          libmirplatform-dev (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libglm-dev,
@@ -175,7 +175,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirserver61 (= ${binary:Version}),
+Depends: libmirserver60 (= ${binary:Version}),
       libmirplatform-dev (= ${binary:Version}),
       libmircommon-dev (= ${binary:Version}),
       libmircore-dev (= ${binary:Version}),

--- a/debian/libmirserver60.install
+++ b/debian/libmirserver60.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirserver.so.60

--- a/debian/libmirserver61.install
+++ b/debian/libmirserver61.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirserver.so.61

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -164,7 +164,7 @@ install(DIRECTORY
     ${CMAKE_SOURCE_DIR}/src/include/server/mir DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mirserver-internal"
 )
 
-set(MIRSERVER_ABI 61) # Be sure to increment MIR_VERSION_MINOR at the same time
+set(MIRSERVER_ABI 60) # Be sure to increment MIR_VERSION_MINOR at the same time
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 
 set_target_properties(


### PR DESCRIPTION
In 2.16 mirserver was 59, in 2.17 it should be 60