### PR TITLE
bugfix: BasicScreenShooter now selects a GLRenderingProvider based off of its compatibility with the BufferAllocator

### DIFF
--- a/src/server/compositor/basic_screen_shooter.h
+++ b/src/server/compositor/basic_screen_shooter.h
@@ -46,6 +46,7 @@ public:
         Executor& executor,
         std::span<std::shared_ptr<graphics::GLRenderingProvider>> const& providers,
         std::shared_ptr<renderer::RendererFactory> render_factory,
+        std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
         std::shared_ptr<mir::graphics::GLConfig> const& config);
 
     void capture(
@@ -92,7 +93,9 @@ private:
     std::shared_ptr<Self> const self;
     Executor& executor;
 
-    static auto select_provider(std::span<std::shared_ptr<graphics::GLRenderingProvider>> const& providers)
+    static auto select_provider(
+        std::span<std::shared_ptr<graphics::GLRenderingProvider>> const& providers,
+        std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator)
         -> std::shared_ptr<graphics::GLRenderingProvider>;
 };
 }

--- a/src/server/compositor/default_configuration.cpp
+++ b/src/server/compositor/default_configuration.cpp
@@ -120,6 +120,7 @@ auto mir::DefaultServerConfiguration::the_screen_shooter() -> std::shared_ptr<co
                     thread_pool_executor,
                     providers,
                     the_renderer_factory(),
+                    the_buffer_allocator(),
                     the_gl_config());
             }
             catch (...)

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -32,6 +32,7 @@
 #include "mir/test/doubles/stub_scene_element.h"
 #include "mir/test/doubles/stub_renderable.h"
 #include "mir/test/doubles/stub_gl_config.h"
+#include "mir/test/doubles/stub_buffer_allocator.h"
 
 #include <gtest/gtest.h>
 
@@ -98,6 +99,8 @@ struct BasicScreenShooter : Test
                     }
                     BOOST_THROW_EXCEPTION((std::runtime_error{"CPU output support not available?!"}));
                 });
+        ON_CALL(*gl_provider, suitability_for_allocator(_))
+            .WillByDefault(Return(mg::probe::supported));
         ON_CALL(*gl_provider, suitability_for_display(_))
             .WillByDefault(Return(mg::probe::supported));
 
@@ -107,6 +110,7 @@ struct BasicScreenShooter : Test
             executor,
             gl_providers,
             renderer_factory,
+            buffer_allocator,
             std::make_shared<mtd::StubGLConfig>());
     }
 
@@ -135,6 +139,7 @@ struct BasicScreenShooter : Test
     std::shared_ptr<mtd::MockGlRenderingProvider> gl_provider{std::make_shared<testing::NiceMock<mtd::MockGlRenderingProvider>>()};
     std::vector<std::shared_ptr<mg::GLRenderingProvider>> gl_providers{gl_provider};
     std::shared_ptr<MockRendererFactory> renderer_factory{std::make_shared<testing::NiceMock<MockRendererFactory>>()};
+    std::shared_ptr<mtd::StubBufferAllocator> buffer_allocator;
     std::shared_ptr<mtd::AdvanceableClock> clock{std::make_shared<mtd::AdvanceableClock>()};
     mtd::ExplicitExecutor executor;
     std::unique_ptr<mc::BasicScreenShooter> shooter;
@@ -249,6 +254,7 @@ TEST_F(BasicScreenShooter, ensures_renderer_is_current_on_only_one_thread)
         mir::thread_pool_executor,
         gl_providers,
         renderer_factory,
+        buffer_allocator,
         std::make_shared<mtd::StubGLConfig>());
 
     ON_CALL(*next_renderer, render(_))


### PR DESCRIPTION
fixes: #3431 