### PR TITLE
Fix missing `wl_surface.enter` events for outputs enabled at runtime.

### DIFF
--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -224,7 +224,10 @@ void mf::OutputGlobal::bind(wl_resource* resource)
 {
     auto const instance = new OutputInstance(resource, this);
     instances[instance->client].push_back(instance);
-    instance->output_config_changed(output_config);
+    for (auto const& listener : listeners)
+    {
+        listener->output_config_changed(output_config);
+    }
     instance->send_done();
 }
 


### PR DESCRIPTION
In my [previous fix](https://github.com/canonical/mir/pull/3430) for #3414, I accidentally disabled sending `wl_surface.enter` events for surfaces on outputs enabled at runtime. This PR resolves that issue while still addressing #3414.