### PR TITLE
Add dependencies to mir-x11-kiosk

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -636,6 +636,8 @@ Depends: ${misc:Depends},
          inotify-tools,
          mir-platform-graphics-wayland,
          xwayland,
+         dmz-cursor-theme,
+         xkb-data
 Description: Display server for Ubuntu - kiosk hosting X11 apps
  .
  Contains an "X11 kiosk" compositor based on the Mir display server


### PR DESCRIPTION
These are needed to make it work in a snap environment, so make life easy by adding them here