### PR TITLE
gbm-kms: Make cursor transitions across outputs smoother

### DIFF
--- a/src/platforms/gbm-kms/server/kms/cursor.cpp
+++ b/src/platforms/gbm-kms/server/kms/cursor.cpp
@@ -347,12 +347,13 @@ void mgg::Cursor::place_cursor_at_locked(
         return;
 
     bool set_on_all_outputs = true;
+    auto const cursor_rect = geometry::Rectangle(position - hotspot, size);
 
     for_each_used_output([&](KMSOutput& output, DisplayConfigurationOutput const& conf)
     {
         auto const output_rect = conf.extents();
 
-        if (output_rect.contains(position))
+        if (output_rect.overlaps(cursor_rect))
         {
             auto const orientation = conf.orientation;
             auto const relative_to_extants = position - output_rect.top_left;

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_cursor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_cursor.cpp
@@ -548,11 +548,11 @@ TEST_F(MesaCursorTest, move_to_moves_cursor_to_right_output)
 
     cursor.show(stub_image);
 
-    EXPECT_CALL(*output_container.outputs[0], move_cursor(geom::Point{10,10}));
+    EXPECT_CALL(*output_container.outputs[0], move_cursor(geom::Point{10,-4}));
     EXPECT_CALL(*output_container.outputs[1], move_cursor(_))
         .Times(0);
 
-    cursor.move_to({10, 10});
+    cursor.move_to({10, -4});
 
     output_container.verify_and_clear_expectations();
 
@@ -576,7 +576,7 @@ TEST_F(MesaCursorTest, move_to_moves_cursor_to_right_output)
     EXPECT_CALL(*output_container.outputs[1], move_cursor(_))
         .Times(0);
 
-    cursor.move_to({-1, -1});
+    cursor.move_to({-64, -64});
 
     output_container.verify_and_clear_expectations();
 }


### PR DESCRIPTION
Keep hardware cursor planes visible on all outputs intersected by the cursor geometry instead of only its position.

Issue: [#3449](https://github.com/canonical/mir/issues/3449)