### PR TITLE
All problems in computer science can be solved by another level of indirection

### DIFF
--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -95,7 +95,7 @@ struct TestConfigFile : PendingLoad, miral::TestServer
 
     void TearDown() override
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        puts("====>> Before testing::Mock::VerifyAndClearExpectations() <<====");
         testing::Mock::VerifyAndClearExpectations(this);
         miral::TestServer::TearDown();
     }

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -97,9 +97,9 @@ struct TestConfigFile : PendingLoad, miral::TestServer
     {
         puts("====>> Before testing::Mock::VerifyAndClearExpectations() <<====");
         testing::Mock::VerifyAndClearExpectations(this);
-        puts("====>> After testing::Mock::VerifyAndClearExpectations() <<====");
-        wait_for_load();
-        puts("====>> Before miral::TestServer::TearDown() <<====");
+        // puts("====>> After testing::Mock::VerifyAndClearExpectations() <<====");
+        // wait_for_load();
+        // puts("====>> Before miral::TestServer::TearDown() <<====");
         miral::TestServer::TearDown();
         puts("====>> After miral::TestServer::TearDown() <<====");
     }

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -99,6 +99,10 @@ struct TestConfigFile : PendingLoad, miral::TestServer
         testing::Mock::VerifyAndClearExpectations(this);
         miral::TestServer::TearDown();
     }
+
+    ~TestConfigFile()
+    {
+    }
 };
 
 char const* const home = "/tmp/test_reloading_config_file/home";

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -95,9 +95,18 @@ struct TestConfigFile : PendingLoad, miral::TestServer
 
     void TearDown() override
     {
+        puts("====>> Before testing::Mock::VerifyAndClearExpectations() <<====");
         testing::Mock::VerifyAndClearExpectations(this);
+        puts("====>> After testing::Mock::VerifyAndClearExpectations() <<====");
         wait_for_load();
+        puts("====>> Before miral::TestServer::TearDown() <<====");
         miral::TestServer::TearDown();
+        puts("====>> After miral::TestServer::TearDown() <<====");
+    }
+
+    ~TestConfigFile()
+    {
+        puts("====>> TestConfigFile::~TestConfigFile() <<====");
     }
 };
 

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -66,7 +66,7 @@ private:
     bool pending_loads = false;
 };
 
-struct TestConfigFile : miral::TestServer, PendingLoad
+struct TestConfigFile : PendingLoad, miral::TestServer
 {
     TestConfigFile();
     MOCK_METHOD(void, load, (std::istream& in, std::filesystem::path path), ());

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -96,8 +96,6 @@ struct TestConfigFile : PendingLoad, miral::TestServer
     void TearDown() override
     {
         reloading_config_file.reset();
-        stop_server();
-        testing::Mock::VerifyAndClearExpectations(this);
         miral::TestServer::TearDown();
     }
 };

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -95,6 +95,7 @@ struct TestConfigFile : PendingLoad, miral::TestServer
 
     void TearDown() override
     {
+        reloading_config_file.reset();
         stop_server();
         testing::Mock::VerifyAndClearExpectations(this);
         miral::TestServer::TearDown();

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -95,18 +95,9 @@ struct TestConfigFile : PendingLoad, miral::TestServer
 
     void TearDown() override
     {
-        puts("====>> Before testing::Mock::VerifyAndClearExpectations() <<====");
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
         testing::Mock::VerifyAndClearExpectations(this);
-        // puts("====>> After testing::Mock::VerifyAndClearExpectations() <<====");
-        // wait_for_load();
-        // puts("====>> Before miral::TestServer::TearDown() <<====");
         miral::TestServer::TearDown();
-        // puts("====>> After miral::TestServer::TearDown() <<====");
-    }
-
-    ~TestConfigFile()
-    {
-        // puts("====>> TestConfigFile::~TestConfigFile() <<====");
     }
 };
 

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -95,13 +95,9 @@ struct TestConfigFile : PendingLoad, miral::TestServer
 
     void TearDown() override
     {
-        puts("====>> Before testing::Mock::VerifyAndClearExpectations() <<====");
+        stop_server();
         testing::Mock::VerifyAndClearExpectations(this);
         miral::TestServer::TearDown();
-    }
-
-    ~TestConfigFile()
-    {
     }
 };
 

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -101,12 +101,12 @@ struct TestConfigFile : PendingLoad, miral::TestServer
         // wait_for_load();
         // puts("====>> Before miral::TestServer::TearDown() <<====");
         miral::TestServer::TearDown();
-        puts("====>> After miral::TestServer::TearDown() <<====");
+        // puts("====>> After miral::TestServer::TearDown() <<====");
     }
 
     ~TestConfigFile()
     {
-        puts("====>> TestConfigFile::~TestConfigFile() <<====");
+        // puts("====>> TestConfigFile::~TestConfigFile() <<====");
     }
 };
 

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -96,6 +96,7 @@ struct TestConfigFile : PendingLoad, miral::TestServer
     void TearDown() override
     {
         testing::Mock::VerifyAndClearExpectations(this);
+        wait_for_load();
         miral::TestServer::TearDown();
     }
 };

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -92,6 +92,12 @@ struct TestConfigFile : PendingLoad, miral::TestServer
         miral::TestServer::SetUp();
         ON_CALL(*this, load(testing::_, testing::_)).WillByDefault([this]{ notify_load(); });
     }
+
+    void TearDown() override
+    {
+        testing::Mock::VerifyAndClearExpectations(this);
+        miral::TestServer::TearDown();
+    }
 };
 
 char const* const home = "/tmp/test_reloading_config_file/home";


### PR DESCRIPTION
The `miral::ConfigFile` "Watcher" can be destroyed before the main loop invokes the handler it supports. So add another level of indirection to check it is still there. 

Plus some hygienic improvements to the test fixture.

Fixes: #3612