### PR TITLE
feature: users can specify an app id for the wayland surface when running on the wayland platform

### DIFF
--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -96,8 +96,9 @@ mgw::Display::Display(
     std::shared_ptr<WlDisplayProvider> provider,
     std::shared_ptr<GLConfig> const&,
     std::shared_ptr<DisplayReport> const& report,
-    std::optional<std::string> const& app_id) :
-    DisplayClient{wl_display, std::move(provider), app_id},
+    std::optional<std::string> const& app_id,
+    std::optional<std::string> const& title) :
+    DisplayClient{wl_display, std::move(provider), app_id, title},
     report{report},
     shutdown_signal{::eventfd(0, EFD_CLOEXEC)},
     flush_signal{::eventfd(0, EFD_SEMAPHORE)},

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -95,8 +95,9 @@ mgw::Display::Display(
     wl_display* const wl_display,
     std::shared_ptr<WlDisplayProvider> provider,
     std::shared_ptr<GLConfig> const&,
-    std::shared_ptr<DisplayReport> const& report) :
-    DisplayClient{wl_display, std::move(provider)},
+    std::shared_ptr<DisplayReport> const& report,
+    std::optional<std::string> const& app_id) :
+    DisplayClient{wl_display, std::move(provider), app_id},
     report{report},
     shutdown_signal{::eventfd(0, EFD_CLOEXEC)},
     flush_signal{::eventfd(0, EFD_SEMAPHORE)},

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -62,7 +62,8 @@ public:
         std::shared_ptr<WlDisplayProvider> provider,
         std::shared_ptr<GLConfig> const& gl_config,
         std::shared_ptr<DisplayReport> const& report,
-        std::optional<std::string> const& app_id);
+        std::optional<std::string> const& app_id,
+        std::optional<std::string> const& title);
 
     ~Display();
 

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -61,7 +61,8 @@ public:
         wl_display* const wl_display,
         std::shared_ptr<WlDisplayProvider> provider,
         std::shared_ptr<GLConfig> const& gl_config,
-        std::shared_ptr<DisplayReport> const& report);
+        std::shared_ptr<DisplayReport> const& report,
+        std::optional<std::string> const& app_id);
 
     ~Display();
 

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -271,6 +271,8 @@ void mgw::DisplayClient::Output::done()
         xdg_toplevel_set_fullscreen(shell_toplevel, output);
         if (owner_->app_id)
             xdg_toplevel_set_app_id(shell_toplevel, owner_->app_id.value().c_str());
+        if (owner_->title)
+            xdg_toplevel_set_title(shell_toplevel, owner_->title.value().c_str());
         wl_surface_set_buffer_scale(surface, host_scale);
         wl_surface_commit(surface);
 
@@ -450,10 +452,12 @@ void mgw::DisplayClient::Output::set_next_image(std::unique_ptr<Framebuffer> con
 mgw::DisplayClient::DisplayClient(
     wl_display* display,
     std::shared_ptr<WlDisplayProvider> provider,
-    std::optional<std::string> const& app_id) :
+    std::optional<std::string> const& app_id,
+    std::optional<std::string> const& title) :
     display{display},
     provider{std::move(provider)},
     app_id{app_id},
+    title{title},
     keyboard_context_{xkb_context_new(XKB_CONTEXT_NO_FLAGS)},
     registry{nullptr, [](auto){}}
 {

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -269,6 +269,8 @@ void mgw::DisplayClient::Output::done()
         xdg_toplevel_add_listener(shell_toplevel, &shell_toplevel_listener, this);
 
         xdg_toplevel_set_fullscreen(shell_toplevel, output);
+        if (owner_->app_id)
+            xdg_toplevel_set_app_id(shell_toplevel, owner_->app_id.value().c_str());
         wl_surface_set_buffer_scale(surface, host_scale);
         wl_surface_commit(surface);
 
@@ -447,9 +449,11 @@ void mgw::DisplayClient::Output::set_next_image(std::unique_ptr<Framebuffer> con
 
 mgw::DisplayClient::DisplayClient(
     wl_display* display,
-    std::shared_ptr<WlDisplayProvider> provider) :
+    std::shared_ptr<WlDisplayProvider> provider,
+    std::optional<std::string> const& app_id) :
     display{display},
     provider{std::move(provider)},
+    app_id{app_id},
     keyboard_context_{xkb_context_new(XKB_CONTEXT_NO_FLAGS)},
     registry{nullptr, [](auto){}}
 {

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -54,7 +54,8 @@ class DisplayClient
 public:
     DisplayClient(
         wl_display* display,
-        std::shared_ptr<WlDisplayProvider> provider);
+        std::shared_ptr<WlDisplayProvider> provider,
+        std::optional<std::string> const& app_id);
 
     virtual ~DisplayClient();
 
@@ -62,6 +63,7 @@ protected:
 
     wl_display* const display;
     std::shared_ptr<WlDisplayProvider> const provider;
+    std::optional<std::string> const app_id;
 
     auto display_configuration() const -> std::unique_ptr<DisplayConfiguration>;
     void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f);

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -55,7 +55,8 @@ public:
     DisplayClient(
         wl_display* display,
         std::shared_ptr<WlDisplayProvider> provider,
-        std::optional<std::string> const& app_id);
+        std::optional<std::string> const& app_id,
+        std::optional<std::string> const& title);
 
     virtual ~DisplayClient();
 
@@ -64,6 +65,7 @@ protected:
     wl_display* const display;
     std::shared_ptr<WlDisplayProvider> const provider;
     std::optional<std::string> const app_id;
+    std::optional<std::string> const title;
 
     auto display_configuration() const -> std::unique_ptr<DisplayConfiguration>;
     void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f);

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -71,10 +71,12 @@ auto make_initialised_egl_display(struct wl_display* wl_display) -> EGLDisplay
 mgw::Platform::Platform(
     struct wl_display* const wl_display,
     std::shared_ptr<mg::DisplayReport> const& report,
-    std::optional<std::string> const& app_id) :
+    std::optional<std::string> const& app_id,
+    std::optional<std::string> const& title) :
     wl_display{wl_display},
     report{report},
     app_id{app_id},
+    title{title},
     provider{std::make_shared<WlDisplayProvider>(make_initialised_egl_display(wl_display))}
 {
 }
@@ -83,7 +85,7 @@ mir::UniqueModulePtr<mg::Display> mgw::Platform::create_display(
     std::shared_ptr<DisplayConfigurationPolicy> const&,
     std::shared_ptr<GLConfig> const& gl_config)
 {
-    return mir::make_module_ptr<mgw::Display>(wl_display, provider, gl_config, report, app_id);
+    return mir::make_module_ptr<mgw::Display>(wl_display, provider, gl_config, report, app_id, title);
 }
 
 auto mgw::Platform::maybe_create_provider(const DisplayProvider::Tag& type_tag) -> std::shared_ptr<DisplayProvider>

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -68,9 +68,13 @@ auto make_initialised_egl_display(struct wl_display* wl_display) -> EGLDisplay
 }
 }
 
-mgw::Platform::Platform(struct wl_display* const wl_display, std::shared_ptr<mg::DisplayReport> const& report) :
+mgw::Platform::Platform(
+    struct wl_display* const wl_display,
+    std::shared_ptr<mg::DisplayReport> const& report,
+    std::optional<std::string> const& app_id) :
     wl_display{wl_display},
     report{report},
+    app_id{app_id},
     provider{std::make_shared<WlDisplayProvider>(make_initialised_egl_display(wl_display))}
 {
 }
@@ -79,7 +83,7 @@ mir::UniqueModulePtr<mg::Display> mgw::Platform::create_display(
     std::shared_ptr<DisplayConfigurationPolicy> const&,
     std::shared_ptr<GLConfig> const& gl_config)
 {
-    return mir::make_module_ptr<mgw::Display>(wl_display, provider, gl_config, report);
+    return mir::make_module_ptr<mgw::Display>(wl_display, provider, gl_config, report, app_id);
 }
 
 auto mgw::Platform::maybe_create_provider(const DisplayProvider::Tag& type_tag) -> std::shared_ptr<DisplayProvider>

--- a/src/platforms/wayland/platform.h
+++ b/src/platforms/wayland/platform.h
@@ -34,7 +34,9 @@ class WlDisplayProvider;
 class Platform : public graphics::DisplayPlatform
 {
 public:
-    Platform(struct wl_display* const wl_display, std::shared_ptr<DisplayReport> const& report);
+    Platform(struct wl_display* const wl_display,
+        std::shared_ptr<DisplayReport> const& report,
+        std::optional<std::string> const& app_id);
     ~Platform() = default;
 
     UniqueModulePtr<Display> create_display(
@@ -47,6 +49,7 @@ private:
 
     struct wl_display* const wl_display;
     std::shared_ptr<DisplayReport> const report;
+    std::optional<std::string> const app_id;
 
     std::shared_ptr<WlDisplayProvider> const provider;
 };

--- a/src/platforms/wayland/platform.h
+++ b/src/platforms/wayland/platform.h
@@ -36,7 +36,8 @@ class Platform : public graphics::DisplayPlatform
 public:
     Platform(struct wl_display* const wl_display,
         std::shared_ptr<DisplayReport> const& report,
-        std::optional<std::string> const& app_id);
+        std::optional<std::string> const& app_id,
+        std::optional<std::string> const& title);
     ~Platform() = default;
 
     UniqueModulePtr<Display> create_display(
@@ -50,6 +51,7 @@ private:
     struct wl_display* const wl_display;
     std::shared_ptr<DisplayReport> const report;
     std::optional<std::string> const app_id;
+    std::optional<std::string> const title;
 
     std::shared_ptr<WlDisplayProvider> const provider;
 };

--- a/src/platforms/wayland/platform_symbols.cpp
+++ b/src/platforms/wayland/platform_symbols.cpp
@@ -60,7 +60,7 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
 
     std::optional<std::string> title;
     if (options->is_set(wayland_surface_title_option))
-        app_id = options->get<std::string>(wayland_surface_title_option);
+        title = options->get<std::string>(wayland_surface_title_option);
 
     mir::assert_entry_point_signature<mg::CreateDisplayPlatform>(&create_display_platform);
     return mir::make_module_ptr<mgw::Platform>(mpw::connection(*options), report, app_id, title);

--- a/src/platforms/wayland/platform_symbols.cpp
+++ b/src/platforms/wayland/platform_symbols.cpp
@@ -40,8 +40,11 @@ mir::ModuleProperties const description = {
     mir::libname()
 };
 
-char const* wayland_surface_app_id_option{"wayland-surface-app-id"};
-char const* wayland_surface_app_id_option_description{"Defines the XdgToplevel app id on the surface created by the wayland platform"};
+const char* const wayland_surface_app_id_option{"wayland-surface-app-id"};
+const char* const wayland_surface_app_id_option_description{"Defines the XdgToplevel app id on the surface created by the wayland platform"};
+
+const char* const wayland_surface_title_option{"wayland-surface-title"};
+const char* const wayland_surface_title_option_description{"Defines the XdgTopLevel title on the surface created by the wayland platform"};
 }
 
 mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
@@ -55,8 +58,12 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
     if (options->is_set(wayland_surface_app_id_option))
         app_id = options->get<std::string>(wayland_surface_app_id_option);
 
+    std::optional<std::string> title;
+    if (options->is_set(wayland_surface_title_option))
+        app_id = options->get<std::string>(wayland_surface_title_option);
+
     mir::assert_entry_point_signature<mg::CreateDisplayPlatform>(&create_display_platform);
-    return mir::make_module_ptr<mgw::Platform>(mpw::connection(*options), report, app_id);
+    return mir::make_module_ptr<mgw::Platform>(mpw::connection(*options), report, app_id, title);
 }
 
 void add_graphics_platform_options(boost::program_options::options_description& config)
@@ -67,6 +74,10 @@ void add_graphics_platform_options(boost::program_options::options_description& 
         (wayland_surface_app_id_option,
          boost::program_options::value<std::string>(),
          wayland_surface_app_id_option_description);
+    config.add_options()
+        (wayland_surface_title_option,
+         boost::program_options::value<std::string>(),
+         wayland_surface_title_option_description);
 }
 
 auto probe_graphics_platform(

--- a/src/platforms/wayland/platform_symbols.cpp
+++ b/src/platforms/wayland/platform_symbols.cpp
@@ -39,6 +39,9 @@ mir::ModuleProperties const description = {
     MIR_VERSION_MICRO,
     mir::libname()
 };
+
+char const* wayland_window_app_id_option{"wayland-window-app-id"};
+char const* wayland_window_app_id_option_description{"Defines the XdgToplevel app id on the surface created by the wayland platform"};
 }
 
 mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
@@ -48,14 +51,22 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
     std::shared_ptr<mir::ConsoleServices> const& /*console*/,
     std::shared_ptr<mg::DisplayReport> const& report)
 {
+    std::optional<std::string> app_id;
+    if (options->is_set(wayland_window_app_id_option))
+        app_id = options->get<std::string>(wayland_window_app_id_option);
+
     mir::assert_entry_point_signature<mg::CreateDisplayPlatform>(&create_display_platform);
-    return mir::make_module_ptr<mgw::Platform>(mpw::connection(*options), report);
+    return mir::make_module_ptr<mgw::Platform>(mpw::connection(*options), report, app_id);
 }
 
 void add_graphics_platform_options(boost::program_options::options_description& config)
 {
     mir::assert_entry_point_signature<mg::AddPlatformOptions>(&add_graphics_platform_options);
     mpw::add_connection_options(config);
+    config.add_options()
+        (wayland_window_app_id_option,
+         boost::program_options::value<std::string>(),
+         wayland_window_app_id_option_description);
 }
 
 auto probe_graphics_platform(

--- a/src/platforms/wayland/platform_symbols.cpp
+++ b/src/platforms/wayland/platform_symbols.cpp
@@ -40,8 +40,8 @@ mir::ModuleProperties const description = {
     mir::libname()
 };
 
-char const* wayland_window_app_id_option{"wayland-window-app-id"};
-char const* wayland_window_app_id_option_description{"Defines the XdgToplevel app id on the surface created by the wayland platform"};
+char const* wayland_surface_app_id_option{"wayland-surface-app-id"};
+char const* wayland_surface_app_id_option_description{"Defines the XdgToplevel app id on the surface created by the wayland platform"};
 }
 
 mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
@@ -52,8 +52,8 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
     std::shared_ptr<mg::DisplayReport> const& report)
 {
     std::optional<std::string> app_id;
-    if (options->is_set(wayland_window_app_id_option))
-        app_id = options->get<std::string>(wayland_window_app_id_option);
+    if (options->is_set(wayland_surface_app_id_option))
+        app_id = options->get<std::string>(wayland_surface_app_id_option);
 
     mir::assert_entry_point_signature<mg::CreateDisplayPlatform>(&create_display_platform);
     return mir::make_module_ptr<mgw::Platform>(mpw::connection(*options), report, app_id);
@@ -64,9 +64,9 @@ void add_graphics_platform_options(boost::program_options::options_description& 
     mir::assert_entry_point_signature<mg::AddPlatformOptions>(&add_graphics_platform_options);
     mpw::add_connection_options(config);
     config.add_options()
-        (wayland_window_app_id_option,
+        (wayland_surface_app_id_option,
          boost::program_options::value<std::string>(),
-         wayland_window_app_id_option_description);
+         wayland_surface_app_id_option_description);
 }
 
 auto probe_graphics_platform(


### PR DESCRIPTION
## What's new?
- Added the `--wayland-surface-app-id=<APP_ID>` option for the wayland platform that, when set, will call [xdg_top_level::set_app_id](https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id) with the value `APP_ID`
- Added the `--wayland-surface-title=<TITLE>` option for the wayland platform that, when set, will call [xdg_top_level::set_title](https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_title) with the value `TITLE`
