### PR TITLE
Require minimim GCC version (i.e. GCC 13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${build_types}")
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(MINIMUM_GNUCXX_COMPILER_VERSION "13.0")
+
+if(${CMAKE_COMPILER_IS_GNUCXX} AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MINIMUM_GNUCXX_COMPILER_VERSION})
+  message(FATAL_ERROR "Insufficent gcc version. Found ${CMAKE_CXX_COMPILER_VERSION}, expected >= ${MINIMUM_GNUCXX_COMPILER_VERSION}")
+endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -g -Wall -pedantic -Wextra -fPIC")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -g -Wall -fno-strict-aliasing -pedantic -Wnon-virtual-dtor -Wextra -fPIC")


### PR DESCRIPTION
## Context
I ran into issues trying to build Mir on Pop!_OS, which is currently still based on _Ubuntu 22.04 LTS_. The reason was twofold:

* _Ubuntu 22.04 LTS_ ships with _GCC 11_
* _Ubuntu 22.04 LTS_ ships with an incompatible version of _google-mock_ (googletest), possibly other libraries

For this initial PR I'll only be focused on the _GCC_ issue.

## Details
Cmake has a flag `CMAKE_CXX_STANDARD` that is used to specify the required _C++_ specification, but incomplete _GCC_ versions will still pass that test even if they don't fully conform to the specification. For example, you can enable _C++20_ and _C++23_ support in _GCC 11_ with `g++ -std=c++20` and `g++ -std=c++23` respectfully, even if though they aren't feature complete.

The problem I ran into was that _GCC 11_ was missing certain Standard Library headers, specifically `<format>`. From what I can gather from the [GCC changelog](https://gcc.gnu.org/gcc-13/changes.html), _GCC 13_ was the first version that included `std::format` support.

## My workaround
I eventually had success by adding some PPA repositories with a newer `GCC` and newer library versions.

* _GCC 13_; <https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/ppa>
* _googletest_ and other libraries: <https://launchpad.net/~savoury1/+archive/ubuntu/build-tools>

**NOTE:** I don't specifically recommend these, I'm just sharing how I got it working.

Once _GCC 13_ was installed, I configured `update-alternatives` so I could easily switch _GCC_ and _G++_ versions with `sudo update-alternatives --config gcc`.

For testing I installed _GCC 9_, _GCC 11_, and _GCC 13_.

* _GCC 9_ has no support for `-std=c++20`
* _GCC 11_ supports both `-std=c++20` and `-std=c++23`, but is missing key standard libraries
* _GCC 13_ works

## Solution
I added a "minimum GXX version" constant and a check to the `CMakeLists.txt` file that halts the build script if you're not running at least _GCC 13_. The check is only done if we know for sure that compiler is _GCC_ (i.e. `GNU` to cmake).

## Future work
It's very possible that other compilers like _Clang_ and _MSVC_ may have similar discrepancies (i.e. the _C++20_ standard can be enabled even if it's not fully supported).

Also, the minimum _google-mock_ version in `debian/control` should be updated. To what version requires a bit more research. 

Feedback is welcome. If I missed a contributions guide or reference, let me know and I'll update this accordingly.