### PR TITLE
(#3414) Don't re-send wl_output.geometry if unchanged

### DIFF
--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -226,10 +226,6 @@ void mf::OutputGlobal::bind(wl_resource* resource)
     instances[instance->client].push_back(instance);
     instance->output_config_changed(output_config);
     instance->send_done();
-    for (auto const& listener : listeners)
-    {
-        listener->output_config_changed(output_config);
-    }
 }
 
 void mf::OutputGlobal::instance_destroyed(OutputInstance* instance)


### PR DESCRIPTION
Fixes #3414

Removes a duplicate call to `OutputConfigListener::output_config_changed` during the binding of the output object.