### PR TITLE
OutputManager: When listeners are registered, they need to be notified of existing globals

### DIFF
--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -310,6 +310,11 @@ auto mf::OutputManager::output_for(graphics::DisplayConfigurationOutputId id) ->
 void mf::OutputManager::add_listener(OutputManagerListener* listener)
 {
     listeners.push_back(listener);
+
+    for (auto const& [_, output_global] : outputs)
+    {
+        listener->output_global_created(output_global.get());
+    }
 }
 
 void mf::OutputManager::remove_listener(OutputManagerListener* listener)


### PR DESCRIPTION
In particular, `WindowWlSurfaceRole::output_global_created()` uses the notification to register as an observer on the global. Without this, it cannot track configuration changes 