### PR TITLE
frontend/wayland: `wp_viewporter` support

### DIFF
--- a/include/platform/mir/graphics/renderable.h
+++ b/include/platform/mir/graphics/renderable.h
@@ -51,6 +51,13 @@ public:
     virtual std::shared_ptr<Buffer> buffer() const = 0;
 
     virtual geometry::Rectangle screen_position() const = 0;
+    /**
+     * The region of \ref buffer that should be sampled from.
+     *
+     * This is in buffer coordinates, so {{0, 0}, {buffer->size().width, buffer->size().height} means
+     * “use the whole buffer”.
+     */
+    virtual geometry::RectangleD src_bounds() const = 0;
     virtual std::optional<geometry::Rectangle> clip_area() const = 0;
 
     // These are from the old CompositingCriteria. There is a little bit

--- a/src/gl/tessellation_helpers.cpp
+++ b/src/gl/tessellation_helpers.cpp
@@ -14,32 +14,58 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 #include "mir/gl/tessellation_helpers.h"
+#include "mir/geometry/forward.h"
 #include "mir/graphics/renderable.h"
 #include "mir/graphics/buffer.h"
 
 namespace mg = mir::graphics;
 namespace mgl = mir::gl;
 namespace geom = mir::geometry;
+
+namespace
+{
+struct SrcTexCoords
+{
+    GLfloat top;
+    GLfloat bottom;
+    GLfloat left;
+    GLfloat right;
+};
+
+auto tex_coords_from_rect(geom::Size buffer_size, geom::RectangleD sample_rect) -> SrcTexCoords
+{
+    /* GL Texture coordinates are normalised to the size of the buffer, so (0.0, 0.0) is the top-left
+     * and (1.0, 1.0) is the bottom-right
+     */
+    SrcTexCoords coords;
+    coords.top = sample_rect.top().as_value() / buffer_size.height.as_uint32_t();
+    coords.bottom = sample_rect.bottom().as_value() / buffer_size.height.as_uint32_t();
+    coords.left = sample_rect.left().as_value() / buffer_size.width.as_uint32_t();
+    coords.right = sample_rect.right().as_value() / buffer_size.width.as_uint32_t();
+    return coords;
+}
+}
+
 mgl::Primitive mgl::tessellate_renderable_into_rectangle(
     mg::Renderable const& renderable, geom::Displacement const& offset)
 {
     auto rect = renderable.screen_position();
     rect.top_left = rect.top_left - offset;
-    GLfloat left = rect.top_left.x.as_int();
-    GLfloat right = left + rect.size.width.as_int();
-    GLfloat top = rect.top_left.y.as_int();
-    GLfloat bottom = top + rect.size.height.as_int();
+    GLfloat const left = rect.top_left.x.as_int();
+    GLfloat const right = left + rect.size.width.as_int();
+    GLfloat const top = rect.top_left.y.as_int();
+    GLfloat const bottom = top + rect.size.height.as_int();
 
     mgl::Primitive rectangle;
     rectangle.type = GL_TRIANGLE_STRIP;
 
-    GLfloat const tex_right = 1.0f;
-    GLfloat const tex_bottom = 1.0f;
+    auto const [tex_top, tex_bottom, tex_left, tex_right] =
+        tex_coords_from_rect(renderable.buffer()->size(), renderable.src_bounds());
 
     auto& vertices = rectangle.vertices;
-    vertices[0] = {{left,  top,    0.0f}, {0.0f,      0.0f}};
-    vertices[1] = {{left,  bottom, 0.0f}, {0.0f,      tex_bottom}};
-    vertices[2] = {{right, top,    0.0f}, {tex_right, 0.0f}};
+    vertices[0] = {{left,  top,    0.0f}, {tex_left, tex_top}};
+    vertices[1] = {{left,  bottom, 0.0f}, {tex_left, tex_bottom}};
+    vertices[2] = {{right, top,    0.0f}, {tex_right, tex_top}};
     vertices[3] = {{right, bottom, 0.0f}, {tex_right, tex_bottom}};
     return rectangle;
 }

--- a/src/include/gl/mir/gl/tessellation_helpers.h
+++ b/src/include/gl/mir/gl/tessellation_helpers.h
@@ -18,6 +18,7 @@
 #define MIR_GL_TESSELLATION_HELPERS_H_
 #include "mir/gl/primitive.h"
 #include "mir/geometry/displacement.h"
+#include "mir/geometry/rectangle.h"
 
 namespace mir
 {

--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -62,6 +62,7 @@ set(
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/frontend/pointer_input_dispatcher.h
   session_credentials.cpp
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/frontend/buffer_stream.h
+  wp_viewporter.cpp             wp_viewporter.h
 )
 
 add_custom_command(

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -28,6 +28,7 @@
 #include "wayland_executor.h"
 #include "desktop_file_manager.h"
 #include "foreign_toplevel_manager_v1.h"
+#include "wp_viewporter.h"
 
 #include "mir/main_loop.h"
 #include "mir/thread_name.h"
@@ -328,6 +329,8 @@ mf::WaylandConnector::WaylandConnector(
         session_lock_});
 
     shm_global = std::make_unique<WlShm>(display.get(), executor);
+
+    viewporter = std::make_unique<WpViewporter>(display.get());
 
     char const* wayland_display = nullptr;
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -84,6 +84,7 @@ class WlSeat;
 class WlShm;
 class WlSubcompositor;
 class WlSurface;
+class WpViewporter;
 class DesktopFileManager;
 
 class WaylandExtensions
@@ -207,6 +208,7 @@ private:
     std::shared_ptr<DesktopFileManager> desktop_file_manager;
     std::unique_ptr<WlDataDeviceManager> data_device_manager_global;
     std::unique_ptr<WlShm> shm_global;
+    std::unique_ptr<WpViewporter> viewporter;
     std::shared_ptr<Executor> const executor;
     std::shared_ptr<graphics::GraphicBufferAllocator> const allocator;
     std::shared_ptr<shell::Shell> const shell;

--- a/src/server/frontend_wayland/wp_viewporter.cpp
+++ b/src/server/frontend_wayland/wp_viewporter.cpp
@@ -1,0 +1,150 @@
+
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "wp_viewporter.h"
+#include "mir/geometry/forward.h"
+#include "mir/wayland/protocol_error.h"
+#include "mir/wayland/weak.h"
+#include "wl_surface.h"
+
+#include <utility>
+
+namespace mf = mir::frontend;
+
+namespace
+{
+class ViewporterInstance : public mir::wayland::Viewporter
+{
+public:
+    ViewporterInstance(wl_resource* resource)
+        : Viewporter(resource, Version<1>{})
+    {
+    }
+
+private:
+    void get_viewport(wl_resource* id, wl_resource* surface) override
+    {
+        auto surf = mf::WlSurface::from(surface);
+        try
+        {
+            new mf::Viewport(id, surf);
+        }
+        catch (std::logic_error const&)
+        {
+            // We get a std::logic_error if the surface already had a viewport; translate to protocol exception here
+            throw mir::wayland::ProtocolError{
+                resource,
+                Viewporter::Error::viewport_exists,
+                "Surface already has a viewport associated"};
+        }
+    }
+};
+}
+
+mf::WpViewporter::WpViewporter(wl_display* display)
+    : Global(display, Version<1>{})
+{   
+}
+
+void mf::WpViewporter::bind(wl_resource* new_resource)
+{
+    new ViewporterInstance(new_resource);
+}
+
+mf::Viewport::Viewport(wl_resource* new_viewport, WlSurface* surface)
+    : wayland::Viewport(new_viewport, Version<1>{})
+{
+    surface->associate_viewport(wayland::make_weak<Viewport>(this));
+    this->surface = wayland::make_weak<wayland::Surface>(surface);
+}
+
+mf::Viewport::~Viewport()
+{
+}
+
+auto mf::Viewport::dirty() -> bool
+{
+    return std::exchange(dirty_, false);
+}
+
+void mf::Viewport::set_source(double x, double y, double width, double height)
+{
+    if (!surface)
+    {
+        throw wayland::ProtocolError{
+            resource,
+            Error::no_surface,
+            "Surface associated with viewport has been destroyed"};
+    }
+    // We know the parameters are coming from a 16.16 wl_fixed value, so doubles give exact representation
+    if (x < 0 || y < 0 || width <= 0 || height <= 0)
+    {
+        // All values == -1 means “unset the source viewport”
+        if ((x == y) && (y == width) && (width == height) && (height == -1.0f))
+        {
+            source = std::nullopt;
+        }
+        else
+        {
+            throw wayland::ProtocolError{
+                resource,
+                Error::bad_value,
+                "Source viewport (%f, %f), (%f × %f) invalid: (x,y) must be non-negative, (width, height) must be positive",
+                x, y,
+                width, height
+            };
+        }
+    }
+    else
+    {
+        source = geometry::RectangleD{{x, y}, {width, height}};
+    }
+    dirty_ = true;
+}
+
+void mf::Viewport::set_destination(int32_t width, int32_t height)
+{
+    if (!surface)
+    {
+        throw wayland::ProtocolError{
+            resource,
+            Error::no_surface,
+            "Surface associated with viewport has been destroyed"};
+    }
+    if (width <= 0 || height <= 0)
+    {
+        if (width == -1 && height == -1)
+        {
+            destination = std::nullopt;
+        }
+        else
+        {
+            throw wayland::ProtocolError{
+                resource,
+                Error::bad_value,
+                "Destination viewport (%i × %i) invalid: (width, height) must both be positive",
+                width, height
+            };
+        }
+    }
+    else
+    {   
+        destination = geometry::Size{width, height};
+    }
+
+    dirty_ = true;
+}

--- a/src/server/frontend_wayland/wp_viewporter.h
+++ b/src/server/frontend_wayland/wp_viewporter.h
@@ -1,0 +1,65 @@
+
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_FRONTEND_WP_VIEWPORTER_H
+#define MIR_FRONTEND_WP_VIEWPORTER_H
+
+#include "mir/wayland/weak.h"
+#include "viewporter_wrapper.h"
+#include "wayland_wrapper.h"
+
+#include "mir/geometry/rectangle.h"
+
+#include <optional>
+
+namespace mir::frontend
+{
+class WlSurface;
+
+class WpViewporter : public wayland::Viewporter::Global
+{
+public:
+    WpViewporter(wl_display* display);
+
+private:
+    void bind(wl_resource* new_wp_viewporter) override;
+};
+
+class Viewport : public wayland::Viewport
+{
+public:
+    Viewport(wl_resource* new_viewport, WlSurface* surface);
+    ~Viewport() override;
+
+    // Threadsafety: This is a Wayland object, these should only be referenced on the Wayland mainloop
+    std::optional<geometry::RectangleD> source;
+    std::optional<geometry::Size> destination;
+
+    /**
+     * Have the source or destination values changed since the last call to dirty()?
+     */
+    auto dirty() -> bool;
+private:
+    void set_source(double x, double y, double width, double height) override;
+    void set_destination(int32_t width, int32_t height) override;
+
+    bool dirty_;
+    wayland::Weak<wayland::Surface> surface;
+};
+}
+
+#endif // MIR_FRONTEND_WP_VIEWPORTER_H

--- a/src/server/graphics/software_cursor.cpp
+++ b/src/server/graphics/software_cursor.cpp
@@ -80,6 +80,11 @@ public:
         return {position, buffer_->size()};
     }
 
+    geom::RectangleD src_bounds() const override
+    {
+        return {geom::PointD{0, 0}, geom::SizeD{buffer_->size()}};
+    }
+
     std::optional<geometry::Rectangle> clip_area() const override
     {
         return std::optional<geometry::Rectangle>();

--- a/src/server/input/touchspot_controller.cpp
+++ b/src/server/input/touchspot_controller.cpp
@@ -63,6 +63,11 @@ public:
         return {position, buffer_->size()};
     }
 
+    geom::RectangleD src_bounds() const override
+    {
+        return {{0, 0}, geom::SizeD{buffer_->size()}};
+    }
+
     std::optional<geometry::Rectangle> clip_area() const override
     {
         return std::optional<geometry::Rectangle>();

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -719,6 +719,9 @@ public:
     geom::Rectangle screen_position() const override
     { return screen_position_; }
 
+    geom::RectangleD src_bounds() const override
+    { return entry->source_rect(); }
+
     std::optional<geom::Rectangle> clip_area() const override
     { return clip_area_; }
 

--- a/src/server/shell/basic_idle_handler.cpp
+++ b/src/server/shell/basic_idle_handler.cpp
@@ -65,6 +65,11 @@ public:
         return {{-coverage_size / 2, -coverage_size / 2}, {coverage_size, coverage_size}};
     }
 
+    auto src_bounds() const -> geom::RectangleD override
+    {
+        return {{0, 0}, geom::SizeD{buffer_->size()}};
+    }
+
     auto clip_area() const -> std::optional<geom::Rectangle> override
     {
         return {};

--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -36,6 +36,7 @@ mir_generate_protocol_wrapper(mirwayland "z" wlr-screencopy-unstable-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "zwlr_" wlr-virtual-pointer-unstable-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "ext_" ext-session-lock-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "zmir_" mir-shell-unstable-v1.xml)
+mir_generate_protocol_wrapper(mirwayland "wp_" viewporter.xml)
 
 target_link_libraries(mirwayland
   PUBLIC

--- a/tests/acceptance-tests/wayland/miral_integration.cpp
+++ b/tests/acceptance-tests/wayland/miral_integration.cpp
@@ -31,7 +31,8 @@ WlcsExtensionDescriptor const extensions[] = {
     {"zxdg_shell_unstable_v6",      1},
     {"wlr_layer_shell_unstable_v1", 1},
     {"zwp_pointer_constraints_v1",  1},
-    {"zwp_relative_pointer_manager_v1", 1}
+    {"zwp_relative_pointer_manager_v1", 1},
+    {"wp_viewporter", 1},
 };
 
 WlcsIntegrationDescriptor const descriptor{

--- a/tests/include/mir/test/doubles/fake_renderable.h
+++ b/tests/include/mir/test/doubles/fake_renderable.h
@@ -92,6 +92,11 @@ public:
     {
         return rect;
     }
+
+    geometry::RectangleD src_bounds() const override
+    {
+        return {{0, 0}, geometry::SizeD{buf->size()}};
+    }
     
     std::optional<geometry::Rectangle> clip_area() const override
     {

--- a/tests/include/mir/test/doubles/mock_renderable.h
+++ b/tests/include/mir/test/doubles/mock_renderable.h
@@ -48,6 +48,7 @@ struct MockRenderable : public graphics::Renderable
     MOCK_CONST_METHOD0(id, ID());
     MOCK_CONST_METHOD0(buffer, std::shared_ptr<graphics::Buffer>());
     MOCK_CONST_METHOD0(screen_position, geometry::Rectangle());
+    MOCK_CONST_METHOD0(src_bounds, geometry::RectangleD());
     MOCK_CONST_METHOD0(clip_area, std::optional<geometry::Rectangle>());
     MOCK_CONST_METHOD0(alpha, float());
     MOCK_CONST_METHOD0(transformation, glm::mat4());

--- a/tests/include/mir/test/doubles/stub_renderable.h
+++ b/tests/include/mir/test/doubles/stub_renderable.h
@@ -72,6 +72,10 @@ public:
     {
         return rect;
     }
+    geometry::RectangleD src_bounds() const override
+    {
+        return {{0, 0}, geometry::SizeD{stub_buffer->size()}};
+    }
     std::optional<geometry::Rectangle> clip_area() const override
     {
         return std::optional<geometry::Rectangle>();

--- a/tests/platform_test_harness/graphics_platform_test_harness.cpp
+++ b/tests/platform_test_harness/graphics_platform_test_harness.cpp
@@ -426,6 +426,11 @@ void basic_software_buffer_drawing(
             return mir::geometry::Rectangle{top_left, buffer()->size()};
         }
 
+        auto src_bounds() const -> mir::geometry::RectangleD override
+        {
+            return {{0, 0}, mir::geometry::SizeD{buffer()->size()}};
+        }
+
         auto alpha() const -> float override
         {
             return 1.0f;

--- a/wayland-protocols/viewporter.xml
+++ b/wayland-protocols/viewporter.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="viewporter">
+
+  <copyright>
+    Copyright © 2013-2016 Collabora, Ltd.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="wp_viewporter" version="1">
+    <description summary="surface cropping and scaling">
+      The global interface exposing surface cropping and scaling
+      capabilities is used to instantiate an interface extension for a
+      wl_surface object. This extended interface will then allow
+      cropping and scaling the surface contents, effectively
+      disconnecting the direct relationship between the buffer and the
+      surface size.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unbind from the cropping and scaling interface">
+	Informs the server that the client will not be using this
+	protocol object anymore. This does not affect any other objects,
+	wp_viewport objects included.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="viewport_exists" value="0"
+             summary="the surface already has a viewport object associated"/>
+    </enum>
+
+    <request name="get_viewport">
+      <description summary="extend surface interface for crop and scale">
+	Instantiate an interface extension for the given wl_surface to
+	crop and scale its content. If the given wl_surface already has
+	a wp_viewport object associated, the viewport_exists
+	protocol error is raised.
+      </description>
+      <arg name="id" type="new_id" interface="wp_viewport"
+           summary="the new viewport interface id"/>
+      <arg name="surface" type="object" interface="wl_surface"
+           summary="the surface"/>
+    </request>
+  </interface>
+
+  <interface name="wp_viewport" version="1">
+    <description summary="crop and scale interface to a wl_surface">
+      An additional interface to a wl_surface object, which allows the
+      client to specify the cropping and scaling of the surface
+      contents.
+
+      This interface works with two concepts: the source rectangle (src_x,
+      src_y, src_width, src_height), and the destination size (dst_width,
+      dst_height). The contents of the source rectangle are scaled to the
+      destination size, and content outside the source rectangle is ignored.
+      This state is double-buffered, see wl_surface.commit.
+
+      The two parts of crop and scale state are independent: the source
+      rectangle, and the destination size. Initially both are unset, that
+      is, no scaling is applied. The whole of the current wl_buffer is
+      used as the source, and the surface size is as defined in
+      wl_surface.attach.
+
+      If the destination size is set, it causes the surface size to become
+      dst_width, dst_height. The source (rectangle) is scaled to exactly
+      this size. This overrides whatever the attached wl_buffer size is,
+      unless the wl_buffer is NULL. If the wl_buffer is NULL, the surface
+      has no content and therefore no size. Otherwise, the size is always
+      at least 1x1 in surface local coordinates.
+
+      If the source rectangle is set, it defines what area of the wl_buffer is
+      taken as the source. If the source rectangle is set and the destination
+      size is not set, then src_width and src_height must be integers, and the
+      surface size becomes the source rectangle size. This results in cropping
+      without scaling. If src_width or src_height are not integers and
+      destination size is not set, the bad_size protocol error is raised when
+      the surface state is applied.
+
+      The coordinate transformations from buffer pixel coordinates up to
+      the surface-local coordinates happen in the following order:
+        1. buffer_transform (wl_surface.set_buffer_transform)
+        2. buffer_scale (wl_surface.set_buffer_scale)
+        3. crop and scale (wp_viewport.set*)
+      This means, that the source rectangle coordinates of crop and scale
+      are given in the coordinates after the buffer transform and scale,
+      i.e. in the coordinates that would be the surface-local coordinates
+      if the crop and scale was not applied.
+
+      If src_x or src_y are negative, the bad_value protocol error is raised.
+      Otherwise, if the source rectangle is partially or completely outside of
+      the non-NULL wl_buffer, then the out_of_buffer protocol error is raised
+      when the surface state is applied. A NULL wl_buffer does not raise the
+      out_of_buffer error.
+
+      If the wl_surface associated with the wp_viewport is destroyed,
+      all wp_viewport requests except 'destroy' raise the protocol error
+      no_surface.
+
+      If the wp_viewport object is destroyed, the crop and scale
+      state is removed from the wl_surface. The change will be applied
+      on the next wl_surface.commit.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove scaling and cropping from the surface">
+	The associated wl_surface's crop and scale state is removed.
+	The change is applied on the next wl_surface.commit.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="bad_value" value="0"
+	     summary="negative or zero values in width or height"/>
+      <entry name="bad_size" value="1"
+	     summary="destination size is not integer"/>
+      <entry name="out_of_buffer" value="2"
+	     summary="source rectangle extends outside of the content area"/>
+      <entry name="no_surface" value="3"
+	     summary="the wl_surface was destroyed"/>
+    </enum>
+
+    <request name="set_source">
+      <description summary="set the source rectangle for cropping">
+	Set the source rectangle of the associated wl_surface. See
+	wp_viewport for the description, and relation to the wl_buffer
+	size.
+
+	If all of x, y, width and height are -1.0, the source rectangle is
+	unset instead. Any other set of values where width or height are zero
+	or negative, or x or y are negative, raise the bad_value protocol
+	error.
+
+	The crop and scale state is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="x" type="fixed" summary="source rectangle x"/>
+      <arg name="y" type="fixed" summary="source rectangle y"/>
+      <arg name="width" type="fixed" summary="source rectangle width"/>
+      <arg name="height" type="fixed" summary="source rectangle height"/>
+    </request>
+
+    <request name="set_destination">
+      <description summary="set the surface size for scaling">
+	Set the destination size of the associated wl_surface. See
+	wp_viewport for the description, and relation to the wl_buffer
+	size.
+
+	If width is -1 and height is -1, the destination size is unset
+	instead. Any other pair of values for width and height that
+	contains zero or negative values raises the bad_value protocol
+	error.
+
+	The crop and scale state is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="width" type="int" summary="surface width"/>
+      <arg name="height" type="int" summary="surface height"/>
+    </request>
+  </interface>
+
+</protocol>


### PR DESCRIPTION
Accidentally all squashed together into a single mega-commit, here's `wp_viewporter`.

You can test with the `weston-scaler` client in... weston, and also with https://github.com/canonical/wlcs/pull/340