### PR TITLE
feature: provide a way to specify an additional data source for configuration data

### DIFF
--- a/include/miral/miral/configuration_data_source.h
+++ b/include/miral/miral/configuration_data_source.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_CONFIGURATION_SOURCE_H
+#define MIRAL_CONFIGURATION_SOURCE_H
+
+#include <functional>
+#include <map>
+#include <string>
+#include <memory>
+
+namespace mir { class Server; }
+
+namespace miral
+{
+
+/// Used to define another source of configuration data. By default, configuration
+/// options are parsed from command line parameters and the Mir configuration file.
+/// Using this class, compositor authors can provide another way to set configuration
+/// options. For example, one may parse a JSON file to the map and define configuration
+/// variable in that way.
+class ConfigurationDataSource
+{
+public:
+    explicit ConfigurationDataSource(std::function<std::map<std::string, std::string>()> const&);
+    void operator()(mir::Server& server) const;
+
+    struct Self;
+    std::shared_ptr<Self> self;
+};
+}
+
+#endif //MIRAL_CONFIGURATION_SOURCE_H

--- a/include/platform/mir/options/default_configuration.h
+++ b/include/platform/mir/options/default_configuration.h
@@ -45,12 +45,16 @@ public:
     // before the first invocation of the_options() - typically during initialization.
     boost::program_options::options_description_easy_init add_options();
 
+    void set_options_map(std::map<std::string, std::string> const& options);
+
 private:
     // MUST be the first member to ensure it's destroyed last, lest we attempt to
     // call destructors in DSOs we've unloaded.
     std::vector<std::shared_ptr<SharedLibrary>> platform_libraries;
 
     std::string const config_file;
+
+    std::optional<std::map<std::string, std::string>> options_map;
 
     void add_platform_options();
     // accessed via the base interface, when access to add_options() has been "lost"
@@ -67,6 +71,10 @@ private:
         ProgramOption& options) const;
 
     virtual void parse_config_file(
+        boost::program_options::options_description& desc,
+        ProgramOption& options) const;
+
+    virtual void parse_custom(
         boost::program_options::options_description& desc,
         ProgramOption& options) const;
 

--- a/include/platform/mir/options/program_option.h
+++ b/include/platform/mir/options/program_option.h
@@ -45,6 +45,10 @@ public:
         boost::program_options::options_description const& description,
         std::string const& filename);
 
+    void parse_map(
+        boost::program_options::options_description const& description,
+        std::map<std::string, std::string> const& map);
+
     bool is_set(char const* name) const override;
     bool get(char const* name, bool default_) const override;
     std::string get(char const*, char const* default_) const override;

--- a/src/include/server/mir/server.h
+++ b/src/include/server/mir/server.h
@@ -24,6 +24,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <map>
 
 struct wl_display;
 
@@ -185,6 +186,10 @@ public:
     /// 1. $XDG_CONFIG_HOME (if set, otherwise $HOME/.config (if set))
     /// 2. $XDG_CONFIG_DIRS (if set, otherwise /etc/xdg)
     void set_config_filename(std::string const& config_file);
+
+    /// Set an alternative source for configuration data.
+    void set_configuration_data_source(
+        std::function<std::map<std::string, std::string>()> const&);
 
     /// Returns the configuration options.
     /// This will be null before initialization starts. It will be available

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(miral-external OBJECT
     application_authorizer.cpp          ${miral_include}/miral/application_authorizer.h
     application_info.cpp                ${miral_include}/miral/application_info.h
     canonical_window_manager.cpp        ${miral_include}/miral/canonical_window_manager.h
+    configuration_data_source.cpp       ${miral_include}/miral/configuration_data_source.h
     configuration_option.cpp            ${miral_include}/miral/configuration_option.h
     ${miral_include}/miral/command_line_option.h
     cursor_theme.cpp                    ${miral_include}/miral/cursor_theme.h

--- a/src/miral/configuration_data_source.cpp
+++ b/src/miral/configuration_data_source.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "miral/configuration_data_source.h"
+#include <mir/server.h>
+
+struct miral::ConfigurationDataSource::Self
+{
+    std::function<std::map<std::string, std::string>()> get_map;
+};
+
+miral::ConfigurationDataSource::ConfigurationDataSource(
+    std::function<std::map<std::string, std::string>()> const& get_map)
+    : self{std::make_shared<Self>(get_map)}
+{
+}
+
+void miral::ConfigurationDataSource::operator()(mir::Server& server) const
+{
+    server.set_configuration_data_source(self->get_map);
+}

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -456,6 +456,8 @@ local: *;
 MIRAL_5.1 {
 global:
   extern "C++" {
+    miral::ConfigurationDataSource::ConfigurationDataSource*;
+    miral::ConfigurationDataSource::operator*;
     miral::Decorations::Decorations*;
     miral::Decorations::always_csd*;
     miral::Decorations::always_ssd*;
@@ -469,7 +471,9 @@ global:
     miral::IdleListener::on_wake*;
     miral::IdleListener::operator*;
     miral::WindowManagerTools::move_cursor_to*;
-    typeinfo?for?miral::IdleListener;
+    typeinfo?for?miral::ConfigurationDataSource;
     typeinfo?for?miral::Decorations;
+    typeinfo?for?miral::IdleListener;
   };
 } MIRAL_5.0;
+

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -269,6 +269,11 @@ boost::program_options::options_description_easy_init mo::DefaultConfiguration::
     return program_options->add_options();
 }
 
+void mo::DefaultConfiguration::set_options_map(std::map<std::string, std::string> const& options)
+{
+    options_map = options;
+}
+
 std::shared_ptr<mo::Option> mo::DefaultConfiguration::the_options() const
 {
     if (!options)
@@ -277,6 +282,7 @@ std::shared_ptr<mo::Option> mo::DefaultConfiguration::the_options() const
         parse_arguments(*program_options, *options, argc, argv);
         parse_environment(*program_options, *options);
         parse_config_file(*program_options, *options);
+        parse_custom(*program_options, *options);
         this->options = options;
     }
     return options;
@@ -342,4 +348,12 @@ void mo::DefaultConfiguration::parse_config_file(
 {
     if (!config_file.empty())
         options.parse_file(desc, config_file);
+}
+
+void mo::DefaultConfiguration::parse_custom(
+    boost::program_options::options_description& desc,
+    mir::options::ProgramOption& options) const
+{
+    if (options_map)
+        options.parse_map(desc, options_map.value());
 }

--- a/src/platform/options/program_option.cpp
+++ b/src/platform/options/program_option.cpp
@@ -119,6 +119,23 @@ void mo::ProgramOption::parse_file(
     po::notify(options);
 }
 
+void mo::ProgramOption::parse_map(
+    po::options_description const& desc,
+    std::map<std::string, std::string> const& map)
+{
+    boost::program_options::parsed_options opts(&desc);
+    for (auto const& [key, val] : map)
+    {
+        boost::program_options::basic_option<char> opt;
+        opt.string_key = key;
+        opt.value.push_back(val);
+        opts.options.push_back(opt);
+    }
+
+    po::store(opts, options);
+    po::notify(options);
+}
+
 bool mo::ProgramOption::is_set(char const* name) const
 {
     return options.count(parse_name(name));

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -202,3 +202,10 @@ MIR_PLATFORM_2.17 {
  local: *;
 };
 
+MIR_PLATFORM_2.18 {
+ global:
+  extern "C++" {
+    mir::options::DefaultConfiguration::set_options_map*;
+  };
+ local: *;
+} MIR_PLATFORM_2.17;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1344,12 +1344,13 @@ local: *;
 MIR_SERVER_INTERNAL_2.18 {
 global:
   extern "C++" {
-    mir::DefaultServerConfiguration::the_led_observer_registrar*;
     mir::DecorationStrategy::?DecorationStrategy*;
     mir::DecorationStrategy::DecorationStrategy*;
     mir::DecorationStrategy::operator*;
     mir::DefaultServerConfiguration::set_the_decoration_strategy*;
     mir::DefaultServerConfiguration::the_decoration_strategy*;
+    mir::DefaultServerConfiguration::the_led_observer_registrar*;
+    mir::Server::set_configuration_data_source*;
     mir::Server::set_the_decoration_strategy*;
     mir::Server::the_decoration_strategy*;
     mir::Server::the_idle_handler*;
@@ -1369,6 +1370,9 @@ global:
     mir::input::receiver::XKBMapperRegistrar::xkb_modifiers*;
     mir::shell::IdleHandlerObserver::?IdleHandlerObserver*;
     mir::shell::IdleHandlerObserver::IdleHandlerObserver*;
+    non-virtual?thunk?to?mir::DecorationStrategy::?DecorationStrategy*;
+    non-virtual?thunk?to?mir::DefaultServerConfiguration::set_the_decoration_strategy*;
+    non-virtual?thunk?to?mir::DefaultServerConfiguration::the_decoration_strategy*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_led_observer_registrar*;
     non-virtual?thunk?to?mir::input::receiver::XKBMapperRegistrar::clear_all_keymaps*;
     non-virtual?thunk?to?mir::input::receiver::XKBMapperRegistrar::clear_keymap_for_device*;
@@ -1382,19 +1386,16 @@ global:
     non-virtual?thunk?to?mir::input::receiver::XKBMapperRegistrar::unregister_interest*;
     non-virtual?thunk?to?mir::input::receiver::XKBMapperRegistrar::xkb_modifiers*;
     non-virtual?thunk?to?mir::shell::IdleHandlerObserver::?IdleHandlerObserver*;
-    typeinfo?for?mir::input::receiver::XKBMapperRegistrar;
-    typeinfo?for?mir::shell::IdleHandlerObserver;
-    vtable?for?mir::input::receiver::XKBMapperRegistrar;
-    vtable?for?mir::shell::IdleHandlerObserver;
-    non-virtual?thunk?to?mir::DecorationStrategy::?DecorationStrategy*;
-    non-virtual?thunk?to?mir::DefaultServerConfiguration::set_the_decoration_strategy*;
-    non-virtual?thunk?to?mir::DefaultServerConfiguration::the_decoration_strategy*;
     non-virtual?thunk?to?mir::shell::IdleHandlerObserver::?IdleHandlerObserver*;
     typeinfo?for?mir::DecorationStrategy;
+    typeinfo?for?mir::input::receiver::XKBMapperRegistrar;
+    typeinfo?for?mir::shell::IdleHandlerObserver;
     typeinfo?for?mir::shell::IdleHandlerObserver;
     virtual?thunk?to?mir::DefaultServerConfiguration::set_the_decoration_strategy*;
     virtual?thunk?to?mir::DefaultServerConfiguration::the_decoration_strategy*;
     vtable?for?mir::DecorationStrategy;
+    vtable?for?mir::input::receiver::XKBMapperRegistrar;
+    vtable?for?mir::shell::IdleHandlerObserver;
     vtable?for?mir::shell::IdleHandlerObserver;
   };
 } MIR_SERVER_INTERNAL_2.17;

--- a/tools/symbols_map_generator/main.py
+++ b/tools/symbols_map_generator/main.py
@@ -41,8 +41,19 @@ class LibraryInfo(TypedDict):
     header_directories: list[HeaderDirectory]
     map_file: str
 
+def get_version_from_library_version_str(version: str) -> str:
+    """
+    Given a string like MIR_SERVER_INTERNAL_5.0.0, returns the version
+    string (e.g. 5.0.0)
+    """
+    s = version.split("_")
+    return s[len(s) - 1]
+
 
 def get_major_version_from_str(version: str) -> int:
+    """
+    Given a string like 5.0.0, returns the major version (e.g. 5).
+    """
     return int(version.split('.')[0])
 
 
@@ -482,7 +493,7 @@ def main():
 
         # Remake the stanzas for the previous symbols
         for symbol in previous_symbols:
-            major = get_major_version_from_str(symbol.version)
+            major = get_major_version_from_str(get_version_from_library_version_str(symbol.version))
 
             # If we are going up by a major version, then we should add
             # all existing symbols to the new stanza


### PR DESCRIPTION
## Why?
In miracle (and probably other compositors), people may want to specify configuration options in a different format (e.g. a json file, a yaml file, etc.). To facilitate this, users should be able to specify a simple map that contains the key-value pairs that were parsed from another source.

## What's new?
- Added a new class to miral called `ConfigurationDataSource`
- Added `DefaultConfiguration::set_options_map` (maybe this should be in the constructor, but the constructors were a bit large)
- Added `DefaultConfiguration::parse_custom`
- Added `ProgramOption::parse_map`
- Fixed the symbols map generator

## To test
In your main runner function, do something like:

```c++
return runner.run_with(
        {
            ...
            ConfigurationDataSource([]()
            {
                return std::map<std::string, std::string>{
                    {"startup-apps", "gedit"}
                };
            }),
            ...
         });
```