### PR TITLE
Drop overengineered, leaky and broken error reporting on VT switch

### DIFF
--- a/include/platform/mir/console_services.h
+++ b/include/platform/mir/console_services.h
@@ -99,11 +99,8 @@ public:
      * \note    It is *not* an error to call this with the number of the active VT.
      *          This will be a no-op.
      * \param vt_number     [in] Number of the VT to switch to
-     * \param error_handler [in] Functor to call should an asynchronous error occur.
      */
-    virtual void switch_to(
-        int vt_number,
-        std::function<void(std::exception const&)> error_handler) = 0;
+    virtual void switch_to(int vt_number) = 0;
 
 protected:
     VTSwitcher() = default;

--- a/src/server/console/ioctl_vt_switcher.cpp
+++ b/src/server/console/ioctl_vt_switcher.cpp
@@ -15,11 +15,10 @@
  */
 
 #include "ioctl_vt_switcher.h"
-
-#include <boost/exception/enable_error_info.hpp>
-#include <boost/exception/info.hpp>
+#include "mir/log.h"
 
 #include <sys/ioctl.h>
+#include <string.h>
 #include <sys/vt.h>
 
 mir::console::IoctlVTSwitcher::IoctlVTSwitcher(mir::Fd vt_fd)
@@ -28,19 +27,10 @@ mir::console::IoctlVTSwitcher::IoctlVTSwitcher(mir::Fd vt_fd)
 }
 
 void mir::console::IoctlVTSwitcher::switch_to(
-    int vt_number,
-    std::function<void(std::exception const&)> error_handler)
+    int vt_number)
 {
     if (ioctl(vt_fd, VT_ACTIVATE, vt_number) == -1)
     {
-        auto const error = boost::enable_error_info(
-            std::system_error{
-                errno,
-                std::system_category(),
-                "Kernel request to change VT switch failed"})
-                << boost::throw_line(__LINE__)
-                << boost::throw_function(__PRETTY_FUNCTION__)
-                << boost::throw_file(__FILE__);
-        error_handler(error);
+        mir::log_error("%s:%d: Kernel request to change VT switch failed: %s", __FILE__, __LINE__, strerror(errno));
     }
 }

--- a/src/server/console/ioctl_vt_switcher.h
+++ b/src/server/console/ioctl_vt_switcher.h
@@ -30,8 +30,7 @@ public:
     IoctlVTSwitcher(mir::Fd vt_fd);
 
     void switch_to(
-        int vt_number,
-        std::function<void(std::exception const&)> error_handler) override;
+        int vt_number) override;
 
 private:
     mir::Fd const vt_fd;

--- a/src/server/input/vt_filter.cpp
+++ b/src/server/input/vt_filter.cpp
@@ -45,15 +45,7 @@ bool mir::input::VTFilter::handle(MirEvent const& event)
         [this](int vtno)
         {
             switcher->switch_to(
-                vtno,
-                [](std::exception const&)
-                {
-                    mir::log(
-                        mir::logging::Severity::error,
-                        "VT switch key handler",
-                        std::current_exception(),
-                        "Failed to switch to requested VT");
-                });
+                vtno);
         };
 
     if (mir_keyboard_event_action(keyboard_event) == mir_keyboard_action_down &&


### PR DESCRIPTION
This was broken as, despite passing an exception around, the exception is never thrown and so `current_exception()` is null and we get a segfault.

It was leaky as we called `new std::function<void(std::exception const&)>{error_handler};` and never delete.

It was over-engineered as there is no need to pass an exception around to log a runtime failure. 