### PR TITLE
docs: adding a threat model diagram for Ubuntu Frame

### DIFF
--- a/doc/sphinx/explanation/index.md
+++ b/doc/sphinx/explanation/index.md
@@ -4,6 +4,7 @@ These pages provide additional detail about a number of aspects related to using
 - [Architecture](architecture): an overview of Mir's architecture for contributors
 - [Libraries](libraries): an overview of Mir's libraries and how they depend on one another
 - [Graphics support](mir-graphics-support): what's required to run Mir compositors
+- [Threat Model](threat-model): defining a security threat model for Mir
 - [What is Wayland anyway?](ok-so-what-is-this-wayland-thing-anyway): so what is it?
 - [Windowing paradigms](window-positions-under-wayland): how are windows managed?
 - [Component reports](component_reports): information on Mir's debug and performance reporting infrastructure
@@ -14,6 +15,7 @@ These pages provide additional detail about a number of aspects related to using
 architecture
 libraries
 mir-graphics-support
+threat-model
 ok-so-what-is-this-wayland-thing-anyway
 window-positions-under-wayland
 component_reports

--- a/doc/sphinx/explanation/threat-model.md
+++ b/doc/sphinx/explanation/threat-model.md
@@ -1,0 +1,13 @@
+# Threat Model
+Mir is a C++ library for building compositors, not a product itself. As such,
+when discussing the threat model for Mir, it is useful to discuss it in terms
+of an actual product that is built on Mir. With this in mind, we will define
+the threat model of **Ubuntu Frame** in this document.
+
+## Ubuntu Frame Threat Model Diagram
+Ubuntu Frame is published as a snap. As such, the threat model for frame assumes
+that the snap is secure, and proceeds to outline the frame snap's interactions
+with the outside world.
+
+```{mermaid} ubuntu_frame_threat_model.mmd
+```

--- a/doc/sphinx/explanation/ubuntu_frame_threat_model.mmd
+++ b/doc/sphinx/explanation/ubuntu_frame_threat_model.mmd
@@ -1,0 +1,32 @@
+%%{ init: { 'flowchart': { 'curve': 'monotoneY' } } }%%
+flowchart
+    shell((Mir-based Shell))
+    vnc_server(VNC Server)
+    vnc_client(VNC Client)
+    osk(On-screen Keyboard)
+    snapd(Snapd)
+    operator_app(Operator App)
+    user(User)
+    display(Display)
+    app(App)
+
+    subgraph snap [Snap]
+        vnc_server--input-->shell
+        shell--screen content-->vnc_server
+
+        osk--content/input-->shell
+        shell--input-->osk
+    end
+    
+    shell--contents/configuration--->display
+    snapd--configuration-->shell
+    display--visuals-->user
+    operator_app--help message-->shell
+    user--input events-->shell
+    display--properties-->shell
+    vnc_server<--vnc-->vnc_client
+    app--window contents-->shell
+    shell--input/window management-->app
+
+    classDef boundary fill:none,stroke-dasharray: 5 5
+    snap:::boundary


### PR DESCRIPTION
To view: https://canonical-mir--3484.com.readthedocs.build/3484/explanation/threat-model/