### PR TITLE
Fix decorations eating into application area

### DIFF
--- a/src/include/server/mir/shell/decoration.h
+++ b/src/include/server/mir/shell/decoration.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_SHELL_DECORATION_H_
+#define MIR_SHELL_DECORATION_H_
+
+#include "mir/geometry/forward.h"
+#include "mir_toolkit/common.h"
+
+namespace mir::shell::decoration
+{
+    auto compute_size_with_decorations(geometry::Size content_size, MirWindowType type, MirWindowState state) -> geometry::Size;
+}
+
+#endif

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -25,6 +25,7 @@
 
 #include "mir/frontend/wayland.h"
 #include "mir/scene/surface.h"
+#include "mir/shell/decoration.h"
 #include "mir/shell/shell.h"
 #include "mir/shell/surface_specification.h"
 #include "mir/events/input_event.h"
@@ -717,13 +718,19 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
 
         XWaylandSurfaceRole::populate_surface_data_scaled(wl_surface, scale, spec, keep_alive_until_spec_is_used);
 
+        auto const window_type = mir_window_type_freestyle;
+        auto const window_state = state.active_mir_state();
+        auto const corrected_size = mir::shell::decoration::compute_size_with_decorations(
+            cached.geometry.size, window_type, window_state);
+
         // May be overridden by anything in the pending spec
-        spec.width = cached.geometry.size.width;
-        spec.height = cached.geometry.size.height;
+        spec.width = corrected_size.width;
+        spec.height = corrected_size.height;
         spec.top_left = cached.geometry.top_left;
-        spec.type = mir_window_type_freestyle;
-        spec.state = state.active_mir_state();
+        spec.type = window_type;
+        spec.state = window_state;
     }
+
 
     std::vector<std::function<void()>> reply_functions;
 

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -566,6 +566,16 @@ void mf::XWaylandSurface::take_focus()
     connection->flush();
 }
 
+auto correct_requested_size(geom::Size requested_size, std::weak_ptr<mir::scene::Surface> weak_surface) -> geom::Size
+{
+    if (auto surface = weak_surface.lock())
+    {
+        return mir::shell::decoration::compute_size_with_decorations(requested_size, surface->type(), surface->state());
+    }
+
+    return requested_size;
+}
+
 void mf::XWaylandSurface::configure_request(xcb_configure_request_event_t* event)
 {
     std::unique_lock lock{mutex};
@@ -579,12 +589,14 @@ void mf::XWaylandSurface::configure_request(xcb_configure_request_event_t* event
     // Mir seems to not like it when only one dimension is specified
     if (event->value_mask & XCB_CONFIG_WINDOW_WIDTH || event->value_mask & XCB_CONFIG_WINDOW_HEIGHT)
     {
-        pending_spec(lock).width = event->value_mask & XCB_CONFIG_WINDOW_WIDTH ?
-            geom::Width{event->width} :
-            cached.geometry.size.width;
-        pending_spec(lock).height = event->value_mask & XCB_CONFIG_WINDOW_HEIGHT ?
-            geom::Height{event->height} :
-            cached.geometry.size.height;
+        auto const requested_width =
+            event->value_mask & XCB_CONFIG_WINDOW_WIDTH ? geom::Width{event->width} : cached.geometry.size.width;
+        auto const requested_height =
+            event->value_mask & XCB_CONFIG_WINDOW_HEIGHT ? geom::Height{event->height} : cached.geometry.size.height;
+        auto const corrected_size =
+            correct_requested_size(geom::Size{requested_width, requested_height}, weak_scene_surface);
+        pending_spec(lock).width = corrected_size.width;
+        pending_spec(lock).height = corrected_size.height;
     }
 
     if (!weak_scene_surface.lock())
@@ -620,10 +632,13 @@ void mf::XWaylandSurface::configure_notify(xcb_configure_notify_event_t* event)
         {
             log_debug("Processing configure notify because it came from someone else");
         }
+
+        auto const corrected_size = correct_requested_size(geometry.size, weak_scene_surface);
+
         cached.geometry = geometry;
         pending_spec(lock).top_left = geometry.top_left;
-        pending_spec(lock).width = geometry.size.width;
-        pending_spec(lock).height = geometry.size.height;
+        pending_spec(lock).width = corrected_size.width;
+        pending_spec(lock).height = corrected_size.height;
         lock.unlock();
         apply_any_mods_to_scene_surface();
     }

--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -42,10 +42,10 @@ namespace geom = mir::geometry;
 namespace msh = mir::shell;
 namespace msd = mir::shell::decoration;
 
-namespace
+namespace mir::shell::decoration
 {
 // See src/server/shell/decoration/window.h for a full description of each property
-msd::StaticGeometry const default_geometry{
+StaticGeometry const default_geometry {
     geom::Height{24},   // titlebar_height
     geom::Width{6},     // side_border_width
     geom::Height{6},    // bottom_border_height
@@ -57,7 +57,10 @@ msd::StaticGeometry const default_geometry{
     geom::Displacement{5, 5}, // icon_padding
     geom::Width{1},     // detail_line_width
 };
+}
 
+namespace
+{
 template<typename OBJ>
 struct PropertyComparison
 {

--- a/src/server/shell/decoration/window.h
+++ b/src/server/shell/decoration/window.h
@@ -63,6 +63,8 @@ struct StaticGeometry
     geometry::Width const icon_line_width;            ///< Width for lines in button icons
 };
 
+extern StaticGeometry const default_geometry;
+
 /// Information about the geometry and type of decorations for a given window
 /// Data is pulled from the surface on construction and immutable after that
 class WindowState


### PR DESCRIPTION
Now `xlogo` and other X11 applications are sized correctly!