### PR TITLE
platforms/eglstream-kms: Don't invoke callback under `configuration_mutex`

### DIFF
--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -547,8 +547,10 @@ void mge::Display::register_configuration_change_handler(
                 monitor->process_events(
                     [conf_change_handler, this](mir::udev::Monitor::EventType, mir::udev::Device const&)
                     {
-                        std::lock_guard lock{configuration_mutex};
-                        display_configuration.update();
+                        {
+                            std::lock_guard lock{configuration_mutex};
+                            display_configuration.update();
+                        }
                         conf_change_handler();
                     });
             }));


### PR DESCRIPTION
The `conf_change_handler()` callback comes from external code, and could do anything. In practice, it *now* ends up (eventually) calling `Display::configuration`, which *also* tries to take the configuration mutex, with hilarious consequences!

Drop the lock before invoking the callback.

Fixes: #3375