### PR TITLE
Configuration: Split options into global and per-module configuration

### DIFF
--- a/include/common/mir/shared_library.h
+++ b/include/common/mir/shared_library.h
@@ -17,6 +17,7 @@
 #ifndef MIR_SHARED_LIBRARY_H_
 #define MIR_SHARED_LIBRARY_H_
 
+#include <compare>
 #include <string>
 
 namespace mir
@@ -49,6 +50,21 @@ public:
         (void*&)result = load_symbol(function_name.c_str(), version.c_str());
         return result;
     }
+
+    class Handle
+    {
+    public:    
+        auto operator<=>(Handle const& rhs) const -> std::strong_ordering;
+        auto operator==(Handle const& rhs) const -> bool = default;
+        auto operator!=(Handle const& rhs) const -> bool = default;
+    private:
+        friend class SharedLibrary;
+
+        Handle(void* handle);
+        void* handle;
+    };
+
+    auto get_handle() const -> Handle;
 private:
     void* const so;
     void* load_symbol(char const* function_name) const;
@@ -57,6 +73,5 @@ private:
     SharedLibrary& operator=(SharedLibrary const&) = delete;
 };
 }
-
 
 #endif /* MIR_SHARED_LIBRARY_H_ */

--- a/include/common/mir/shared_library.h
+++ b/include/common/mir/shared_library.h
@@ -53,12 +53,13 @@ public:
 
     class Handle
     {
-    public:    
+    public:
         auto operator<=>(Handle const& rhs) const -> std::strong_ordering;
         auto operator==(Handle const& rhs) const -> bool = default;
         auto operator!=(Handle const& rhs) const -> bool = default;
     private:
         friend class SharedLibrary;
+        friend struct std::hash<Handle>;
 
         Handle(void* handle);
         void* handle;
@@ -73,5 +74,11 @@ private:
     SharedLibrary& operator=(SharedLibrary const&) = delete;
 };
 }
+
+template<>
+struct std::hash<mir::SharedLibrary::Handle>
+{
+    auto operator()(mir::SharedLibrary::Handle const& h) const noexcept -> std::size_t;
+};
 
 #endif /* MIR_SHARED_LIBRARY_H_ */

--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -68,7 +68,7 @@ extern char const* const auto_console;
 
 extern char const* const vt_option_name;
 
-class OptionsProvider
+class Configuration
 {
 public:
     /**
@@ -81,11 +81,11 @@ public:
     virtual auto the_options_for(SharedLibrary const& module) const -> std::shared_ptr<options::Option> = 0;
 
 protected:
-    OptionsProvider() = default;
-    virtual ~OptionsProvider() = default;
+    Configuration() = default;
+    virtual ~Configuration() = default;
 
-    OptionsProvider(OptionsProvider const&) = delete;
-    OptionsProvider& operator=(OptionsProvider const&) = delete;
+    Configuration(Configuration const&) = delete;
+    Configuration& operator=(Configuration const&) = delete;
 };
 }
 }

--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -78,7 +78,7 @@ public:
     /**
      * All options, including those added by the specified module
      */
-    virtual auto the_options_for(SharedLibrary const& module) const -> std::shared_ptr<options::Option> = 0;
+    virtual auto options_for(SharedLibrary const& module) const -> std::shared_ptr<options::Option> = 0;
 
 protected:
     Configuration() = default;

--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -23,6 +23,8 @@
 
 namespace mir
 {
+class SharedLibrary;
+
 namespace options
 {
 extern char const* const arw_server_socket_opt;
@@ -66,17 +68,24 @@ extern char const* const auto_console;
 
 extern char const* const vt_option_name;
 
-class Configuration
+class OptionsProvider
 {
 public:
-    virtual std::shared_ptr<options::Option> the_options() const = 0;
+    /**
+     * The options not associated with a specific loaded module
+     */
+    virtual std::shared_ptr<options::Option> global_options() const = 0;
+    /**
+     * All options, including those added by the specified module
+     */
+    virtual auto the_options_for(SharedLibrary const& module) const -> std::shared_ptr<options::Option> = 0;
 
 protected:
+    OptionsProvider() = default;
+    virtual ~OptionsProvider() = default;
 
-    Configuration() = default;
-    virtual ~Configuration() = default;
-    Configuration(Configuration const&) = delete;
-    Configuration& operator=(Configuration const&) = delete;
+    OptionsProvider(OptionsProvider const&) = delete;
+    OptionsProvider& operator=(OptionsProvider const&) = delete;
 };
 }
 }

--- a/include/platform/mir/options/default_configuration.h
+++ b/include/platform/mir/options/default_configuration.h
@@ -28,7 +28,7 @@ namespace mir
 {
 namespace options
 {
-class DefaultConfiguration : public OptionsProvider
+class DefaultConfiguration : public Configuration
 {
 public:
     DefaultConfiguration(int argc, char const* argv[]);

--- a/include/platform/mir/options/default_configuration.h
+++ b/include/platform/mir/options/default_configuration.h
@@ -56,7 +56,7 @@ private:
     void add_platform_options();
     // accessed via the base interface, when access to add_options() has been "lost"
     std::shared_ptr<options::Option> global_options() const override;
-    auto the_options_for(SharedLibrary const& module) const -> std::shared_ptr<Option> override;
+    auto options_for(SharedLibrary const& module) const -> std::shared_ptr<Option> override;
 
     virtual void parse_arguments(
         boost::program_options::options_description desc,

--- a/include/platform/mir/options/program_option.h
+++ b/include/platform/mir/options/program_option.h
@@ -39,7 +39,7 @@ public:
 
     void parse_environment(
         boost::program_options::options_description const& description,
-        char const* prefix);
+        std::function<std::string(std::string)> env_var_name_mapper);
 
     void parse_file(
         boost::program_options::options_description const& description,

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "mir/shared_library.h"
+#include <compare>
 
 #ifdef MIR_DONT_USE_DLVSYM
 #include <mir/log.h>
@@ -73,4 +74,19 @@ void* mir::SharedLibrary::load_symbol(char const* function_name, char const* ver
         BOOST_THROW_EXCEPTION(std::runtime_error(dlerror()));
     }
 #endif
+}
+
+auto mir::SharedLibrary::get_handle() const -> Handle
+{
+    return Handle{so};
+}
+
+mir::SharedLibrary::Handle::Handle(void* handle)
+    : handle{handle}
+{
+}
+
+auto mir::SharedLibrary::Handle::operator<=>(Handle const& rhs) const -> std::strong_ordering
+{
+    return handle <=> rhs.handle;
 }

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -16,6 +16,7 @@
 
 #include "mir/shared_library.h"
 #include <compare>
+#include <cstddef>
 
 #ifdef MIR_DONT_USE_DLVSYM
 #include <mir/log.h>
@@ -89,4 +90,10 @@ mir::SharedLibrary::Handle::Handle(void* handle)
 auto mir::SharedLibrary::Handle::operator<=>(Handle const& rhs) const -> std::strong_ordering
 {
     return handle <=> rhs.handle;
+}
+
+auto std::hash<mir::SharedLibrary::Handle>::operator()(mir::SharedLibrary::Handle const& handle) const noexcept
+    -> std::size_t
+{
+    return std::hash<void*>{}(handle.handle);
 }

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -485,7 +485,6 @@ global:
     non-virtual?thunk?to?mir::logging::Logger::log*;
     non-virtual?thunk?to?mir::logging::MultiLogger::log*;
     operator*;
-    std::hash?mir::SharedLibrary::Handle?::operator*;
     typeinfo?for?MirInputConfig;
     typeinfo?for?MirInputDevice;
     typeinfo?for?MirKeyboardConfig;
@@ -500,7 +499,6 @@ global:
     typeinfo?for?mir::IntOwnedFd;
     typeinfo?for?mir::NonBlockingExecutor;
     typeinfo?for?mir::PosixRWMutex;
-    typeinfo?for?mir::SharedLibrary::Handle;
     typeinfo?for?mir::SharedLibrary;
     typeinfo?for?mir::SharedLibraryProberReport;
     typeinfo?for?mir::Signal;
@@ -704,5 +702,7 @@ MIR_COMMON_2.19 {
     mir::SharedLibrary::Handle::?Handle*;
     mir::SharedLibrary::Handle::operator*;
     mir::SharedLibrary::get_handle*;
+    std::hash?mir::SharedLibrary::Handle?::operator*;
+    typeinfo?for?mir::SharedLibrary::Handle;
   };
 } MIR_COMMON_2.18;

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -328,6 +328,7 @@ global:
     mir::SharedLibrary::get_handle*;
     mir::SharedLibrary::Handle::?Handle*;
     mir::SharedLibrary::Handle::operator*;
+    std::hash?mir::SharedLibrary::Handle?::operator*;
     mir::SharedLibraryProberReport::?SharedLibraryProberReport*;
     mir::SharedLibraryProberReport::SharedLibraryProberReport*;
     mir::SharedLibraryProberReport::operator*;

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -323,12 +323,11 @@ global:
     mir::RecursiveReadWriteMutex::write_lock*;
     mir::RecursiveReadWriteMutex::write_unlock*;
     mir::SharedLibrary::?SharedLibrary*;
-    mir::SharedLibrary::SharedLibrary*;
-    mir::SharedLibrary::load_symbol*;
-    mir::SharedLibrary::get_handle*;
     mir::SharedLibrary::Handle::?Handle*;
     mir::SharedLibrary::Handle::operator*;
-    std::hash?mir::SharedLibrary::Handle?::operator*;
+    mir::SharedLibrary::SharedLibrary*;
+    mir::SharedLibrary::get_handle*;
+    mir::SharedLibrary::load_symbol*;
     mir::SharedLibraryProberReport::?SharedLibraryProberReport*;
     mir::SharedLibraryProberReport::SharedLibraryProberReport*;
     mir::SharedLibraryProberReport::operator*;
@@ -489,6 +488,7 @@ global:
     non-virtual?thunk?to?mir::logging::Logger::log*;
     non-virtual?thunk?to?mir::logging::MultiLogger::log*;
     operator*;
+    std::hash?mir::SharedLibrary::Handle?::operator*;
     typeinfo?for?MirInputConfig;
     typeinfo?for?MirInputDevice;
     typeinfo?for?MirKeyboardConfig;
@@ -503,8 +503,8 @@ global:
     typeinfo?for?mir::IntOwnedFd;
     typeinfo?for?mir::NonBlockingExecutor;
     typeinfo?for?mir::PosixRWMutex;
-    typeinfo?for?mir::SharedLibrary;
     typeinfo?for?mir::SharedLibrary::Handle;
+    typeinfo?for?mir::SharedLibrary;
     typeinfo?for?mir::SharedLibraryProberReport;
     typeinfo?for?mir::Signal;
     typeinfo?for?mir::ThreadPoolExecutor;
@@ -696,8 +696,12 @@ global:
 };
 
 MIR_COMMON_2.18 {
-  global: extern "C++" {
+global:
+  extern "C++" {
     MirTouchpadConfig::disable_with_external_mouse*;
     mir::event_type_to_c_str*;
+    std::hash::operator*;
+    typeinfo?for?std::hash;
   };
 } MIR_COMMON_2.17;
+

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -323,10 +323,7 @@ global:
     mir::RecursiveReadWriteMutex::write_lock*;
     mir::RecursiveReadWriteMutex::write_unlock*;
     mir::SharedLibrary::?SharedLibrary*;
-    mir::SharedLibrary::Handle::?Handle*;
-    mir::SharedLibrary::Handle::operator*;
     mir::SharedLibrary::SharedLibrary*;
-    mir::SharedLibrary::get_handle*;
     mir::SharedLibrary::load_symbol*;
     mir::SharedLibraryProberReport::?SharedLibraryProberReport*;
     mir::SharedLibraryProberReport::SharedLibraryProberReport*;
@@ -696,12 +693,16 @@ global:
 };
 
 MIR_COMMON_2.18 {
-global:
-  extern "C++" {
+  global: extern "C++" {
     MirTouchpadConfig::disable_with_external_mouse*;
     mir::event_type_to_c_str*;
-    std::hash::operator*;
-    typeinfo?for?std::hash;
   };
 } MIR_COMMON_2.17;
 
+MIR_COMMON_2.19 {
+  global: extern "C++" {
+    mir::SharedLibrary::Handle::?Handle*;
+    mir::SharedLibrary::Handle::operator*;
+    mir::SharedLibrary::get_handle*;
+  };
+} MIR_COMMON_2.18;

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -325,6 +325,9 @@ global:
     mir::SharedLibrary::?SharedLibrary*;
     mir::SharedLibrary::SharedLibrary*;
     mir::SharedLibrary::load_symbol*;
+    mir::SharedLibrary::get_handle*;
+    mir::SharedLibrary::Handle::?Handle*;
+    mir::SharedLibrary::Handle::operator*;
     mir::SharedLibraryProberReport::?SharedLibraryProberReport*;
     mir::SharedLibraryProberReport::SharedLibraryProberReport*;
     mir::SharedLibraryProberReport::operator*;
@@ -500,6 +503,7 @@ global:
     typeinfo?for?mir::NonBlockingExecutor;
     typeinfo?for?mir::PosixRWMutex;
     typeinfo?for?mir::SharedLibrary;
+    typeinfo?for?mir::SharedLibrary::Handle;
     typeinfo?for?mir::SharedLibraryProberReport;
     typeinfo?for?mir::Signal;
     typeinfo?for?mir::ThreadPoolExecutor;

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -138,7 +138,7 @@ class Logger;
 namespace options
 {
 class Option;
-class OptionsProvider;
+class Configuration;
 }
 
 namespace report
@@ -161,7 +161,7 @@ class DefaultServerConfiguration : public virtual ServerConfiguration
 {
 public:
     DefaultServerConfiguration(int argc, char const* argv[]);
-    explicit DefaultServerConfiguration(std::shared_ptr<options::OptionsProvider> const& configuration_options);
+    explicit DefaultServerConfiguration(std::shared_ptr<options::Configuration> const& configuration_options);
 
     /** @name DisplayServer dependencies
      * dependencies of DisplayServer on the rest of the Mir
@@ -348,7 +348,7 @@ public:
 
 protected:
     std::shared_ptr<options::Option> the_options() const;
-    auto the_options_provider() const -> std::shared_ptr<options::OptionsProvider>;
+    auto the_options_provider() const -> std::shared_ptr<options::Configuration>;
     std::shared_ptr<input::DefaultInputDeviceHub>  the_default_input_device_hub();
     std::shared_ptr<graphics::DisplayConfigurationObserver> the_display_configuration_observer();
     std::shared_ptr<input::SeatObserver> the_seat_observer();
@@ -436,7 +436,7 @@ protected:
     std::shared_ptr<DecorationStrategy> decoration_strategy;
 
 private:
-    std::shared_ptr<options::OptionsProvider> const configuration_options;
+    std::shared_ptr<options::Configuration> const configuration_options;
     std::shared_ptr<input::EventFilter> default_filter;
     CachedPtr<ObserverMultiplexer<graphics::DisplayConfigurationObserver>>
         display_configuration_observer_multiplexer;

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -17,6 +17,7 @@
 #define MIR_DEFAULT_SERVER_CONFIGURATION_H_
 
 #include "mir/cached_ptr.h"
+#include "mir/options/option.h"
 #include "mir/server_configuration.h"
 #include "mir/shell/window_manager_builder.h"
 
@@ -137,7 +138,7 @@ class Logger;
 namespace options
 {
 class Option;
-class Configuration;
+class OptionsProvider;
 }
 
 namespace report
@@ -160,7 +161,7 @@ class DefaultServerConfiguration : public virtual ServerConfiguration
 {
 public:
     DefaultServerConfiguration(int argc, char const* argv[]);
-    explicit DefaultServerConfiguration(std::shared_ptr<options::Configuration> const& configuration_options);
+    explicit DefaultServerConfiguration(std::shared_ptr<options::OptionsProvider> const& configuration_options);
 
     /** @name DisplayServer dependencies
      * dependencies of DisplayServer on the rest of the Mir
@@ -347,6 +348,7 @@ public:
 
 protected:
     std::shared_ptr<options::Option> the_options() const;
+    auto the_options_provider() const -> std::shared_ptr<options::OptionsProvider>;
     std::shared_ptr<input::DefaultInputDeviceHub>  the_default_input_device_hub();
     std::shared_ptr<graphics::DisplayConfigurationObserver> the_display_configuration_observer();
     std::shared_ptr<input::SeatObserver> the_seat_observer();
@@ -434,7 +436,7 @@ protected:
     std::shared_ptr<DecorationStrategy> decoration_strategy;
 
 private:
-    std::shared_ptr<options::Configuration> const configuration_options;
+    std::shared_ptr<options::OptionsProvider> const configuration_options;
     std::shared_ptr<input::EventFilter> default_filter;
     CachedPtr<ObserverMultiplexer<graphics::DisplayConfigurationObserver>>
         display_configuration_observer_multiplexer;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -408,6 +408,12 @@ void mo::DefaultConfiguration::parse_arguments(
         // Maybe the unparsed tokens are for a module?
         for (auto const& [_, module_option_desc] : module_options_desc)
         {
+            if (tokens.empty())
+            {
+                // There aren't any unparsed arguments, so we're done here
+                break;
+            }
+
             /* We assume that argv[0] is *not* an option; instead, it's the name of the binary
              * So when reparsing, we need to add a fake argv[0]
              */

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -252,7 +252,7 @@ void mo::DefaultConfiguration::add_platform_options()
 
                 add_platform_options(options->second);
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error&)
             {
                 /* We've failed to add the options - probably because it's not a graphics platform,
                  * or because it's got the wrong version - unload it; it's unnecessary.

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -300,7 +300,7 @@ std::shared_ptr<mo::Option> mo::DefaultConfiguration::global_options() const
     return options;
 }
 
-auto mo::DefaultConfiguration::the_options_for(SharedLibrary const& module) const -> std::shared_ptr<Option>
+auto mo::DefaultConfiguration::options_for(SharedLibrary const& module) const -> std::shared_ptr<Option>
 {
     auto parsed_options = module_options[module.get_handle()];
     if (!parsed_options)

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -22,6 +22,8 @@
 #include "mir/shared_library_prober.h"
 #include "mir/logging/null_shared_library_prober_report.h"
 
+#include <format>
+
 namespace mo = mir::options;
 
 char const* const mo::arw_server_socket_opt       = "arw-file";

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "mir/options/program_option.h"
 #include "mir/shared_library.h"
 #include "mir/options/default_configuration.h"
 #include "mir/graphics/platform.h"
@@ -66,6 +67,62 @@ char const* const mo::vt_option_name = "vt";
 namespace
 {
 bool const enable_input_default        = true;
+}
+
+template<typename Value>
+auto mo::DefaultConfiguration::LibraryMap<Value>::find(SharedLibrary const& lib) const -> decltype(values)::const_iterator
+{
+    return std::find_if(
+        values.begin(),
+        values.end(),
+        [&lib](auto const& candidate) { return candidate.first == lib.get_handle(); });
+}
+
+template<typename Value>
+auto mo::DefaultConfiguration::LibraryMap<Value>::find(SharedLibrary const& lib) -> decltype(values)::iterator
+{
+    return std::find_if(
+        values.begin(),
+        values.end(),
+        [&lib](auto const& candidate) { return candidate.first == lib.get_handle(); });
+}
+
+template<typename Value>
+auto mo::DefaultConfiguration::LibraryMap<Value>::operator[](SharedLibrary const& lib) -> Value&
+{
+    auto existing = find(lib);
+    if (existing != values.end())
+    {
+        return existing->second;
+    }
+
+    values.emplace_back(std::make_pair(lib.get_handle(), Value{}));
+    return values.back().second;
+}
+
+template<typename Value>
+auto mo::DefaultConfiguration::LibraryMap<Value>::at(SharedLibrary const& lib) const -> Value const&
+{
+    auto existing = find(lib);
+
+    if (existing == values.end())
+    {
+        BOOST_THROW_EXCEPTION((std::out_of_range{"SharedLibrary not in map"}));
+    }
+
+    return existing->second;
+}
+
+template<typename Value>
+auto mo::DefaultConfiguration::LibraryMap<Value>::begin() const -> decltype(values)::const_iterator
+{
+    return values.cbegin();
+}
+
+template<typename Value>
+auto mo::DefaultConfiguration::LibraryMap<Value>::end() const -> decltype(values)::const_iterator
+{
+    return values.cend();
 }
 
 mo::DefaultConfiguration::DefaultConfiguration(int argc, char const* argv[]) :
@@ -200,6 +257,17 @@ mo::DefaultConfiguration::DefaultConfiguration(
         add_platform_options();
 }
 
+namespace
+{
+auto option_header_for(mir::SharedLibrary const& module) -> std::string
+{
+    auto const describe_module = module.load_function<mir::graphics::DescribeModule>("describe_graphics_module", MIR_SERVER_GRAPHICS_PLATFORM_VERSION);
+    auto const description = describe_module();
+
+    return std::format("Options for module {}", description->name);
+}
+}
+
 void mo::DefaultConfiguration::add_platform_options()
 {
     namespace po = boost::program_options;
@@ -226,15 +294,19 @@ void mo::DefaultConfiguration::add_platform_options()
 
         for (auto& platform : platform_libraries)
         {
-            /* Ideally we'd namespace these options with the platform,
-             * and display them in a group as $FOO-platform-specific.
-             */
             try
             {
                 auto add_platform_options = platform->load_function<mir::graphics::AddPlatformOptions>("add_graphics_platform_options", MIR_SERVER_GRAPHICS_PLATFORM_VERSION);
-                add_platform_options(*this->program_options);
+                auto [options, inserted] = module_options_desc.emplace(
+                    *platform,
+                    std::forward_as_tuple(option_header_for(*platform)));
+
+                // *Pretty* sure this is impossible, but let's be sure!
+                assert(inserted && "Attempted to add platform options twice for the same module");
+
+                add_platform_options(options->second);
             }
-            catch (std::runtime_error&)
+            catch (std::runtime_error& e)
             {
                 /* We've failed to add the options - probably because it's not a graphics platform,
                  * or because it's got the wrong version - unload it; it's unnecessary.
@@ -269,7 +341,7 @@ boost::program_options::options_description_easy_init mo::DefaultConfiguration::
     return program_options->add_options();
 }
 
-std::shared_ptr<mo::Option> mo::DefaultConfiguration::the_options() const
+std::shared_ptr<mo::Option> mo::DefaultConfiguration::global_options() const
 {
     if (!options)
     {
@@ -282,6 +354,31 @@ std::shared_ptr<mo::Option> mo::DefaultConfiguration::the_options() const
     return options;
 }
 
+auto mo::DefaultConfiguration::the_options_for(SharedLibrary const& module) const -> std::shared_ptr<Option>
+{
+    auto parsed_options = module_options[module];
+    if (!parsed_options)
+    {
+        auto options = std::make_shared<ProgramOption>();
+        auto& module_option_desc = module_options_desc.at(module);
+
+        /* We can't combine the parsed global options with a parse of the module-specific options,
+         * but we *can* combine the global options description with the module options description
+         * and (re)parse everything against that.
+         */
+        boost::program_options::options_description joint_desc;
+        joint_desc.add(*program_options).add(module_option_desc);
+
+        parse_arguments(joint_desc, *options, argc, argv);
+        parse_environment(joint_desc, *options);
+        parse_config_file(joint_desc, *options);
+
+        module_options[module] = options;
+        parsed_options = options;
+    }
+
+    return parsed_options;
+}
 
 void mo::DefaultConfiguration::parse_arguments(
     boost::program_options::options_description desc,
@@ -300,10 +397,25 @@ void mo::DefaultConfiguration::parse_arguments(
 
         options.parse_arguments(desc, argc, argv);
 
-        auto const unparsed_arguments = options.unparsed_command_line();
+        auto unparsed_arguments = options.unparsed_command_line();
         std::vector<char const*> tokens;
         for (auto const& token : unparsed_arguments)
             tokens.push_back(token.c_str());
+
+        // Maybe the unparsed tokens are for a module?
+        for (auto const& [_, module_option_desc] : module_options_desc)
+        {
+            mo::ProgramOption tmp_options;
+            tmp_options.parse_arguments(module_option_desc, tokens.size(), tokens.data());
+
+            tokens.clear();
+            unparsed_arguments = tmp_options.unparsed_command_line();
+            for (auto const& token : unparsed_arguments)
+            {
+                tokens.push_back(token.c_str());
+            }
+        }
+
         if (!tokens.empty()) unparsed_arguments_handler(tokens.size(), tokens.data());
 
         // See the ExitWithOutput documentation for information about its usage.
@@ -311,6 +423,14 @@ void mo::DefaultConfiguration::parse_arguments(
         {
             std::ostringstream help_text;
             help_text << desc;
+            for (auto& [_, module_desc] : module_options_desc)
+            {
+                // We don't want to print out headers for platforms that don't have any options
+                if (!module_desc.options().empty())
+                {
+                    help_text << module_desc;
+                }
+            }
             BOOST_THROW_EXCEPTION(mir::ExitWithOutput(help_text.str()));
         }
 
@@ -329,11 +449,70 @@ void mo::DefaultConfiguration::parse_arguments(
     }
 }
 
+namespace
+{
+auto is_an_option(boost::program_options::options_description const& options, std::string const& name) -> bool
+{
+    return std::find_if(
+        options.options().cbegin(),
+        options.options().cend(),
+        [&name](auto const& option) -> bool
+        {
+            return option->long_name() == name;
+        }) != options.options().cend();
+}
+}
+
 void mo::DefaultConfiguration::parse_environment(
     boost::program_options::options_description& desc,
     mo::ProgramOption& options) const
 {
-    options.parse_environment(desc, "MIR_SERVER_");
+    options.parse_environment(
+        desc,
+        [=, this](std::string const& from) -> std::string
+        {
+            auto const prefix = "MIR_SERVER_";
+            auto const sizeof_prefix = strlen(prefix);
+
+            if (!from.starts_with(prefix))
+            {
+                return std::string{};
+            }
+
+            std::string result(from, sizeof_prefix);
+
+            for(auto& ch : result)
+            {
+                if (ch == '_') ch = '-';
+                else ch = std::tolower(ch, std::locale::classic()); // avoid current locale
+            }
+
+            /* Now, we want to not fail on any options that are module-specific but
+             * not for *this* module (or for the global parse)
+             *
+             * So, we check:
+             * 1. Is the result an option in `desc` (ie: an option we're trying to parse)? Return it. Or,
+             * 2. Is the option in one of the module-specific option descriptors? Ignore it.
+             * 3. Otherwise, return it as normal, and cause a failure
+             */
+
+            if (is_an_option(desc, result))
+            {
+                return result;
+            }
+
+            // Is it an option for a different module?
+            for (auto const& [_, module_opt_desc] : module_options_desc)
+            {
+                if (is_an_option(module_opt_desc, result))
+                {
+                    // We want to ignore this for now, rather than raise an unknown option error
+                    return std::string{};
+                }
+            }
+
+            return result;
+        });
 }
 
 void mo::DefaultConfiguration::parse_config_file(

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -404,9 +404,14 @@ void mo::DefaultConfiguration::parse_arguments(
         for (auto const& token : unparsed_arguments)
             tokens.push_back(token.c_str());
 
+        auto const argv0 = argc > 0 ? argv[0] : "fake argv[0]";
         // Maybe the unparsed tokens are for a module?
         for (auto const& [_, module_option_desc] : module_options_desc)
         {
+            /* We assume that argv[0] is *not* an option; instead, it's the name of the binary
+             * So when reparsing, we need to add a fake argv[0]
+             */
+            tokens.insert(tokens.begin(), argv0);
             mo::ProgramOption tmp_options;
             tmp_options.parse_arguments(module_option_desc, tokens.size(), tokens.data());
 

--- a/src/platform/options/program_option.cpp
+++ b/src/platform/options/program_option.cpp
@@ -58,26 +58,9 @@ std::vector<std::string> mo::ProgramOption::unparsed_command_line() const
 
 void mo::ProgramOption::parse_environment(
     po::options_description const& desc,
-    char const* prefix)
+    std::function<std::string(std::string)> env_var_mapper)
 {
-    auto parsed_options = po::parse_environment(
-        desc,
-        [=](std::string const& from) -> std::string
-        {
-             auto const sizeof_prefix = strlen(prefix);
-
-             if (from.length() < sizeof_prefix || 0 != from.find(prefix)) return std::string();
-
-             std::string result(from, sizeof_prefix);
-
-             for(auto& ch : result)
-             {
-                 if (ch == '_') ch = '-';
-                 else ch = std::tolower(ch, std::locale::classic()); // avoid current locale
-             }
-
-             return result;
-        });
+    auto parsed_options = po::parse_environment(desc, env_var_mapper);
 
     po::store(parsed_options, options);
 }

--- a/src/server/default_server_configuration.cpp
+++ b/src/server/default_server_configuration.cpp
@@ -23,6 +23,7 @@
 #include "mir/frontend/wayland.h"
 
 #include "mir/logging/dumb_console_logger.h"
+#include "mir/options/option.h"
 #include "mir/options/program_option.h"
 #include "mir/frontend/session_credentials.h"
 #include "mir/frontend/session_authorizer.h"
@@ -55,7 +56,7 @@ mir::DefaultServerConfiguration::DefaultServerConfiguration(int argc, char const
 {
 }
 
-mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::Configuration> const& configuration_options) :
+mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::OptionsProvider> const& configuration_options) :
     configuration_options(configuration_options),
     enabled_wayland_extensions(frontend::get_standard_extensions())
 {
@@ -64,7 +65,13 @@ mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::
 auto mir::DefaultServerConfiguration::the_options() const
 ->std::shared_ptr<options::Option>
 {
-    return configuration_options->the_options();
+    return configuration_options->global_options();
+}
+
+auto mir::DefaultServerConfiguration::the_options_provider() const
+    -> std::shared_ptr<mo::OptionsProvider>
+{
+    return configuration_options;
 }
 
 std::shared_ptr<ms::SessionListener>

--- a/src/server/default_server_configuration.cpp
+++ b/src/server/default_server_configuration.cpp
@@ -56,7 +56,7 @@ mir::DefaultServerConfiguration::DefaultServerConfiguration(int argc, char const
 {
 }
 
-mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::OptionsProvider> const& configuration_options) :
+mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::Configuration> const& configuration_options) :
     configuration_options(configuration_options),
     enabled_wayland_extensions(frontend::get_standard_extensions())
 {
@@ -69,7 +69,7 @@ auto mir::DefaultServerConfiguration::the_options() const
 }
 
 auto mir::DefaultServerConfiguration::the_options_provider() const
-    -> std::shared_ptr<mo::OptionsProvider>
+    -> std::shared_ptr<mo::Configuration>
 {
     return configuration_options;
 }

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -140,7 +140,7 @@ auto mir::DefaultServerConfiguration::the_display_platforms() -> std::vector<std
 
         try
         {
-            auto const platform_modules = mg::select_display_modules(*the_options(), the_console_services(), *the_shared_library_prober_report());
+            auto const platform_modules = mg::select_display_modules(*the_options_provider(), the_console_services(), *the_shared_library_prober_report());
 
             for (auto const& [device, platform]: platform_modules)
             {
@@ -178,7 +178,7 @@ auto mir::DefaultServerConfiguration::the_display_platforms() -> std::vector<std
                 display_platforms.push_back(
                     create_display_platform(
                         device,
-                        the_options(),
+                        the_options_provider()->the_options_for(*platform),
                         the_emergency_cleanup(),
                         the_console_services(),
                         the_display_report()));
@@ -261,7 +261,7 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
             }
             else
             {
-                platform_modules = mir::graphics::rendering_modules_for_device(platforms, display_targets, *the_options(), the_console_services());
+                platform_modules = mir::graphics::rendering_modules_for_device(platforms, display_targets, *the_options_provider(), the_console_services());
             }
 
             for (auto const& [device, platform]: platform_modules)
@@ -296,13 +296,15 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
                         device.device->devnode());
                 }
 
+                mir::log_info("Hello? Do we see this for %s", description->name);
+
                 // TODO: Do we want to be able to continue on partial failure here?
                 rendering_platform_map.emplace(
                     description->name,
                     create_rendering_platform(
                         device,
                         display_targets,
-                        *the_options(),
+                        *the_options_provider()->the_options_for(*platform),
                         *the_emergency_cleanup()));
                 // Add this module to the list searched by the input stack later
                 // TODO: Come up with a more principled solution for combined input/rendering/output platforms

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -151,7 +151,7 @@ auto mir::DefaultServerConfiguration::the_display_platforms() -> std::vector<std
                 auto describe_module = platform->load_function<mg::DescribeModule>(
                     "describe_graphics_module",
                     MIR_SERVER_GRAPHICS_PLATFORM_VERSION);
-                
+
                 auto description = describe_module();
                 if (!device.device)
                 {
@@ -295,8 +295,6 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
                         device.device->driver(),
                         device.device->devnode());
                 }
-
-                mir::log_info("Hello? Do we see this for %s", description->name);
 
                 // TODO: Do we want to be able to continue on partial failure here?
                 rendering_platform_map.emplace(

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -178,7 +178,7 @@ auto mir::DefaultServerConfiguration::the_display_platforms() -> std::vector<std
                 display_platforms.push_back(
                     create_display_platform(
                         device,
-                        the_options_provider()->the_options_for(*platform),
+                        the_options_provider()->options_for(*platform),
                         the_emergency_cleanup(),
                         the_console_services(),
                         the_display_report()));
@@ -302,7 +302,7 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
                     create_rendering_platform(
                         device,
                         display_targets,
-                        *the_options_provider()->the_options_for(*platform),
+                        *the_options_provider()->options_for(*platform),
                         *the_emergency_cleanup()));
                 // Add this module to the list searched by the input stack later
                 // TODO: Come up with a more principled solution for combined input/rendering/output platforms

--- a/src/server/graphics/platform_probe.cpp
+++ b/src/server/graphics/platform_probe.cpp
@@ -14,7 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "mir/graphics/default_display_configuration_policy.h"
+ #include "platform_probe.h"
+
 #include "mir/graphics/display.h"
 #include "mir/log.h"
 #include "mir/graphics/platform.h"
@@ -23,8 +24,6 @@
 #include "mir/shared_library_prober.h"
 #include "mir/shared_library_prober_report.h"
 #include "mir/udev/wrapper.h"
-
-#include "platform_probe.h"
 
 #include <algorithm>
 #include <boost/throw_exception.hpp>

--- a/src/server/graphics/platform_probe.cpp
+++ b/src/server/graphics/platform_probe.cpp
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "mir/graphics/default_display_configuration_policy.h"
 #include "mir/graphics/display.h"
 #include "mir/log.h"
 #include "mir/graphics/platform.h"
@@ -80,11 +81,24 @@ auto probe_module(
     }
     return supported_devices;
 }
+
+auto is_graphics_module(mir::SharedLibrary const& module) -> bool
+{
+    try
+    {
+        module.load_function<mg::DescribeModule>("describe_graphics_module", MIR_SERVER_GRAPHICS_PLATFORM_VERSION);
+        return true;
+    }
+    catch (std::exception const&)
+    {
+        return false;
+    }
+}
 }
 
 auto mir::graphics::probe_display_module(
     SharedLibrary const& module,
-    options::Option const& options,
+    mo::Option const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<SupportedDevice>
 {
     return probe_module(
@@ -102,7 +116,7 @@ auto mir::graphics::probe_display_module(
 auto mir::graphics::probe_rendering_module(
     std::span<std::shared_ptr<mg::DisplayPlatform>> const& platforms,
     SharedLibrary const& module,
-    options::Option const& options,
+    mo::Option const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<SupportedDevice>
 {
     return probe_module(
@@ -269,13 +283,13 @@ auto mg::modules_for_device(
 
 auto mir::graphics::display_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
-    options::Option const& options,
+    mo::OptionsProvider const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>
 {
     return modules_for_device(
         [&options, &console](mir::SharedLibrary const& module) -> std::vector<mg::SupportedDevice>
         {
-            return mg::probe_display_module(module, options, console);
+            return mg::probe_display_module(module, *options.the_options_for(module), console);
         },
         modules,
         TypePreference::prefer_nested);
@@ -284,13 +298,20 @@ auto mir::graphics::display_modules_for_device(
 auto mir::graphics::rendering_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
     std::span<std::shared_ptr<DisplayPlatform>> const& platforms,
-    options::Option const& options,
+    mo::OptionsProvider const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>
 {
     return modules_for_device(
         [&platforms, &options, &console](SharedLibrary const& module) -> std::vector<SupportedDevice>
         {
-            return probe_rendering_module(platforms, module, options, console);
+            if (is_graphics_module(module))
+            {
+                return probe_rendering_module(platforms, module, *options.the_options_for(module), console);
+            }
+            else
+            {
+                return {};
+            }
         },
         modules,
         TypePreference::prefer_hardware);
@@ -372,14 +393,15 @@ auto dso_filename_alphabetically_before(mir::SharedLibrary const& a, mir::Shared
 }
 
 auto mg::select_display_modules(
-    options::Option const& options,
+    options::OptionsProvider const& options,
     std::shared_ptr<ConsoleServices> const& console,
     SharedLibraryProberReport& lib_loader_report)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>
 {
     std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>> platform_modules;
 
-    auto const& path = options.get<std::string>(options::platform_path);
+    auto const global_options = options.global_options();
+    auto const& path = global_options->get<std::string>(options::platform_path);
     auto platforms = mir::libraries_for_path(path, lib_loader_report);
 
     if (platforms.empty())
@@ -398,17 +420,7 @@ auto mg::select_display_modules(
             platforms.end(),
             [](auto const& module)
             {
-                try
-                {
-                    module->template load_function<mir::graphics::DescribeModule>(
-                        "describe_graphics_module",
-                        MIR_SERVER_GRAPHICS_PLATFORM_VERSION);
-                    return false;
-                }
-                catch (std::runtime_error const&)
-                {
-                    return true;
-                }
+                return !is_graphics_module(*module);
             }),
         platforms.end());
 
@@ -457,17 +469,17 @@ auto mg::select_display_modules(
         });
     auto virtual_platform = virtual_platform_pos != platforms.end() ? *virtual_platform_pos : std::shared_ptr<SharedLibrary>{};
 
-    if (options.is_set(options::platform_display_libs))
+    if (global_options->is_set(options::platform_display_libs))
     {
         auto const manually_selected_platforms =
-            select_platforms_from_list(options.get<std::string>(options::platform_display_libs), platforms);
+            select_platforms_from_list(global_options->get<std::string>(options::platform_display_libs), platforms);
 
         for (auto const& platform : manually_selected_platforms)
         {
             auto supported_devices =
                 graphics::probe_display_module(
                     *platform,
-                    options,
+                    *options.the_options_for(*platform),
                     console);
 
             bool found_supported_device{false};
@@ -519,7 +531,7 @@ auto mg::select_display_modules(
     if (virtual_platform)
     {
         auto virtual_probe = probe_display_module(
-            *virtual_platform, options, console);
+            *virtual_platform, *options.the_options_for(*virtual_platform), console);
         if (virtual_probe.size() && virtual_probe.front().support_level >= mg::probe::supported)
         {
             platform_modules.emplace_back(std::move(virtual_probe.front()), std::move(virtual_platform));

--- a/src/server/graphics/platform_probe.cpp
+++ b/src/server/graphics/platform_probe.cpp
@@ -282,7 +282,7 @@ auto mg::modules_for_device(
 
 auto mir::graphics::display_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
-    mo::OptionsProvider const& options,
+    mo::Configuration const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>
 {
     return modules_for_device(
@@ -297,7 +297,7 @@ auto mir::graphics::display_modules_for_device(
 auto mir::graphics::rendering_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
     std::span<std::shared_ptr<DisplayPlatform>> const& platforms,
-    mo::OptionsProvider const& options,
+    mo::Configuration const& options,
     std::shared_ptr<ConsoleServices> const& console) -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>
 {
     return modules_for_device(
@@ -392,7 +392,7 @@ auto dso_filename_alphabetically_before(mir::SharedLibrary const& a, mir::Shared
 }
 
 auto mg::select_display_modules(
-    options::OptionsProvider const& options,
+    options::Configuration const& options,
     std::shared_ptr<ConsoleServices> const& console,
     SharedLibraryProberReport& lib_loader_report)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>

--- a/src/server/graphics/platform_probe.cpp
+++ b/src/server/graphics/platform_probe.cpp
@@ -288,7 +288,7 @@ auto mir::graphics::display_modules_for_device(
     return modules_for_device(
         [&options, &console](mir::SharedLibrary const& module) -> std::vector<mg::SupportedDevice>
         {
-            return mg::probe_display_module(module, *options.the_options_for(module), console);
+            return mg::probe_display_module(module, *options.options_for(module), console);
         },
         modules,
         TypePreference::prefer_nested);
@@ -305,7 +305,7 @@ auto mir::graphics::rendering_modules_for_device(
         {
             if (is_graphics_module(module))
             {
-                return probe_rendering_module(platforms, module, *options.the_options_for(module), console);
+                return probe_rendering_module(platforms, module, *options.options_for(module), console);
             }
             else
             {
@@ -478,7 +478,7 @@ auto mg::select_display_modules(
             auto supported_devices =
                 graphics::probe_display_module(
                     *platform,
-                    *options.the_options_for(*platform),
+                    *options.options_for(*platform),
                     console);
 
             bool found_supported_device{false};
@@ -530,7 +530,7 @@ auto mg::select_display_modules(
     if (virtual_platform)
     {
         auto virtual_probe = probe_display_module(
-            *virtual_platform, *options.the_options_for(*virtual_platform), console);
+            *virtual_platform, *options.options_for(*virtual_platform), console);
         if (virtual_probe.size() && virtual_probe.front().support_level >= mg::probe::supported)
         {
             platform_modules.emplace_back(std::move(virtual_probe.front()), std::move(virtual_platform));

--- a/src/server/graphics/platform_probe.h
+++ b/src/server/graphics/platform_probe.h
@@ -29,7 +29,7 @@ class ConsoleServices;
 
 namespace options
 {
-class OptionsProvider;
+class Configuration;
 }
 
 namespace graphics
@@ -61,19 +61,19 @@ auto probe_rendering_module(
 
 auto display_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
-    options::OptionsProvider const& options,
+    options::Configuration const& options,
     std::shared_ptr<ConsoleServices> const& console)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>;
 
 auto rendering_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
     std::span<std::shared_ptr<DisplayPlatform>> const& platforms,
-    options::OptionsProvider const& options,
+    options::Configuration const& options,
     std::shared_ptr<ConsoleServices> const& console)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>;
 
 auto select_display_modules(
-    options::OptionsProvider const& options,
+    options::Configuration const& options,
     std::shared_ptr<ConsoleServices> const& console,
     SharedLibraryProberReport& lib_loader_report)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>;

--- a/src/server/graphics/platform_probe.h
+++ b/src/server/graphics/platform_probe.h
@@ -20,13 +20,17 @@
 #include <vector>
 #include <memory>
 #include "mir/shared_library.h"
-#include "mir/options/program_option.h"
 #include "mir/graphics/platform.h"
 #include "mir/shared_library_prober_report.h"
 
 namespace mir
 {
 class ConsoleServices;
+
+namespace options
+{
+class OptionsProvider;
+}
 
 namespace graphics
 {
@@ -57,19 +61,19 @@ auto probe_rendering_module(
 
 auto display_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
-    options::Option const& options,
+    options::OptionsProvider const& options,
     std::shared_ptr<ConsoleServices> const& console)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>;
 
 auto rendering_modules_for_device(
     std::vector<std::shared_ptr<SharedLibrary>> const& modules,
     std::span<std::shared_ptr<DisplayPlatform>> const& platforms,
-    options::Option const& options,
+    options::OptionsProvider const& options,
     std::shared_ptr<ConsoleServices> const& console)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>;
 
 auto select_display_modules(
-    options::Option const& options,
+    options::OptionsProvider const& options,
     std::shared_ptr<ConsoleServices> const& console,
     SharedLibraryProberReport& lib_loader_report)
     -> std::vector<std::pair<SupportedDevice, std::shared_ptr<SharedLibrary>>>;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -208,7 +208,7 @@ auto wrap_##name(decltype(Self::name##_wrapper)::result_type const& wrapped)\
 struct mir::Server::ServerConfiguration : mir::DefaultServerConfiguration
 {
     ServerConfiguration(
-        std::shared_ptr<options::Configuration> const& configuration_options,
+        std::shared_ptr<options::OptionsProvider> const& configuration_options,
         std::shared_ptr<Self> const& self) :
         DefaultServerConfiguration(configuration_options),
         self(self.get())

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -208,7 +208,7 @@ auto wrap_##name(decltype(Self::name##_wrapper)::result_type const& wrapped)\
 struct mir::Server::ServerConfiguration : mir::DefaultServerConfiguration
 {
     ServerConfiguration(
-        std::shared_ptr<options::OptionsProvider> const& configuration_options,
+        std::shared_ptr<options::Configuration> const& configuration_options,
         std::shared_ptr<Self> const& self) :
         DefaultServerConfiguration(configuration_options),
         self(self.get())

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -68,6 +68,7 @@ global:
     mir::DefaultServerConfiguration::the_main_loop*;
     mir::DefaultServerConfiguration::the_mediating_display_changer*;
     mir::DefaultServerConfiguration::the_options*;
+    mir::DefaultServerConfiguration::the_options_provider*;
     mir::DefaultServerConfiguration::the_persistent_surface_store*;
     mir::DefaultServerConfiguration::the_pointer_input_dispatcher*;
     mir::DefaultServerConfiguration::the_primary_selection_clipboard*;

--- a/tests/mir_test_framework/command_line_server_configuration.cpp
+++ b/tests/mir_test_framework/command_line_server_configuration.cpp
@@ -23,7 +23,6 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <cstring>
 
 namespace mo=mir::options;

--- a/tests/unit-tests/graphics/test_platform_prober.cpp
+++ b/tests/unit-tests/graphics/test_platform_prober.cpp
@@ -193,7 +193,7 @@ public:
         return std::make_shared<mo::ProgramOption>();
     }
 
-    auto the_options_for(mir::SharedLibrary const& /*module*/) const -> std::shared_ptr<mo::Option> override
+    auto options_for(mir::SharedLibrary const& /*module*/) const -> std::shared_ptr<mo::Option> override
     {
         return std::make_shared<mo::ProgramOption>();
     }

--- a/tests/unit-tests/graphics/test_platform_prober.cpp
+++ b/tests/unit-tests/graphics/test_platform_prober.cpp
@@ -182,7 +182,7 @@ public:
 #endif
 };
 
-class StubOptionsProvider : public mo::OptionsProvider
+class StubOptionsProvider : public mo::Configuration
 {
 public:
     StubOptionsProvider() = default;
@@ -653,7 +653,7 @@ public:
         return *(options->global_options());
     }
 
-    auto the_options_provider() -> mo::OptionsProvider const&
+    auto the_options_provider() -> mo::Configuration const&
     {
         if (!options)
         {
@@ -683,7 +683,7 @@ private:
      * would call mo::Configuration::~Configiration and fail, whereas std::make_shared<mo::DefaultConfiguration> will capture
      * mo::DefaultConfiguration::~DefaultConfiguration and compile.
      */
-    std::shared_ptr<mo::OptionsProvider> options;
+    std::shared_ptr<mo::Configuration> options;
     std::shared_ptr<mir::SharedLibraryProberReport> const report;
 
     std::vector<std::unique_ptr<mtf::TemporaryEnvironmentValue>> temporary_env;

--- a/tests/unit-tests/graphics/test_platform_prober.cpp
+++ b/tests/unit-tests/graphics/test_platform_prober.cpp
@@ -639,7 +639,7 @@ public:
 
     auto the_options() -> mir::options::Option const&
     {
-        char const* argv0 = "Platform Probing Acceptance Test";
+        static char const* argv0 = "Platform Probing Acceptance Test";
 
         /* We remake options each time the_options() is called as option parsing
          * happens at options->the_options() time and we want to make sure we capture

--- a/tests/unit-tests/options/test_program_option.cpp
+++ b/tests/unit-tests/options/test_program_option.cpp
@@ -209,28 +209,6 @@ TEST_F(ProgramOption, unparsed_command_line_returns_unprocessed_tokens)
     EXPECT_THAT(po.unparsed_command_line(), ElementsAre("--hello", "world", "--answer", "42"));
 }
 
-TEST(ProgramOptionEnv, parse_environment)
-{
-    // Env variables should be uppercase and "_" delimited
-    char const* name = "some-key";
-    char const* key = "SOME_KEY";
-    char const* value = "test_value";
-    auto const env = std::string(__PRETTY_FUNCTION__) + key;
-    setenv(env.c_str(), value, true);
-
-    bpo::options_description desc;
-    desc.add_options()
-        (name, bpo::value<std::string>());
-
-    mir::options::ProgramOption po;
-    po.parse_environment(desc, __PRETTY_FUNCTION__);
-
-    EXPECT_EQ(value, po.get(name, "default"));
-    EXPECT_EQ("default", po.get("garbage", "default"));
-    EXPECT_TRUE(po.is_set(name));
-    EXPECT_FALSE(po.is_set("garbage"));
-}
-
 // TODO need to parse something
 TEST(ProgramOptionFile, parse_files)
 {

--- a/tests/unit-tests/options/test_program_option.cpp
+++ b/tests/unit-tests/options/test_program_option.cpp
@@ -209,6 +209,50 @@ TEST_F(ProgramOption, unparsed_command_line_returns_unprocessed_tokens)
     EXPECT_THAT(po.unparsed_command_line(), ElementsAre("--hello", "world", "--answer", "42"));
 }
 
+TEST(ProgramOptionEnv, parse_environment)
+{
+    // Env variables should be uppercase and "_" delimited
+    char const* name = "some-key";
+    char const* key = "SOME_KEY";
+    char const* value = "test_value";
+    auto const prefix = std::string{__PRETTY_FUNCTION__} + "_";
+
+    auto const mapper = [&prefix](std::string const& from) -> std::string
+    {
+        if (from.starts_with(prefix))
+        {
+            auto result = from.substr(prefix.size());
+
+            for(auto& ch : result)
+            {
+                if (ch == '_') ch = '-';
+                else ch = std::tolower(ch, std::locale::classic());
+            }
+
+            return result;
+        }
+        else
+        {
+            return std::string{};
+        }
+    };
+
+    auto const env = prefix + key;
+    setenv(env.c_str(), value, true);
+
+    bpo::options_description desc;
+    desc.add_options()
+        (name, bpo::value<std::string>());
+
+    mir::options::ProgramOption po;
+    po.parse_environment(desc, mapper);
+
+    EXPECT_EQ(value, po.get(name, "default"));
+    EXPECT_EQ("default", po.get("garbage", "default"));
+    EXPECT_TRUE(po.is_set(name));
+    EXPECT_FALSE(po.is_set("garbage"));
+}
+
 // TODO need to parse something
 TEST(ProgramOptionFile, parse_files)
 {


### PR DESCRIPTION
This lets each module define its own options, without needing the option names to be unique across all modules.

Also organises the module-specific options into their own sections at the end of the help text.