### PR TITLE
fix-decorated-window-sizing

### DIFF
--- a/include/core/mir/optional_value.h
+++ b/include/core/mir/optional_value.h
@@ -50,6 +50,11 @@ public:
         return value_;
     }
 
+    T value_or(T default_) const
+    {
+        return is_set() ? value() : default_;
+    }
+
     T&& consume()
     {
         die_if_unset();

--- a/src/include/server/mir/shell/decoration.h
+++ b/src/include/server/mir/shell/decoration.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_SHELL_DECORATION_H_
+#define MIR_SHELL_DECORATION_H_
+
+#include "mir/geometry/forward.h"
+#include "mir_toolkit/common.h"
+
+namespace mir::shell::decoration
+{
+    auto compute_size_with_decorations(geometry::Size content_size, MirWindowType type, MirWindowState state) -> geometry::Size;
+}
+
+#endif

--- a/src/miral/window_info_internal.cpp
+++ b/src/miral/window_info_internal.cpp
@@ -59,36 +59,26 @@ miral::WindowInfo::AspectRatio const miral::default_min_aspect_ratio{
 miral::WindowInfo::AspectRatio const miral::default_max_aspect_ratio{
     clamp(WindowInfo::AspectRatio{std::numeric_limits<unsigned>::max(), 0U})};
 
-namespace
-{
-template<typename Value>
-auto optional_value_or_default(mir::optional_value<Value> const& optional_value, Value default_ = Value{})
--> Value
-{
-    return optional_value.is_set() ? optional_value.value() : default_;
-}
-}
-
 miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) :
     window{window},
-    name{optional_value_or_default(params.name(), {""})},
-    type{optional_value_or_default(params.type(), mir_window_type_normal)},
-    state{optional_value_or_default(params.state(), mir_window_state_restored)},
+    name{params.name().value_or({""})},
+    type{params.type().value_or(mir_window_type_normal)},
+    state{params.state().value_or(mir_window_state_restored)},
     restore_rect{},
-    min_width{optional_value_or_default(params.min_width(), miral::default_min_width)},
-    min_height{optional_value_or_default(params.min_height(), miral::default_min_height)},
-    max_width{optional_value_or_default(params.max_width(), miral::default_max_width)},
-    max_height{optional_value_or_default(params.max_height(), miral::default_max_height)},
-    preferred_orientation{optional_value_or_default(params.preferred_orientation(), mir_orientation_mode_any)},
-    confine_pointer(optional_value_or_default(params.confine_pointer(), mir_pointer_unconfined)),
-    width_inc{optional_value_or_default(params.width_inc(), default_width_inc)},
-    height_inc{optional_value_or_default(params.height_inc(), default_height_inc)},
-    min_aspect(optional_value_or_default(params.min_aspect(), default_min_aspect_ratio)),
-    max_aspect(optional_value_or_default(params.max_aspect(), default_max_aspect_ratio)),
-    shell_chrome(optional_value_or_default(params.shell_chrome(), mir_shell_chrome_normal)),
-    depth_layer(optional_value_or_default(params.depth_layer(), mir_depth_layer_application)),
-    attached_edges(optional_value_or_default(params.attached_edges(), mir_placement_gravity_center)),
-    ignore_exclusion_zones{optional_value_or_default(params.ignore_exclusion_zones(), false)}
+    min_width{params.min_width().value_or(miral::default_min_width)},
+    min_height{params.min_height().value_or(miral::default_min_height)},
+    max_width{params.max_width().value_or(miral::default_max_width)},
+    max_height{params.max_height().value_or(miral::default_max_height)},
+    preferred_orientation{params.preferred_orientation().value_or(mir_orientation_mode_any)},
+    confine_pointer(params.confine_pointer().value_or(mir_pointer_unconfined)),
+    width_inc{params.width_inc().value_or(default_width_inc)},
+    height_inc{params.height_inc().value_or(default_height_inc)},
+    min_aspect(params.min_aspect().value_or(default_min_aspect_ratio)),
+    max_aspect(params.max_aspect().value_or(default_max_aspect_ratio)),
+    shell_chrome(params.shell_chrome().value_or(mir_shell_chrome_normal)),
+    depth_layer(params.depth_layer().value_or(mir_depth_layer_application)),
+    attached_edges(params.attached_edges().value_or(mir_placement_gravity_center)),
+    ignore_exclusion_zones{params.ignore_exclusion_zones().value_or(false)}
 {
     if (params.output_id().is_set())
         output_id = params.output_id().value();

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -25,6 +25,7 @@
 
 #include "mir/frontend/wayland.h"
 #include "mir/scene/surface.h"
+#include "mir/shell/decoration.h"
 #include "mir/shell/shell.h"
 #include "mir/shell/surface_specification.h"
 #include "mir/events/input_event.h"
@@ -718,13 +719,19 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
 
         XWaylandSurfaceRole::populate_surface_data_scaled(wl_surface, scale, spec, keep_alive_until_spec_is_used);
 
+        auto const window_type = mir_window_type_freestyle;
+        auto const window_state = state.active_mir_state();
+        auto const corrected_size = mir::shell::decoration::compute_size_with_decorations(
+            cached.geometry.size, window_type, window_state);
+
         // May be overridden by anything in the pending spec
-        spec.width = cached.geometry.size.width;
-        spec.height = cached.geometry.size.height;
+        spec.width = corrected_size.width;
+        spec.height = corrected_size.height;
         spec.top_left = cached.geometry.top_left;
-        spec.type = mir_window_type_freestyle;
-        spec.state = state.active_mir_state();
+        spec.type = window_type;
+        spec.state = window_state;
     }
+
 
     std::vector<std::function<void()>> reply_functions;
 

--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -42,10 +42,10 @@ namespace geom = mir::geometry;
 namespace msh = mir::shell;
 namespace msd = mir::shell::decoration;
 
-namespace
+namespace mir::shell::decoration
 {
 // See src/server/shell/decoration/window.h for a full description of each property
-msd::StaticGeometry const default_geometry{
+StaticGeometry const default_geometry {
     geom::Height{24},   // titlebar_height
     geom::Width{6},     // side_border_width
     geom::Height{6},    // bottom_border_height
@@ -57,7 +57,10 @@ msd::StaticGeometry const default_geometry{
     geom::Displacement{5, 5}, // icon_padding
     geom::Width{1},     // detail_line_width
 };
+}
 
+namespace
+{
 template<typename OBJ>
 struct PropertyComparison
 {

--- a/src/server/shell/decoration/window.h
+++ b/src/server/shell/decoration/window.h
@@ -63,6 +63,8 @@ struct StaticGeometry
     geometry::Width const icon_line_width;            ///< Width for lines in button icons
 };
 
+extern StaticGeometry const default_geometry;
+
 /// Information about the geometry and type of decorations for a given window
 /// Data is pulled from the surface on construction and immutable after that
 class WindowState

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1375,6 +1375,7 @@ global:
     mir::scene::TextInputChange::operator*;
     mir::shell::IdleHandlerObserver::?IdleHandlerObserver*;
     mir::shell::IdleHandlerObserver::IdleHandlerObserver*;
+    mir::shell::decoration::compute_size_with_decorations*;
     non-virtual?thunk?to?mir::DecorationStrategy::?DecorationStrategy*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::set_the_decoration_strategy*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_decoration_strategy*;


### PR DESCRIPTION
When SSD is applied the client only cares about the content area. So we need to adjust size related requests to reflect whole window 

Fixes #3572