### PR TITLE
platform/DRMFormat: Don't require a `FormatInfo` for each format.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -77,7 +77,7 @@ Description: Display server for Ubuntu - server library
  .
  Contains the shared library needed by server applications for Mir.
 
-Package: libmirplatform28
+Package: libmirplatform29
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -140,7 +140,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirplatform28 (= ${binary:Version}),
+Depends: libmirplatform29 (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libboost-program-options-dev,
          ${misc:Depends},

--- a/debian/libmirplatform28.install
+++ b/debian/libmirplatform28.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirplatform.so.28

--- a/debian/libmirplatform29.install
+++ b/debian/libmirplatform29.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirplatform.so.29

--- a/include/platform/mir/graphics/drm_formats.h
+++ b/include/platform/mir/graphics/drm_formats.h
@@ -54,6 +54,7 @@ public:
 
     struct FormatInfo;
 private:
+    uint32_t fourcc;
     FormatInfo const* info;
 };
 

--- a/include/platform/mir/graphics/drm_formats.h
+++ b/include/platform/mir/graphics/drm_formats.h
@@ -27,35 +27,47 @@ namespace mir::graphics
 class DRMFormat
 {
 public:
-    struct RGBComponentInfo
+    struct FormatInfo;
+    class Info
     {
-        uint32_t red_bits;
-        uint32_t green_bits;
-        uint32_t blue_bits;
-        std::optional<uint32_t> alpha_bits;
+    public:
+        struct RGBComponentInfo
+        {
+            uint32_t red_bits;
+            uint32_t green_bits;
+            uint32_t blue_bits;
+            std::optional<uint32_t> alpha_bits;
+        };
+
+        auto opaque_equivalent() const -> std::optional<DRMFormat>;
+        auto alpha_equivalent() const -> std::optional<DRMFormat>;
+
+        bool has_alpha() const;
+
+        auto components() const -> std::optional<RGBComponentInfo> const&;
+    private:
+        friend class DRMFormat;
+        Info(FormatInfo const* info);
+
+        FormatInfo const* info;
     };
 
-    // This could be constexpr, at the cost of moving a bunch of implementation into the header
-    explicit DRMFormat(uint32_t fourcc_format);
+    constexpr explicit DRMFormat(uint32_t fourcc_format)
+        : fourcc{fourcc_format}
+    {
+    }
 
     auto name() const -> char const*;
 
-    auto opaque_equivalent() const -> std::optional<DRMFormat> const;
-    auto alpha_equivalent() const -> std::optional<DRMFormat> const;
-
-    bool has_alpha() const;
-
-    auto components() const -> std::optional<RGBComponentInfo> const&;
+    auto info() const -> std::optional<Info const>;
 
     operator uint32_t() const;
 
     auto as_mir_format() const -> std::optional<MirPixelFormat>;
     static auto from_mir_format(MirPixelFormat format) -> DRMFormat;
 
-    struct FormatInfo;
 private:
     uint32_t fourcc;
-    FormatInfo const* info;
 };
 
 auto drm_modifier_to_string(uint64_t modifier) -> std::string;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # We need MIRPLATFORM_ABI in both libmirplatform and the platform implementations.
-set(MIRPLATFORM_ABI 28)
+set(MIRPLATFORM_ABI 29)
 
 set(MIRAL_VERSION_MAJOR 5)
 set(MIRAL_VERSION_MINOR 1)

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -493,7 +493,7 @@ auto mg::DRMFormat::info() const -> std::optional<Info const>
         mir::log_warning("Detailed info for format %s missing; please report so this can be added", name());
         unknown_formats->insert(fourcc);
     }
-    return {};
+    return std::nullopt;
 }
 
 mg::DRMFormat::operator uint32_t() const

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -490,7 +490,8 @@ auto mg::DRMFormat::info() const -> std::optional<Info const>
     auto unknown_formats = unknown_formats_guard.lock();
     if (!unknown_formats->contains(fourcc))
     {
-        mir::log_warning("Detailed info for format %s missing; please report so this can be added", name());
+        mir::log_warning(
+            "Detailed info for format %s missing; please report this to https://github.com/canonical/mir/issues/new so this can be added", name());
         unknown_formats->insert(fourcc);
     }
     return std::nullopt;

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -69,7 +69,7 @@ struct mg::DRMFormat::FormatInfo
     bool has_alpha;
     std::optional<uint32_t> opaque_equivalent;
     std::optional<uint32_t> alpha_equivalent;
-    std::optional<mg::DRMFormat::RGBComponentInfo> components;
+    std::optional<Info::RGBComponentInfo> components;
 };
 
 namespace
@@ -80,7 +80,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_XRGB4444,
         DRM_FORMAT_ARGB4444,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, {}
         },
     },
@@ -89,7 +89,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_XBGR4444,
         DRM_FORMAT_ABGR4444,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, {}
         },
     },
@@ -98,7 +98,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_RGBX4444,
         DRM_FORMAT_RGBA4444,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, {}
         },
     },
@@ -107,7 +107,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_BGRX4444,
         DRM_FORMAT_BGRA4444,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, {}
         },
     },
@@ -116,7 +116,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_XRGB4444,
         DRM_FORMAT_ARGB4444,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, 4
         },
     },
@@ -125,7 +125,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_XBGR4444,
         DRM_FORMAT_ABGR4444,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, 4
         },
     },
@@ -134,7 +134,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_RGBX4444,
         DRM_FORMAT_RGBA4444,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, 4
         },
     },
@@ -143,7 +143,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_BGRX4444,
         DRM_FORMAT_BGRA4444,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, 4
         },
     },
@@ -152,7 +152,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_XRGB1555,
         DRM_FORMAT_ARGB1555,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, {}
         },
     },
@@ -161,7 +161,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_XBGR1555,
         DRM_FORMAT_ABGR1555,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, {}
         },
     },
@@ -170,7 +170,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_RGBX5551,
         DRM_FORMAT_RGBA5551,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, {}
         },
     },
@@ -179,7 +179,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_BGRX5551,
         DRM_FORMAT_BGRA5551,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, {}
         },
     },
@@ -188,7 +188,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_XRGB1555,
         DRM_FORMAT_ARGB1555,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, 1
         },
     },
@@ -197,7 +197,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_XBGR1555,
         DRM_FORMAT_ABGR1555,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, 1
         },
     },
@@ -206,7 +206,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_RGBX5551,
         DRM_FORMAT_RGBA5551,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, 1
         },
     },
@@ -215,7 +215,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_BGRX5551,
         DRM_FORMAT_BGRA5551,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, 1
         },
     },
@@ -224,7 +224,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_RGB565,
         {},
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 6, 5, {}
         },
     },
@@ -233,7 +233,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_BGR565,
         {},
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             5, 6, 5, {}
         },
     },
@@ -242,7 +242,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_RGB888,
         {},
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
     },
@@ -251,7 +251,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_BGR888,
         {},
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
     },
@@ -260,7 +260,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_XRGB8888,
         DRM_FORMAT_ARGB8888,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
     },
@@ -269,7 +269,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_XBGR8888,
         DRM_FORMAT_ABGR8888,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
     },
@@ -278,7 +278,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_RGBX8888,
         DRM_FORMAT_RGBA8888,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
     },
@@ -287,7 +287,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_BGRX8888,
         DRM_FORMAT_BGRA8888,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
     },
@@ -296,7 +296,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_XRGB8888,
         DRM_FORMAT_ARGB8888,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, 8
         },
     },
@@ -305,7 +305,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_XBGR8888,
         DRM_FORMAT_ABGR8888,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, 8
         },
     },
@@ -314,7 +314,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_RGBX8888,
         DRM_FORMAT_RGBA8888,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, 8
         },
     },
@@ -323,7 +323,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_BGRX8888,
         DRM_FORMAT_BGRA8888,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, 8
         },
     },
@@ -332,7 +332,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_XRGB2101010,
         DRM_FORMAT_ARGB2101010,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, {}
         },
     },
@@ -341,7 +341,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_XBGR2101010,
         DRM_FORMAT_ABGR2101010,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, {}
         },
     },
@@ -350,7 +350,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_RGBX1010102,
         DRM_FORMAT_RGBA1010102,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, {}
         },
     },
@@ -359,7 +359,7 @@ constexpr std::array const formats = {
         false,
         DRM_FORMAT_BGRX1010102,
         DRM_FORMAT_BGRA1010102,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, {}
         },
     },
@@ -368,7 +368,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_XRGB2101010,
         DRM_FORMAT_ARGB2101010,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, 2
         },
     },
@@ -377,7 +377,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_XBGR2101010,
         DRM_FORMAT_ABGR2101010,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, 2
         },
     },
@@ -386,7 +386,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_RGBX1010102,
         DRM_FORMAT_RGBA1010102,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, 2
         },
     },
@@ -395,7 +395,7 @@ constexpr std::array const formats = {
         true,
         DRM_FORMAT_BGRX1010102,
         DRM_FORMAT_BGRA1010102,
-        mg::DRMFormat::RGBComponentInfo{
+        mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, 2
         },
     },
@@ -442,24 +442,6 @@ constexpr auto maybe_info_for_format(uint32_t fourcc_format) -> mg::DRMFormat::F
     }
 
 }
-
-constexpr auto info_for_format(uint32_t fourcc_format) -> mg::DRMFormat::FormatInfo const*
-{
-    auto const info = maybe_info_for_format(fourcc_format);
-
-    if (info)
-    {
-        return info;
-    }
-    return nullptr;
-}
-
-}
-
-mg::DRMFormat::DRMFormat(uint32_t fourcc_format)
-    : fourcc{fourcc_format},
-      info{info_for_format(fourcc_format)}
-{
 }
 
 auto mg::DRMFormat::name() const -> const char*
@@ -467,42 +449,38 @@ auto mg::DRMFormat::name() const -> const char*
     return drm_format_to_string(fourcc);
 }
 
-auto mg::DRMFormat::opaque_equivalent() const -> const std::optional<DRMFormat>
+auto mg::DRMFormat::Info::opaque_equivalent() const -> std::optional<DRMFormat>
 {
-    if (info)
+    return info->opaque_equivalent.transform([](auto const& fourcc) { return DRMFormat{fourcc};});
+}
+
+auto mg::DRMFormat::Info::alpha_equivalent() const -> std::optional<DRMFormat>
+{
+    return info->alpha_equivalent.transform([](auto const& fourcc) { return DRMFormat{fourcc};});
+}
+
+bool mg::DRMFormat::Info::has_alpha() const
+{
+    return info->has_alpha;
+}
+
+auto mg::DRMFormat::Info::components() const -> std::optional<Info::RGBComponentInfo> const&
+{
+    return info->components;
+}
+
+mg::DRMFormat::Info::Info(FormatInfo const* info)
+    : info{info}
+{
+}
+
+auto mg::DRMFormat::info() const -> std::optional<Info const>
+{
+    if (auto info = maybe_info_for_format(fourcc))
     {
-        return info->opaque_equivalent.transform([](auto const& fourcc) { return DRMFormat{fourcc};});
+        return Info(info);
     }
     return {};
-}
-
-auto mg::DRMFormat::alpha_equivalent() const -> const std::optional<DRMFormat>
-{
-    if (info)
-    {
-        return info->alpha_equivalent.transform([](auto const& fourcc) { return DRMFormat{fourcc};});
-    }
-    return {};
-}
-
-bool mg::DRMFormat::has_alpha() const
-{
-    if (info)
-    {
-        return info->has_alpha;
-    }
-    // The safe default if we don't know is “true”
-    return true;
-}
-
-auto mg::DRMFormat::components() const -> std::optional<RGBComponentInfo> const&
-{
-    static std::optional<RGBComponentInfo> no_components = std::nullopt;
-    if (info)
-    {
-        return info->components;
-    }
-    return no_components;
 }
 
 mg::DRMFormat::operator uint32_t() const

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -24,6 +24,8 @@
 #include <array>
 #include <boost/throw_exception.hpp>
 
+#include "mir/log.h"
+
 #ifdef MIR_HAVE_DRM_GET_MODIFIER_NAME
 #include <xf86drm.h>
 #endif
@@ -480,6 +482,11 @@ auto mg::DRMFormat::info() const -> std::optional<Info const>
     {
         return Info(info);
     }
+    /* TODO: This could fire quite frequently.
+     * Ideally we would have a rate-limited (or once-per-format) logger, but for now, just
+     * throw it in the debug stream.
+     */
+    mir::log_debug("Detailed info for format %s missing; please report so this can be added", name());
     return {};
 }
 

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -948,9 +948,6 @@ namespace
 {
 auto format_has_known_alpha(mg::DRMFormat format) -> std::optional<bool>
 {
-    /* TODO: It would be sensible to log when we don't have Info for the format,
-     * but this will happen a lot, so we would want some ratelimiting in the logger
-     */
     return format.info().transform([](auto const& info) { return info.has_alpha(); });
 }
 }

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -944,6 +944,17 @@ private:
     std::shared_ptr<mgc::EGLContextExecutor> const egl_delegate;
 };
 
+namespace
+{
+auto format_has_known_alpha(mg::DRMFormat format) -> std::optional<bool>
+{
+    /* TODO: It would be sensible to log when we don't have Info for the format,
+     * but this will happen a lot, so we would want some ratelimiting in the logger
+     */
+    return format.info().transform([](auto const& info) { return info.has_alpha(); });
+}
+}
+
 class DmabufTexBuffer :
     public mg::BufferBasic,
     public mg::DMABufBuffer
@@ -965,7 +976,7 @@ public:
           on_consumed{std::move(on_consumed)},
           on_release{std::move(on_release)},
           size_{dma_buf.size()},
-          has_alpha{dma_buf.format().has_alpha()},
+          has_alpha{format_has_known_alpha(dma_buf.format()).value_or(true)},  // Has-alpha is the safe default for unknown formats
           planes_{dma_buf.planes()},
           modifier_{dma_buf.modifier()},
           format_{dma_buf.format()}

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -10,14 +10,15 @@ MIR_PLATFORM_2.17 {
     mir::graphics::DMABufEGLProvider::DMABufEGLProvider*;
     mir::graphics::DMABufEGLProvider::as_texture*;
     mir::graphics::DRMFormat::DRMFormat*;
-    mir::graphics::DRMFormat::alpha_equivalent*;
+    mir::graphics::DRMFormat::Info::alpha_equivalent*;
     mir::graphics::DRMFormat::as_mir_format*;
-    mir::graphics::DRMFormat::components*;
+    mir::graphics::DRMFormat::Info::components*;
     mir::graphics::DRMFormat::from_mir_format*;
-    mir::graphics::DRMFormat::has_alpha*;
+    mir::graphics::DRMFormat::Info::has_alpha*;
     mir::graphics::DRMFormat::name*;
-    mir::graphics::DRMFormat::opaque_equivalent*;
+    mir::graphics::DRMFormat::Info::opaque_equivalent*;
     mir::graphics::DRMFormat::operator?unsigned?int*; /* Is actually operator uint32_t(), but 🤷 */
+    mir::graphics::DRMFormat::info*;
     mir::graphics::DisplayConfiguration::operator*;
     mir::graphics::DisplayConfiguration::valid*;
     mir::graphics::DisplayConfigurationOutput::extents*;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -1,4 +1,4 @@
-MIR_PLATFORM_2.17 {
+MIR_PLATFORM_2.18 {
  global:
   extern "C++" {
     mir::graphics::AtomicFrame::increment*;

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -729,7 +729,9 @@ public:
     { return transformation_; }
 
     bool shaped() const override
-    { return entry->pixel_format().has_alpha(); }
+    {
+        return entry->pixel_format().info().transform([](auto info) { return info.has_alpha();}).value_or(true);
+    }
 
     mg::Renderable::ID id() const override
     { return id_; }


### PR DESCRIPTION
We're now using `DRMFormat` in a situation (linux-dmabuf) where:
* We don't actually need to care about many the properties of the format, and
* We're processing formats submitted by cilents.

This means that the existing “throw an exception if we haven't got a `FormatInfo`” approach works badly; we will disconnect clients with a Wayland internal error if they submit buffers in a format we haven't explicitly listed, even though it *would* work if we just treated the format as an opaque identifier.

So, don't do that anymore. Instead, store the fourcc code directly in `DRMFormat`, only look up the `FormatInfo` (now `DRMFormat::Info`) when code asks for it.

Additionally, we log the first time code asks for the `DRMFormat::Info` for a format we haven't got info for; this way we can fill out the needed formats on an as-noticed basis.

Fixes: #3462