### PR TITLE
feature: a test harness for window managers + tests for the MinimalWindowManager

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ include_directories(
 
 option(MIR_BUILD_ACCEPTANCE_TESTS "Build acceptance tests" ON)
 option(MIR_BUILD_INTEGRATION_TESTS "Build integration tests" ON)
+option(MIR_BUILD_WINDOW_MANAGEMENT_TESTS "Build window management tests" ON)
 option(MIR_BUILD_PERFORMANCE_TESTS "Build performance tests" ON)
 option(MIR_BUILD_MIRAL_TESTS "Build miral tests" ON)
 option(MIR_BUILD_UNIT_TESTS "Build unit tests" ON)
@@ -108,6 +109,10 @@ include_directories(
 if (MIR_BUILD_INTEGRATION_TESTS)
   add_subdirectory(integration-tests/)
 endif (MIR_BUILD_INTEGRATION_TESTS)
+
+if (MIR_BUILD_WINDOW_MANAGEMENT_TESTS)
+  add_subdirectory(window_management_tests/)
+endif(MIR_BUILD_WINDOW_MANAGEMENT_TESTS)
 
 if (MIR_BUILD_UNIT_TESTS)
   add_subdirectory(unit-tests/)

--- a/tests/include/mir_test_framework/window_management_test_harness.h
+++ b/tests/include/mir_test_framework/window_management_test_harness.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_TEST_FRAMEWORK_WINDOW_MANAGEMENT_TEST_HARNESS_H
+#define MIR_TEST_FRAMEWORK_WINDOW_MANAGEMENT_TEST_HARNESS_H
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <miral/window_management_policy.h>
+#include <miral/application.h>
+#include <miral/window_manager_tools.h>
+#include <mir/shell/surface_specification.h>
+#include "mir/test/doubles/fake_display_configuration_observer_registrar.h"
+#include "mir_test_framework/headless_in_process_server.h"
+
+namespace mir::scene
+{
+class Surface;
+class Session;
+}
+
+namespace mir_test_framework
+{
+using WindowManagementPolicyBuilder =
+    std::function<std::unique_ptr<miral::WindowManagementPolicy>(miral::WindowManagerTools const& tools)>;
+
+/// A harness for window management testing. To use, extend this class and provide the
+/// necessary virtual methods.
+class WindowManagementTestHarness : public mir_test_framework::HeadlessInProcessServer
+{
+public:
+    WindowManagementTestHarness();
+    void SetUp() override;
+    void TearDown() override;
+
+    auto open_application(std::string const& name) -> miral::Application;
+
+    /// Create a window with the provided spec
+    auto create_window(
+        miral::Application const&,
+        mir::shell::SurfaceSpecification spec) -> miral::Window;
+
+    void publish_event(MirEvent const& event);
+    void request_resize(miral::Window const&, MirInputEvent const*, MirResizeEdge);
+    void request_move(miral::Window const&, MirInputEvent const*);
+
+    auto focused_surface() -> std::shared_ptr<mir::scene::Surface>;
+    auto tools() -> miral::WindowManagerTools const&;
+    virtual auto get_builder() -> WindowManagementPolicyBuilder = 0;
+    virtual auto get_output_rectangles() -> std::vector<mir::geometry::Rectangle> = 0;
+
+    struct Self;
+    std::shared_ptr<Self> self;
+};
+
+}
+
+#endif //MIR_TEST_FRAMEWORK_WINDOW_MANAGEMENT_TEST_HARNESS_H

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/src/include/server
   ${PROJECT_SOURCE_DIR}/src/include/client
   ${PROJECT_SOURCE_DIR}/include/renderers/sw
+  ${PROJECT_SOURCE_DIR}/include/miral
   ${CMAKE_SOURCE_DIR}
 )
 
@@ -45,6 +46,7 @@ add_library(mir-public-test-framework OBJECT
   test_display_server.cpp  ${PROJECT_SOURCE_DIR}/include/test/miral/test_display_server.h
   ${PROJECT_SOURCE_DIR}/tests/include/mir_test_framework/mmap_wrapper.h
   mmap_wrapper.cpp
+  window_management_test_harness.cpp ${PROJECT_SOURCE_DIR}/tests/include/mir_test_framework/window_management_test_harness.h
 )
 
 target_link_libraries(mir-public-test-framework

--- a/tests/mir_test_framework/window_management_test_harness.cpp
+++ b/tests/mir_test_framework/window_management_test_harness.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/test/doubles/fake_display.h"
+#include "mir/test/doubles/stub_buffer_stream.h"
+#include "mir_test_framework/window_management_test_harness.h"
+#include <mir/executor.h>
+#include <mir/scene/surface.h>
+#include <mir/scene/surface_observer.h>
+#include <mir/shell/surface_specification.h>
+#include <mir/shell/shell.h>
+#include <mir/wayland/weak.h>
+#include <miral/window_manager_tools.h>
+#include <miral/set_window_management_policy.h>
+
+#include <queue>
+
+namespace ms = mir::scene;
+namespace msh = mir::shell;
+namespace mf = mir::frontend;
+namespace mi = mir::input;
+namespace mtd = mir::test::doubles;
+namespace mg = mir::graphics;
+namespace mc = mir::compositor;
+namespace geom = mir::geometry;
+using namespace testing;
+
+struct mir_test_framework::WindowManagementTestHarness::Self : public ms::SurfaceObserver
+{
+    explicit Self() : tools{nullptr}
+    {
+    }
+
+    void attrib_changed(ms::Surface const*, MirWindowAttrib, int) override {}
+    void window_resized_to(ms::Surface const*, geom::Size const&) override {}
+    void content_resized_to(ms::Surface const*, geom::Size const&) override {}
+    void moved_to(ms::Surface const*, geom::Point const&) override {}
+    void hidden_set_to(ms::Surface const*, bool) override {}
+    void frame_posted(ms::Surface const*, geom::Rectangle const&) override {}
+    void alpha_set_to(ms::Surface const*, float) override {}
+    void orientation_set_to(ms::Surface const*, MirOrientation) override {}
+    void transformation_set_to(ms::Surface const*, glm::mat4 const&) override {}
+    void reception_mode_set_to(ms::Surface const*, mir::input::InputReceptionMode) override {}
+
+    void cursor_image_set_to(
+        ms::Surface const*,
+        std::weak_ptr<mg::CursorImage> const&) override {}
+
+    void client_surface_close_requested(ms::Surface const* surf) override
+    {
+        auto it = std::find_if(known_surfaces.begin(), known_surfaces.end(), [surf](std::shared_ptr<ms::Surface> const& s)
+        {
+            return s.get() == surf;
+        });
+
+        if (it != known_surfaces.end())
+        {
+            surfaces_to_destroy.push_back(*it);
+            known_surfaces.erase(it);
+        }
+    }
+
+    void renamed(ms::Surface const*, std::string const&) override {}
+
+    void cursor_image_removed(ms::Surface const*) override {}
+    void placed_relative(ms::Surface const*, geom::Rectangle const&) override {}
+    void input_consumed(ms::Surface const*, std::shared_ptr<MirEvent const> const&) override {}
+    void application_id_set_to(ms::Surface const*, std::string const&) override {}
+    void depth_layer_set_to(ms::Surface const*, MirDepthLayer) override {}
+    void entered_output(ms::Surface const*, mg::DisplayConfigurationOutputId const&) override {}
+    void left_output(ms::Surface const*, mg::DisplayConfigurationOutputId const&) override {}
+
+    std::vector<std::shared_ptr<mc::BufferStream>> streams;
+    std::vector<std::shared_ptr<ms::Surface>> known_surfaces;
+    std::vector<std::shared_ptr<ms::Surface>> surfaces_to_destroy;
+    mtd::FakeDisplay* display = nullptr;
+    miral::WindowManagerTools tools;
+};
+
+mir_test_framework::WindowManagementTestHarness::WindowManagementTestHarness()
+    : self{std::make_shared<Self>()}
+{
+}
+
+void mir_test_framework::WindowManagementTestHarness::SetUp()
+{
+    miral::SetWindowManagementPolicy policy([&](miral::WindowManagerTools const& tools)
+    {
+        self->tools = tools;
+        return get_builder()(tools);
+    });
+    policy(server);
+
+
+    auto fake_display = std::make_unique<mtd::FakeDisplay>(get_output_rectangles());
+    self->display = fake_display.get();
+    preset_display(std::move(fake_display));
+
+    mir_test_framework::HeadlessInProcessServer::SetUp();
+}
+
+void mir_test_framework::WindowManagementTestHarness::TearDown()
+{
+    mir_test_framework::HeadlessInProcessServer::TearDown();
+}
+
+auto mir_test_framework::WindowManagementTestHarness::open_application(
+    std::string const& name) -> miral::Application
+{
+    return server.the_shell()->open_session(
+        __LINE__,
+        mir::Fd{mir::Fd::invalid},
+        name,
+        std::shared_ptr<mir::frontend::EventSink>());;
+}
+
+auto mir_test_framework::WindowManagementTestHarness::create_window(
+    miral::Application const& session,
+    mir::shell::SurfaceSpecification spec) -> miral::Window
+{
+    auto stream = std::make_shared<mir::test::doubles::StubBufferStream>();
+    self->streams.push_back(stream);
+    spec.streams = std::vector<msh::StreamSpecification>();
+    spec.streams.value().push_back(msh::StreamSpecification{
+        stream,
+        geom::Displacement{},
+    });
+
+    self->display->configuration()->for_each_output([&](mg::DisplayConfigurationOutput const& output)
+    {
+        spec.output_id = output.id;
+    });
+    auto surface = server.the_shell()->create_surface(
+        session,
+        {},
+        spec,
+        self,
+        &mir::immediate_executor);
+    self->known_surfaces.push_back(surface);
+    server.the_shell()->surface_ready(surface);
+
+    return {session, surface};
+}
+
+void mir_test_framework::WindowManagementTestHarness::publish_event(MirEvent const& event)
+{
+    server.the_shell()->handle(event);
+    for (auto const& surface : self->surfaces_to_destroy)
+    {
+        server.the_shell()->destroy_surface(surface->session().lock(), surface);
+    }
+}
+
+void mir_test_framework::WindowManagementTestHarness::request_resize(
+    miral::Window const& window,
+    MirInputEvent const* event,
+    MirResizeEdge edge)
+{
+    auto surface = window.operator std::shared_ptr<ms::Surface>();
+    server.the_shell()->request_resize(surface->session().lock(), surface, event, edge);
+}
+
+void mir_test_framework::WindowManagementTestHarness::request_move(
+    miral::Window const& window, MirInputEvent const* event)
+{
+    auto surface = window.operator std::shared_ptr<ms::Surface>();
+    server.the_shell()->request_move(surface->session().lock(), surface, event);
+}
+
+auto mir_test_framework::WindowManagementTestHarness::focused_surface() -> std::shared_ptr<ms::Surface>
+{
+    return server.the_shell()->focused_surface();
+}
+
+auto mir_test_framework::WindowManagementTestHarness::tools() -> miral::WindowManagerTools const&
+{
+    return self->tools;
+}

--- a/tests/window_management_tests/CMakeLists.txt
+++ b/tests/window_management_tests/CMakeLists.txt
@@ -1,0 +1,65 @@
+include(CMakeDependentOption)
+
+include_directories(
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${PROJECT_SOURCE_DIR}/src/include/platform
+  ${PROJECT_SOURCE_DIR}/src/include/cookie
+  ${PROJECT_SOURCE_DIR}/src/include/common
+  ${PROJECT_SOURCE_DIR}/src/include/server
+  ${PROJECT_SOURCE_DIR}/src/include/client
+  ${PROJECT_SOURCE_DIR}/src/include/gl
+  ${PROJECT_SOURCE_DIR}/include/renderers/sw
+)
+
+link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+mir_add_wrapped_executable(mir_window_management_tests NOINSTALL
+  test_minimal_window_manager.cpp
+)
+
+if (MIR_USE_PRECOMPILED_HEADERS)
+  target_precompile_headers(
+    mir_window_management_tests
+    PRIVATE
+    <gmock/gmock.h>
+    <gtest/gtest.h>
+    <vector>
+    <string>
+    <exception>
+    <memory>
+  )
+endif()
+
+add_dependencies(mir_window_management_tests GMock)
+
+target_link_libraries(
+  mir_window_management_tests
+
+  mir-test-static
+  mir-test-framework-static
+  mir-test-doubles-static
+
+  mircommon
+  miral
+
+  Boost::system
+
+  # GBM platform dependencies
+  PkgConfig::DRM
+  # Shared platform dependencies
+  PkgConfig::EGL
+  PkgConfig::GLESv2
+  ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.
+)
+
+
+CMAKE_DEPENDENT_OPTION(
+  MIR_RUN_WINDOW_MANAGEMENT_TESTS
+  "Run window management tests as part of default testing"
+  ON
+  "MIR_BUILD_WINDOW_MANAGEMENT_TESTS"
+  OFF)
+
+if (MIR_RUN_WINDOW_MANAGEMENT_TESTS)
+  mir_discover_tests_with_fd_leak_detection(mir_window_management_tests)
+endif (MIR_RUN_WINDOW_MANAGEMENT_TESTS)

--- a/tests/window_management_tests/test_minimal_window_manager.cpp
+++ b/tests/window_management_tests/test_minimal_window_manager.cpp
@@ -1,0 +1,491 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <miral/minimal_window_manager.h>
+#include <mir/scene/session.h>
+#include <mir/wayland/weak.h>
+#include <mir/scene/surface.h>
+#include <mir/executor.h>
+#include <mir/events/event_builders.h>
+#include <mir/events/pointer_event.h>
+#include <mir/compositor/buffer_stream.h>
+#include <mir/graphics/buffer_basic.h>
+#include <mir/test/doubles/stub_buffer_stream.h>
+
+#include "mir_test_framework/window_management_test_harness.h"
+#include <linux/input.h>
+
+namespace ms = mir::scene;
+namespace msh = mir::shell;
+namespace geom = mir::geometry;
+namespace mg = mir::graphics;
+namespace mev = mir::events;
+using namespace testing;
+
+MATCHER_P(LockedEq, value, "")
+{
+    return arg.lock() == value;
+}
+
+class MinimalWindowManagerTest : public mir_test_framework::WindowManagementTestHarness
+{
+public:
+    auto get_builder() -> mir_test_framework::WindowManagementPolicyBuilder override
+    {
+        return [&](miral::WindowManagerTools const& tools)
+        {
+            return std::make_unique<miral::MinimalWindowManager>(tools);
+        };
+    }
+
+    auto get_output_rectangles() -> std::vector<mir::geometry::Rectangle> override
+    {
+        return {
+            mir::geometry::Rectangle{{0, 0}, {800, 600}},
+            mir::geometry::Rectangle{{800, 0}, {800, 600}}
+        };
+    }
+};
+
+TEST_F(MinimalWindowManagerTest, new_window_has_focus)
+{
+    auto const app = open_application("test");
+    msh::SurfaceSpecification spec;
+    spec.width = geom::Width {100};
+    spec.height = geom::Height{100};
+    spec.depth_layer = mir_depth_layer_application;
+    auto window = create_window(app, spec);
+    EXPECT_EQ(focused_surface(), window.operator std::shared_ptr<ms::Surface>());
+}
+
+TEST_F(MinimalWindowManagerTest, alt_f4_closes_active_window)
+{
+    auto const app = open_application("test");
+    msh::SurfaceSpecification spec;
+    spec.width = geom::Width {100};
+    spec.height = geom::Height{100};
+    spec.depth_layer = mir_depth_layer_application;
+    auto window = create_window(app, spec);
+    auto surface = window.operator std::shared_ptr<ms::Surface>();
+    EXPECT_EQ(focused_surface(), surface);
+
+    // Process an alt + f4 input
+    std::chrono::nanoseconds const event_timestamp = std::chrono::system_clock::now().time_since_epoch();
+    MirKeyboardAction const action{mir_keyboard_action_down};
+    xkb_keysym_t const keysym{0};
+    int const scan_code{KEY_F4};
+    MirInputEventModifiers const modifiers{mir_input_event_modifier_alt};
+    auto const event = mir::events::make_key_event(
+        mir_input_event_type_key,
+        event_timestamp,
+        action,
+        keysym,
+        scan_code,
+        modifiers);
+    publish_event(*event);
+
+    EXPECT_EQ(focused_surface(), nullptr);
+}
+
+TEST_F(MinimalWindowManagerTest, can_navigate_between_apps_using_alt_tab)
+{
+    // Create two apps, each with a single window
+    auto const app1 = open_application("test");
+    msh::SurfaceSpecification spec1;
+    spec1.width = geom::Width {100};
+    spec1.height = geom::Height{100};
+    spec1.depth_layer = mir_depth_layer_application;
+    auto window1 = create_window(app1, spec1);
+    auto const app2 = open_application("test-1");
+    msh::SurfaceSpecification spec2;
+    spec2.width = geom::Width {100};
+    spec2.height = geom::Height{100};
+    spec2.depth_layer = mir_depth_layer_application;
+    auto window2 = create_window(app2, spec2);
+
+    EXPECT_EQ(focused_surface(), window2.operator std::shared_ptr<ms::Surface>());
+
+    // Process an alt + tab input
+    auto const alt_tab_down_event = mir::events::make_key_event(
+        mir_input_event_type_key,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_keyboard_action_down,
+        0,
+        KEY_TAB,
+        mir_input_event_modifier_alt);
+    publish_event(*alt_tab_down_event);
+
+    // Assert that the focused window is window1
+    auto surface1 = window1.operator std::shared_ptr<ms::Surface>();
+    EXPECT_EQ(focused_surface(), surface1);
+
+    // Finish an alt + tab input
+    auto const alt_tab_upevent = mir::events::make_key_event(
+        mir_input_event_type_key,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_keyboard_action_down,
+        0,
+        KEY_LEFTALT,
+        mir_input_event_modifier_none);
+    publish_event(*alt_tab_upevent);
+
+    // Assert that the focused window is window1
+    EXPECT_EQ(focused_surface(), surface1);
+}
+
+TEST_F(MinimalWindowManagerTest, can_navigate_within_an_app_using_alt_grave)
+{
+    // Create two windows on the same app
+    auto const app1 = open_application("test");
+    msh::SurfaceSpecification spec1;
+    spec1.width = geom::Width {100};
+    spec1.height = geom::Height{100};
+    spec1.depth_layer = mir_depth_layer_application;
+    auto window1 = create_window(app1, spec1);
+
+    msh::SurfaceSpecification spec2;
+    spec2.width = geom::Width {100};
+    spec2.height = geom::Height{100};
+    spec2.depth_layer = mir_depth_layer_application;
+    auto window2 = create_window(app1, spec2);
+
+    EXPECT_EQ(focused_surface(), window2.operator std::shared_ptr<ms::Surface>());
+
+    // Process an alt + grave input
+    auto const alt_grave_down_event = mir::events::make_key_event(
+        mir_input_event_type_key,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_keyboard_action_down,
+        0,
+        KEY_GRAVE,
+        mir_input_event_modifier_alt);
+    publish_event(*alt_grave_down_event);
+
+    // Assert that the focused window is window1
+    auto surface1 = window1.operator std::shared_ptr<ms::Surface>();
+    EXPECT_EQ(focused_surface(), surface1);
+
+    // Finish an alt + grave input
+    auto const alt_grave_upevent = mir::events::make_key_event(
+        mir_input_event_type_key,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_keyboard_action_down,
+        0,
+        KEY_GRAVE,
+        mir_input_event_modifier_none);
+    publish_event(*alt_grave_upevent);
+
+    // Assert that the focused window is window1
+    EXPECT_EQ(focused_surface(), surface1);
+}
+
+TEST_F(MinimalWindowManagerTest, can_select_window_with_pointer)
+{
+    // Create two apps, each with a single window
+    auto const app1 = open_application("test");
+    msh::SurfaceSpecification spec1;
+    spec1.width = geom::Width {100};
+    spec1.height = geom::Height{100};
+    spec1.depth_layer = mir_depth_layer_application;
+    auto window1 = create_window(app1, spec1);
+    auto const app2 = open_application("test-1");
+    msh::SurfaceSpecification spec2;
+    spec2.width = geom::Width {50};
+    spec2.height = geom::Height{50};
+    spec2.depth_layer = mir_depth_layer_application;
+    auto window2 = create_window(app2, spec2);
+
+    EXPECT_EQ(focused_surface(), window2.operator std::shared_ptr<ms::Surface>());
+
+    auto const select_event = mir::events::make_pointer_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_none,
+        mir_pointer_action_button_down,
+        mir_pointer_button_primary,
+        geom::PointF{
+            window1.top_left().x.as_int() + window1.size().width.as_int() - 1,
+            window1.top_left().y.as_int() + window1.size().height.as_int() - 1},
+        {},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    publish_event(*select_event);
+
+    EXPECT_EQ(focused_surface(), window1.operator std::shared_ptr<ms::Surface>());
+}
+
+TEST_F(MinimalWindowManagerTest, can_select_window_with_touch)
+{
+    // Create two apps, each with a single window
+    auto const app1 = open_application("test");
+    msh::SurfaceSpecification spec1;
+    spec1.width = geom::Width {100};
+    spec1.height = geom::Height{100};
+    spec1.depth_layer = mir_depth_layer_application;
+    auto window1 = create_window(app1, spec1);
+    msh::SurfaceSpecification spec2;
+    spec2.width = geom::Width {50};
+    spec2.height = geom::Height{50};
+    spec2.depth_layer = mir_depth_layer_application;
+    auto window2 = create_window(app1, spec2);
+
+    EXPECT_EQ(focused_surface(), window2.operator std::shared_ptr<ms::Surface>());
+
+    auto const select_event = mir::events::make_touch_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_none);
+    mir::events::add_touch(
+        *select_event,
+        (int)std::chrono::system_clock::now().time_since_epoch().count(),
+        mir_touch_action_down,
+        mir_touch_tooltype_finger,
+        static_cast<float>(window1.top_left().x.as_int() + window1.size().width.as_int() - 1),
+        static_cast<float>(window1.top_left().y.as_int() + window1.size().height.as_int() - 1),
+        1.f, 0.f, 0.f, 0.f);
+    publish_event(*select_event);
+
+    EXPECT_EQ(focused_surface(), window1.operator std::shared_ptr<ms::Surface>());
+}
+
+TEST_F(MinimalWindowManagerTest, can_move_window_with_pointer)
+{
+    auto const app = open_application("test");
+    msh::SurfaceSpecification spec;
+    spec.width = geom::Width {100};
+    spec.height = geom::Height{100};
+    spec.depth_layer = mir_depth_layer_application;
+    auto window = create_window(app, spec);
+
+    // Start pointer movement
+    auto initial_window_position = window.top_left();
+    geom::PointF start_ptr_pos{window.top_left().x.as_int() + 50, window.top_left().y.as_int() + 50};
+    geom::PointF end_ptr_pos{window.top_left().x.as_int() + 100, window.top_left().y.as_int() + 100};
+    auto const start_event = mir::events::make_pointer_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_alt,
+        mir_pointer_action_button_down,
+        mir_pointer_button_primary,
+        start_ptr_pos,
+        {},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    publish_event(*start_event);
+
+    // Move pointer right and down
+    auto const end_event = mir::events::make_pointer_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_alt,
+        mir_pointer_action_motion,
+        mir_pointer_button_primary,
+        end_ptr_pos,
+        {},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    publish_event(*end_event);
+
+    // Assert that the window is moved
+    EXPECT_EQ(window.top_left(), geom::Point(initial_window_position.x.as_int() + 50, initial_window_position.y.as_int() + 50));
+}
+
+TEST_F(MinimalWindowManagerTest, can_move_window_with_pointer_even_when_maximized)
+{
+    auto const app = open_application("test");
+    mir::shell::SurfaceSpecification spec;
+    spec.state = mir_window_state_maximized;
+    spec.depth_layer = mir_depth_layer_application;
+    spec.width = geom::Width{100};
+    spec.height = geom::Height{100};
+    spec.top_left = geom::Point{0, 0};
+    auto window = create_window(app, spec);
+
+    // Start pointer movement
+    auto initial_window_position = window.top_left();
+    geom::PointF start_ptr_pos{window.top_left().x.as_int() + 0, window.top_left().y.as_int() + 0};
+    geom::PointF end_ptr_pos{window.top_left().x.as_int() + 50, window.top_left().y.as_int() + 50};
+    auto const start_event = mir::events::make_pointer_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_alt,
+        mir_pointer_action_button_down,
+        mir_pointer_button_primary,
+        start_ptr_pos,
+        {},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    publish_event(*start_event);
+
+    // Move pointer right and down
+    auto const end_event = mir::events::make_pointer_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_alt,
+        mir_pointer_action_motion,
+        mir_pointer_button_primary,
+        end_ptr_pos,
+        {},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    publish_event(*end_event);
+
+    // Assert that the window is moved
+    EXPECT_EQ(window.top_left(), geom::Point(initial_window_position.x.as_int() + 50, initial_window_position.y.as_int() + 50));
+
+    auto& info = tools().info_for(window);
+    EXPECT_EQ(info.state(), mir_window_state_restored);
+}
+
+TEST_F(MinimalWindowManagerTest, can_move_window_with_touch)
+{
+    auto const app = open_application("test");
+    msh::SurfaceSpecification spec;
+    spec.width = geom::Width {100};
+    spec.height = geom::Height{100};
+    spec.depth_layer = mir_depth_layer_application;
+    auto window = create_window(app, spec);
+
+    // Start pointer movement
+    auto initial_window_position = window.top_left();
+    geom::PointF start_ptr_pos{window.top_left().x.as_int() + 50, window.top_left().y.as_int() + 50};
+    geom::PointF end_ptr_pos{window.top_left().x.as_int() + 100, window.top_left().y.as_int() + 100};
+
+    // Start movement
+    auto const start_event = mir::events::make_touch_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_shift);
+    mir::events::add_touch(
+        *start_event,
+        (int)std::chrono::system_clock::now().time_since_epoch().count(),
+        mir_touch_action_down,
+        mir_touch_tooltype_finger,
+        start_ptr_pos.x.as_value(), start_ptr_pos.y.as_value(), 1.f, 0.f, 0.f, 0.f);
+
+    request_move(window, start_event->to_input());
+
+    // Move pointer right and down
+    auto const move_event = mir::events::make_touch_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_shift);
+    mir::events::add_touch(
+        *move_event,
+        (int)std::chrono::system_clock::now().time_since_epoch().count(),
+        mir_touch_action_change,
+        mir_touch_tooltype_finger,
+        end_ptr_pos.x.as_value(), end_ptr_pos.y.as_value(), 1.f, 0.f, 0.f, 0.f);
+    publish_event(*move_event);
+
+    // Assert that the window is moved
+    EXPECT_EQ(window.top_left(), geom::Point(initial_window_position.x.as_int() + 50, initial_window_position.y.as_int() + 50));
+}
+
+TEST_F(MinimalWindowManagerTest, can_resize_south_east_with_pointer)
+{
+    auto const app = open_application("test");
+    msh::SurfaceSpecification spec;
+    spec.width = geom::Width {100};
+    spec.height = geom::Height{100};
+    spec.depth_layer = mir_depth_layer_application;
+    auto window = create_window(app, spec);
+
+    // Move pointer to edge of surface to simulate starting a resize from the right edge
+    geom::PointF start_ptr_pos{100, 100};
+    geom::PointF end_ptr_pos{50, 50};
+
+    // Initiate the resize
+    auto const start_event = mir::events::make_pointer_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_none,
+        mir_pointer_action_motion,
+        mir_pointer_button_primary,
+        start_ptr_pos,
+        {},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    request_resize(
+        window,
+        start_event->to_input(),
+        mir_resize_edge_southeast);
+
+    // Move the pointer
+    auto const move_event = mir::events::make_pointer_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_none,
+        mir_pointer_action_motion,
+        mir_pointer_button_primary,
+        end_ptr_pos,
+        {},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    publish_event(*move_event);
+
+    // Assert that the window is resized
+    EXPECT_EQ(window.size(), geom::Size(50, 50));
+}
+
+TEST_F(MinimalWindowManagerTest, can_resize_south_east_with_touch)
+{
+    auto const app = open_application("test");
+    msh::SurfaceSpecification spec;
+    spec.width = geom::Width {100};
+    spec.height = geom::Height{100};
+    spec.depth_layer = mir_depth_layer_application;
+    auto window = create_window(app, spec);
+
+    // Initiate the resize
+    auto const start_event = mir::events::make_touch_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_none);
+    mir::events::add_touch(
+        *start_event,
+        (int)std::chrono::system_clock::now().time_since_epoch().count(),
+        mir_touch_action_down,
+        mir_touch_tooltype_finger,
+        100, 100, 1.f, 0.f, 0.f, 0.f);
+    request_resize(
+        window,
+        start_event->to_input(),
+        mir_resize_edge_southeast);
+
+    // Move the touch to (50, 50)
+    auto const move_event = mir::events::make_touch_event(
+        0,
+        std::chrono::system_clock::now().time_since_epoch(),
+        mir_input_event_modifier_none);
+    mir::events::add_touch(
+        *move_event,
+        (int)std::chrono::system_clock::now().time_since_epoch().count(),
+        mir_touch_action_change,
+        mir_touch_tooltype_finger,
+        50, 50, 1.f, 0.f, 0.f, 0.f);
+    publish_event(*move_event);
+
+    // Assert that the window is resized
+    EXPECT_EQ(window.size(), geom::Size(50, 50));
+}


### PR DESCRIPTION
This PR establishes an initial test harness that is suitable for `MinimalWindowManager`. We might need more harnessing for `FloatingWindowManager`, but that should come as a follow up if we need it. 

## What's new?
- Built out the `WindowManagementTestHarness`
- Wrote some initial integration tests for the `MinimalWindowManager`