### PR TITLE
docs: re-do the mir test plan

### DIFF
--- a/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
+++ b/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
@@ -19,8 +19,8 @@ We will run the test plan on the `miral-app` test compositor.
 
 ## Tests
 Each test must be performed across a combination of different display
-platforms and different Ubuntu releases. The following matrix provides
-the environments in which we need to test:
+platforms and Ubuntu releases. The following matrix provides the environments
+in which we need to test:
 
 |                                | 24.04    | 24.10      |
 |--------------------------------|----------|------------|
@@ -31,20 +31,16 @@ the environments in which we need to test:
 | wayland                        |          |            |
 | virtual                        |          |            |
 
-### Platform Selection
-The first set of tests confirms that platforms are selected appropriately.
 
-> Note that this section should NOT be run for each platform
-> by nature. The remaining test sections _**should**_ be run for each platform
-> in the matrix.
+To check which display platform we've selected, we can run `miral-app`
+and grep for the platform string as follows:
 
-To verify the platform in each instance, do:
-
-```
+```sh
 miral-app | grep "Selected display driver:"
 ```
 
-The tests are as follows:
+Given the types of outputs that you have configured in your environment,
+you should encounter one of the following scenarios for each output:
 
 1. When NOT on an Nvidia platform and NOT in a hosted environment,
    then `mir:gbm-kms` is selected
@@ -74,6 +70,11 @@ The tests are as follows:
    ```sh
    gvncviewer localhost
    ```
+
+### Run Compositors that are Built for Testing
+1. Run the `mir-test-smoke-runner` and confirm that the final output is:
+   `Smoke testing complete with returncode 0`.
+
 
 ### Applications
 For each empty box in the matrix above, ensure that the following applications can start
@@ -146,36 +147,7 @@ miral-app --window-manager=tiling # a tiling window manager
 miral-app -kiosk # a typical kiosk
 ```
 
-### Run Compositors that are Built for Testing
-1. Run the `mir-test-smoke-runner` and confirm that the final output is:
-   `Smoke testing complete with returncode 0`.
-2. Run the tests found in `mir-test-tools` and confirm the contents on the screen. A useful script for doing this is:
-   ```bash
-    #! /bin/bash
-
-    set -e
-   
-    if [ -x "$(command -v fgconsole)" ]
-    then
-        trap "sudo chvt $(sudo fgconsole)" EXIT
-    fi
-   
-    if [ -v DISPLAY ]
-    then
-        snap run mir-test-tools.gtk3-test
-        snap run mir-test-tools.qt-test
-        snap run mir-test-tools.sdl2-test
-        snap run mir-test-tools.smoke-test
-        snap run mir-test-tools.performance-test
-        snap run mir-test-tools.mir-flutter-app
-    fi
-   
-    sudo snap run mir-test-tools.gtk3-test
-    sudo snap run mir-test-tools.qt-test
-    sudo snap run mir-test-tools.sdl2-test
-    sudo snap run mir-test-tools.smoke-test
-    sudo snap run mir-test-tools.performance-test
-    sudo snap run mir-test-tools.mir-flutter-app
-   
-    echo All tests passed
-   ```
+## Testing Downstream Snaps (e.g. Ubuntu Frame and Miriway)
+1. Run your downstream snap
+2. Run the tests found in `mir-test-tools` and confirm the contents on the screen.
+   A useful script for doing can be found in `mir-test-tools.selftest`.

--- a/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
+++ b/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
@@ -17,7 +17,7 @@ We will run the test plan on the `miral-app` test compositor.
     ```
 2. Confirm that you can run `miral-app`
 
-## Tests
+## Testing each graphics platform
 Each test must be performed across a combination of different display
 platforms and Ubuntu releases. The following matrix provides the environments
 in which we need to test:
@@ -51,15 +51,14 @@ you should encounter one of the following scenarios for each output:
    then `mir:x11` is selected
 4. When you are running the compositor hosted in a session that supports wayland
    _and_ you force Mir to use the `mir:wayland` platform using:
-   ```
-   miral-app --wayland-host=$WAYLAND_DISPLAY
-   ```
+    ```
+    miral-app --wayland-host=$WAYLAND_DISPLAY
+    ```
    then `mir:wayland` is selected.
 
 5. Check that the virtual platform can run and you can connect to it via a VNC:
    ```sh
-   WAYLAND_DISPLAY=wayland-1 miral-app --platform-display-lib=mir:virtual \
-       --virtual-output=1280x1024 \
+   MIR_SERVER_PLATFORM_DISPLAY_LIBS=mir:virtual MIR_SERVER_VIRTUAL_OUTPUT=1280x1024 WAYLAND_DISPLAY=wayland-1 miral-app \
        --add-wayland-extension=zwp_virtual_keyboard_manager_v1:zwlr_virtual_pointer_manager_v1:zwlr_screencopy_manager_v1
    ```
    After, in a separate VT, connect to the VNC:
@@ -71,12 +70,28 @@ you should encounter one of the following scenarios for each output:
    gvncviewer localhost
    ```
 
-### Run Compositors that are Built for Testing
-1. Run the `mir-test-smoke-runner` and confirm that the final output is:
-   `Smoke testing complete with returncode 0`.
+## The smoke tests
+These verify our demo clients work with `mir_demo_server` and should be run for
+each platform on each of the ubuntu series (see previous section).
+
+1. Decide which platform that you want to run the smoke tests on (e.g. gbm-kms,
+   virtual, X11, etc.)
+2. Run `mir-smoke-test-runner` like so:
+    ```sh
+    MIR_SERVER_PLATFORM_DISPLAY_LIBS=<YOUR_PLATFORM> mir-smoke-test-runner
+    ```
+
+    For example, if I wanted to run the tests on the virtual platform, I would run:
+
+    ```sh
+    MIR_SERVER_PLATFORM_DISPLAY_LIBS=mir:virtual MIR_SERVER_VIRTUAL_OUTPUT=1280x1024 mir-smoke-test-runner
+    ```
+
+    (Note that you do **not** have to connect via VNC for the smoke tests to run with the virtual platform.)
+3. Confirm that the final output of the test is: `Smoke testing complete with returncode 0`.
 
 
-### Applications
+## Applications
 For each empty box in the matrix above, ensure that the following applications can start
 
 1. Test that the following QT Wayland applications can be started and can receive input:
@@ -113,7 +128,7 @@ For each empty box in the matrix above, ensure that the following applications c
    gnome-terminal
    ```
 
-### Mir Console Providers
+## Mir Console Providers
 
 Run with different console providers and ensure that the compositor can start:
 
@@ -150,4 +165,8 @@ miral-app -kiosk # a typical kiosk
 ## Testing Downstream Snaps (e.g. Ubuntu Frame and Miriway)
 1. Run your downstream snap
 2. Run the tests found in `mir-test-tools` and confirm the contents on the screen.
-   A useful script for doing can be found in `mir-test-tools.selftest`.
+   A useful script for running all of the tests at once is in the snap:
+
+   ```sh
+   /snap/mir-test-tools/current/bin/selftest
+   ```

--- a/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
+++ b/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
@@ -163,10 +163,8 @@ miral-app -kiosk # a typical kiosk
 ```
 
 ## Testing Downstream Snaps (e.g. Ubuntu Frame and Miriway)
-1. Run your downstream snap
-2. Run the tests found in `mir-test-tools` and confirm the contents on the screen.
-   A useful script for running all of the tests at once is in the snap:
+For each of our downstream snaps, check that you have installed a build with the Mir version under test (typically from the `beta` channel). Then run the tests for that snap.
 
-   ```sh
+E.g. for `mir-test-tools`:
+```sh
    /snap/mir-test-tools/current/bin/selftest
-   ```

--- a/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
+++ b/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
@@ -1,0 +1,174 @@
+# How to test Mir for a release
+The following document details the criteria that must be met before we can
+publish an official release of Mir. When adding to this test plan, please
+do not fail to consider how your additions may be automated in the future, as
+this is the end goal of our release testing.
+
+Note that all of these tests must be run _after_ a release branch is created
+in the Mir repository, such that the right repositories are updated beforehand.
+
+## Setup
+1. Install mir from the release candidate PPA
+    ```
+    sudo add-apt-repository --update ppa:mir-team/rc
+    sudo apt install mir-demos mir-platform-graphics-virtual mir-graphics-drivers-desktop mir-test-tools
+    ```
+2. Install the `mir-test-tools` from the `22/beta` _or_ `24/beta` track (depending
+   on which you are trying to test):
+    ```
+    sudo snap refresh
+    sudo snap install mir-test-tools --channel=24/beta
+    # ... or ...
+    sudo snap install mir-test-tools --channel=22/beta
+    ```
+3. Install `miriway` from the latest `beta` track:
+    ```
+    sudo snap refresh
+    sudo snap install miriway --classic --chanel=latest/beta
+    ```
+
+## Tests
+Manual tests must be performed across a combination of different display
+platforms and different Ubuntu releases. It is important also that we test both
+the `snap` and the `non-snap` version for each platform.
+
+|                                | core24 snap | 24.04 LTS | 24.10 |
+|--------------------------------|-------------|----------|------------|
+| gbm-kms                        |             |          |            |
+| eglstream-kms                  |             |          |            |
+| eglstream-kms + gbm-kms hybrid |             |          |            |
+| x11                        |             |          |            |
+| wayland                    |             |          |            |
+| virtual                        |             |          |            |
+
+### Platform Selection
+For the following tests, we must test that the compositor can start with the correct
+display platform chosen. **Note that this section should NOT be run for each platform
+by nature**. The remaining test sections _**should**_ be run for each platform
+in the matrix.
+
+1. Test that platforms are selected appropriately
+   - When you are not on an Nvidia platform, verify that `gbm-kms` is selected
+     for each output when the compositor is _not_ running in a hosted environment.
+   - When you have an Nvidia card _and_ you are using Nvidia drivers, then
+     the `eglstream-kms` platform should be selected for that particular output.
+   - When you are hosted by an X compositor, the `x11` platform will be chosen
+
+2. Platforms can be forced to run on a particular display platform if the environment supports it.
+   Platforms are specified with `--platform-display-libs=mir:<platform_name>`
+   - To specify `egl-stream-kms`, you must have an Nvidia card with proprietary drivers
+   - You can force an Nvidia card to use `gbm-kms`
+   - To specify `x11`, you must be on a hosted platform
+   - To specify `wayland`, you must be on a hosted wayland platform
+
+3. Check that the virtual platform can run and you can connect to it via a VNC:
+   ```sh
+   WAYLAND_DISPLAY=wayland-1 miral-app --platform-display-lib=mir:virtual \
+       --virtual-output=1280x1024 \
+       --add-wayland-extension=zwp_virtual_keyboard_manager_v1:zwlr_virtual_pointer_manager_v1:zwlr_screencopy_manager_v1
+   ```
+   After, in a separate VT, connect to the VNC:
+   ```sh
+   WAYLAND_DISPLAY=wayland-1 ubuntu-frame-vnc
+   ```
+   Then, check that you can connect via a VNC viewer:
+   ```sh
+   gvncviewer localhost
+   ```
+
+### Applications
+For each empty box in the matrix above, ensure that the following applications can start
+
+1. Test that the following QT Wayland applications can be started and can receive input:
+    ```sh
+    sudo apt install qtwayland5 kate qterminal
+    
+    # First...
+    kate
+   
+    # Then...
+    qtwayland5
+   
+    # Finally..
+    qterminal
+    ```
+2. Test that `weston-terminal` can be started and can receive input:
+    ```
+    sudo apt install weston
+    weston
+    ```
+3. Test that `glmark2-wayland` can be run:
+    ```sh
+    sudo apt install glmark2-wayland
+    glmark2-wayland
+    ```
+4. Test that `gnome-terminal` can be started and can receive input:
+   ```sh
+   sudo apt install gnome-terminal
+   gnome-terminal
+   ```
+
+### Mir Configuration Options
+
+1. Run any Mir compositor with different console providers and ensure that the compositor can start:
+    ```sh
+    miral-app --console-provider=vt --vt=4
+    ```
+    - This requires running with root privileges 
+    - You need to ensure that `XDG_RUNTIME_DIR` is set in the environment. If using `sudo`, 
+      it might strip this out; running something like `sudo env XDG_RUNTIME_DIR=/run/user/1000 miral-shell ...`
+      will ensure this is set. 
+    
+    ```sh
+    miral-app --console-provider=logind
+    ```
+    - You can switch to vt4, sign in
+    
+    ```sh
+    miral-app --console-provider=minimal 
+    ```
+    - This is used when all others fail
+    - This does not provide VT switching capabilities (Ctrl-Alt-F1, etc) 
+    - This is _only_ used for the `gbm-x11`, `gbm-wayland`, and `virtual` platforms 
+
+2. Run `miral-app` with different window managers and confirm that the window management
+   styles work as expected:
+    ```sh
+    miral-app --window-manager=floating # traditional floating window manager
+    miral-app --window-manager=tiling # a tiling window manager
+    miral-app --kiosk # a typical kiosk
+    ```
+
+### Run Compositors that are Built for Testing
+1. Run the `mir-test-smoke-runner` and confirm that the final output is:
+   `Smoke testing complete with returncode 0`.
+2. Run the tests found in `mir-test-tools` and confirm the contents on the screen. A useful script for doing this is:
+   ```bash
+    #! /bin/bash
+
+    set -e
+   
+    if [ -x "$(command -v fgconsole)" ]
+    then
+        trap "sudo chvt $(sudo fgconsole)" EXIT
+    fi
+   
+    if [ -v DISPLAY ]
+    then
+        snap run mir-test-tools.gtk3-test
+        snap run mir-test-tools.qt-test
+        snap run mir-test-tools.sdl2-test
+        snap run mir-test-tools.smoke-test
+        snap run mir-test-tools.performance-test
+        snap run mir-test-tools.mir-flutter-app
+    fi
+   
+    sudo snap run mir-test-tools.gtk3-test
+    sudo snap run mir-test-tools.qt-test
+    sudo snap run mir-test-tools.sdl2-test
+    sudo snap run mir-test-tools.smoke-test
+    sudo snap run mir-test-tools.performance-test
+    sudo snap run mir-test-tools.mir-flutter-app
+   
+    echo All tests passed
+   ```

--- a/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
+++ b/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
@@ -105,7 +105,15 @@ For each empty box in the matrix above, ensure that the following applications c
     sudo apt install glmark2-wayland
     glmark2-wayland
     ```
-4. Test that `gnome-terminal` can be started and can receive input:
+4. (If using gbm-kms on a system with multiple GPUs) Test hybrid support with `glmark2-wayland`
+    ```sh
+    sudo apt install glmark2-wayland
+    glmark2-wayland
+    DRI_PRIME=0 glmark2-wayland
+    DRI_PRIME=1 glmark2-wayland
+    ```
+    (If more than 2 GPUs, may do `DRI_PRIME=2 glmark2-wayland`, etc)
+5. Test that `gnome-terminal` can be started and can receive input:
    ```sh
    sudo apt install gnome-terminal
    gnome-terminal

--- a/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
+++ b/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
@@ -130,27 +130,39 @@ For each empty box in the matrix above, ensure that the following applications c
 
 ## Mir Console Providers
 
-Run with different console providers and ensure that the compositor can start:
+For each Ubuntu release ensure that the compositor can start with each of the console providers:
 
-```sh
-miral-app --console-provider=vt --vt=4
-```
-- This requires running with root privileges 
-- You need to ensure that `XDG_RUNTIME_DIR` is set in the environment. If using `sudo`, 
-    it might strip this out; running something like `sudo env XDG_RUNTIME_DIR=/run/user/1000 miral-shell ...`
-    will ensure this is set. 
+|         | 24.04    | 24.10      |
+|---------|----------|------------|
+| vt      |          |            |
+| logind  |          |            |
+| minimal |          |            |
 
-```sh
-miral-app --console-provider=logind
-```
-- You can switch to vt4 and sign in
 
-```sh
-miral-app --console-provider=minimal 
-```
-- This is used when all others fail
-- This does not provide VT switching capabilities (Ctrl-Alt-F1, etc) 
-- This is _only_ used for the `gbm-x11`, `gbm-wayland`, and `virtual` platforms 
+The following describes how to select each console provider:
+
+1. **vt**:
+    ```sh
+    miral-app --console-provider=vt --vt=4
+    ```
+    - This requires running with root privileges 
+    - You need to ensure that `XDG_RUNTIME_DIR` is set in the environment. If using `sudo`, 
+        it might strip this out; running something like `sudo env XDG_RUNTIME_DIR=/run/user/1000 miral-shell ...`
+        will ensure this is set. 
+
+2. **logind**:
+    ```sh
+    miral-app --console-provider=logind
+    ```
+    - You can switch to vt4 and sign in
+
+3. **minimal**:
+    ```sh
+    miral-app --console-provider=minimal 
+    ```
+    - This is used when all others fail
+    - This does not provide VT switching capabilities (Ctrl-Alt-F1, etc) 
+    - This is _only_ used for the `gbm-x11`, `gbm-wayland`, and `virtual` platforms 
 
 ## Window Manager Examples
 Run with different window managers and confirm that the window management

--- a/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
+++ b/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
@@ -53,21 +53,14 @@ The tests are as follows:
    is selected
 3. When you are running the compositor hosted in a session that supports X11,
    then `mir:x11` is selected
-4. When you have an Nvidia card connected to an output _and_ the system
-   is using Nvidia's proprietary drivers, you may force Mir to use the
-   `mir:gbm-kms` platform using:
-   ```
-   miral-app --platform-display-libs=mir:gbm-kms
-   ```
-   Verify that `mir:gbm-kms` is selected.
-5. When you are running the compositor hosted in a session that supports wayland
+4. When you are running the compositor hosted in a session that supports wayland
    _and_ you force Mir to use the `mir:wayland` platform using:
    ```
-   miral-app --platform-display-libs=mir:wayland --wayland-host=$WAYLAND_DISPLAY
+   miral-app --wayland-host=$WAYLAND_DISPLAY
    ```
    then `mir:wayland` is selected.
 
-6. Check that the virtual platform can run and you can connect to it via a VNC:
+5. Check that the virtual platform can run and you can connect to it via a VNC:
    ```sh
    WAYLAND_DISPLAY=wayland-1 miral-app --platform-display-lib=mir:virtual \
        --virtual-output=1280x1024 \

--- a/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
+++ b/doc/sphinx/how-to/how-to-test-mir-for-a-release.md
@@ -122,7 +122,7 @@ For each empty box in the matrix above, ensure that the following applications c
     ```sh
     miral-app --console-provider=logind
     ```
-    - You can switch to vt4, sign in
+    - You can switch to vt4 and sign in
     
     ```sh
     miral-app --console-provider=minimal 

--- a/doc/sphinx/how-to/index.md
+++ b/doc/sphinx/how-to/index.md
@@ -17,4 +17,5 @@ getting_involved_in_mir
 how-to-use-checkbox-mir
 how-to-calibrate-a-touchscreen-device
 how-to-enable-graphics-core22-on-a-device
+how-to-test-mir-for-a-release
 ```


### PR DESCRIPTION
Click https://canonical-mir--3392.com.readthedocs.build/3392/how-to/how-to-test-mir-for-a-release/ to read the content

## What's new?
- Taking https://wiki.ubuntu.com/Process/Merges/TestPlans/Mir as a basis, I have redone the test plan while keeping in mind our goal of automating it in the future

## To follow
1. Integrate 2.16 findings into this test plan
2. Integrate hybrid wack-a-mole findings into this test plan