### PR TITLE
graphics/PlatformProbe: Implement a more principled `GraphicBufferAllocator` selector

### DIFF
--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -22,7 +22,6 @@
 
 #include <memory>
 #include <string>
-#include <mutex>
 
 namespace mir
 {

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -39,7 +39,6 @@
 #include "mir/main_loop.h"
 #include "mir/udev/wrapper.h"
 
-#include <algorithm>
 #include <boost/throw_exception.hpp>
 
 #include <sstream>

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -39,6 +39,7 @@
 #include "mir/main_loop.h"
 #include "mir/udev/wrapper.h"
 
+#include <algorithm>
 #include <boost/throw_exception.hpp>
 
 #include <sstream>
@@ -358,8 +359,75 @@ mir::DefaultServerConfiguration::the_buffer_allocator()
     return buffer_allocator(
         [&]() -> std::shared_ptr<graphics::GraphicBufferAllocator>
         {
+            /* Theory:
+             * We iterate over each DisplaySink and each RenderingPlatform, and
+             * collate:
+             * *) If the RenderingPlatform is *best* at driving that sink, and
+             * *) If the RenderingPlatform is *unable* to drive that sink
+             *
+             * We then filter to just the RenderingPlatform(s) that are able to
+             * drive the most DisplaySink.
+             *
+             * Of that list, we pick the RenderingPlatform that has the highest
+             * number of “best” suitabilities.
+             */
+            struct PlatformData
+            {
+                std::shared_ptr<mg::RenderingPlatform> platform;
+                std::shared_ptr<mg::GLRenderingProvider> provider;
+                int best_count;
+                int unsupported_count;
+            };
+            std::vector<PlatformData> providers;
+            providers.reserve(the_rendering_platforms().size());
+            for (auto const& platform : the_rendering_platforms())
+            {
+                providers.push_back({
+                        platform,
+                        platform->acquire_provider<mg::GLRenderingProvider>(platform),
+                        0,
+                        0
+                });
+            }
+
+            the_display()->for_each_display_sync_group(
+                [&](auto& sync_group)
+                {
+                    sync_group.for_each_display_sink(
+                        [&](auto& sink)
+                        {
+                            for (auto &[platform, provider, best_count, unsupported_count] : providers)
+                            {
+                                auto suitability = provider->suitability_for_display(sink);
+                                if (suitability >= mg::probe::best)
+                                {
+                                    best_count++;
+                                }
+                                else if (suitability == mg::probe::unsupported)
+                                {
+                                    unsupported_count++;
+                                }
+                            }
+                        });
+                });
+
+            // providers.size() is guaranteed to be ≥ 1, as we're guaranteed to have at least one rendering platform
+
+            auto const least_unsupported_count = std::min_element(
+                providers.begin(), providers.end(),
+                [](auto const& a, auto const& b) { return a.unsupported_count < b.unsupported_count; })->unsupported_count;
+
+            auto const last_good_provider = std::remove_if(
+                providers.begin(), providers.end(),
+                [least_unsupported_count](auto const& provider) { return provider.unsupported_count > least_unsupported_count; });
+
+            // Now, find the best platform out of the ones that support the most Sinks
+            auto const best_provider = std::max_element(
+                providers.begin(), last_good_provider,
+                [](auto const& a, auto const&b) { return a.best_count < b.best_count; });
+
             // TODO: More than one BufferAllocator
-            return the_rendering_platforms().front()->create_buffer_allocator(*the_display());
+            return best_provider->platform->create_buffer_allocator(*the_display());
         });
 }
 

--- a/src/server/graphics/platform_probe.h
+++ b/src/server/graphics/platform_probe.h
@@ -30,6 +30,8 @@ class ConsoleServices;
 
 namespace graphics
 {
+class RenderingPlatform;
+
 enum class TypePreference
 {
     prefer_nested,
@@ -71,6 +73,11 @@ auto select_display_modules(
     std::shared_ptr<ConsoleServices> const& console,
     SharedLibraryProberReport& lib_loader_report)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>;
+
+auto select_buffer_allocating_renderer(
+    Display& display,
+    std::span<std::shared_ptr<RenderingPlatform>> rendering_platforms)
+    -> std::shared_ptr<RenderingPlatform>;
 }
 }
 

--- a/tests/include/mir/test/doubles/mock_gl_rendering_provider.h
+++ b/tests/include/mir/test/doubles/mock_gl_rendering_provider.h
@@ -21,6 +21,7 @@
 
 #include "mir/graphics/gl_config.h"
 #include "mir/graphics/platform.h"
+#include "mir/renderer/gl/gl_surface.h"
 
 namespace mir::test::doubles
 {


### PR DESCRIPTION
This implements an actual selection process for the GraphicBufferAllocator:
* First, find the `RenderingPlatform`(s) with *fewest* displays they *can't* drive, then
* Select the `RenderingPlatform` with the highest number of displays probed 'best' for

In the case of ties, the algorithm picks the first `RenderingPlatform` in the list;
due to the selections elsewhere, that will be the first platform in alphabetical order

Fixes: #3400