### PR TITLE
bugfix: mircommon-internal-dev was erroneously including some libs

### DIFF
--- a/src/common/mircommon-internal.pc.in
+++ b/src/common/mircommon-internal.pc.in
@@ -2,7 +2,7 @@ prefix=@CMAKE_INSTALL_PREFIX@
 includedir=@PKGCONFIG_INCLUDEDIR@/mircommon-internal
 
 Name: mircommon-internal
-Description: Mir server internal headers
+Description: Mir common internal headers
 Version: @MIR_VERSION@
-Libs: -L${libdir} -lmircommon
+Requires: mircommon mircore
 Cflags: -I${includedir}


### PR DESCRIPTION
My local version of `pkgconfig` doesn't complain about this, but it is most definitely an error!