### PR TITLE
platforms/common: Move DRMEventHandler in from eglstream-kms.

### DIFF
--- a/src/platforms/common/server/kms-utils/CMakeLists.txt
+++ b/src/platforms/common/server/kms-utils/CMakeLists.txt
@@ -6,6 +6,9 @@ add_library(${KMS_UTILS_STATIC_LIBRARY} STATIC
   drm_mode_resources.h
   kms_connector.cpp
   kms_connector.h
+  drm_event_handler.h
+  threaded_drm_event_handler.h
+  threaded_drm_event_handler.cpp
 )
 
 target_include_directories(${KMS_UTILS_STATIC_LIBRARY}
@@ -14,4 +17,5 @@ target_include_directories(${KMS_UTILS_STATIC_LIBRARY}
 
 target_link_libraries(${KMS_UTILS_STATIC_LIBRARY}
   PkgConfig::DRM
+  mircore
 )

--- a/src/platforms/common/server/kms-utils/drm_event_handler.h
+++ b/src/platforms/common/server/kms-utils/drm_event_handler.h
@@ -14,8 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_PLATFORM_EGLSTREAM_DRM_EVENT_HANDLER_H_
-#define MIR_PLATFORM_EGLSTREAM_DRM_EVENT_HANDLER_H_
+#ifndef MIR_PLATFORM_KMS_DRM_EVENT_HANDLER_H_
+#define MIR_PLATFORM_KMS_DRM_EVENT_HANDLER_H_
 
 #include <future>
 
@@ -23,7 +23,7 @@ namespace mir
 {
 namespace graphics
 {
-namespace eglstream
+namespace kms
 {
 class DRMEventHandler
 {
@@ -55,4 +55,4 @@ public:
 }
 }
 
-#endif //MIR_PLATFORM_EGLSTREAM_DRM_EVENT_HANDLER_H_
+#endif //MIR_PLATFORM_KMS_DRM_EVENT_HANDLER_H_

--- a/src/platforms/common/server/kms-utils/threaded_drm_event_handler.cpp
+++ b/src/platforms/common/server/kms-utils/threaded_drm_event_handler.cpp
@@ -29,7 +29,7 @@
 #include <fcntl.h>
 #include <algorithm>
 
-namespace mge = mir::graphics::eglstream;
+namespace mge = mir::graphics::kms;
 
 
 

--- a/src/platforms/common/server/kms-utils/threaded_drm_event_handler.h
+++ b/src/platforms/common/server/kms-utils/threaded_drm_event_handler.h
@@ -14,8 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_PLATFORM_EGLSTREAM_THREADED_DRM_EVENT_HANDLER_H_
-#define MIR_PLATFORM_EGLSTREAM_THREADED_DRM_EVENT_HANDLER_H_
+#ifndef MIR_PLATFORM_KMS_THREADED_DRM_EVENT_HANDLER_H_
+#define MIR_PLATFORM_KMS_THREADED_DRM_EVENT_HANDLER_H_
 
 #include "drm_event_handler.h"
 
@@ -31,7 +31,7 @@ namespace mir
 {
 namespace graphics
 {
-namespace eglstream
+namespace kms
 {
 class ThreadedDRMEventHandler : public DRMEventHandler
 {
@@ -79,4 +79,4 @@ private:
 }
 }
 
-#endif //MIR_PLATFORM_EGLSTREAM_THREADED_DRM_EVENT_HANDLER_H_
+#endif //MIR_PLATFORM_KMS_THREADED_DRM_EVENT_HANDLER_H_

--- a/src/platforms/eglstream-kms/server/CMakeLists.txt
+++ b/src/platforms/eglstream-kms/server/CMakeLists.txt
@@ -21,9 +21,6 @@ add_library(mirplatformgraphicseglstreamkmsobjects OBJECT
   egl_output.cpp
   utils.cpp
   utils.h
-  drm_event_handler.h
-  threaded_drm_event_handler.h
-  threaded_drm_event_handler.cpp
 )
 
 target_link_libraries(mirplatformgraphicseglstreamkmsobjects

--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -25,7 +25,7 @@
 
 #include "kms-utils/drm_mode_resources.h"
 #include "mir/graphics/platform.h"
-#include "threaded_drm_event_handler.h"
+#include "kms-utils/threaded_drm_event_handler.h"
 
 #include "mir/graphics/display_configuration.h"
 #include "mir/graphics/display_configuration_policy.h"
@@ -49,6 +49,7 @@
 
 namespace mg = mir::graphics;
 namespace mge = mir::graphics::eglstream;
+namespace mgk = mir::graphics::kms;
 namespace geom = mir::geometry;
 
 #ifndef EGL_NV_output_drm_flip_event
@@ -133,7 +134,7 @@ public:
         EGLDisplay dpy,
         EGLContext ctx,
         EGLConfig config,
-        std::shared_ptr<mge::DRMEventHandler> event_handler,
+        std::shared_ptr<mgk::DRMEventHandler> event_handler,
         std::shared_ptr<mge::kms::EGLOutput> output,
         std::shared_ptr<mg::DisplayReport> display_report)
         : dpy{dpy},
@@ -429,7 +430,7 @@ private:
     std::shared_ptr<mge::kms::EGLOutput> output;
     EGLStreamKHR output_stream;
     mir::Fd const drm_node;
-    std::shared_ptr<mge::DRMEventHandler> const event_handler;
+    std::shared_ptr<mgk::DRMEventHandler> const event_handler;
     std::future<void> pending_flip;
     mg::EGLExtensions::LazyDisplayExtensions<mg::EGLExtensions::NVStreamAttribExtensions> nv_stream;
     std::shared_ptr<mg::DisplayReport> const display_report;
@@ -465,7 +466,7 @@ mge::Display::Display(
       config{choose_config(display, gl_conf)},
       context{create_context(display, config)},
       display_configuration{create_display_configuration(this->drm_node, display, context)},
-      event_handler{std::make_shared<ThreadedDRMEventHandler>(drm_node)},
+      event_handler{std::make_shared<mgk::ThreadedDRMEventHandler>(drm_node)},
       display_report{std::move(display_report)}
 {
     auto ret = drmSetClientCap(drm_node, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);

--- a/src/platforms/eglstream-kms/server/display.h
+++ b/src/platforms/eglstream-kms/server/display.h
@@ -32,9 +32,13 @@ class DisplayConfigurationPolicy;
 class GLConfig;
 class DisplayReport;
 
-namespace eglstream
+namespace kms
 {
 class DRMEventHandler;
+}
+
+namespace eglstream
+{
 
 class Display : public mir::graphics::Display
 {
@@ -72,7 +76,7 @@ private:
     std::mutex mutable configuration_mutex;
     KMSDisplayConfiguration display_configuration;
 
-    std::shared_ptr<DRMEventHandler> const event_handler;
+    std::shared_ptr<graphics::kms::DRMEventHandler> const event_handler;
     std::vector<std::unique_ptr<DisplaySyncGroup>> active_sync_groups;
     std::shared_ptr<DisplayConfigurationPolicy> const configuration_policy;
     std::shared_ptr<DisplayReport> const display_report;

--- a/tests/unit-tests/platforms/CMakeLists.txt
+++ b/tests/unit-tests/platforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(virtual)
 
 set(UNIT_TEST_SOURCES
   ${UNIT_TEST_SOURCES}
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_threaded_drm_event_handler.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/test_rendering_platform.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/test_rendering_platform.h
 )

--- a/tests/unit-tests/platforms/eglstream-kms/server/CMakeLists.txt
+++ b/tests/unit-tests/platforms/eglstream-kms/server/CMakeLists.txt
@@ -1,6 +1,5 @@
 list(APPEND EGLSTREAM_KMS_UNIT_TEST_SOURCES
   $<TARGET_OBJECTS:mirplatformgraphicseglstreamkmsobjects>
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_threaded_drm_event_handler.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_utils.cpp
 )
 set(EGLSTREAM_KMS_UNIT_TEST_SOURCES ${EGLSTREAM_KMS_UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/platforms/test_threaded_drm_event_handler.cpp
+++ b/tests/unit-tests/platforms/test_threaded_drm_event_handler.cpp
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "src/platforms/eglstream-kms/server/threaded_drm_event_handler.h"
+#include "src/platforms/common/server/kms-utils/threaded_drm_event_handler.h"
 
 #include "mir/test/doubles/mock_drm.h"
 
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-namespace mge = mir::graphics::eglstream;
+namespace mgk = mir::graphics::kms;
 namespace mtd = mir::test::doubles;
 
 using namespace testing;
@@ -119,8 +119,8 @@ TEST_F(ThreadedDRMEventHandlerTest, flip_completion_handle_becomes_ready_on_flip
 {
     using namespace std::literals::chrono_literals;
 
-    mge::ThreadedDRMEventHandler handler{mock_drm_fd};
-    mge::ThreadedDRMEventHandler::KMSCrtcId const crtc_id{55};
+    mgk::ThreadedDRMEventHandler handler{mock_drm_fd};
+    mgk::ThreadedDRMEventHandler::KMSCrtcId const crtc_id{55};
 
     auto completion_handle = handler.expect_flip_event(crtc_id, [](auto, auto){});
 
@@ -136,8 +136,8 @@ TEST_F(ThreadedDRMEventHandlerTest, calls_frame_callback_on_flip_completion)
 {
     using namespace std::literals::chrono_literals;
 
-    mge::ThreadedDRMEventHandler handler{mock_drm_fd};
-    mge::ThreadedDRMEventHandler::KMSCrtcId const crtc_id{55};
+    mgk::ThreadedDRMEventHandler handler{mock_drm_fd};
+    mgk::ThreadedDRMEventHandler::KMSCrtcId const crtc_id{55};
     int constexpr frame_sec{10};
     int constexpr frame_usec{400};
     unsigned int constexpr expected_frame_no{3441};
@@ -158,8 +158,8 @@ TEST_F(ThreadedDRMEventHandlerTest, handles_spurious_drm_events)
 {
     using namespace std::literals::chrono_literals;
 
-    mge::ThreadedDRMEventHandler handler{mock_drm_fd};
-    mge::ThreadedDRMEventHandler::KMSCrtcId const crtc_id{55};
+    mgk::ThreadedDRMEventHandler handler{mock_drm_fd};
+    mgk::ThreadedDRMEventHandler::KMSCrtcId const crtc_id{55};
     int constexpr frame_sec{10};
     int constexpr frame_usec{400};
     unsigned int constexpr expected_frame_no{3441};
@@ -183,9 +183,9 @@ TEST_F(ThreadedDRMEventHandlerTest, dispatches_event_for_correct_crtc)
 {
     using namespace std::literals::chrono_literals;
 
-    mge::ThreadedDRMEventHandler handler{mock_drm_fd};
-    mge::ThreadedDRMEventHandler::KMSCrtcId const crtc_one{55};
-    mge::ThreadedDRMEventHandler::KMSCrtcId const crtc_two{44};
+    mgk::ThreadedDRMEventHandler handler{mock_drm_fd};
+    mgk::ThreadedDRMEventHandler::KMSCrtcId const crtc_one{55};
+    mgk::ThreadedDRMEventHandler::KMSCrtcId const crtc_two{44};
 
     std::atomic<bool> first_flip_done{false};
     std::atomic<bool> second_flip_done{false};


### PR DESCRIPTION
This should be useful when transitioning to the Atomic KMS API in gbm-kms.