### PR TITLE
miniscule fix for building on systems where the hardcoded path to libdrm headers doesn't exist

### DIFF
--- a/src/platform/graphics/CMakeLists.txt
+++ b/src/platform/graphics/CMakeLists.txt
@@ -49,13 +49,15 @@ if (DRM_VERSION VERSION_GREATER 2.4.107)
       PkgConfig::DRM)
 endif()
 
+find_path(DRM_FOURCC_INCLUDE_DIR NAMES "drm_fourcc.h" PATH_SUFFIXES "libdrm" "" HINTS ${DRM_INCLUDE_DIRS})
+
 add_custom_command(
   OUTPUT
     drm-formats
   VERBATIM
   COMMAND
     "sh" "-c"
-      "grep \"#define DRM_FORMAT\" /usr/include/libdrm/drm_fourcc.h | \
+      "grep \"#define DRM_FORMAT\" ${DRM_FOURCC_INCLUDE_DIR}/drm_fourcc.h | \
        grep -v DRM_FORMAT_BIG_ENDIAN |                             \
        grep -v MOD |                                               \
        grep -v DRM_FORMAT_RESERVED |                               \
@@ -64,13 +66,14 @@ add_custom_command(
        sed \"s/\\(.*\\)/STRINGIFY(\\1)/\" >                        \
        ${DRM_FORMATS_FILE}"
 )
+
 add_custom_command(
   OUTPUT
     drm-formats-big-endian
   VERBATIM
   COMMAND
     "sh" "-c"
-      "grep \"#define DRM_FORMAT\" /usr/include/libdrm/drm_fourcc.h | \
+      "grep \"#define DRM_FORMAT\" ${DRM_FOURCC_INCLUDE_DIR}/drm_fourcc.h | \
        grep -v DRM_FORMAT_BIG_ENDIAN |                             \
        grep -v MOD |                                               \
        grep -v DRM_FORMAT_RESERVED |                               \
@@ -88,7 +91,7 @@ add_custom_command(
   VERBATIM
   COMMAND
     "sh" "-c"
-      "grep \"#define [[:alnum:]]*_FORMAT_MOD_\\([[:alnum:]]\\|_\\)*[[:space:]]\" /usr/include/drm/drm_fourcc.h | \
+      "grep \"#define [[:alnum:]]*_FORMAT_MOD_\\([[:alnum:]]\\|_\\)*[[:space:]]\" ${DRM_FOURCC_INCLUDE_DIR}/drm_fourcc.h | \
        tr -s [:blank:] ' ' |                                              \
        cut -f2 -d' ' |                                                    \
        sed \"s/\\(.*\\)/STRINGIFY(\\1)/\" >                               \

--- a/src/platform/graphics/CMakeLists.txt
+++ b/src/platform/graphics/CMakeLists.txt
@@ -49,7 +49,7 @@ if (DRM_VERSION VERSION_GREATER 2.4.107)
       PkgConfig::DRM)
 endif()
 
-find_path(DRM_FOURCC_INCLUDE_DIR NAMES "drm_fourcc.h" PATH_SUFFIXES "libdrm" "" HINTS ${DRM_INCLUDE_DIRS})
+find_path(DRM_FOURCC_INCLUDE_DIR NAMES "drm_fourcc.h" PATH_SUFFIXES "libdrm" "" HINTS ${DRM_INCLUDE_DIRS} REQUIRED NO_DEFAULT_PATHS)
 
 add_custom_command(
   OUTPUT


### PR DESCRIPTION
, e.g. NixOS.
I hope this still works on other systems.