### PR TITLE
(#3300) bugfix for a race condition in VirtualPointerV1

### DIFF
--- a/src/server/frontend_wayland/virtual_pointer_v1.cpp
+++ b/src/server/frontend_wayland/virtual_pointer_v1.cpp
@@ -202,7 +202,12 @@ mf::VirtualPointerV1::VirtualPointerV1(
 
 mf::VirtualPointerV1::~VirtualPointerV1()
 {
-    ctx->device_registry->remove_device(pointer_device);
+    // Destruction must happen on the linearising_executor to prevent races with create_and_dispatch_event
+    mir::linearising_executor.spawn(
+        [pointer_device=pointer_device, device_registry=ctx->device_registry]()
+    {
+        device_registry->remove_device(pointer_device);
+    });
 }
 
 void mf::VirtualPointerV1::motion(uint32_t time, double dx, double dy)


### PR DESCRIPTION
fixes https://github.com/canonical/mir/issues/3300

See [this comment](https://github.com/canonical/mir/issues/3300#issuecomment-2088897189) to understand my rationale here. I think this should fix it, but I don't have a solid repo on my end (and I don't see this in CI anywhere). All other code paths seemed to be fine.