### PR TITLE
Refresh the Alpine builds

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -36,8 +36,8 @@ jobs:
                  "lxd:ubuntu-24.04:spread/build/ubuntu:tsan_clang"'
         fi
 
-        TASKS+='"lxd:alpine-3.18:spread/build/alpine:amd64"
-                "lxd:alpine-3.19:spread/build/alpine:amd64"
+        TASKS+='"lxd:alpine-3.19:spread/build/alpine:amd64"
+                "lxd:alpine-3.20:spread/build/alpine:amd64"
                 "lxd:alpine-edge:spread/build/alpine:amd64"
                 "lxd:ubuntu-24.04:spread/build/sbuild:debian_sid"
                 "lxd:ubuntu-24.04:spread/build/sbuild:ubuntu"

--- a/spread.yaml
+++ b/spread.yaml
@@ -5,8 +5,8 @@ kill-timeout: 45m
 backends:
     lxd:
         systems:
-            - alpine-3.18
             - alpine-3.19
+            - alpine-3.20
             - alpine-edge
             - ubuntu-24.04
             - fedora-39


### PR DESCRIPTION
Alpine 3.20 is out and Alpine 3.18 is old (e.g. doesn't have __cpp_lib_format (std::format))