### PR TITLE
platform/graphics: Use interface Option type in interfaces.

### DIFF
--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -41,7 +41,6 @@ class Surface;
 namespace options
 {
 class Option;
-class ProgramOption;
 }
 namespace renderer::software
 {
@@ -564,13 +563,13 @@ typedef void(*AddPlatformOptions)(
 typedef std::vector<mir::graphics::SupportedDevice>(*PlatformProbe)(
     std::shared_ptr<mir::ConsoleServices> const&,
     std::shared_ptr<mir::udev::Context> const&,
-    mir::options::ProgramOption const& options);
+    mir::options::Option const& options);
 
 typedef std::vector<mir::graphics::SupportedDevice>(*RenderProbe)(
     std::span<std::shared_ptr<mir::graphics::DisplayPlatform>> const&,
     mir::ConsoleServices&,
     std::shared_ptr<mir::udev::Context> const&,
-    mir::options::ProgramOption const&);
+    mir::options::Option const&);
 
 typedef mir::ModuleProperties const*(*DescribeModule)();
 }
@@ -628,13 +627,13 @@ void add_graphics_platform_options(
 auto probe_display_platform(
     std::shared_ptr<mir::ConsoleServices> const& console,
     std::shared_ptr<mir::udev::Context> const& udev,
-    mir::options::ProgramOption const& options) -> std::vector<mir::graphics::SupportedDevice>;
+    mir::options::Option const& options) -> std::vector<mir::graphics::SupportedDevice>;
 
 auto probe_rendering_platform(
     std::span<std::shared_ptr<mir::graphics::DisplayPlatform>> const& targets,
     mir::ConsoleServices& console,
     std::shared_ptr<mir::udev::Context> const& udev,
-    mir::options::ProgramOption const& options) -> std::vector<mir::graphics::SupportedDevice>;
+    mir::options::Option const& options) -> std::vector<mir::graphics::SupportedDevice>;
 
 mir::ModuleProperties const* describe_graphics_module();
 

--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -94,7 +94,7 @@ auto probe_rendering_platform(
     std::span<std::shared_ptr<mg::DisplayPlatform>> const& displays,
     mir::ConsoleServices& /*console*/,
     std::shared_ptr<mir::udev::Context> const& udev,
-    mo::ProgramOption const& /*options*/) -> std::vector<mg::SupportedDevice>
+    mo::Option const& /*options*/) -> std::vector<mg::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::RenderProbe>(&probe_rendering_platform);
 
@@ -312,7 +312,7 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
 auto probe_display_platform(
     std::shared_ptr<mir::ConsoleServices> const& console,
     std::shared_ptr<mir::udev::Context> const& udev,
-    mo::ProgramOption const&) -> std::vector<mg::SupportedDevice>
+    mo::Option const&) -> std::vector<mg::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_display_platform);
 

--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -116,7 +116,7 @@ public:
 auto probe_display_platform(
     std::shared_ptr<mir::ConsoleServices> const& console,
     std::shared_ptr<mir::udev::Context> const& udev,
-    mir::options::ProgramOption const& options) -> std::vector<mir::graphics::SupportedDevice>
+    mir::options::Option const& options) -> std::vector<mir::graphics::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_display_platform);
 
@@ -310,7 +310,7 @@ auto probe_rendering_platform(
     std::span<std::shared_ptr<mg::DisplayPlatform>> const& platforms,
     mir::ConsoleServices&,
     std::shared_ptr<mir::udev::Context> const& udev,
-    mir::options::ProgramOption const& options) -> std::vector<mir::graphics::SupportedDevice>
+    mir::options::Option const& options) -> std::vector<mir::graphics::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::RenderProbe>(&probe_rendering_platform);
 

--- a/src/platforms/renderer-generic-egl/platform_symbols.cpp
+++ b/src/platforms/renderer-generic-egl/platform_symbols.cpp
@@ -55,7 +55,7 @@ auto probe_rendering_platform(
     std::span<std::shared_ptr<mg::DisplayPlatform>> const& displays,
     mir::ConsoleServices&,
     std::shared_ptr<mir::udev::Context> const&,
-    mo::ProgramOption const&) -> std::vector<mg::SupportedDevice>
+    mo::Option const&) -> std::vector<mg::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::RenderProbe>(&probe_rendering_platform);
 

--- a/src/platforms/virtual/graphics.cpp
+++ b/src/platforms/virtual/graphics.cpp
@@ -68,7 +68,7 @@ void add_graphics_platform_options(boost::program_options::options_description& 
 auto probe_display_platform(
     std::shared_ptr<mir::ConsoleServices> const&,
     std::shared_ptr<mir::udev::Context> const&,
-    mo::ProgramOption const& options) -> std::vector<mg::SupportedDevice>
+    mo::Option const& options) -> std::vector<mg::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_display_platform);
     std::vector<mg::SupportedDevice> result;

--- a/src/platforms/wayland/platform_symbols.cpp
+++ b/src/platforms/wayland/platform_symbols.cpp
@@ -59,7 +59,7 @@ void add_graphics_platform_options(boost::program_options::options_description& 
 }
 
 auto probe_graphics_platform(
-    mo::ProgramOption const& options) -> std::optional<mg::SupportedDevice>
+    mo::Option const& options) -> std::optional<mg::SupportedDevice>
 {
     if (mpw::connection_options_supplied(options))
     {
@@ -75,7 +75,7 @@ auto probe_graphics_platform(
 auto probe_display_platform(
     std::shared_ptr<mir::ConsoleServices> const&,
     std::shared_ptr<mir::udev::Context> const&,
-    mo::ProgramOption const& options) -> std::vector<mg::SupportedDevice>
+    mo::Option const& options) -> std::vector<mg::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_display_platform);
     if (auto probe = probe_graphics_platform(options))

--- a/src/platforms/x11/graphics/graphics.cpp
+++ b/src/platforms/x11/graphics/graphics.cpp
@@ -100,7 +100,7 @@ auto probe_graphics_platform() -> std::optional<mg::SupportedDevice>
 auto probe_display_platform(
     std::shared_ptr<mir::ConsoleServices> const&,
     std::shared_ptr<mir::udev::Context> const&,
-    mir::options::ProgramOption const&) -> std::vector<mg::SupportedDevice>
+    mir::options::Option const&) -> std::vector<mg::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_display_platform);
     if (auto probe = probe_graphics_platform())

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -235,7 +235,7 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
                         graphics::probe_rendering_module(
                             display_targets,
                             *platform,
-                            dynamic_cast<mir::options::ProgramOption&>(*the_options()),
+                            *the_options(),
                             the_console_services());
 
                     bool found_supported_device{false};
@@ -261,7 +261,7 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
             }
             else
             {
-                platform_modules = mir::graphics::rendering_modules_for_device(platforms, display_targets, dynamic_cast<mir::options::ProgramOption&>(*the_options()), the_console_services());
+                platform_modules = mir::graphics::rendering_modules_for_device(platforms, display_targets, *the_options(), the_console_services());
             }
 
             for (auto const& [device, platform]: platform_modules)

--- a/src/server/graphics/platform_probe.cpp
+++ b/src/server/graphics/platform_probe.cpp
@@ -84,7 +84,7 @@ auto probe_module(
 
 auto mir::graphics::probe_display_module(
     SharedLibrary const& module,
-    options::ProgramOption const& options,
+    options::Option const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<SupportedDevice>
 {
     return probe_module(
@@ -102,7 +102,7 @@ auto mir::graphics::probe_display_module(
 auto mir::graphics::probe_rendering_module(
     std::span<std::shared_ptr<mg::DisplayPlatform>> const& platforms,
     SharedLibrary const& module,
-    options::ProgramOption const& options,
+    options::Option const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<SupportedDevice>
 {
     return probe_module(
@@ -269,7 +269,7 @@ auto mg::modules_for_device(
 
 auto mir::graphics::display_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
-    options::ProgramOption const& options,
+    options::Option const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>
 {
     return modules_for_device(
@@ -284,7 +284,7 @@ auto mir::graphics::display_modules_for_device(
 auto mir::graphics::rendering_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
     std::span<std::shared_ptr<DisplayPlatform>> const& platforms,
-    options::ProgramOption const& options,
+    options::Option const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>
 {
     return modules_for_device(
@@ -467,7 +467,7 @@ auto mg::select_display_modules(
             auto supported_devices =
                 graphics::probe_display_module(
                     *platform,
-                    dynamic_cast<mir::options::ProgramOption const&>(options),
+                    options,
                     console);
 
             bool found_supported_device{false};
@@ -513,13 +513,13 @@ auto mg::select_display_modules(
             // We don't need to probe the virtual platform; that is done separately below.
             platforms.erase(virtual_platform_pos);
         }
-        platform_modules = display_modules_for_device(platforms, dynamic_cast<mir::options::ProgramOption const&>(options), console);
+        platform_modules = display_modules_for_device(platforms, options, console);
     }
 
     if (virtual_platform)
     {
         auto virtual_probe = probe_display_module(
-            *virtual_platform, dynamic_cast<mo::ProgramOption const&>(options), console);
+            *virtual_platform, options, console);
         if (virtual_probe.size() && virtual_probe.front().support_level >= mg::probe::supported)
         {
             platform_modules.emplace_back(std::move(virtual_probe.front()), std::move(virtual_platform));

--- a/src/server/graphics/platform_probe.h
+++ b/src/server/graphics/platform_probe.h
@@ -46,25 +46,25 @@ auto modules_for_device(
 
 auto probe_display_module(
     SharedLibrary const& module,
-    options::ProgramOption const& options,
+    options::Option const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<SupportedDevice>;
 
 auto probe_rendering_module(
     std::span<std::shared_ptr<DisplayPlatform>> const& platforms,
     SharedLibrary const& module,
-    options::ProgramOption const& options,
+    options::Option const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<SupportedDevice>;
 
 auto display_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
-    options::ProgramOption const& options,
+    options::Option const& options,
     std::shared_ptr<ConsoleServices> const& console)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>;
 
 auto rendering_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
     std::span<std::shared_ptr<DisplayPlatform>> const& platforms,
-    options::ProgramOption const& options,
+    options::Option const& options,
     std::shared_ptr<ConsoleServices> const& console)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>;
 

--- a/tests/mir_test_framework/platform_graphics_dummy.cpp
+++ b/tests/mir_test_framework/platform_graphics_dummy.cpp
@@ -23,16 +23,12 @@ namespace mg = mir::graphics;
 
 namespace mir
 {
-namespace options
-{
-class ProgramOption;
-}
 }
 
 auto probe_display_platform(
     std::shared_ptr<mir::ConsoleServices> const&,
     std::shared_ptr<mir::udev::Context> const&,
-    mir::options::ProgramOption const&) -> std::vector<mir::graphics::SupportedDevice>
+    mir::options::Option const&) -> std::vector<mir::graphics::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_display_platform);
     std::vector<mg::SupportedDevice> result;
@@ -49,7 +45,7 @@ auto probe_rendering_platform(
     std::span<std::shared_ptr<mg::DisplayPlatform>> const&,
     mir::ConsoleServices&,
     std::shared_ptr<mir::udev::Context> const&,
-    mir::options::ProgramOption const&) -> std::vector<mir::graphics::SupportedDevice>
+    mir::options::Option const&) -> std::vector<mir::graphics::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::RenderProbe>(&probe_rendering_platform);
     std::vector<mg::SupportedDevice> result;

--- a/tests/mir_test_framework/platform_graphics_throw.cpp
+++ b/tests/mir_test_framework/platform_graphics_throw.cpp
@@ -132,7 +132,7 @@ private:
 auto probe_display_platform(
     std::shared_ptr<mir::ConsoleServices> const&,
     std::shared_ptr<mir::udev::Context> const&,
-    mir::options::ProgramOption const&) -> std::vector<mir::graphics::SupportedDevice>
+    mir::options::Option const&) -> std::vector<mir::graphics::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_display_platform);
     std::vector<mg::SupportedDevice> result;
@@ -149,7 +149,7 @@ auto probe_rendering_platform(
     std::span<std::shared_ptr<mg::DisplayPlatform>> const&,
     mir::ConsoleServices&,
     std::shared_ptr<mir::udev::Context> const&,
-    mir::options::ProgramOption const&) -> std::vector<mir::graphics::SupportedDevice>
+    mir::options::Option const&) -> std::vector<mir::graphics::SupportedDevice>
 {
     mir::assert_entry_point_signature<mg::RenderProbe>(&probe_rendering_platform);
     std::vector<mg::SupportedDevice> result;


### PR DESCRIPTION
There's no particular reason these interfaces need the concrete `ProgramOption`, and it's simpler if we don't need to wildly `dynamic_cast<ProgramOption>` everywhere.