### PR TITLE
Fix rendering of resized XWayland applications with client side decorations

### DIFF
--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -1228,13 +1228,12 @@ void mf::XWaylandSurface::apply_any_mods_to_scene_surface()
             spec.value()->top_left.value() == scene_surface->top_left())
             spec.value()->top_left.consume();
 
-        if (spec.value()->width.is_set() &&
-            spec.value()->width.value() == scene_surface->content_size().width)
+        if (spec.value()->width.is_set() && spec.value()->width.value() == scene_surface->content_size().width &&
+            spec.value()->height.is_set() && spec.value()->height.value() == scene_surface->content_size().height)
+        {
             spec.value()->width.consume();
-
-        if (spec.value()->height.is_set() &&
-            spec.value()->height.value() == scene_surface->content_size().height)
             spec.value()->height.consume();
+        }
 
         if (!spec.value()->is_empty())
         {


### PR DESCRIPTION
Previously, resizing didn't work at all unless you did a vertical resize followed by a horizontal one (or vice versa). Now, resizes work but only if you shrink the application. Any resizing outside application bounds stops after a couple of pixels.