### PR TITLE
spread: drop cross-build from `ubuntu` task

### DIFF
--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -26,40 +26,6 @@ execute: |
       dpkg-dev \
       $( $NODBG || echo wlcs-dbgsym )
 
-    # set host and build environment up
-    source <( dpkg-architecture --print-set --host-arch ${ARCH} )
-
-    # if cross-building
-    if [ "${DEB_BUILD_ARCH}" != "${DEB_HOST_ARCH}" ]; then
-        # add host architecture
-        dpkg --add-architecture "${DEB_HOST_ARCH}"
-
-        # don't run tests
-        DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS} nocheck"
-
-        # limit existing apt sources to build architecture
-        sed -i "s/^deb \(\[arch=.*\] \)\?/deb [arch=${DEB_BUILD_ARCH}] /" \
-          /etc/apt/sources.list
-
-        case "${DEB_HOST_ARCH}" in
-          amd64|i386)
-            ARCHIVE_URL="http://archive.ubuntu.com/ubuntu"
-            ;;
-          *)
-            ARCHIVE_URL="http://ports.ubuntu.com/ubuntu-ports"
-            ;;
-        esac
-
-        # add host architecture apt sources
-        printf "deb [arch=${DEB_HOST_ARCH}] ${ARCHIVE_URL} \
-          %s main multiverse universe restricted\n" \
-          $(lsb_release -sc){,-security,-updates} \
-        > /etc/apt/sources.list.d/cross-${DEB_HOST_ARCH}.list
-
-        apt-get update
-        apt-get --yes install qemu-user-static binfmt-support
-    fi
-
     # Mark the "release" in the changelog
     debchange --release "CI release"
 


### PR DESCRIPTION
We're only cross-building in `sbuild`.