### PR TITLE
bugfix: ignoring certain miral symbols purposefully due to inlining

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -143,7 +143,6 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::PrintTo(miral::Window const&, std::basic_ostream<char, std::char_traits<char> >*)@MIRAL_5.0" 5.0.0
  (c++)"miral::SessionLockListener::SessionLockListener(std::function<void ()> const&, std::function<void ()> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::SessionLockListener::operator()(mir::Server&) const@MIRAL_5.0" 5.0.0
- (c++)"miral::SessionLockListener::~SessionLockListener()@MIRAL_5.0" 5.0.0
  (c++)"miral::SetCommandLineHandler::SetCommandLineHandler(std::function<void (int, char const* const*)> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::SetCommandLineHandler::operator()(mir::Server&) const@MIRAL_5.0" 5.0.0
  (c++)"miral::SetCommandLineHandler::~SetCommandLineHandler()@MIRAL_5.0" 5.0.0
@@ -156,8 +155,6 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::StartupInternalClient::StartupInternalClient(std::function<void (wl_display*)>, std::function<void (std::weak_ptr<mir::scene::Session>)>)@MIRAL_5.0" 5.0.0
  (c++)"miral::StartupInternalClient::operator()(mir::Server&)@MIRAL_5.0" 5.0.0
  (c++)"miral::StartupInternalClient::~StartupInternalClient()@MIRAL_5.0" 5.0.0
- (c++)"miral::WaylandExtensions::Context::Context()@MIRAL_5.0" 5.0.0
- (c++)"miral::WaylandExtensions::Context::~Context()@MIRAL_5.0" 5.0.0
  (c++)"miral::WaylandExtensions::EnableInfo::app() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WaylandExtensions::EnableInfo::name() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WaylandExtensions::EnableInfo::user_preference() const@MIRAL_5.0" 5.0.0
@@ -393,7 +390,6 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::equivalent_display_area(miral::Output const&, miral::Output const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::kill(std::shared_ptr<mir::scene::Session> const&, int)@MIRAL_5.0" 5.0.0
  (c++)"miral::name_of[abi:cxx11](std::shared_ptr<mir::scene::Session> const&)@MIRAL_5.0" 5.0.0
- (c++)"miral::operator!=(miral::Window const&, std::shared_ptr<mir::scene::Surface> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::operator<(miral::Window const&, miral::Window const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::operator==(miral::Output::PhysicalSizeMM const&, miral::Output::PhysicalSizeMM const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::operator==(miral::Window const&, miral::Window const&)@MIRAL_5.0" 5.0.0
@@ -436,5 +432,4 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"typeinfo for miral::WindowManagementPolicy@MIRAL_5.0" 5.0.0
  (c++)"vtable for miral::CanonicalWindowManagerPolicy@MIRAL_5.0" 5.0.0
  (c++)"vtable for miral::MinimalWindowManager@MIRAL_5.0" 5.0.0
- (c++)"vtable for miral::WaylandExtensions::Context@MIRAL_5.0" 5.0.0
  (c++)"vtable for miral::WindowManagementPolicy@MIRAL_5.0" 5.0.0

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -124,7 +124,6 @@ global:
     miral::PrependEventFilter::PrependEventFilter*;
     miral::PrependEventFilter::operator*;
     miral::PrintTo*;
-    miral::SessionLockListener::?SessionLockListener*;
     miral::SessionLockListener::SessionLockListener*;
     miral::SessionLockListener::operator*;
     miral::SetCommandLineHandler::?SetCommandLineHandler*;
@@ -140,8 +139,6 @@ global:
     miral::StartupInternalClient::StartupInternalClient*;
     miral::StartupInternalClient::operator*;
     miral::WaylandExtensions::?WaylandExtensions*;
-    miral::WaylandExtensions::Context::?Context*;
-    miral::WaylandExtensions::Context::Context*;
     miral::WaylandExtensions::Context::operator*;
     miral::WaylandExtensions::EnableInfo::app*;
     miral::WaylandExtensions::EnableInfo::name*;
@@ -451,9 +448,7 @@ global:
     vtable?for?miral::CanonicalWindowManagerPolicy;
     vtable?for?miral::FdHandle;
     vtable?for?miral::MinimalWindowManager;
-    vtable?for?miral::WaylandExtensions::Context;
     vtable?for?miral::WindowManagementPolicy;
   };
 local: *;
 };
-

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -262,6 +262,7 @@ global:
     mir::compositor::Stream::Stream*;
     mir::compositor::Stream::has_submitted_buffer*;
     mir::compositor::Stream::lock_compositor_buffer*;
+    mir::compositor::Stream::next_submission_for_compositor*;
     mir::compositor::Stream::pixel_format*;
     mir::compositor::Stream::set_frame_posted_callback*;
     mir::compositor::Stream::set_scale*;
@@ -783,6 +784,7 @@ global:
     non-virtual?thunk?to?mir::ServerConfiguration::?ServerConfiguration*;
     non-virtual?thunk?to?mir::ServerStatusListener::?ServerStatusListener*;
     non-virtual?thunk?to?mir::compositor::BufferStream::?BufferStream*;
+    non-virtual?thunk?to?mir::compositor::BufferStream::Submission::?Submission*;
     non-virtual?thunk?to?mir::compositor::Compositor::?Compositor*;
     non-virtual?thunk?to?mir::compositor::CompositorReport::?CompositorReport*;
     non-virtual?thunk?to?mir::compositor::DisplayBufferCompositor::?DisplayBufferCompositor*;
@@ -794,6 +796,7 @@ global:
     non-virtual?thunk?to?mir::compositor::Stream::?Stream*;
     non-virtual?thunk?to?mir::compositor::Stream::has_submitted_buffer*;
     non-virtual?thunk?to?mir::compositor::Stream::lock_compositor_buffer*;
+    non-virtual?thunk?to?mir::compositor::Stream::next_submission_for_compositor*;
     non-virtual?thunk?to?mir::compositor::Stream::pixel_format*;
     non-virtual?thunk?to?mir::compositor::Stream::set_frame_posted_callback*;
     non-virtual?thunk?to?mir::compositor::Stream::set_scale*;
@@ -1237,6 +1240,7 @@ global:
     vtable?for?mir::ServerActionQueue;
     vtable?for?mir::ServerConfiguration;
     vtable?for?mir::ServerStatusListener;
+    vtable?for?mir::compositor::BufferStream::Submission;
     vtable?for?mir::compositor::BufferStream;
     vtable?for?mir::compositor::Compositor;
     vtable?for?mir::compositor::CompositorReport;


### PR DESCRIPTION
## What's new?
- The symbols generator script now has a "quirk" check to filter out symbols that we do not want to generate
- Removed a few miral symbols purposefully because they cause us headaches