### PR TITLE
Attempt to fix XWayland app scaling

### DIFF
--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -1267,7 +1267,7 @@ void mf::XWaylandSurface::prep_surface_spec(ProofOfMutexLock const&, msh::Surfac
         }
     }
 
-    auto scale_size_clamped = [inv_scale](auto& optional_prop)
+    auto scale_size_clamped = [](auto& optional_prop)
         {
             if (optional_prop)
             {
@@ -1275,7 +1275,7 @@ void mf::XWaylandSurface::prep_surface_spec(ProofOfMutexLock const&, msh::Surfac
                 using UnderlyingType = typename ValueType::ValueType;
                 auto constexpr raw_max = std::numeric_limits<UnderlyingType>::max();
 
-                double const double_value = optional_prop.value().as_value() * inv_scale;
+                double const double_value = optional_prop.value().as_value();
                 optional_prop = std::max(ValueType{1}, ValueType{std::min(double_value, double{raw_max})});
             }
         };

--- a/src/server/frontend_xwayland/xwayland_surface_observer.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.cpp
@@ -152,7 +152,7 @@ void mf::XWaylandSurfaceObserver::input_consumed(ms::Surface const*, std::shared
                 if (local)
                 {
                     // Scale positions based on the XWayland scale
-                    local = as_point(as_displacement(local.value()) * scale);
+                    local = as_point(as_displacement(local.value()));
                 }
                 return std::make_pair(global, local);
             });

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -86,7 +86,7 @@ void mf::XWaylandSurfaceRole::populate_surface_data_scaled(
         for (auto& rect : spec.input_shape.value())
         {
             rect.top_left = as_point(as_displacement(rect.top_left) * inv_scale);
-            rect.size = rect.size * inv_scale;
+            rect.size = rect.size;
         }
     }
 }

--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -155,13 +155,15 @@ msd::BasicDecoration::BasicDecoration(
     std::shared_ptr<mg::GraphicBufferAllocator> const& buffer_allocator,
     std::shared_ptr<Executor> const& executor,
     std::shared_ptr<input::CursorImages> const& cursor_images,
-    std::shared_ptr<ms::Surface> const& window_surface)
+    std::shared_ptr<ms::Surface> const& window_surface,
+    float x11_scale)
     : threadsafe_self{std::make_shared<ThreadsafeAccess<BasicDecoration>>(executor)},
       static_geometry{std::make_shared<StaticGeometry>(default_geometry)},
       shell{shell},
       buffer_allocator{buffer_allocator},
       cursor_images{cursor_images},
       session{window_surface->session().lock()},
+      scale{x11_scale},
       buffer_streams{std::make_unique<BufferStreams>(session)},
       renderer{std::make_unique<Renderer>(buffer_allocator, static_geometry)},
       window_surface{window_surface},

--- a/src/server/shell/decoration/basic_decoration.h
+++ b/src/server/shell/decoration/basic_decoration.h
@@ -72,7 +72,8 @@ public:
         std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
         std::shared_ptr<Executor> const& executor,
         std::shared_ptr<input::CursorImages> const& cursor_images,
-        std::shared_ptr<scene::Surface> const& window_surface);
+        std::shared_ptr<scene::Surface> const& window_surface,
+        float x11_scale);
     ~BasicDecoration();
 
     void window_state_updated();

--- a/src/server/shell/decoration/basic_manager.cpp
+++ b/src/server/shell/decoration/basic_manager.cpp
@@ -94,7 +94,7 @@ void msd::BasicManager::decorate(std::shared_ptr<ms::Surface> const& surface)
         lock.unlock();
         auto decoration = decoration_builder(locked_shell, surface);
         lock.lock();
-        decoration->set_scale(scale);
+        /* decoration->set_scale(scale); */
         decorations[surface.get()] = std::move(decoration);
     }
 }

--- a/src/server/shell/decoration/input.cpp
+++ b/src/server/shell/decoration/input.cpp
@@ -244,9 +244,7 @@ auto msd::InputManager::resize_edge_rect(
     case mir_resize_edge_northeast:
     {
         geom::Point top_left{
-            as_x(window_state.window_size().width) -
-                as_delta(static_geometry.resize_corner_input_size.width),
-            0};
+            as_x(window_state.titlebar_width() - static_geometry.resize_corner_input_size.width), 0};
         return {top_left, static_geometry.resize_corner_input_size};
     }
 
@@ -254,19 +252,21 @@ auto msd::InputManager::resize_edge_rect(
     {
         geom::Point top_left{
             0,
-            as_y(window_state.window_size().height) -
-                as_delta(static_geometry.resize_corner_input_size.height)};
+            as_y(
+                window_state.side_border_height() + window_state.titlebar_height() +
+                window_state.bottom_border_height() - static_geometry.resize_corner_input_size.height)};
         return {top_left, static_geometry.resize_corner_input_size};
     }
 
     case mir_resize_edge_southeast:
     {
         geom::Point top_left{
-            as_x(window_state.window_size().width) -
-                as_delta(static_geometry.resize_corner_input_size.width),
-            as_y(window_state.window_size().height) -
-                as_delta(static_geometry.resize_corner_input_size.height)};
-        return {top_left, static_geometry.resize_corner_input_size};
+            as_x(window_state.titlebar_width() - static_geometry.resize_corner_input_size.width),
+            as_y(
+                (as_height(window_state.window_size().height - static_geometry.resize_corner_input_size.height * 2.0)) *
+                    window_state.scale() +
+                window_state.titlebar_height())};
+        return {top_left, static_geometry.resize_corner_input_size * 2.0};
     }
 
     default: return {};

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -16,6 +16,7 @@
 
 
 #include "renderer.h"
+#include "mir/logging/logger.h"
 #include "window.h"
 #include "input.h"
 
@@ -26,7 +27,10 @@
 
 #include <boost/throw_exception.hpp>
 #include <boost/filesystem.hpp>
+#include <cassert>
 #include <ft2build.h>
+#include <iostream>
+#include <string>
 #include FT_FREETYPE_H
 
 #include <locale>

--- a/src/server/shell/decoration/window.cpp
+++ b/src/server/shell/decoration/window.cpp
@@ -112,7 +112,7 @@ auto msd::WindowState::titlebar_width() const -> geom::Width
     {
     case BorderType::Full:
     case BorderType::Titlebar:
-        return window_size().width;;
+        return as_width(window_size().width * scale_ - side_border_width() * (scale() - 1) * 2);
     case BorderType::None:
         return {};
     }
@@ -156,7 +156,7 @@ auto msd::WindowState::side_border_height() const -> geom::Height
     switch (border_type_)
     {
     case BorderType::Full:
-        return window_size().height - as_delta(titlebar_height()) - as_delta(bottom_border_height());
+        return  as_height(window_size().height - (titlebar_height() + bottom_border_height())) * scale_;
     case BorderType::Titlebar:
     case BorderType::None:
         return {};
@@ -199,19 +199,16 @@ auto msd::WindowState::left_border_rect() const -> geom::Rectangle
         {geom::X{}, as_y(titlebar_height())},
         {side_border_width(), side_border_height()}};
 }
-
 auto msd::WindowState::right_border_rect() const -> geom::Rectangle
 {
     return {
-        {as_x(window_size().width - side_border_width()), as_y(titlebar_height())},
+        {as_x(titlebar_width() - side_border_width()), as_y(titlebar_height())},
         {side_border_width(), side_border_height()}};
 }
-
 auto msd::WindowState::bottom_border_rect() const -> geom::Rectangle
 {
     return {
-        {geom::X{}, as_y(window_size().height - bottom_border_height())},
-        {bottom_border_width(), bottom_border_height()}};
+        {geom::X{}, as_y(titlebar_height() + side_border_height())}, {bottom_border_width(), bottom_border_height()}};
 }
 
 auto msd::WindowState::button_rect(unsigned n) const -> geom::Rectangle

--- a/src/server/shell/decoration/window.cpp
+++ b/src/server/shell/decoration/window.cpp
@@ -112,7 +112,7 @@ auto msd::WindowState::titlebar_width() const -> geom::Width
     {
     case BorderType::Full:
     case BorderType::Titlebar:
-        return window_size().width;
+        return window_size().width;;
     case BorderType::None:
         return {};
     }

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <boost/lexical_cast.hpp>
 #include <mir/shell/system_compositor_window_manager.h>
 #include <mir/main_loop.h>
 #include "mir/default_server_configuration.h"
@@ -69,11 +70,14 @@ auto mir::DefaultServerConfiguration::the_decoration_manager() -> std::shared_pt
     return decoration_manager(
         [this]()->std::shared_ptr<msd::Manager>
         {
+            auto options = the_options();
+            auto x11_scale = boost::lexical_cast<float>(options->get<std::string>(options::x11_scale_opt));
             return std::make_shared<msd::BasicManager>(
                 *the_display_configuration_observer_registrar(),
                 [buffer_allocator = the_buffer_allocator(),
                  executor = the_main_loop(),
-                 cursor_images = the_cursor_images()](
+                 cursor_images = the_cursor_images(),
+                 x11_scale](
                     std::shared_ptr<shell::Shell> const& shell,
                     std::shared_ptr<scene::Surface> const& surface) -> std::unique_ptr<msd::Decoration>
                 {
@@ -82,7 +86,8 @@ auto mir::DefaultServerConfiguration::the_decoration_manager() -> std::shared_pt
                         buffer_allocator,
                         executor,
                         cursor_images,
-                        surface);
+                        surface,
+                        x11_scale);
                 });
         });
 }


### PR DESCRIPTION
Probably caused by my changes:
- [x] While apps and their decorations render correctly on XWayland now, input events are only received in the original area (non-scaled). So for a 2.0 scale factor, only the top left quarter works correctly.
- [ ] Wayland apps with server side decorations are broken: I probably broke something while focusing on fixing XWayland, but that's fine. I'll return to this once I fixed the XWayland problems and have a global view on what was changes.
- [ ] (?) Dragging to resize is not 1:1 with the mouse. Still works though

Already exists on main:
- [ ] Maximized windows are scaled outside the bounds of the screen, which shouldn't happen.