### PR TITLE
Log input devices

### DIFF
--- a/include/platform/mir/input/input_report.h
+++ b/include/platform/mir/input/input_report.h
@@ -32,10 +32,6 @@ public:
 
     virtual void received_event_from_kernel(int64_t when, int type, int code, int value) = 0;
 
-    virtual void published_key_event(int dest_fd, uint32_t seq_id, int64_t event_time) = 0;
-
-    virtual void published_motion_event(int dest_fd, uint32_t seq_id, int64_t event_time) = 0;
-
     virtual void opened_input_device(char const* device_name, char const* input_platform) = 0;
     virtual void failed_to_open_input_device(char const* device_name, char const* input_platform) = 0;
 

--- a/include/platform/mir/input/input_report.h
+++ b/include/platform/mir/input/input_report.h
@@ -32,9 +32,6 @@ public:
 
     virtual void received_event_from_kernel(int64_t when, int type, int code, int value) = 0;
 
-    virtual void opened_input_device(char const* device_name, char const* input_platform) = 0;
-    virtual void failed_to_open_input_device(char const* device_name, char const* input_platform) = 0;
-
 protected:
     InputReport() = default;
     InputReport(InputReport const&) = delete;

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -435,8 +435,7 @@ void mie::Platform::device_added(libinput_device* dev)
     }
     catch(...)
     {
-        mir::log_error("Failure opening device %s", libinput_device_get_sysname(dev));
-        log_info("FAILED to opened device: %s", describe(dev).c_str());
+        log_error("Failure opening device %s", describe(dev).c_str());
     }
 }
 

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -61,7 +61,7 @@ std::string describe(libinput_device* dev)
 
     if (auto const name = libinput_device_get_name(dev))
     {
-        desc += ": " + std::string(name);
+        desc += " " + std::string(name);
     }
 
     return desc;
@@ -418,8 +418,6 @@ void mie::Platform::device_added(libinput_device* dev)
 {
     auto device_ptr = make_libinput_device(lib, dev);
 
-    log_info("Added %s", describe(dev).c_str());
-
     auto device_it = find_device(device_ptr.get());
     if (end(devices) != device_it)
     {
@@ -433,11 +431,12 @@ void mie::Platform::device_added(libinput_device* dev)
 
         input_device_registry->add_device(devices.back());
 
-        report->opened_input_device(libinput_device_get_sysname(dev), "evdev-input");
-    } catch(...)
+        log_info("Opened device: %s", describe(dev).c_str());
+    }
+    catch(...)
     {
         mir::log_error("Failure opening device %s", libinput_device_get_sysname(dev));
-        report->failed_to_open_input_device(libinput_device_get_sysname(dev), "evdev-input");
+        log_info("FAILED to opened device: %s", describe(dev).c_str());
     }
 }
 
@@ -461,7 +460,7 @@ void mie::Platform::device_removed(libinput_device* dev)
         udev_device_unref(udev_device);
     }
 
-    log_info("Removed %s", describe(dev).c_str());
+    log_info("Removed device: %s", describe(dev).c_str());
 }
 
 auto mie::Platform::find_device(libinput_device* dev) -> decltype(devices)::iterator

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -360,17 +360,17 @@ void log_configuration(std::shared_ptr<mi::DefaultDevice> const handle)
 
     if (auto const pointer_config = handle->pointer_configuration())
     {
-        result += ", " + format(pointer_config.value());
+        result += ", pointer_config=" + format(pointer_config.value());
     }
 
     if (auto const touchpad_config = handle->touchpad_configuration())
     {
-        result += ", " + format(touchpad_config.value());
+        result += ", touchpad_config=" + format(touchpad_config.value());
     }
 
     if (auto const touchscreen_config = handle->touchscreen_configuration())
     {
-        result += ", " + format(touchscreen_config.value());
+        result += ", touchscreen_config=" + format(touchscreen_config.value());
     }
 
     mir::log_info("Device configuration: %s", result.c_str());

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -28,7 +28,7 @@
 #include "mir/dispatch/multiplexing_dispatchable.h"
 #include "mir/dispatch/action_queue.h"
 #include "mir/server_action_queue.h"
-#define MIR_LOG_COMPONENT "Input"
+#define MIR_LOG_COMPONENT "input-hub"
 #include "mir/log.h"
 
 #include "boost/throw_exception.hpp"

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -218,6 +218,7 @@ struct std::formatter<mi::DeviceCapabilities>
 
         if (contains(c, DeviceCapability::pointer))
         {
+            write_delim();
             out = std::format_to(out, "pointer");
         }
 

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -355,7 +355,7 @@ auto format(MirTouchscreenConfig c)
 
 void log_configuration(std::shared_ptr<mi::DefaultDevice> const handle)
 {
-    auto result = std::format("Device configuration: {}, capabilities={}",
+    auto result = std::format("{}, capabilities={}",
                          handle->name(), format(handle->capabilities()));
 
     if (auto const pointer_config = handle->pointer_configuration())
@@ -372,6 +372,8 @@ void log_configuration(std::shared_ptr<mi::DefaultDevice> const handle)
     {
         result += ", " + format(touchscreen_config.value());
     }
+
+    mir::log_info("Device configuration: %s", result.c_str());
 }
 }
 

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -486,7 +486,8 @@ auto mi::DefaultInputDeviceHub::add_device(std::shared_ptr<InputDevice> const& d
         seat->add_device(*handle);
         dev->start(seat, input_dispatchable);
 
-        mir::log_info(std::format("Device configuration: {}", handle));
+        // Configuration changes are processed on the queue, don't log until they complete
+        queue->enqueue([handle]{ mir::log_info(std::format("Device configuration: {}", handle)); });
 
         return handle;
     }

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -443,7 +443,7 @@ struct std::formatter<std::shared_ptr<mi::DefaultDevice>>
 
         if (auto const touchpad_config = handle->touchpad_configuration())
         {
-            out = std::format_to(out, ", touchpad_config=", touchpad_config.value());
+            out = std::format_to(out, ", touchpad_config={}", touchpad_config.value());
         }
 
         if (auto const touchscreen_config = handle->touchscreen_configuration())

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -308,7 +308,7 @@ struct std::formatter<MirPointerConfig>
             break;
         }
 
-        out = std::format_to(out, "acceleration={:.2f},", c.cursor_acceleration_bias());
+        out = std::format_to(out, "acceleration_bias={:.2f},", c.cursor_acceleration_bias());
         out = std::format_to(out, "hscale={:.2f},", c.horizontal_scroll_scale());
         return std::format_to(out, "vscale={:.2f}}}", c.vertical_scroll_scale());
     }

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -196,186 +196,262 @@ mi::DefaultInputDeviceHub::DefaultInputDeviceHub(
     input_dispatchable->add_watch(device_queue);
 }
 
-namespace
+template <>
+struct std::formatter<mi::DeviceCapabilities>
 {
-auto format(mi::DeviceCapabilities c)
+    constexpr auto parse(std::format_parse_context& ctx)
+    {
+        return ctx.begin();
+    }
+
+    constexpr auto format(mi::DeviceCapabilities const& c, std::format_context& ctx) const
+    {
+        using mi::DeviceCapability;
+
+        auto out = std::format_to(ctx.out(), "{{");
+
+        auto write_delim = [&out, caps_written = false] () mutable
+        {
+            if (caps_written) out = std::format_to(out, "|");
+            caps_written = true;
+        };
+
+        if (contains(c, DeviceCapability::pointer))
+        {
+            out = std::format_to(out, "pointer");
+        }
+
+        if (contains(c, DeviceCapability::keyboard))
+        {
+            write_delim();
+            out = std::format_to(out, "keyboard");
+        }
+
+        if (contains(c, DeviceCapability::touchpad))
+        {
+            write_delim();
+            out = std::format_to(out, "touchpad");
+        }
+
+        if (contains(c, DeviceCapability::touchscreen))
+        {
+            write_delim();
+            out = std::format_to(out, "touchscreen");
+        }
+
+        if (contains(c, DeviceCapability::gamepad))
+        {
+            write_delim();
+            out = std::format_to(out, "gamepad");
+        }
+
+        if (contains(c, DeviceCapability::joystick))
+        {
+            write_delim();
+            out = std::format_to(out, "joystick");
+        }
+
+        if (contains(c, DeviceCapability::switch_))
+        {
+            write_delim();
+            out = std::format_to(out, "switch");
+        }
+
+        if (contains(c, DeviceCapability::multitouch))
+        {
+            write_delim();
+            out = std::format_to(out, "multitouch");
+        }
+
+        if (contains(c, DeviceCapability::alpha_numeric))
+        {
+            write_delim();
+            out = std::format_to(out, "alpha_numeric");
+        }
+
+        return std::format_to(out, "}}");
+    }
+};
+
+template <>
+struct std::formatter<MirPointerConfig>
 {
-    using namespace std::string_literals;
-    using mi::DeviceCapability;
-
-    auto result = "{"s;
-
-    if (contains(c, DeviceCapability::pointer))
-        result += "pointer|";
-    if (contains(c, DeviceCapability::keyboard))
-        result += "keyboard|";
-    if (contains(c, DeviceCapability::touchpad))
-        result += "touchpad|";
-    if (contains(c, DeviceCapability::touchscreen))
-        result += "touchscreen|";
-    if (contains(c, DeviceCapability::gamepad))
-        result += "gamepad|";
-    if (contains(c, DeviceCapability::joystick))
-        result += "joystick|";
-    if (contains(c, DeviceCapability::switch_))
-        result += "switch|";
-    if (contains(c, DeviceCapability::multitouch))
-        result += "multitouch|";
-    if (contains(c, DeviceCapability::alpha_numeric))
-        result += "alpha_numeric|";
-
-    if (result.length() == 1)
+    constexpr auto parse(std::format_parse_context& ctx)
     {
-        result += "}";
-    }
-    else
-    {
-        result.back() = '}';
+        return ctx.begin();
     }
 
-    return result;
-}
+    constexpr auto format(MirPointerConfig const& c, std::format_context& ctx) const
+    {
+        auto out = std::format_to(ctx.out(), "{{");
 
-auto format(MirPointerConfig c)
+        switch (c.handedness())
+        {
+        case mir_pointer_handedness_right:
+            out = std::format_to(out, "handedness=right,");
+            break;
+
+        case mir_pointer_handedness_left:
+            out = std::format_to(out, "handedness=left,");
+            break;
+        }
+
+        switch (c.acceleration())
+        {
+        case mir_pointer_acceleration_adaptive:
+            out = std::format_to(out, "acceleration=adaptive,");
+            break;
+
+        case mir_pointer_acceleration_none:
+            out = std::format_to(out, "acceleration=none,");
+            break;
+        }
+
+        out = std::format_to(out, "acceleration={:.2f},", c.cursor_acceleration_bias());
+        out = std::format_to(out, "hscale={:.2f},", c.horizontal_scroll_scale());
+        return std::format_to(out, "vscale={:.2f}}}", c.vertical_scroll_scale());
+    }
+};
+
+template <>
+struct std::formatter<MirTouchpadConfig>
 {
-    using namespace std::string_literals;
-
-    auto result = "{"s;
-
-    switch (c.handedness())
+    constexpr auto parse(std::format_parse_context& ctx)
     {
-    case mir_pointer_handedness_right:
-        result += "handedness=right,";
-        break;
-
-    case mir_pointer_handedness_left:
-        result += "handedness=left,";
-        break;
+        return ctx.begin();
     }
 
-    switch (c.acceleration())
+    constexpr auto format(MirTouchpadConfig const& c, std::format_context& ctx) const
     {
-    case mir_pointer_acceleration_adaptive:
-        result += "acceleration=adaptive,";
-        break;
+        auto out = std::format_to(ctx.out(), "{{");
 
-    case mir_pointer_acceleration_none:
-        result += "acceleration=none,";
-        break;
+        auto write_delim = [&out, caps_written = false] () mutable
+        {
+            if (caps_written) out = std::format_to(out, "|");
+            caps_written = true;
+        };
+
+        switch (c.click_mode())
+        {
+        case mir_touchpad_click_mode_none:
+            write_delim();
+            out = std::format_to(out, "click_mode=none");
+            break;
+        case mir_touchpad_click_mode_area_to_click:
+            write_delim();
+            out = std::format_to(out, "click_mode=area_to_click");
+            break;
+        case mir_touchpad_click_mode_finger_count:
+            write_delim();
+            out = std::format_to(out, "click_mode=finger_count");
+            break;
+        }
+
+        switch (c.scroll_mode())
+        {
+        case mir_touchpad_scroll_mode_none:
+            write_delim();
+            out = std::format_to(out, "scroll_mode=none");
+            break;
+
+        case mir_touchpad_scroll_mode_two_finger_scroll:
+            write_delim();
+            out = std::format_to(out, "scroll_mode=two_finger");
+            break;
+
+        case mir_touchpad_scroll_mode_edge_scroll:
+            write_delim();
+            out = std::format_to(out, "scroll_mode=edge");
+            break;
+
+        case mir_touchpad_scroll_mode_button_down_scroll:
+            write_delim();
+            out = std::format_to(out, "scroll_mode=button_down,scroll_button={},", c.button_down_scroll_button());
+            break;
+        }
+
+        if (c.tap_to_click())
+        {
+            write_delim();
+            out = std::format_to(out, "tap_to_click");
+        }
+
+        if (c.middle_mouse_button_emulation())
+        {
+            write_delim();
+            out = std::format_to(out, "middle_mouse_button_emulation");
+        }
+
+
+        if (c.disable_with_mouse())
+        {
+            write_delim();
+            out = std::format_to(out, "disable_with_mouse");
+        }
+
+        if (c.disable_while_typing())
+        {
+            write_delim();
+            out = std::format_to(out, "disable_while_typing");
+        }
+
+        return std::format_to(out, "}}");
     }
+};
 
-    result += std::format("acceleration={:.2f},", c.cursor_acceleration_bias());
-    result += std::format("hscale={:.2f},", c.horizontal_scroll_scale());
-    result += std::format("vscale={:.2f},", c.vertical_scroll_scale());
-
-    result.back() = '}';
-    return result;
-}
-
-auto format(MirTouchpadConfig c)
+template <>
+struct std::formatter<MirTouchscreenConfig>
 {
-    using namespace std::string_literals;
-
-    auto result = "{"s;
-
-    switch (c.click_mode())
+    constexpr auto parse(std::format_parse_context& ctx)
     {
-    case mir_touchpad_click_mode_none:
-        result += "click_mode=none,";
-        break;
-    case mir_touchpad_click_mode_area_to_click:
-        result += "click_mode=area_to_click,";
-        break;
-    case mir_touchpad_click_mode_finger_count:
-        result += "click_mode=finger_count,";
-        break;
+        return ctx.begin();
     }
 
-    switch (c.scroll_mode())
+    constexpr auto format(MirTouchscreenConfig const& c, std::format_context& ctx) const
     {
-    case mir_touchpad_scroll_mode_none:
-        result += "scroll_mode=none,";
-        break;
+        switch (c.mapping_mode())
+        {
+        case mir_touchscreen_mapping_mode_to_output:
+            return std::format_to(ctx.out(), "{{mapping_mode=to_output}}");
 
-    case mir_touchpad_scroll_mode_two_finger_scroll:
-        result += "scroll_mode=two_finger,";
-        break;
+        case mir_touchscreen_mapping_mode_to_display_wall:
+            return std::format_to(ctx.out(), "{{mapping_mode=to_display_wall}}");
 
-    case mir_touchpad_scroll_mode_edge_scroll:
-        result += "scroll_mode=edge,";
-        break;
-
-    case mir_touchpad_scroll_mode_button_down_scroll:
-        result += "scroll_mode=button_down,";
-        result += std::format("scroll_button={},", c.button_down_scroll_button());
-        break;
+        default:
+            return ctx.out();
+        }
     }
+};
 
-    if (c.tap_to_click())
-    {
-        result += "tap_to_click,";
-    }
-
-    if (c.middle_mouse_button_emulation())
-    {
-        result += "middle_mouse_button_emulation,";
-    }
-
-
-    if (c.disable_with_mouse())
-    {
-        result += "disable_with_mouse,";
-    }
-
-    if (c.disable_while_typing())
-    {
-        result += "disable_while_typing,";
-    }
-
-    result.back() = '}';
-    return result;
-}
-
-auto format(MirTouchscreenConfig c)
+template <>
+struct std::formatter<std::shared_ptr<mi::DefaultDevice>>
 {
-    using namespace std::string_literals;
-
-    switch (c.mapping_mode())
+    constexpr auto parse(std::format_parse_context& ctx)
     {
-    case mir_touchscreen_mapping_mode_to_output:
-        return "{mapping_mode=to_output}"s;
-
-    case mir_touchscreen_mapping_mode_to_display_wall:
-        return "{mapping_mode=to_display_wall}"s;
-
-    default:
-        return "{}"s;
-    }
-}
-
-void log_configuration(std::shared_ptr<mi::DefaultDevice> const handle)
-{
-    auto result = std::format("{}, capabilities={}",
-                         handle->name(), format(handle->capabilities()));
-
-    if (auto const pointer_config = handle->pointer_configuration())
-    {
-        result += ", pointer_config=" + format(pointer_config.value());
+        return ctx.begin();
     }
 
-    if (auto const touchpad_config = handle->touchpad_configuration())
+    auto format(std::shared_ptr<mi::DefaultDevice> const& handle, std::format_context& ctx) const
     {
-        result += ", touchpad_config=" + format(touchpad_config.value());
-    }
+        auto out = std::format_to(ctx.out(), "{}, capabilities={}", handle->name(), handle->capabilities());
 
-    if (auto const touchscreen_config = handle->touchscreen_configuration())
-    {
-        result += ", touchscreen_config=" + format(touchscreen_config.value());
-    }
+        if (auto const pointer_config = handle->pointer_configuration())
+        {
+            out = std::format_to(out, ", pointer_config={}", pointer_config.value());
+        }
 
-    mir::log_info("Device configuration: %s", result.c_str());
-}
-}
+        if (auto const touchpad_config = handle->touchpad_configuration())
+        {
+            out = std::format_to(out, ", touchpad_config=", touchpad_config.value());
+        }
+
+        if (auto const touchscreen_config = handle->touchscreen_configuration())
+        {
+            out = std::format_to(out, ", touchscreen_config={}", touchscreen_config.value());
+        }
+        return out;
+    }
+};
 
 auto mi::DefaultInputDeviceHub::add_device(std::shared_ptr<InputDevice> const& device) -> std::weak_ptr<Device>
 {
@@ -409,7 +485,7 @@ auto mi::DefaultInputDeviceHub::add_device(std::shared_ptr<InputDevice> const& d
         seat->add_device(*handle);
         dev->start(seat, input_dispatchable);
 
-        log_configuration(handle);
+        mir::log_info(std::format("Device configuration: {}", handle));
 
         return handle;
     }

--- a/src/server/report/logging/input_report.cpp
+++ b/src/server/report/logging/input_report.cpp
@@ -123,25 +123,3 @@ void mrl::InputReport::received_event_from_kernel(int64_t when, int type, int co
 
     logger->log(ml::Severity::informational, ss.str(), component());
 }
-
-void mrl::InputReport::opened_input_device(char const* device_name, char const* input_platform)
-{
-    std::stringstream ss;
-
-    ss << "Input device opened "
-       << " name=" << device_name
-       << " platform=" << input_platform;
-
-    logger->log(ml::Severity::informational, ss.str(), component());
-}
-
-void mrl::InputReport::failed_to_open_input_device(char const* device_name, char const* input_platform)
-{
-    std::stringstream ss;
-
-    ss << "Failure opening input device "
-       << " name=" << device_name
-       << " platform=" << input_platform;
-
-    logger->log(ml::Severity::informational, ss.str(), component());
-}

--- a/src/server/report/logging/input_report.cpp
+++ b/src/server/report/logging/input_report.cpp
@@ -124,30 +124,6 @@ void mrl::InputReport::received_event_from_kernel(int64_t when, int type, int co
     logger->log(ml::Severity::informational, ss.str(), component());
 }
 
-void mrl::InputReport::published_key_event(int dest_fd, uint32_t seq_id, int64_t event_time)
-{
-    std::stringstream ss;
-
-    ss << "Published key event"
-       << " seq_id=" << seq_id
-       << " time=" << ml::input_timestamp(std::chrono::nanoseconds(event_time))
-       << " dest_fd=" << dest_fd;
-
-    logger->log(ml::Severity::informational, ss.str(), component());
-}
-
-void mrl::InputReport::published_motion_event(int dest_fd, uint32_t seq_id, int64_t event_time)
-{
-    std::stringstream ss;
-
-    ss << "Published motion event"
-       << " seq_id=" << seq_id
-       << " time=" << ml::input_timestamp(std::chrono::nanoseconds(event_time))
-       << " dest_fd=" << dest_fd;
-
-    logger->log(ml::Severity::informational, ss.str(), component());
-}
-
 void mrl::InputReport::opened_input_device(char const* device_name, char const* input_platform)
 {
     std::stringstream ss;

--- a/src/server/report/logging/input_report.h
+++ b/src/server/report/logging/input_report.h
@@ -40,9 +40,6 @@ public:
 
     void received_event_from_kernel(int64_t when, int type, int code, int value) override;
 
-    void published_key_event(int dest_fd, uint32_t seq_id, int64_t event_time) override;
-    void published_motion_event(int dest_fd, uint32_t seq_id, int64_t event_time) override;
-
     void opened_input_device(char const* device_name, char const* input_platform) override;
     void failed_to_open_input_device(char const* device_name, char const* input_platform) override;
 private:

--- a/src/server/report/logging/input_report.h
+++ b/src/server/report/logging/input_report.h
@@ -40,8 +40,6 @@ public:
 
     void received_event_from_kernel(int64_t when, int type, int code, int value) override;
 
-    void opened_input_device(char const* device_name, char const* input_platform) override;
-    void failed_to_open_input_device(char const* device_name, char const* input_platform) override;
 private:
     char const* component();
     std::shared_ptr<mir::logging::Logger> const logger;

--- a/src/server/report/lttng/input_report.cpp
+++ b/src/server/report/lttng/input_report.cpp
@@ -26,13 +26,3 @@ void mir::report::lttng::InputReport::received_event_from_kernel(int64_t when, i
 {
     mir_tracepoint(mir_server_input, received_event_from_kernel, when, type, code, value);
 }
-
-void mir::report::lttng::InputReport::opened_input_device(char const* name, char const* platform)
-{
-    mir_tracepoint(mir_server_input, opened_input_device, name, platform);
-}
-
-void mir::report::lttng::InputReport::failed_to_open_input_device(char const* name, char const* platform)
-{
-    mir_tracepoint(mir_server_input, failed_to_open_input_device, name, platform);
-}

--- a/src/server/report/lttng/input_report.cpp
+++ b/src/server/report/lttng/input_report.cpp
@@ -27,16 +27,6 @@ void mir::report::lttng::InputReport::received_event_from_kernel(int64_t when, i
     mir_tracepoint(mir_server_input, received_event_from_kernel, when, type, code, value);
 }
 
-void mir::report::lttng::InputReport::published_key_event(int dest_fd, uint32_t seq_id, int64_t event_time)
-{
-    mir_tracepoint(mir_server_input, published_key_event, dest_fd, seq_id, event_time);
-}
-
-void mir::report::lttng::InputReport::published_motion_event(int dest_fd, uint32_t seq_id, int64_t event_time)
-{
-    mir_tracepoint(mir_server_input, published_motion_event, dest_fd, seq_id, event_time);
-}
-
 void mir::report::lttng::InputReport::opened_input_device(char const* name, char const* platform)
 {
     mir_tracepoint(mir_server_input, opened_input_device, name, platform);

--- a/src/server/report/lttng/input_report.h
+++ b/src/server/report/lttng/input_report.h
@@ -36,9 +36,6 @@ public:
 
     void received_event_from_kernel(int64_t when, int type, int code, int value) override;
 
-    void published_key_event(int dest_fd, uint32_t seq_id, int64_t event_time) override;
-    void published_motion_event(int dest_fd, uint32_t seq_id, int64_t event_time) override;
-
     void opened_input_device(char const* device_name, char const* input_platform) override;
     void failed_to_open_input_device(char const* device_name, char const* input_platform) override;
 private:

--- a/src/server/report/lttng/input_report.h
+++ b/src/server/report/lttng/input_report.h
@@ -36,8 +36,6 @@ public:
 
     void received_event_from_kernel(int64_t when, int type, int code, int value) override;
 
-    void opened_input_device(char const* device_name, char const* input_platform) override;
-    void failed_to_open_input_device(char const* device_name, char const* input_platform) override;
 private:
     ServerTracepointProvider tp_provider;
 };

--- a/src/server/report/null/input_report.cpp
+++ b/src/server/report/null/input_report.cpp
@@ -21,11 +21,3 @@ namespace mrn = mir::report::null;
 void mrn::InputReport::received_event_from_kernel(int64_t /* when */, int /* type */, int /* code */, int /* value */)
 {
 }
-
-void mrn::InputReport::opened_input_device(char const* /* name */, char const* /* platform */)
-{
-}
-
-void mrn::InputReport::failed_to_open_input_device(char const* /* name */, char const* /* platform */)
-{
-}

--- a/src/server/report/null/input_report.cpp
+++ b/src/server/report/null/input_report.cpp
@@ -22,14 +22,6 @@ void mrn::InputReport::received_event_from_kernel(int64_t /* when */, int /* typ
 {
 }
 
-void mrn::InputReport::published_key_event(int /* dest_fd */, uint32_t /* seq_id */, int64_t /* event_time */)
-{
-}
-
-void mrn::InputReport::published_motion_event(int /* dest_fd */, uint32_t /* seq_id */, int64_t /* event_time */)
-{
-}
-
 void mrn::InputReport::opened_input_device(char const* /* name */, char const* /* platform */)
 {
 }

--- a/src/server/report/null/input_report.h
+++ b/src/server/report/null/input_report.h
@@ -34,9 +34,6 @@ public:
     virtual ~InputReport() noexcept = default;
 
     void received_event_from_kernel(int64_t when, int type, int code, int value) override;
-
-    void opened_input_device(char const* device_name, char const* input_platform) override;
-    void failed_to_open_input_device(char const* device_name, char const* input_platform) override;
 };
 
 }

--- a/src/server/report/null/input_report.h
+++ b/src/server/report/null/input_report.h
@@ -35,9 +35,6 @@ public:
 
     void received_event_from_kernel(int64_t when, int type, int code, int value) override;
 
-    void published_key_event(int dest_fd, uint32_t seq_id, int64_t event_time) override;
-    void published_motion_event(int dest_fd, uint32_t seq_id, int64_t event_time) override;
-
     void opened_input_device(char const* device_name, char const* input_platform) override;
     void failed_to_open_input_device(char const* device_name, char const* input_platform) override;
 };


### PR DESCRIPTION
Drops some unused code from the "Input Report", and replaces the optional logging with direct logging.

This now includes logging the actual configuration of the device