### PR TITLE
Add clang format and editorconfig files.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,30 @@
+---
+BasedOnStyle: GNU
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments:
+  PadOperators: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+ColumnLimit: 120
+Cpp11BracedListStyle: true
+IndentCaseBlocks: true
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+PackConstructorInitializers: Never
+PenaltyReturnTypeOnItsOwnLine: 1000000
+PointerAlignment: Left
+QualifierAlignment: Right
+SpaceBeforeParens: ControlStatements
+Standard: Latest
+TabWidth: 4
+AllowShortLambdasOnASingleLine: None
+AllowShortFunctionsOnASingleLine: None

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[*.{c,h,cpp,hpp}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This is a PR to discuss if the current state of clang-format fits our desired needs (beautifully formatted code). 

Based on the clang format config proposed by @hbatagelo. Decided to sneak in an editorconfig file since that also helped.