### PR TITLE
Drop in a mutex to lock around data access

### DIFF
--- a/tests/mir_test_framework/window_management_test_harness.cpp
+++ b/tests/mir_test_framework/window_management_test_harness.cpp
@@ -109,6 +109,7 @@ void mir_test_framework::WindowManagementTestHarness::SetUp()
 
     auto fake_display = std::make_unique<mtd::FakeDisplay>(get_output_rectangles());
     {
+        std::lock_guard lock{self->mutex};
         self->display = fake_display.get();
     }
     preset_display(std::move(fake_display));

--- a/tests/mir_test_framework/window_management_test_harness.cpp
+++ b/tests/mir_test_framework/window_management_test_harness.cpp
@@ -61,6 +61,7 @@ struct mir_test_framework::WindowManagementTestHarness::Self : public ms::Surfac
 
     void client_surface_close_requested(ms::Surface const* surf) override
     {
+        std::lock_guard lock{mutex};
         auto it = std::find_if(known_surfaces.begin(), known_surfaces.end(), [surf](std::shared_ptr<ms::Surface> const& s)
         {
             return s.get() == surf;
@@ -83,6 +84,7 @@ struct mir_test_framework::WindowManagementTestHarness::Self : public ms::Surfac
     void entered_output(ms::Surface const*, mg::DisplayConfigurationOutputId const&) override {}
     void left_output(ms::Surface const*, mg::DisplayConfigurationOutputId const&) override {}
 
+    std::mutex mutable mutex;
     std::vector<std::shared_ptr<mc::BufferStream>> streams;
     std::vector<std::shared_ptr<ms::Surface>> known_surfaces;
     std::vector<std::shared_ptr<ms::Surface>> surfaces_to_destroy;
@@ -106,7 +108,9 @@ void mir_test_framework::WindowManagementTestHarness::SetUp()
 
 
     auto fake_display = std::make_unique<mtd::FakeDisplay>(get_output_rectangles());
-    self->display = fake_display.get();
+    {
+        self->display = fake_display.get();
+    }
     preset_display(std::move(fake_display));
 
     mir_test_framework::HeadlessInProcessServer::SetUp();
@@ -132,7 +136,11 @@ auto mir_test_framework::WindowManagementTestHarness::create_window(
     mir::shell::SurfaceSpecification spec) -> miral::Window
 {
     auto stream = std::make_shared<mir::test::doubles::StubBufferStream>();
-    self->streams.push_back(stream);
+
+    {
+        std::lock_guard lock{self->mutex};
+        self->streams.push_back(stream);
+    }
     spec.streams = std::vector<msh::StreamSpecification>();
     spec.streams.value().push_back(msh::StreamSpecification{
         stream,
@@ -158,6 +166,7 @@ auto mir_test_framework::WindowManagementTestHarness::create_window(
 void mir_test_framework::WindowManagementTestHarness::publish_event(MirEvent const& event)
 {
     server.the_shell()->handle(event);
+    std::lock_guard lock{self->mutex};
     for (auto const& surface : self->surfaces_to_destroy)
     {
         server.the_shell()->destroy_surface(surface->session().lock(), surface);


### PR DESCRIPTION
I can't convince myself that all access to `mir_test_framework::WindowManagementTestHarness::Self` data members is thread safe. So dropping in a mutex to see if it fixes the weird failures we see (mostly on riscv64).