### PR TITLE
inotify_init1(IN_CLOEXEC)

### DIFF
--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -627,7 +627,7 @@ auto miral::ReloadingYamlFileDisplayConfig::inotify_config_path() -> std::option
 
     if (!config_path_) return std::nullopt;
 
-    mir::Fd inotify_fd{inotify_init()};
+    mir::Fd inotify_fd{inotify_init1(IN_CLOEXEC)};
 
     if (inotify_fd < 0)
         BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to initialize inotify_fd"}));

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -501,7 +501,7 @@ void mf::ForeignSurfaceObserver::application_id_set_to(
 // GDesktopFileCache
 mf::GDesktopFileCache::GDesktopFileCache(const std::shared_ptr<MainLoop> &main_loop)
     : main_loop{main_loop},
-      inotify_fd{inotify_init()}
+      inotify_fd{inotify_init1(IN_CLOEXEC)}
 {
     refresh_app_cache();
 


### PR DESCRIPTION
As [mentioned](https://github.com/canonical/mir/pull/3544#discussion_r1716168734) by @RAOF, we don't want the FD leaking to child processes 