### PR TITLE
bugfix: libmircommon-internal-dev should not attempt to install libmircommon10 because libmircommon-dev will provide that

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -124,8 +124,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmircommon10 (= ${binary:Version}),
-         libmircommon-dev (= ${binary:Version}),
+Depends: libmircommon-dev (= ${binary:Version}),
          libxkbcommon-dev,
          ${misc:Depends},
 Description: Display server for Ubuntu - development headers

--- a/debian/libmircommon-internal-dev.install
+++ b/debian/libmircommon-internal-dev.install
@@ -1,3 +1,2 @@
 usr/include/mircommon-internal
-usr/lib/*/libmircommon.so
 usr/lib/*/pkgconfig/mircommon-internal.pc


### PR DESCRIPTION
I found this while running CI on `miracle-wm`: https://github.com/mattkae/miracle-wm/actions/runs/8908986732/job/24465567363?pr=116

The error is:

```
Unpacking libmircommon-internal-dev:amd64 (2.16.4+dev380-gf95f846c94-0ubuntu22.04) ...
dpkg: error processing archive /tmp/apt-dpkg-install-meg0dJ/6-libmircommon-internal-dev_2.16.4+dev380-gf95f846c94-0ubuntu22.04_amd64.deb (--unpack):
 trying to overwrite '/usr/lib/x86_64-linux-gnu/libmircommon.so', which is also in package libmircommon-dev:amd64 2.16.4+dev380-gf95f846c94-0ubuntu22.04
Errors were encountered while processing:
 /tmp/apt-dpkg-install-meg0dJ/6-libmircommon-internal-dev_2.16.4+dev380-gf95f846c94-0ubuntu22.04_amd64.deb
needrestart is being skipped since dpkg has failed
E: Sub-process /usr/bin/dpkg returned an error code (1)
```