### PR TITLE
bugfix: screenshots now respect the `GLConfig` and contain a depth + stencil buffer when one is required

### DIFF
--- a/src/platforms/common/server/cpu_copy_output_surface.cpp
+++ b/src/platforms/common/server/cpu_copy_output_surface.cpp
@@ -145,6 +145,7 @@ private:
     EGLContext const ctx;
     DRMFormat const format;
     RenderbufferHandle const colour_buffer;
+    RenderbufferHandle const depth_stencil_render_buffer;
     FramebufferHandle const fbo;
 };
 
@@ -200,8 +201,13 @@ mgc::CPUCopyOutputSurface::Impl::Impl(
     glBindRenderbuffer(GL_RENDERBUFFER, colour_buffer);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8_OES, size().width.as_int(), size().height.as_int());
 
+    glBindRenderbuffer(GL_RENDERBUFFER, depth_stencil_render_buffer);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size().width.as_int(), size().height.as_int());
+
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, colour_buffer);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depth_stencil_render_buffer);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth_stencil_render_buffer);
 
     auto status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)

--- a/src/platforms/common/server/cpu_copy_output_surface.cpp
+++ b/src/platforms/common/server/cpu_copy_output_surface.cpp
@@ -24,6 +24,7 @@
 
 #include "mir/graphics/egl_error.h"
 #include "mir/graphics/platform.h"
+#include "mir/graphics/gl_config.h"
 #include "mir/log.h"
 
 #include "cpu_copy_output_surface.h"
@@ -127,7 +128,8 @@ public:
     Impl(
         EGLDisplay dpy,
         EGLContext share_ctx,
-        mg::CPUAddressableDisplayAllocator& allocator);
+        mg::CPUAddressableDisplayAllocator& allocator,
+        GLConfig const& config);
 
     void bind();
 
@@ -145,15 +147,16 @@ private:
     EGLContext const ctx;
     DRMFormat const format;
     RenderbufferHandle const colour_buffer;
-    RenderbufferHandle const depth_stencil_render_buffer;
+    std::shared_ptr<RenderbufferHandle> depth_stencil_buffer;
     FramebufferHandle const fbo;
 };
 
 mgc::CPUCopyOutputSurface::CPUCopyOutputSurface(
         EGLDisplay dpy,
         EGLContext share_ctx,
-        mg::CPUAddressableDisplayAllocator& allocator)
-        : impl{std::make_unique<Impl>(dpy, share_ctx, allocator)}
+        mg::CPUAddressableDisplayAllocator& allocator,
+        GLConfig const& config)
+        : impl{std::make_unique<Impl>(dpy, share_ctx, allocator, config)}
 {
 }
 
@@ -192,7 +195,8 @@ auto mgc::CPUCopyOutputSurface::layout() const -> Layout
 mgc::CPUCopyOutputSurface::Impl::Impl(
     EGLDisplay dpy,
     EGLContext share_ctx,
-    mg::CPUAddressableDisplayAllocator& allocator)
+    mg::CPUAddressableDisplayAllocator& allocator,
+    GLConfig const& config)
     : allocator{allocator},
       dpy{dpy},
       ctx{create_current_context(dpy, share_ctx)},
@@ -201,13 +205,20 @@ mgc::CPUCopyOutputSurface::Impl::Impl(
     glBindRenderbuffer(GL_RENDERBUFFER, colour_buffer);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8_OES, size().width.as_int(), size().height.as_int());
 
-    glBindRenderbuffer(GL_RENDERBUFFER, depth_stencil_render_buffer);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size().width.as_int(), size().height.as_int());
+    if (config.depth_buffer_bits() || config.stencil_buffer_bits())
+    {
+        depth_stencil_buffer = std::make_shared<RenderbufferHandle>();
+        glBindRenderbuffer(GL_RENDERBUFFER, depth_stencil_buffer->operator GLuint());
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size().width.as_int(), size().height.as_int());
+    }
 
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, colour_buffer);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depth_stencil_render_buffer);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth_stencil_render_buffer);
+    if (depth_stencil_buffer)
+    {
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depth_stencil_buffer->operator GLuint());
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth_stencil_buffer->operator GLuint());
+    }
 
     auto status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE)

--- a/src/platforms/common/server/cpu_copy_output_surface.h
+++ b/src/platforms/common/server/cpu_copy_output_surface.h
@@ -26,7 +26,6 @@
 
 namespace mir::graphics
 {
-
 namespace common
 {
 class CPUCopyOutputSurface : public gl::OutputSurface
@@ -35,7 +34,8 @@ public:
     CPUCopyOutputSurface(
         EGLDisplay dpy,
         EGLContext share_ctx,
-        CPUAddressableDisplayAllocator& allocator);
+        CPUAddressableDisplayAllocator& allocator,
+        GLConfig const& config);
 
     ~CPUCopyOutputSurface() override;
 

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -758,7 +758,8 @@ auto mge::GLRenderingProvider::surface_for_sink(
         return std::make_unique<mgc::CPUCopyOutputSurface>(
             dpy,
             static_cast<EGLContext>(*ctx),
-            *cpu_provider);
+            *cpu_provider,
+            gl_config);
     }
     BOOST_THROW_EXCEPTION((std::runtime_error{"DisplayInterfaceProvider does not support any viable output interface"}));
 }

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -534,7 +534,8 @@ auto mgg::GLRenderingProvider::surface_for_sink(
     return std::make_unique<mgc::CPUCopyOutputSurface>(
         dpy,
         ctx,
-        *cpu_allocator);
+        *cpu_allocator,
+        config);
 }
 
 auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -439,7 +439,8 @@ auto mge::GLRenderingProvider::surface_for_sink(
     return std::make_unique<mgc::CPUCopyOutputSurface>(
         dpy,
         ctx,
-        *cpu_provider);
+        *cpu_provider,
+        config);
 }
 
 auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)

--- a/src/server/compositor/basic_screen_shooter.h
+++ b/src/server/compositor/basic_screen_shooter.h
@@ -45,7 +45,8 @@ public:
         std::shared_ptr<time::Clock> const& clock,
         Executor& executor,
         std::span<std::shared_ptr<graphics::GLRenderingProvider>> const& providers,
-        std::shared_ptr<renderer::RendererFactory> render_factory);
+        std::shared_ptr<renderer::RendererFactory> render_factory,
+        std::shared_ptr<mir::graphics::GLConfig> const& config);
 
     void capture(
         std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
@@ -61,7 +62,8 @@ private:
             std::shared_ptr<Scene> const& scene,
             std::shared_ptr<time::Clock> const& clock,
             std::shared_ptr<graphics::GLRenderingProvider> provider,
-            std::shared_ptr<renderer::RendererFactory> render_factory);
+            std::shared_ptr<renderer::RendererFactory> render_factory,
+            std::shared_ptr<mir::graphics::GLConfig> const& config);
 
         auto render(
             std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
@@ -85,6 +87,7 @@ private:
 
         std::unique_ptr<graphics::DisplaySink> offscreen_sink;
         std::shared_ptr<OneShotBufferDisplayProvider> const output;
+        std::shared_ptr<mir::graphics::GLConfig> config;
     };
     std::shared_ptr<Self> const self;
     Executor& executor;

--- a/src/server/compositor/default_configuration.cpp
+++ b/src/server/compositor/default_configuration.cpp
@@ -113,12 +113,14 @@ auto mir::DefaultServerConfiguration::the_screen_shooter() -> std::shared_ptr<co
                 {
                     BOOST_THROW_EXCEPTION((std::runtime_error{"No platform provides GL rendering support"}));
                 }
+
                 return std::make_shared<compositor::BasicScreenShooter>(
                     the_scene(),
                     the_clock(),
                     thread_pool_executor,
                     providers,
-                    the_renderer_factory());
+                    the_renderer_factory(),
+                    the_gl_config());
             }
             catch (...)
             {

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -31,6 +31,7 @@
 #include "mir/test/doubles/stub_buffer.h"
 #include "mir/test/doubles/stub_scene_element.h"
 #include "mir/test/doubles/stub_renderable.h"
+#include "mir/test/doubles/stub_gl_config.h"
 
 #include <gtest/gtest.h>
 
@@ -105,7 +106,8 @@ struct BasicScreenShooter : Test
             clock,
             executor,
             gl_providers,
-            renderer_factory);
+            renderer_factory,
+            std::make_shared<mtd::StubGLConfig>());
     }
 
     std::unique_ptr<mtd::MockRenderer> next_renderer{std::make_unique<testing::NiceMock<mtd::MockRenderer>>()};
@@ -246,7 +248,8 @@ TEST_F(BasicScreenShooter, ensures_renderer_is_current_on_only_one_thread)
         clock,
         mir::thread_pool_executor,
         gl_providers,
-        renderer_factory);
+        renderer_factory,
+        std::make_shared<mtd::StubGLConfig>());
 
     ON_CALL(*next_renderer, render(_))
         .WillByDefault(


### PR DESCRIPTION
fixes #3438

## What's new?
- `BasicScreenShooter` now respects the `GLConfig`
- When depth and stencil bits are provided, we create a render buffer for them

I was unable to make separate stencil/depth buffers worked, but it is _apparently_ recommended that they are combined. I don't know if this will have any major issues...