### PR TITLE
Add `--idle-timeout-when-locked` for idle timeout when session is locked

### DIFF
--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -46,6 +46,7 @@ extern char const* const wayland_extensions_opt;
 extern char const* const add_wayland_extensions_opt;
 extern char const* const drop_wayland_extensions_opt;
 extern char const* const idle_timeout_opt;
+extern char const* const idle_timeout_on_lock_opt;
 
 extern char const* const enable_key_repeat_opt;
 

--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -46,7 +46,7 @@ extern char const* const wayland_extensions_opt;
 extern char const* const add_wayland_extensions_opt;
 extern char const* const drop_wayland_extensions_opt;
 extern char const* const idle_timeout_opt;
-extern char const* const idle_timeout_on_lock_opt;
+extern char const* const idle_timeout_when_locked_opt;
 
 extern char const* const enable_key_repeat_opt;
 

--- a/src/include/server/mir/shell/idle_handler.h
+++ b/src/include/server/mir/shell/idle_handler.h
@@ -52,6 +52,13 @@ public:
     /// is sent the display is never turned off or dimmed, which is the default.
     virtual void set_display_off_timeout(std::optional<time::Duration> timeout) = 0;
 
+    /// Duration Mir will remain idle before the display is turned off after the session is locked. The display may dim
+    /// some time before this. If not nullopt, this idle timeout takes precedence over the timeout set with
+    /// set_display_off_timeout while the session is locked and remains idle. If Mir becomes active after the session
+    /// is locked, this timeout is disabled. If the session is already locked when this function is called, the new
+    /// timeout will only take effect after the next session lock.
+    virtual void set_display_off_timeout_on_lock(std::optional<time::Duration> timeout) = 0;
+
 private:
     IdleHandler(IdleHandler const&) = delete;
     IdleHandler& operator=(IdleHandler const&) = delete;

--- a/src/include/server/mir/shell/idle_handler.h
+++ b/src/include/server/mir/shell/idle_handler.h
@@ -52,12 +52,10 @@ public:
     /// is sent the display is never turned off or dimmed, which is the default.
     virtual void set_display_off_timeout(std::optional<time::Duration> timeout) = 0;
 
-    /// Duration Mir will remain idle before the display is turned off after the session is locked. The display may dim
-    /// some time before this. If not nullopt, this idle timeout takes precedence over the timeout set with
-    /// set_display_off_timeout while the session is locked and remains idle. If Mir becomes active after the session
-    /// is locked, this timeout is disabled. If the session is already locked when this function is called, the new
-    /// timeout will only take effect after the next session lock.
-    virtual void set_display_off_timeout_on_lock(std::optional<time::Duration> timeout) = 0;
+    /// Duration Mir will remain idle before the display is turned off when the session is locked. The display may dim
+    /// some time before this. If nullopt is sent, the display is never turned off or dimmed during session lock, which
+    /// is the default.
+    virtual void set_display_off_timeout_when_locked(std::optional<time::Duration> timeout) = 0;
 
 private:
     IdleHandler(IdleHandler const&) = delete;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -44,7 +44,7 @@ char const* const mo::wayland_extensions_opt      = "wayland-extensions";
 char const* const mo::add_wayland_extensions_opt  = "add-wayland-extensions";
 char const* const mo::drop_wayland_extensions_opt = "drop-wayland-extensions";
 char const* const mo::idle_timeout_opt            = "idle-timeout";
-char const* const mo::idle_timeout_on_lock_opt    = "idle-timeout-on-lock";
+char const* const mo::idle_timeout_when_locked_opt = "idle-timeout-when-locked";
 
 char const* const mo::off_opt_value = "off";
 char const* const mo::log_opt_value = "log";
@@ -178,13 +178,11 @@ mo::DefaultConfiguration::DefaultConfiguration(
         (enable_key_repeat_opt, po::value<bool>()->default_value(true),
              "Enable server generated key repeat")
         (idle_timeout_opt, po::value<int>()->default_value(0),
-            "Time (in seconds) Mir will remain idle before turning off the display, "
-            "or 0 to keep display on forever.")
-        (idle_timeout_on_lock_opt, po::value<int>()->default_value(-1),
             "Time (in seconds) Mir will remain idle before turning off the display "
-            "after the session is locked. If Mir becomes active while the session is "
-            "locked, the timeout falls back to the one set with --idle-timeout. "
-            "Default: a negative value disables this timeout.")
+            "when the session is not locked, or 0 to keep display on forever.")
+        (idle_timeout_when_locked_opt, po::value<int>()->default_value(0),
+            "Time (in seconds) Mir will remain idle before turning off the display "
+            "when the session is locked, or 0 to keep the display on forever.")
         (fatal_except_opt, "On \"fatal error\" conditions [e.g. drivers behaving "
             "in unexpected ways] throw an exception (instead of a core dump)")
         (debug_opt, "Enable extra development debugging. "

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -44,6 +44,7 @@ char const* const mo::wayland_extensions_opt      = "wayland-extensions";
 char const* const mo::add_wayland_extensions_opt  = "add-wayland-extensions";
 char const* const mo::drop_wayland_extensions_opt = "drop-wayland-extensions";
 char const* const mo::idle_timeout_opt            = "idle-timeout";
+char const* const mo::idle_timeout_on_lock_opt    = "idle-timeout-on-lock";
 
 char const* const mo::off_opt_value = "off";
 char const* const mo::log_opt_value = "log";
@@ -179,6 +180,11 @@ mo::DefaultConfiguration::DefaultConfiguration(
         (idle_timeout_opt, po::value<int>()->default_value(0),
             "Time (in seconds) Mir will remain idle before turning off the display, "
             "or 0 to keep display on forever.")
+        (idle_timeout_on_lock_opt, po::value<int>()->default_value(-1),
+            "Time (in seconds) Mir will remain idle before turning off the display "
+            "after the session is locked. If Mir becomes active while the session is "
+            "locked, the timeout falls back to the one set with --idle-timeout. "
+            "Default: a negative value disables this timeout.")
         (fatal_except_opt, "On \"fatal error\" conditions [e.g. drivers behaving "
             "in unexpected ways] throw an exception (instead of a core dump)")
         (debug_opt, "Enable extra development debugging. "

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -1,4 +1,4 @@
-MIR_PLATFORM_2.19 {
+MIR_PLATFORM_2.18 {
  global:
   extern "C++" {
     mir::graphics::AtomicFrame::increment*;
@@ -125,7 +125,6 @@ MIR_PLATFORM_2.19 {
     mir::options::enable_key_repeat_opt*;
     mir::options::fatal_except_opt*;
     mir::options::idle_timeout_opt;
-    mir::options::idle_timeout_on_lock_opt;
     mir::options::input_report_opt*;
     mir::options::log_opt_value*;
     mir::options::logind_console;
@@ -201,5 +200,12 @@ MIR_PLATFORM_2.19 {
     vtable?for?mir::options::Option;
     vtable?for?mir::options::ProgramOption;
  };
- local: *;
 };
+
+MIR_PLATFORM_2.19 {
+ global:
+  extern "C++" {
+    mir::options::idle_timeout_on_lock_opt;
+ };
+ local: *;
+} MIR_PLATFORM_2.18;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -205,7 +205,7 @@ MIR_PLATFORM_2.18 {
 MIR_PLATFORM_2.19 {
  global:
   extern "C++" {
-    mir::options::idle_timeout_on_lock_opt;
+    mir::options::idle_timeout_when_locked_opt;
  };
  local: *;
 } MIR_PLATFORM_2.18;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -1,4 +1,4 @@
-MIR_PLATFORM_2.18 {
+MIR_PLATFORM_2.19 {
  global:
   extern "C++" {
     mir::graphics::AtomicFrame::increment*;
@@ -125,6 +125,7 @@ MIR_PLATFORM_2.18 {
     mir::options::enable_key_repeat_opt*;
     mir::options::fatal_except_opt*;
     mir::options::idle_timeout_opt;
+    mir::options::idle_timeout_on_lock_opt;
     mir::options::input_report_opt*;
     mir::options::log_opt_value*;
     mir::options::logind_console;
@@ -202,4 +203,3 @@ MIR_PLATFORM_2.18 {
  };
  local: *;
 };
-

--- a/src/server/shell/basic_idle_handler.cpp
+++ b/src/server/shell/basic_idle_handler.cpp
@@ -203,11 +203,11 @@ private:
 class msh::BasicIdleHandler::SessionLockListener : public ms::SessionLockObserver
 {
 public:
-    explicit SessionLockListener(std::function<void()> const& on_lock) : on_lock_{on_lock} {};
+    explicit SessionLockListener(std::function<void()> const& on_lock) : on_lock_{on_lock} {}
 
 private:
-    void on_lock() override { on_lock_(); };
-    void on_unlock() override {};
+    void on_lock() override { on_lock_(); }
+    void on_unlock() override {}
 
     std::function<void()> const on_lock_;
 };

--- a/src/server/shell/basic_idle_handler.h
+++ b/src/server/shell/basic_idle_handler.h
@@ -75,9 +75,14 @@ public:
 
 private:
     class SessionLockListener;
+    class TimeoutRestorer;
+
+    void on_lock();
+    void on_unlock();
 
     void register_observers(ProofOfMutexLock const&);
     void clear_observers(ProofOfMutexLock const&);
+    void restore_off_timeout();
 
     std::shared_ptr<scene::IdleHub> const idle_hub;
     std::shared_ptr<input::Scene> const input_scene;
@@ -88,8 +93,10 @@ private:
 
     std::mutex mutex;
     std::optional<time::Duration> current_off_timeout;
+    std::optional<time::Duration> previous_off_timeout;
     std::optional<time::Duration> current_off_timeout_on_lock;
     std::vector<std::shared_ptr<scene::IdleStateObserver>> observers;
+    std::shared_ptr<TimeoutRestorer> timeout_restorer;
 
     class BasicIdleHandlerObserverMultiplexer: public ObserverMultiplexer<IdleHandlerObserver>
     {

--- a/src/server/shell/basic_idle_handler.h
+++ b/src/server/shell/basic_idle_handler.h
@@ -39,6 +39,7 @@ namespace scene
 {
 class IdleHub;
 class IdleStateObserver;
+class SessionLock;
 }
 namespace shell
 {
@@ -51,7 +52,8 @@ public:
         std::shared_ptr<scene::IdleHub> const& idle_hub,
         std::shared_ptr<input::Scene> const& input_scene,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
-        std::shared_ptr<shell::DisplayConfigurationController> const& display_config_controller);
+        std::shared_ptr<shell::DisplayConfigurationController> const& display_config_controller,
+        std::shared_ptr<scene::SessionLock> const& session_lock);
 
     ~BasicIdleHandler();
 
@@ -70,12 +72,16 @@ public:
     void unregister_interest(IdleHandlerObserver const&) override;
 
 private:
+    class SessionLockListener;
+
     void clear_observers(ProofOfMutexLock const&);
 
     std::shared_ptr<scene::IdleHub> const idle_hub;
     std::shared_ptr<input::Scene> const input_scene;
     std::shared_ptr<graphics::GraphicBufferAllocator> const allocator;
     std::shared_ptr<shell::DisplayConfigurationController> const display_config_controller;
+    std::shared_ptr<scene::SessionLock> const session_lock;
+    std::shared_ptr<SessionLockListener> const session_lock_monitor;
 
     std::mutex mutex;
     std::optional<time::Duration> current_off_timeout;

--- a/src/server/shell/basic_idle_handler.h
+++ b/src/server/shell/basic_idle_handler.h
@@ -59,6 +59,8 @@ public:
 
     void set_display_off_timeout(std::optional<time::Duration> timeout) override;
 
+    void set_display_off_timeout_on_lock(std::optional<time::Duration> timeout) override;
+
     void register_interest(std::weak_ptr<IdleHandlerObserver> const&) override;
 
     void register_interest(
@@ -74,6 +76,7 @@ public:
 private:
     class SessionLockListener;
 
+    void register_observers(ProofOfMutexLock const&);
     void clear_observers(ProofOfMutexLock const&);
 
     std::shared_ptr<scene::IdleHub> const idle_hub;
@@ -85,6 +88,7 @@ private:
 
     std::mutex mutex;
     std::optional<time::Duration> current_off_timeout;
+    std::optional<time::Duration> current_off_timeout_on_lock;
     std::vector<std::shared_ptr<scene::IdleStateObserver>> observers;
 
     class BasicIdleHandlerObserverMultiplexer: public ObserverMultiplexer<IdleHandlerObserver>

--- a/src/server/shell/basic_idle_handler.h
+++ b/src/server/shell/basic_idle_handler.h
@@ -59,7 +59,7 @@ public:
 
     void set_display_off_timeout(std::optional<time::Duration> timeout) override;
 
-    void set_display_off_timeout_on_lock(std::optional<time::Duration> timeout) override;
+    void set_display_off_timeout_when_locked(std::optional<time::Duration> timeout) override;
 
     void register_interest(std::weak_ptr<IdleHandlerObserver> const&) override;
 
@@ -75,14 +75,12 @@ public:
 
 private:
     class SessionLockListener;
-    class TimeoutRestorer;
 
-    void on_lock();
-    void on_unlock();
+    void on_session_lock();
+    void on_session_unlock();
 
     void register_observers(ProofOfMutexLock const&);
     void clear_observers(ProofOfMutexLock const&);
-    void restore_off_timeout();
 
     std::shared_ptr<scene::IdleHub> const idle_hub;
     std::shared_ptr<input::Scene> const input_scene;
@@ -93,10 +91,9 @@ private:
 
     std::mutex mutex;
     std::optional<time::Duration> current_off_timeout;
-    std::optional<time::Duration> previous_off_timeout;
-    std::optional<time::Duration> current_off_timeout_on_lock;
+    std::optional<time::Duration> current_off_timeout_when_locked;
+    bool session_locked{false};
     std::vector<std::shared_ptr<scene::IdleStateObserver>> observers;
-    std::shared_ptr<TimeoutRestorer> timeout_restorer;
 
     class BasicIdleHandlerObserverMultiplexer: public ObserverMultiplexer<IdleHandlerObserver>
     {

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -123,6 +123,12 @@ auto mir::DefaultServerConfiguration::the_idle_handler() -> std::shared_ptr<msh:
                 idle_handler->set_display_off_timeout(std::chrono::seconds{idle_timeout_seconds});
             }
 
+            int const idle_timeout_on_lock = options->get<int>(options::idle_timeout_on_lock_opt);
+            if (idle_timeout_on_lock >= 0)
+            {
+                idle_handler->set_display_off_timeout_on_lock(std::chrono::seconds{idle_timeout_on_lock});
+            }
+
             return idle_handler;
         });
 }

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -124,7 +124,11 @@ auto mir::DefaultServerConfiguration::the_idle_handler() -> std::shared_ptr<msh:
             }
 
             int const idle_timeout_on_lock = options->get<int>(options::idle_timeout_on_lock_opt);
-            if (idle_timeout_on_lock >= 0)
+            if (idle_timeout_on_lock < 0)
+            {
+                idle_handler->set_display_off_timeout_on_lock(std::nullopt);
+            }
+            else
             {
                 idle_handler->set_display_off_timeout_on_lock(std::chrono::seconds{idle_timeout_on_lock});
             }

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -123,14 +123,23 @@ auto mir::DefaultServerConfiguration::the_idle_handler() -> std::shared_ptr<msh:
                 idle_handler->set_display_off_timeout(std::chrono::seconds{idle_timeout_seconds});
             }
 
-            int const idle_timeout_on_lock = options->get<int>(options::idle_timeout_on_lock_opt);
-            if (idle_timeout_on_lock < 0)
+            int const idle_timeout_when_locked = options->get<int>(options::idle_timeout_when_locked_opt);
+            if (idle_timeout_when_locked < 0)
             {
-                idle_handler->set_display_off_timeout_on_lock(std::nullopt);
+                throw mir::AbnormalExit(
+                    "Invalid " +
+                    std::string{options::idle_timeout_when_locked_opt} +
+                    " value " +
+                    std::to_string(idle_timeout_when_locked) +
+                    ", must be > 0");
+            }
+            if (idle_timeout_when_locked == 0)
+            {
+                idle_handler->set_display_off_timeout_when_locked(std::nullopt);
             }
             else
             {
-                idle_handler->set_display_off_timeout_on_lock(std::chrono::seconds{idle_timeout_on_lock});
+                idle_handler->set_display_off_timeout_when_locked(std::chrono::seconds{idle_timeout_when_locked});
             }
 
             return idle_handler;

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -100,7 +100,8 @@ auto mir::DefaultServerConfiguration::the_idle_handler() -> std::shared_ptr<msh:
                 the_idle_hub(),
                 the_input_scene(),
                 the_buffer_allocator(),
-                the_display_configuration_controller());
+                the_display_configuration_controller(),
+                the_session_lock());
 
             auto options = the_options();
             int const idle_timeout_seconds = options->get<int>(options::idle_timeout_opt);

--- a/tests/unit-tests/shell/test_basic_idle_handler.cpp
+++ b/tests/unit-tests/shell/test_basic_idle_handler.cpp
@@ -19,6 +19,7 @@
 #include "mir/test/doubles/mock_idle_hub.h"
 #include "mir/test/doubles/stub_input_scene.h"
 #include "mir/test/doubles/stub_buffer_allocator.h"
+#include "mir/test/doubles/stub_session_lock.h"
 #include "mir/shell/display_configuration_controller.h"
 #include "mir/test/fake_shared.h"
 
@@ -52,11 +53,13 @@ struct BasicIdleHandler: Test
     mtd::StubInputScene input_scene;
     mtd::StubBufferAllocator allocator;
     NiceMock<MockDisplayConfigurationController> display;
+    mtd::StubSessionLock session_lock;
     msh::BasicIdleHandler handler{
         mt::fake_shared(idle_hub),
         mt::fake_shared(input_scene),
         mt::fake_shared(allocator),
-        mt::fake_shared(display)};
+        mt::fake_shared(display),
+        mt::fake_shared(session_lock)};
     std::map<mir::time::Duration, std::weak_ptr<ms::IdleStateObserver>> observers;
 
     void SetUp()
@@ -95,7 +98,8 @@ TEST_F(BasicIdleHandler, does_not_register_observers_by_default)
         mt::fake_shared(idle_hub),
         mt::fake_shared(input_scene),
         mt::fake_shared(allocator),
-        mt::fake_shared(display)};
+        mt::fake_shared(display),
+        mt::fake_shared(session_lock)};
 }
 
 TEST_F(BasicIdleHandler, turns_display_off_when_idle)

--- a/tests/unit-tests/shell/test_basic_idle_handler.cpp
+++ b/tests/unit-tests/shell/test_basic_idle_handler.cpp
@@ -47,13 +47,51 @@ public:
     MOCK_METHOD1(set_power_mode, void(MirPowerMode));
 };
 
+class FakeSessionLock : public ms::SessionLock
+{
+public:
+    void lock() override
+    {
+        auto config_observer = observer.lock();
+        EXPECT_THAT(config_observer, testing::NotNull());
+        config_observer->on_lock();
+    }
+    void unlock() override
+    {
+        auto config_observer = observer.lock();
+        EXPECT_THAT(config_observer, testing::NotNull());
+        config_observer->on_unlock();
+    }
+    void register_interest(std::weak_ptr<ms::SessionLockObserver> const& o) override
+    {
+        ASSERT_THAT(observer.lock(), testing::IsNull())
+            << "FakeSessionLock does not support multiple observers";
+        observer = o;
+    }
+    void register_interest(std::weak_ptr<ms::SessionLockObserver> const& o, mir::Executor&) override
+    {
+        register_interest(o);
+    }
+    void register_early_observer(std::weak_ptr<ms::SessionLockObserver> const& o, mir::Executor&) override
+    {
+        register_interest(o);
+    }
+    void unregister_interest(ms::SessionLockObserver const& o) override
+    {
+        ASSERT_THAT(observer.lock().get(), testing::Eq(&o));
+        observer = std::weak_ptr<ms::SessionLockObserver>();
+    }
+private:
+    std::weak_ptr<ms::SessionLockObserver> observer;
+};
+
 struct BasicIdleHandler: Test
 {
     NiceMock<mtd::MockIdleHub> idle_hub;
     mtd::StubInputScene input_scene;
     mtd::StubBufferAllocator allocator;
     NiceMock<MockDisplayConfigurationController> display;
-    mtd::StubSessionLock session_lock;
+    FakeSessionLock session_lock;
     msh::BasicIdleHandler handler{
         mt::fake_shared(idle_hub),
         mt::fake_shared(input_scene),
@@ -94,12 +132,61 @@ TEST_F(BasicIdleHandler, does_not_register_observers_by_default)
 {
     EXPECT_CALL(idle_hub, register_interest(_, _))
         .Times(0);
+    mtd::StubSessionLock session_lock;
     msh::BasicIdleHandler local_handler{
         mt::fake_shared(idle_hub),
         mt::fake_shared(input_scene),
         mt::fake_shared(allocator),
         mt::fake_shared(display),
         mt::fake_shared(session_lock)};
+}
+
+TEST_F(BasicIdleHandler, off_timeout_on_lock_is_used_when_session_is_locked)
+{
+    EXPECT_CALL(idle_hub, register_interest(_, Eq(30s)))
+        .Times(1);
+    handler.set_display_off_timeout(30s);
+
+    handler.set_display_off_timeout_on_lock(10s);
+
+    EXPECT_CALL(idle_hub, register_interest(_, Eq(10s)))
+        .Times(1);
+    session_lock.lock();
+}
+
+TEST_F(BasicIdleHandler, off_timeout_on_lock_is_not_used_when_session_is_not_locked)
+{
+    EXPECT_CALL(idle_hub, register_interest(_, Eq(30s)))
+        .Times(1);
+    handler.set_display_off_timeout(30s);
+
+    EXPECT_CALL(idle_hub, register_interest(_, Eq(10s)))
+        .Times(0);
+    handler.set_display_off_timeout_on_lock(10s);
+}
+
+TEST_F(BasicIdleHandler, off_timeout_is_restored_when_locked_session_becomes_active)
+{
+    EXPECT_CALL(idle_hub, register_interest(_, Eq(30s)))
+        .Times(2);
+    handler.set_display_off_timeout(30s);
+    handler.set_display_off_timeout_on_lock(10s);
+
+    EXPECT_CALL(idle_hub, register_interest(_, Eq(10s)))
+        .Times(1);
+    session_lock.lock();
+
+    auto const observer = observer_for(0s);
+    observer->active();
+}
+
+TEST_F(BasicIdleHandler, off_timeout_on_lock_is_not_used_if_equal_to_off_timeout)
+{
+    EXPECT_CALL(idle_hub, register_interest(_, Eq(30s)))
+        .Times(1);
+    handler.set_display_off_timeout(30s);
+    handler.set_display_off_timeout_on_lock(30s);
+    session_lock.lock();
 }
 
 TEST_F(BasicIdleHandler, turns_display_off_when_idle)


### PR DESCRIPTION
Fixes #3306.

This PR adds a new configuration option, `--idle-timeout-when-locked`, that allows the compositor to apply a separate idle timeout when the session is locked. The default value is 0, meaning the display will stay on indefinitely when the session is locked.

Examples showing its interaction with the existing `--idle-timeout` option:
- `--idle-timeout=60 --idle-timeout-when-locked=10`: The display turns off after 60s of idle time when the session is unlocked, and after 10s of idle time when the session is locked.
- `--idle-timeout=0 --idle-timeout-when-locked=10`: The display never turns off when idle, but it turns off after 10s of idle time when the session is locked.
- `--idle-timeout=60 --idle-timeout-when-locked=0`: The display turns off after 60s of idle time but never when the session is locked.
- `--idle-timeout=0 --idle-timeout-on-lock=0`: This is the default behavior. The display never turns off, wether the session is locked or unlocked.

### Implementation details:

`BasicIdleHandler` now registers a session lock listener via the `SessionLockListener` class, which takes `on_lock` and `on_unlock` callbacks to track the state of the session lock. When the idle handlers (the dimmer and the power setter) are registered, they will use the timeout value from `--idle-timeout-when-locked` when the session is locked, and from `--idle-timeout` when the session is not locked.