### PR TITLE
Atomic KMS: enable bypass

### DIFF
--- a/include/platform/mir/graphics/dmabuf_buffer.h
+++ b/include/platform/mir/graphics/dmabuf_buffer.h
@@ -62,6 +62,8 @@ public:
     virtual auto layout() const -> gl::Texture::Layout = 0;
 
     virtual auto size() const -> geometry::Size = 0;
+
+    virtual void on_consumed() {};
 };
 }
 }

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -403,7 +403,7 @@ public:
     virtual auto make_surface(DRMFormat format, std::span<uint64_t> modifiers) -> std::unique_ptr<GBMSurface> = 0;
 };
 
-class DmaBufBuffer;
+class DMABufBuffer;
 
 class DmaBufDisplayAllocator : public DisplayAllocator
 {
@@ -412,7 +412,7 @@ public:
     {
     };
 
-    virtual auto framebuffer_for(std::shared_ptr<DmaBufBuffer> buffer)
+    virtual auto framebuffer_for(std::shared_ptr<DMABufBuffer> buffer)
         -> std::unique_ptr<Framebuffer> = 0;
 };
 

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -412,7 +412,7 @@ public:
     {
     };
 
-    virtual auto framebuffer_for(std::shared_ptr<DMABufBuffer> buffer)
+    virtual auto framebuffer_for(mir::graphics::DisplaySink& sink, std::shared_ptr<DMABufBuffer> buffer)
         -> std::unique_ptr<Framebuffer> = 0;
 };
 

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -412,7 +412,7 @@ public:
     {
     };
 
-    virtual auto framebuffer_for(mir::graphics::DisplaySink& sink, std::shared_ptr<DMABufBuffer> buffer)
+    virtual auto framebuffer_for(std::shared_ptr<DMABufBuffer> buffer)
         -> std::unique_ptr<Framebuffer> = 0;
 };
 

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -975,7 +975,7 @@ public:
         : dpy{dpy},
           tex{dpy, extensions, dma_buf, descriptor, std::move(egl_delegate)},
           provider_{std::move(provider)},
-          on_consumed{std::move(on_consumed)},
+          on_consumed_{std::move(on_consumed)},
           on_release{std::move(on_release)},
           size_{dma_buf.size()},
           has_alpha{format_has_known_alpha(dma_buf.format()).value_or(true)},  // Has-alpha is the safe default for unknown formats
@@ -1022,6 +1022,12 @@ public:
         return this;
     }
 
+    void on_consumed() override
+    {
+        on_consumed_();
+        on_consumed_ = [](){};
+    }
+
     auto as_texture() -> DMABufTex*
     {
         /* We only get asked for a texture when the Renderer is about to
@@ -1030,7 +1036,6 @@ public:
          */
         std::lock_guard lock{consumed_mutex};
         on_consumed();
-        on_consumed = [](){};
 
         return &tex;
     }
@@ -1066,7 +1071,7 @@ private:
     std::shared_ptr<mg::DMABufEGLProvider> const provider_;
 
     std::mutex consumed_mutex;
-    std::function<void()> on_consumed;
+    std::function<void()> on_consumed_;
     std::function<void()> const on_release;
 
     geom::Size const size_;

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -374,6 +374,8 @@ auto mga::DmaBufDisplayAllocator::framebuffer_for(std::shared_ptr<DMABufBuffer> 
         geometry::Size size_;
     };
 
+    buffer->on_consumed();
+
     return std::make_unique<AtomicKmsFbHandle>(fb_id, buffer->size());
 }
 

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -346,6 +346,11 @@ auto mga::DmaBufDisplayAllocator::framebuffer_for(std::shared_ptr<DMABufBuffer> 
 {
     auto fb_id = drm_fb_id_from_dma_buffer(drm_fd(), gbm, buffer);
 
+    if (!fb_id)
+    {
+        return {};
+    }
+
     struct AtomicKmsFbHandle : public mg::FBHandle
     {
         AtomicKmsFbHandle(std::shared_ptr<uint32_t> fb_handle, geometry::Size size) :

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -265,9 +265,7 @@ auto mga::DmaBufDisplayAllocator::framebuffer_for(mg::DisplaySink& sink, std::sh
     int dmabuf_fds[4] = {0};
     int pitches[4] = {0};
     int offsets[4] = {0};
-
-    uint64_t modifiers[4] = {};
-    std::fill_n(modifiers, 4, buffer->modifier().value_or(DRM_FORMAT_MOD_NONE));
+    uint64_t modifiers[4] = {0};
 
     mir::log_debug(
         "Buffer format %s",
@@ -282,6 +280,7 @@ auto mga::DmaBufDisplayAllocator::framebuffer_for(mg::DisplaySink& sink, std::sh
         dmabuf_fds[i] = plane_descriptors[i].dma_buf;
         pitches[i] = plane_descriptors[i].stride;
         offsets[i] = plane_descriptors[i].offset;
+        modifiers[i] = buffer->modifier().value_or(DRM_FORMAT_MOD_INVALID);
     }
 
     gbm_import_fd_modifier_data import_data = {
@@ -328,7 +327,7 @@ auto mga::DmaBufDisplayAllocator::framebuffer_for(mg::DisplaySink& sink, std::sh
         (uint32_t*)offsets,
         modifiers,
         fb_id.get(),
-        0);
+        DRM_MODE_FB_MODIFIERS);
 
     if (ret)
     {

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -288,6 +288,16 @@ auto import_gbm_bo(
     };
 
     auto* gbm_bo = gbm_bo_import(gbm.get(), GBM_BO_IMPORT_FD_MODIFIER, (void*)&import_data, GBM_BO_USE_SCANOUT);
+    if (!gbm_bo)
+    {
+        mir::log_debug(
+            "Failed to import buffer type %s:%s (%s [%i])",
+            buffer->format().name(),
+            mg::drm_modifier_to_string(buffer->modifier().value_or(DRM_FORMAT_MOD_INVALID)).c_str(),
+            strerror(errno),
+            errno);
+        return {};
+    }
     return std::shared_ptr<struct gbm_bo>(gbm_bo, &gbm_bo_destroy);
 }
 
@@ -299,7 +309,6 @@ auto drm_fb_id_from_dma_buffer(
     auto gbm_bo = import_gbm_bo(gbm, buffer, dmabuf_fds, pitches, offsets);
     if (!gbm_bo)
     {
-        mir::log_warning("Failed to import buffer");
         return {};
     }
 

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -23,14 +23,7 @@
 #include "mir/graphics/display_report.h"
 #include "mir/graphics/drm_formats.h"
 #include "mir/graphics/platform.h"
-#include "mir/graphics/transformation.h"
-#include "bypass.h"
-#include "mir/fatal.h"
 #include "mir/log.h"
-#include "display_helpers.h"
-#include "egl_helper.h"
-#include "mir/graphics/egl_error.h"
-#include "mir/graphics/gl_config.h"
 #include "mir/graphics/dmabuf_buffer.h"
 
 #include <algorithm>
@@ -249,103 +242,103 @@ void mga::DisplaySink::set_next_image(std::unique_ptr<Framebuffer> content)
 }
 
 namespace {
-    auto const MAX_PLANES = 4zu;
+auto const MAX_PLANES = 4zu;
 
-    auto get_import_buffers(std::shared_ptr<mg::DMABufBuffer> buffer)
-        -> std::tuple<std::array<int, 4>, std::array<int, 4>, std::array<int, 4>, std::array<uint64_t, 4>>
+auto get_import_buffers(std::shared_ptr<mg::DMABufBuffer> buffer)
+    -> std::tuple<std::array<int, 4>, std::array<int, 4>, std::array<int, 4>, std::array<uint64_t, 4>>
+{
+    auto const plane_descriptors = buffer->planes();
+    assert(plane_descriptors.size() <= MAX_PLANES);
+
+    // std::array becuase we can't really return int[4]
+    std::array<int, 4> dmabuf_fds = {0};
+    std::array<int, 4> pitches = {0};
+    std::array<int, 4> offsets = {0};
+    std::array<uint64_t, 4> modifiers = {0};
+
+    for (std::size_t i = 0; i < std::min(MAX_PLANES, plane_descriptors.size()); i++)
     {
-        auto const plane_descriptors = buffer->planes();
-        assert(plane_descriptors.size() <= MAX_PLANES);
-
-        // std::array becuase we can't really return int[4]
-        std::array<int, 4> dmabuf_fds = {0};
-        std::array<int, 4> pitches = {0};
-        std::array<int, 4> offsets = {0};
-        std::array<uint64_t, 4> modifiers = {0};
-
-        for (std::size_t i = 0; i < std::min(MAX_PLANES, plane_descriptors.size()); i++)
-        {
-            dmabuf_fds[i] = plane_descriptors[i].dma_buf;
-            pitches[i] = plane_descriptors[i].stride;
-            offsets[i] = plane_descriptors[i].offset;
-            modifiers[i] = buffer->modifier().value_or(DRM_FORMAT_MOD_INVALID);
-        }
-
-        return std::make_tuple(dmabuf_fds, pitches, offsets, modifiers);
+        dmabuf_fds[i] = plane_descriptors[i].dma_buf;
+        pitches[i] = plane_descriptors[i].stride;
+        offsets[i] = plane_descriptors[i].offset;
+        modifiers[i] = buffer->modifier().value_or(DRM_FORMAT_MOD_INVALID);
     }
 
-    auto import_gbm_bo(
-        std::shared_ptr<struct gbm_device> gbm,
-        std::shared_ptr<mg::DMABufBuffer> buffer,
-        std::array<int, 4> dmabuf_fds,
-        std::array<int, 4> pitches,
-        std::array<int, 4> offsets) -> struct gbm_bo*
+    return std::make_tuple(dmabuf_fds, pitches, offsets, modifiers);
+}
+
+auto import_gbm_bo(
+    std::shared_ptr<struct gbm_device> gbm,
+    std::shared_ptr<mg::DMABufBuffer> buffer,
+    std::array<int, 4> dmabuf_fds,
+    std::array<int, 4> pitches,
+    std::array<int, 4> offsets) -> struct gbm_bo*
+{
+    auto const plane_descriptors = buffer->planes();
+
+    gbm_import_fd_modifier_data import_data = {
+        .width = buffer->size().width.as_uint32_t(),
+        .height = buffer->size().height.as_uint32_t(),
+        .format = buffer->format(),
+        .num_fds = static_cast<uint32_t>(std::min(plane_descriptors.size(), MAX_PLANES)),
+        .fds = {dmabuf_fds[0], dmabuf_fds[1], dmabuf_fds[2], dmabuf_fds[3]},
+        .strides = {pitches[0], pitches[1], pitches[2], pitches[3]},
+        .offsets = {offsets[0], offsets[1], offsets[2], offsets[3]},
+        .modifier = buffer->modifier().value_or(DRM_FORMAT_MOD_NONE),
+    };
+
+    return gbm_bo_import(gbm.get(), GBM_BO_IMPORT_FD_MODIFIER, (void*)&import_data, GBM_BO_USE_SCANOUT);
+}
+
+auto drm_fb_id_from_dma_buffer(
+    mir::Fd drm_fd, std::shared_ptr<struct gbm_device> const gbm, std::shared_ptr<mg::DMABufBuffer> buffer)
+    -> std::shared_ptr<uint32_t>
+{
+    auto [dmabuf_fds, pitches, offsets, modifiers] = get_import_buffers(buffer);
+    auto* gbm_bo = import_gbm_bo(gbm, buffer, dmabuf_fds, pitches, offsets);
+    if (!gbm_bo)
     {
-        auto const plane_descriptors = buffer->planes();
-
-        gbm_import_fd_modifier_data import_data = {
-            .width = buffer->size().width.as_uint32_t(),
-            .height = buffer->size().height.as_uint32_t(),
-            .format = buffer->format(),
-            .num_fds = static_cast<uint32_t>(std::min(plane_descriptors.size(), MAX_PLANES)),
-            .fds = {dmabuf_fds[0], dmabuf_fds[1], dmabuf_fds[2], dmabuf_fds[3]},
-            .strides = {pitches[0], pitches[1], pitches[2], pitches[3]},
-            .offsets = {offsets[0], offsets[1], offsets[2], offsets[3]},
-            .modifier = buffer->modifier().value_or(DRM_FORMAT_MOD_NONE),
-        };
-
-        return gbm_bo_import(gbm.get(), GBM_BO_IMPORT_FD_MODIFIER, (void*)&import_data, GBM_BO_USE_SCANOUT);
+        mir::log_warning("Failed to import buffer");
+        return {};
     }
 
-    auto drm_fb_id_from_dma_buffer(mir::Fd drm_fd, std::shared_ptr<struct gbm_device> const gbm, std::shared_ptr<mg::DMABufBuffer> buffer)
-        -> std::shared_ptr<uint32_t>
-    {
+    auto const plane_descriptors = buffer->planes();
+    uint32_t gem_handles[MAX_PLANES] = {0};
+    for (std::size_t i = 0; i < std::min(MAX_PLANES, plane_descriptors.size()); i++)
+        gem_handles[i] = gbm_bo_get_handle_for_plane(gbm_bo, i).u32;
 
-        auto [dmabuf_fds, pitches, offsets, modifiers] = get_import_buffers(buffer);
-        auto* gbm_bo = import_gbm_bo(gbm, buffer, dmabuf_fds, pitches, offsets);
-        if (!gbm_bo)
+    auto fb_id = std::shared_ptr<uint32_t>{
+        new uint32_t{0},
+        [drm_fd](uint32_t* fb_id)
         {
-            mir::log_warning("Failed to import buffer");
-            return {};
-        }
-
-        auto const plane_descriptors = buffer->planes();
-        uint32_t gem_handles[MAX_PLANES] = {0};
-        for (std::size_t i = 0; i < std::min(MAX_PLANES, plane_descriptors.size()); i++)
-            gem_handles[i] = gbm_bo_get_handle_for_plane(gbm_bo, i).u32;
-
-        auto fb_id = std::shared_ptr<uint32_t>{
-            new uint32_t{0},
-            [drm_fd](uint32_t* fb_id)
+            if (*fb_id)
             {
-                if (*fb_id)
-                {
-                    drmModeRmFB(drm_fd, *fb_id);
-                }
-                delete fb_id;
-            }};
+                drmModeRmFB(drm_fd, *fb_id);
+            }
+            delete fb_id;
+        }};
 
-        auto [width, height] = buffer->size();
-        int ret = drmModeAddFB2WithModifiers(
-            drm_fd,
-            width.as_uint32_t(),
-            height.as_uint32_t(),
-            buffer->format(),
-            gem_handles,
-            reinterpret_cast<uint32_t*>(pitches.data()),
-            reinterpret_cast<uint32_t*>(offsets.data()),
-            modifiers.data(),
-            fb_id.get(),
-            DRM_MODE_FB_MODIFIERS);
+    auto [width, height] = buffer->size();
+    int ret = drmModeAddFB2WithModifiers(
+        drm_fd,
+        width.as_uint32_t(),
+        height.as_uint32_t(),
+        buffer->format(),
+        gem_handles,
+        reinterpret_cast<uint32_t*>(pitches.data()),
+        reinterpret_cast<uint32_t*>(offsets.data()),
+        modifiers.data(),
+        fb_id.get(),
+        DRM_MODE_FB_MODIFIERS);
 
-        if (ret)
-        {
-            mir::log_warning("drmModeAddFB2WithModifiers returned an error: %d", ret);
-            return {};
-        }
-
-        return fb_id;
+    if (ret)
+    {
+        mir::log_warning("drmModeAddFB2WithModifiers returned an error: %d", ret);
+        return {};
     }
+
+    return fb_id;
+}
 }
 
 auto mga::DmaBufDisplayAllocator::framebuffer_for(std::shared_ptr<DMABufBuffer> buffer) -> std::unique_ptr<Framebuffer>

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -33,6 +33,7 @@
 #include "mir/graphics/gl_config.h"
 #include "mir/graphics/dmabuf_buffer.h"
 
+#include <algorithm>
 #include <boost/throw_exception.hpp>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -247,93 +248,114 @@ void mga::DisplaySink::set_next_image(std::unique_ptr<Framebuffer> content)
     }
 }
 
+namespace {
+    auto const MAX_PLANES = 4zu;
+
+    auto get_import_buffers(std::shared_ptr<mg::DMABufBuffer> buffer)
+        -> std::tuple<std::array<int, 4>, std::array<int, 4>, std::array<int, 4>, std::array<uint64_t, 4>>
+    {
+        auto const plane_descriptors = buffer->planes();
+        assert(plane_descriptors.size() <= MAX_PLANES);
+
+        // std::array becuase we can't really return int[4]
+        std::array<int, 4> dmabuf_fds = {0};
+        std::array<int, 4> pitches = {0};
+        std::array<int, 4> offsets = {0};
+        std::array<uint64_t, 4> modifiers = {0};
+
+        for (std::size_t i = 0; i < std::min(MAX_PLANES, plane_descriptors.size()); i++)
+        {
+            dmabuf_fds[i] = plane_descriptors[i].dma_buf;
+            pitches[i] = plane_descriptors[i].stride;
+            offsets[i] = plane_descriptors[i].offset;
+            modifiers[i] = buffer->modifier().value_or(DRM_FORMAT_MOD_INVALID);
+        }
+
+        return std::make_tuple(dmabuf_fds, pitches, offsets, modifiers);
+    }
+
+    auto import_gbm_bo(
+        mg::DisplaySink const& sink,
+        std::shared_ptr<mg::DMABufBuffer> buffer,
+        std::array<int, 4> dmabuf_fds,
+        std::array<int, 4> pitches,
+        std::array<int, 4> offsets) -> struct gbm_bo*
+    {
+        auto* ds = dynamic_cast<mga::DisplaySink const *>(&sink);
+        if (!ds)
+            return nullptr;
+
+        auto const plane_descriptors = buffer->planes();
+
+        gbm_import_fd_modifier_data import_data = {
+            .width = buffer->size().width.as_uint32_t(),
+            .height = buffer->size().height.as_uint32_t(),
+            .format = buffer->format(),
+            .num_fds = static_cast<uint32_t>(std::min(plane_descriptors.size(), MAX_PLANES)),
+            .fds = {dmabuf_fds[0], dmabuf_fds[1], dmabuf_fds[2], dmabuf_fds[3]},
+            .strides = {pitches[0], pitches[1], pitches[2], pitches[3]},
+            .offsets = {offsets[0], offsets[1], offsets[2], offsets[3]},
+            .modifier = buffer->modifier().value_or(DRM_FORMAT_MOD_NONE),
+        };
+
+        return gbm_bo_import(
+            ds->gbm_device().get(), GBM_BO_IMPORT_FD_MODIFIER, (void*)&import_data, GBM_BO_USE_SCANOUT);
+    }
+
+    auto drm_fb_id_from_dma_buffer(mir::Fd drm_fd, mg::DisplaySink const& sink, std::shared_ptr<mg::DMABufBuffer> buffer)
+        -> std::shared_ptr<uint32_t>
+    {
+
+        auto [dmabuf_fds, pitches, offsets, modifiers] = get_import_buffers(buffer);
+        auto* gbm_bo = import_gbm_bo(sink, buffer, dmabuf_fds, pitches, offsets);
+        if (!gbm_bo)
+        {
+            mir::log_warning("Failed to import buffer");
+            return {};
+        }
+
+        auto const plane_descriptors = buffer->planes();
+        uint32_t gem_handles[MAX_PLANES] = {0};
+        for (std::size_t i = 0; i < std::min(MAX_PLANES, plane_descriptors.size()); i++)
+            gem_handles[i] = gbm_bo_get_handle_for_plane(gbm_bo, i).u32;
+
+        auto fb_id = std::shared_ptr<uint32_t>{
+            new uint32_t{0},
+            [drm_fd](uint32_t* fb_id)
+            {
+                if (*fb_id)
+                {
+                    drmModeRmFB(drm_fd, *fb_id);
+                }
+                delete fb_id;
+            }};
+
+        auto [width, height] = buffer->size();
+        int ret = drmModeAddFB2WithModifiers(
+            drm_fd,
+            width.as_uint32_t(),
+            height.as_uint32_t(),
+            buffer->format(),
+            gem_handles,
+            reinterpret_cast<uint32_t*>(pitches.data()),
+            reinterpret_cast<uint32_t*>(offsets.data()),
+            modifiers.data(),
+            fb_id.get(),
+            DRM_MODE_FB_MODIFIERS);
+
+        if (ret)
+        {
+            mir::log_warning("drmModeAddFB2WithModifiers returned an error: %d", ret);
+            return {};
+        }
+
+        return fb_id;
+    }
+}
+
 auto mga::DmaBufDisplayAllocator::framebuffer_for(mg::DisplaySink& sink, std::shared_ptr<DMABufBuffer> buffer) -> std::unique_ptr<Framebuffer>
 {
-    DisplaySink* ds = dynamic_cast<DisplaySink*>(&sink);
-    if(!ds)
-        return {};
-
-    auto plane_descriptors = buffer->planes();
-
-    auto const max_planes = 4zu;
-    assert(plane_descriptors.size() <= 4);
-
-    auto width = buffer->size().width;
-    auto height = buffer->size().height;
-    auto pixel_format = buffer->format();
-
-    int dmabuf_fds[4] = {0};
-    int pitches[4] = {0};
-    int offsets[4] = {0};
-    uint64_t modifiers[4] = {0};
-
-    mir::log_debug(
-        "Buffer format %s",
-        mir::graphics::drm_format_to_string(buffer->format())
-        /* mir::graphics::drm_modifier_to_string(buffer->modifier().value_or(0)).c_str(), */
-        /* buffer->modifier().value_or(0) */
-    );
-
-    for (std::size_t i = 0; i < std::min(max_planes, plane_descriptors.size()); i++)
-    {
-
-        dmabuf_fds[i] = plane_descriptors[i].dma_buf;
-        pitches[i] = plane_descriptors[i].stride;
-        offsets[i] = plane_descriptors[i].offset;
-        modifiers[i] = buffer->modifier().value_or(DRM_FORMAT_MOD_INVALID);
-    }
-
-    gbm_import_fd_modifier_data import_data = {
-        .width = buffer->size().width.as_uint32_t(),
-        .height = buffer->size().height.as_uint32_t(),
-        .format = buffer->format(),
-        .num_fds = static_cast<uint32_t>(std::min(plane_descriptors.size(), max_planes)),
-        .fds = {dmabuf_fds[0], dmabuf_fds[1], dmabuf_fds[2], dmabuf_fds[3]},
-        .strides = {pitches[0], pitches[1], pitches[2], pitches[3]},
-        .offsets = {offsets[0], pitches[1], pitches[2], pitches[3]},
-        .modifier = buffer->modifier().value_or(DRM_FORMAT_MOD_NONE),
-    };
-    struct gbm_bo* gbm_bo = gbm_bo_import(ds->gbm_device().get(), GBM_BO_IMPORT_FD_MODIFIER, (void*)&import_data, GBM_BO_USE_SCANOUT);
-
-    if(!gbm_bo)
-    {
-        mir::log_debug("Failed to import buffer");
-        return {};
-    }
-
-    uint32_t gem_handles[4] = {0};
-    for (std::size_t i = 0; i < std::min(max_planes, plane_descriptors.size()); i++)
-        gem_handles[i] = gbm_bo_get_handle_for_plane(gbm_bo, i).u32;
-
-    auto fb_id = std::shared_ptr<uint32_t>{
-        new uint32_t{0},
-        [drm_fd = drm_fd()](uint32_t* fb_id)
-        {
-            if (*fb_id)
-            {
-                drmModeRmFB(drm_fd, *fb_id);
-            }
-            delete fb_id;
-        }};
-
-
-    int ret = drmModeAddFB2WithModifiers(
-        drm_fd(),
-        width.as_uint32_t(),
-        height.as_uint32_t(),
-        pixel_format,
-        gem_handles,
-        (uint32_t*)pitches,
-        (uint32_t*)offsets,
-        modifiers,
-        fb_id.get(),
-        DRM_MODE_FB_MODIFIERS);
-
-    if (ret)
-    {
-        mir::log_debug("drmModeAddFB2WithModifiers returned an error: %d", ret);
-        return {};
-    }
+    auto fb_id = drm_fb_id_from_dma_buffer(drm_fd(), sink, buffer);
 
     struct AtomicKmsFbHandle : public mg::FBHandle
     {

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -320,7 +320,7 @@ auto drm_fb_id_from_dma_buffer(
     // Note that we capture `gbm_bo` so that its lifetime matches that of the fb_id
     auto fb_id = std::shared_ptr<uint32_t>{
         new uint32_t{0},
-        [drm_fd, gbm_bo](uint32_t* fb_id)
+        [drm_fd, gbm_bo, buffer](uint32_t* fb_id)
         {
             if (*fb_id)
                 drmModeRmFB(drm_fd, *fb_id);

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -21,6 +21,7 @@
 #include "gbm_display_allocator.h"
 #include "mir/fd.h"
 #include "mir/graphics/display_report.h"
+#include "mir/graphics/drm_formats.h"
 #include "mir/graphics/platform.h"
 #include "mir/graphics/transformation.h"
 #include "bypass.h"
@@ -40,9 +41,12 @@
 #include <cstdint>
 #include <drm_fourcc.h>
 
+#include <drm_mode.h>
+#include <gbm.h>
 #include <memory>
 #include <stdexcept>
 #include <chrono>
+#include <xf86drm.h>
 #include <xf86drmMode.h>
 
 namespace mg = mir::graphics;
@@ -253,13 +257,32 @@ auto mga::DmaBufDisplayAllocator::framebuffer_for(std::shared_ptr<DMABufBuffer> 
     auto height = buffer->size().height;
     auto pixel_format = buffer->format();
 
-    uint32_t bo_handles[4] = {0};
+    uint32_t gem_handles[4] = {0};
     uint32_t pitches[4] = {0};
     uint32_t offsets[4] = {0};
 
-    for (std::size_t i = 0; i < std::min(4zu, plane_descriptors.size()); i++)
+    uint64_t modifiers[4] = {};
+    std::fill_n(modifiers, 4, 0);
+
+    mir::log_debug(
+        "Buffer format %s",
+        mir::graphics::drm_format_to_string(buffer->format())
+        /* mir::graphics::drm_modifier_to_string(buffer->modifier().value_or(0)).c_str(), */
+        /* buffer->modifier().value_or(0) */
+    );
+
+    for (std::size_t i = 0; i < std::min(1zu, plane_descriptors.size()); i++)
     {
-        bo_handles[i] = plane_descriptors[i].dma_buf;
+        uint32_t gem_handle = 0;
+        int ret = drmPrimeFDToHandle(drm_fd(), plane_descriptors[i].dma_buf, &gem_handle);
+
+        if(ret)
+        {
+            mir::log_debug("Failed to convert buffer");
+            return {};
+        }
+
+        gem_handles[i] = gem_handle;
         pitches[i] = plane_descriptors[i].stride;
         offsets[i] = plane_descriptors[i].offset;
     }
@@ -275,19 +298,24 @@ auto mga::DmaBufDisplayAllocator::framebuffer_for(std::shared_ptr<DMABufBuffer> 
             delete fb_id;
         }};
 
-    int ret = drmModeAddFB2(
+
+    int ret = drmModeAddFB2WithModifiers(
         drm_fd(),
         width.as_uint32_t(),
         height.as_uint32_t(),
         pixel_format,
-        bo_handles,
+        gem_handles,
         pitches,
         offsets,
+        modifiers,
         fb_id.get(),
         0);
 
     if (ret)
+    {
+        mir::log_debug("drmModeAddFB2WithModifiers returned an error: %d", ret);
         return {};
+    }
 
     struct AtomicKmsFbHandle : public mg::FBHandle
     {

--- a/src/platforms/atomic-kms/server/kms/display_sink.h
+++ b/src/platforms/atomic-kms/server/kms/display_sink.h
@@ -57,7 +57,7 @@ class DmaBufDisplayAllocator : public graphics::DmaBufDisplayAllocator
         {
         }
 
-        virtual auto framebuffer_for(std::shared_ptr<DMABufBuffer> buffer) -> std::unique_ptr<Framebuffer> override;
+        virtual auto framebuffer_for(mir::graphics::DisplaySink& sink, std::shared_ptr<DMABufBuffer> buffer) -> std::unique_ptr<Framebuffer> override;
 
         auto drm_fd() -> mir::Fd const
         {

--- a/src/platforms/atomic-kms/server/kms/display_sink.h
+++ b/src/platforms/atomic-kms/server/kms/display_sink.h
@@ -25,6 +25,7 @@
 #include "platform_common.h"
 #include "kms_framebuffer.h"
 
+#include <boost/iostreams/detail/buffer.hpp>
 #include <future>
 #include <vector>
 #include <memory>
@@ -49,8 +50,28 @@ namespace atomic
 class Platform;
 class KMSOutput;
 
-class DisplaySink : public graphics::DisplaySink,
-                    public graphics::DisplaySyncGroup
+class DmaBufDisplayAllocator : public graphics::DmaBufDisplayAllocator
+{
+    public:
+        DmaBufDisplayAllocator(mir::Fd drm_fd) : drm_fd_{drm_fd}
+        {
+        }
+
+        virtual auto framebuffer_for(std::shared_ptr<DMABufBuffer> buffer) -> std::unique_ptr<Framebuffer> override;
+
+        auto drm_fd() -> mir::Fd const
+        {
+            return drm_fd_;
+        }
+
+    private:
+        mir::Fd const drm_fd_;
+};
+
+class DisplaySink :
+    public graphics::DisplaySink,
+    public graphics::DisplaySyncGroup,
+    public DmaBufDisplayAllocator
 {
 public:
     DisplaySink(
@@ -94,6 +115,7 @@ private:
 
     std::shared_ptr<KMSOutput> const output;
 
+    std::shared_ptr<DmaBufDisplayAllocator> bypass_allocator;
     std::shared_ptr<CPUAddressableDisplayAllocator> kms_allocator;
     std::unique_ptr<GBMDisplayAllocator> gbm_allocator;
 

--- a/src/platforms/atomic-kms/server/kms/display_sink.h
+++ b/src/platforms/atomic-kms/server/kms/display_sink.h
@@ -53,11 +53,13 @@ class KMSOutput;
 class DmaBufDisplayAllocator : public graphics::DmaBufDisplayAllocator
 {
     public:
-        DmaBufDisplayAllocator(mir::Fd drm_fd) : drm_fd_{drm_fd}
+        DmaBufDisplayAllocator(std::shared_ptr<struct gbm_device> const gbm, mir::Fd drm_fd) :
+            drm_fd_{drm_fd},
+            gbm{gbm}
         {
         }
 
-        virtual auto framebuffer_for(mir::graphics::DisplaySink& sink, std::shared_ptr<DMABufBuffer> buffer) -> std::unique_ptr<Framebuffer> override;
+        virtual auto framebuffer_for(std::shared_ptr<DMABufBuffer> buffer) -> std::unique_ptr<Framebuffer> override;
 
         auto drm_fd() -> mir::Fd const
         {
@@ -66,6 +68,7 @@ class DmaBufDisplayAllocator : public graphics::DmaBufDisplayAllocator
 
     private:
         mir::Fd const drm_fd_;
+        std::shared_ptr<struct gbm_device> const gbm;
 };
 
 class DisplaySink :

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -559,7 +559,7 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
         struct FooFramebufferProvider: public FramebufferProvider
         {
         public:
-            FooFramebufferProvider(DmaBufDisplayAllocator* allocator, mg::DisplaySink& sink) : allocator{allocator}, sink{sink}
+            FooFramebufferProvider(DmaBufDisplayAllocator* allocator) : allocator{allocator}
             {
             }
 
@@ -567,7 +567,7 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
             {
                 if(auto dma_buf = std::dynamic_pointer_cast<mir::graphics::DMABufBuffer>(buffer))
                 {
-                    return allocator->framebuffer_for(sink, dma_buf);
+                    return allocator->framebuffer_for(dma_buf);
                 }
 
                 return {};
@@ -575,10 +575,9 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
 
         private:
             DmaBufDisplayAllocator* allocator;
-            mg::DisplaySink& sink;
         };
 
-        return std::make_unique<FooFramebufferProvider>(allocator, sink);
+        return std::make_unique<FooFramebufferProvider>(allocator);
     }
 
     // TODO: Make this not a null implementation, so bypass/overlays can work again

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -48,6 +48,7 @@
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <cassert>
@@ -550,9 +551,35 @@ auto mgg::GLRenderingProvider::import_syncobj(Fd const& syncobj_fd)
     return std::make_unique<drm::Syncobj>(drm_fd, handle);
 }
 
-auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)
+auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
     -> std::unique_ptr<FramebufferProvider>
 {
+    if(auto* allocator = sink.acquire_compatible_allocator<DmaBufDisplayAllocator>())
+    {
+        struct FooFramebufferProvider: public FramebufferProvider
+        {
+        public:
+            FooFramebufferProvider(DmaBufDisplayAllocator* allocator) : allocator{allocator}
+            {
+            }
+
+            auto buffer_to_framebuffer(std::shared_ptr<Buffer> buffer) -> std::unique_ptr<Framebuffer> override
+            {
+                if(auto dma_buf = std::dynamic_pointer_cast<mir::graphics::DMABufBuffer>(buffer))
+                {
+                    return allocator->framebuffer_for(dma_buf);
+                }
+
+                return {};
+            }
+
+        private:
+            DmaBufDisplayAllocator* allocator;
+        };
+
+        return std::make_unique<FooFramebufferProvider>(allocator);
+    }
+
     // TODO: Make this not a null implementation, so bypass/overlays can work again
     class NullFramebufferProvider : public FramebufferProvider
     {

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -559,7 +559,7 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
         struct FooFramebufferProvider: public FramebufferProvider
         {
         public:
-            FooFramebufferProvider(DmaBufDisplayAllocator* allocator) : allocator{allocator}
+            FooFramebufferProvider(DmaBufDisplayAllocator* allocator, mg::DisplaySink& sink) : allocator{allocator}, sink{sink}
             {
             }
 
@@ -567,7 +567,7 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
             {
                 if(auto dma_buf = std::dynamic_pointer_cast<mir::graphics::DMABufBuffer>(buffer))
                 {
-                    return allocator->framebuffer_for(dma_buf);
+                    return allocator->framebuffer_for(sink, dma_buf);
                 }
 
                 return {};
@@ -575,9 +575,10 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
 
         private:
             DmaBufDisplayAllocator* allocator;
+            mg::DisplaySink& sink;
         };
 
-        return std::make_unique<FooFramebufferProvider>(allocator);
+        return std::make_unique<FooFramebufferProvider>(allocator, sink);
     }
 
     // TODO: Make this not a null implementation, so bypass/overlays can work again

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -19,6 +19,7 @@
 #include "mir/compositor/compositor_report.h"
 #include "mir/compositor/scene.h"
 #include "mir/compositor/scene_element.h"
+#include "mir/graphics/dmabuf_buffer.h"
 #include "mir/graphics/renderable.h"
 #include "mir/graphics/display_sink.h"
 #include "mir/graphics/buffer.h"
@@ -27,6 +28,7 @@
 #include "mir/compositor/buffer_stream.h"
 #include "mir/renderer/renderer.h"
 #include "occlusion.h"
+#include <memory>
 
 #define MIR_LOG_COMPONENT "compositor"
 #include "mir/log.h"
@@ -119,6 +121,11 @@ bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
     {
         mir::log_debug("Bypass path\n");
         report->renderables_in_frame(this, renderable_list);
+
+        // TODO: This is ugly, but its here for the purpose of showing more than one or two frames
+        if (auto dmabuf = std::dynamic_pointer_cast<mg::DMABufBuffer>(renderable_list[0]->buffer()))
+            dmabuf->on_consumed();
+
         renderer->suspend();
     }
     else

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -28,8 +28,12 @@
 #include "mir/renderer/renderer.h"
 #include "occlusion.h"
 
+#define MIR_LOG_COMPONENT "compositor"
+#include "mir/log.h"
+
 namespace mc = mir::compositor;
 namespace mg = mir::graphics;
+
 
 mc::DefaultDisplayBufferCompositor::DefaultDisplayBufferCompositor(
     mg::DisplaySink& display_sink,
@@ -113,11 +117,14 @@ bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
 
     if (framebuffers.size() == renderable_list.size() && display_sink.overlay(framebuffers))
     {
+        mir::log_debug("Bypass path\n");
         report->renderables_in_frame(this, renderable_list);
         renderer->suspend();
     }
     else
     {
+        mir::log_debug("composite path\n");
+
         renderer->set_output_transform(display_sink.transformation());
         renderer->set_viewport(view_area);
         renderer->set_output_filter(output_filter->filter());

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -120,11 +120,6 @@ bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
     if (framebuffers.size() == renderable_list.size() && display_sink.overlay(framebuffers))
     {
         report->renderables_in_frame(this, renderable_list);
-
-        // TODO: This is ugly, but its here for the purpose of showing more than one or two frames
-        if (auto dmabuf = std::dynamic_pointer_cast<mg::DMABufBuffer>(renderable_list[0]->buffer()))
-            dmabuf->on_consumed();
-
         renderer->suspend();
     }
     else

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -119,7 +119,6 @@ bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
 
     if (framebuffers.size() == renderable_list.size() && display_sink.overlay(framebuffers))
     {
-        mir::log_debug("Bypass path\n");
         report->renderables_in_frame(this, renderable_list);
 
         // TODO: This is ugly, but its here for the purpose of showing more than one or two frames
@@ -130,8 +129,6 @@ bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
     }
     else
     {
-        mir::log_debug("composite path\n");
-
         renderer->set_output_transform(display_sink.transformation());
         renderer->set_viewport(view_area);
         renderer->set_output_filter(output_filter->filter());

--- a/src/server/compositor/multi_threaded_compositor.cpp
+++ b/src/server/compositor/multi_threaded_compositor.cpp
@@ -254,7 +254,7 @@ public:
     void wait_until_stopped()
     {
         stop();
-        if (stopped_future.wait_for(10s) != std::future_status::ready)
+        if (stopped_future.wait_for(10h) != std::future_status::ready)
             BOOST_THROW_EXCEPTION(std::runtime_error("Compositor thread failed to stop"));
 
         stopped_future.get();


### PR DESCRIPTION
Apologies for the general suckiness of the code, will improve that once it actually works.

To test:
```sh
./build/bin/miral-kiosk --show-splash=off --platform-display-libs=mir:atomic-kms --platform-rendering-libs=mir:gbm-kms --cursor=null &
sleep 2
glmark2-wayland
```

Note that until hardware cursor support is merged, the cursor must be disabled when testing bypass (current implementation works only with one renderable)