### PR TITLE
Atomic kms hardware cursor support

### DIFF
--- a/src/platforms/atomic-kms/server/kms/CMakeLists.txt
+++ b/src/platforms/atomic-kms/server/kms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   atomic_kms_output.cpp
   atomic_kms_output.h
   bypass.cpp
+  cursor.cpp
   display.cpp
   display_buffer.cpp
   platform.cpp

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
@@ -483,9 +483,9 @@ void mga::AtomicKMSOutput::wait_for_page_flip()
     pending_page_flip.get();
 }
 
-std::shared_ptr<uint32_t> mga::AtomicKMSOutput::cursor_gbm_bo_to_drm_fb_id(gbm_bo* gbm_bo)
+mga::AtomicKMSOutput::CursorFbPtr mga::AtomicKMSOutput::cursor_gbm_bo_to_drm_fb_id(gbm_bo* gbm_bo)
 {
-    auto fb_id = std::shared_ptr<uint32_t>{
+    auto fb_id = CursorFbPtr{
         new uint32_t{0},
         [drm_fd = this->drm_fd_](uint32_t* fb_id)
         {

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
@@ -895,7 +895,7 @@ std::vector<uint8_t> edid_for_connector(mir::Fd const& drm_fd, uint32_t connecto
 
 auto formats_for_output(mir::Fd const& drm_fd, mgk::DRMModeConnectorUPtr const& connector) -> std::vector<mg::DRMFormat>
 {
-    // Multiple placeholder supportt is coming in C++26 ...
+    // Multiple placeholder support is coming in C++26 ...
     auto [_, plane, dummy_cursor_plane] = mgk::find_crtc_with_primary_plane(drm_fd, connector);
 
     mgk::ObjectProperties plane_props{drm_fd, plane->plane_id, DRM_MODE_OBJECT_PLANE};

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
@@ -578,7 +578,7 @@ void mga::AtomicKMSOutput::move_cursor(geometry::Point destination)
 
 bool mga::AtomicKMSOutput::clear_cursor()
 {
-    return false;
+    return true;
 }
 
 bool mga::AtomicKMSOutput::has_cursor_plane() const

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
@@ -77,7 +77,8 @@ private:
     bool ensure_crtc();
     void restore_saved_crtc();
 
-    std::shared_ptr<uint32_t> cursor_gbm_bo_to_drm_fb_id(gbm_bo* gbm_bo);
+    using CursorFbPtr = std::unique_ptr<uint32_t, std::function<void(uint32_t*)>>;
+    CursorFbPtr cursor_gbm_bo_to_drm_fb_id(gbm_bo* gbm_bo);
 
     mir::Fd const drm_fd_;
     std::shared_ptr<kms::DRMEventHandler> const event_handler;
@@ -102,7 +103,7 @@ private:
     bool has_hardware_cursor{false};
 
     struct {
-        std::shared_ptr<uint32_t> fb_id;
+        CursorFbPtr fb_id;
         uint32_t width, height;
         int crtc_x, crtc_y;
     } cursor_state;

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
@@ -110,6 +110,7 @@ private:
     bool using_saved_crtc;
 
     CursorState cursor_state;
+    std::mutex cursor_mutex;
 };
 
 }

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
@@ -73,11 +73,19 @@ public:
     int drm_fd() const override;
 
     bool has_cursor_plane() const;
+
+    using CursorFbPtr = std::unique_ptr<uint32_t, std::function<void(uint32_t*)>>;
+    struct CursorState {
+        bool enabled{false};
+        CursorFbPtr fb_id;
+        uint32_t width, height;
+        int crtc_x, crtc_y;
+    };
+
 private:
     bool ensure_crtc();
     void restore_saved_crtc();
 
-    using CursorFbPtr = std::unique_ptr<uint32_t, std::function<void(uint32_t*)>>;
     CursorFbPtr cursor_gbm_bo_to_drm_fb_id(gbm_bo* gbm_bo);
 
     mir::Fd const drm_fd_;
@@ -100,13 +108,8 @@ private:
     std::unique_ptr<kms::ObjectProperties> connector_props;
     drmModeCrtc saved_crtc;
     bool using_saved_crtc;
-    bool cursor_enabled{false};
 
-    struct {
-        CursorFbPtr fb_id;
-        uint32_t width, height;
-        int crtc_x, crtc_y;
-    } cursor_state;
+    CursorState cursor_state;
 };
 
 }

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
@@ -77,6 +77,8 @@ private:
     bool ensure_crtc();
     void restore_saved_crtc();
 
+    std::shared_ptr<uint32_t> cursor_gbm_bo_to_drm_fb_id(gbm_bo* gbm_bo);
+
     mir::Fd const drm_fd_;
     std::shared_ptr<kms::DRMEventHandler> const event_handler;
 
@@ -92,11 +94,18 @@ private:
     kms::DRMModePlaneUPtr current_cursor_plane;
     std::unique_ptr<PropertyBlob> mode;
     std::unique_ptr<kms::ObjectProperties> crtc_props;
-    std::unique_ptr<kms::ObjectProperties> plane_props;
+    std::unique_ptr<kms::ObjectProperties> primary_plane_props;
+    std::unique_ptr<kms::ObjectProperties> cursor_plane_props;
     std::unique_ptr<kms::ObjectProperties> connector_props;
     drmModeCrtc saved_crtc;
     bool using_saved_crtc;
     bool has_hardware_cursor{false};
+
+    struct {
+        std::shared_ptr<uint32_t> fb_id;
+        uint32_t width, height;
+        int crtc_x, crtc_y;
+    } cursor_state;
 };
 
 }

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
@@ -100,7 +100,7 @@ private:
     std::unique_ptr<kms::ObjectProperties> connector_props;
     drmModeCrtc saved_crtc;
     bool using_saved_crtc;
-    bool has_hardware_cursor{false};
+    bool cursor_enabled{false};
 
     struct {
         CursorFbPtr fb_id;

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
@@ -72,6 +72,7 @@ public:
 
     int drm_fd() const override;
 
+    bool has_cursor_plane() const;
 private:
     bool ensure_crtc();
     void restore_saved_crtc();
@@ -87,13 +88,15 @@ private:
     size_t mode_index;
     geometry::Displacement fb_offset;
     kms::DRMModeCrtcUPtr current_crtc;
-    kms::DRMModePlaneUPtr current_plane;
+    kms::DRMModePlaneUPtr current_primary_plane;
+    kms::DRMModePlaneUPtr current_cursor_plane;
     std::unique_ptr<PropertyBlob> mode;
     std::unique_ptr<kms::ObjectProperties> crtc_props;
     std::unique_ptr<kms::ObjectProperties> plane_props;
     std::unique_ptr<kms::ObjectProperties> connector_props;
     drmModeCrtc saved_crtc;
     bool using_saved_crtc;
+    bool has_hardware_cursor{false};
 };
 
 }

--- a/src/platforms/atomic-kms/server/kms/cursor.cpp
+++ b/src/platforms/atomic-kms/server/kms/cursor.cpp
@@ -1,0 +1,438 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cursor.h"
+#include "platform.h"
+#include "kms_output.h"
+#include "kms_output_container.h"
+#include "kms_display_configuration.h"
+#include "mir/geometry/rectangle.h"
+#include "mir/graphics/cursor_image.h"
+
+#include <xf86drm.h>
+
+#include <boost/exception/errinfo_errno.hpp>
+
+#include <stdexcept>
+#include <vector>
+
+namespace mg = mir::graphics;
+namespace mga = mg::atomic;
+namespace geom = mir::geometry;
+
+namespace
+{
+// Transforms a relative position within the display bounds described by \a rect which is rotated with \a orientation
+geom::Displacement transform(geom::Rectangle const& rect, geom::Displacement const& vector, MirOrientation orientation)
+{
+    switch(orientation)
+    {
+    case mir_orientation_left:
+        return {vector.dy.as_int(), rect.size.width.as_int() -vector.dx.as_int()};
+    case mir_orientation_inverted:
+        return {rect.size.width.as_int() -vector.dx.as_int(), rect.size.height.as_int() - vector.dy.as_int()};
+    case mir_orientation_right:
+        return {rect.size.height.as_int() -vector.dy.as_int(), vector.dx.as_int()};
+    default:
+    case mir_orientation_normal:
+        return vector;
+    }
+}
+
+int get_drm_cursor_height(int fd)
+{
+    uint64_t height;
+    drmGetCap(fd, DRM_CAP_CURSOR_HEIGHT, &height);
+    return int(height);
+}
+
+int get_drm_cursor_width(int fd)
+{
+    uint64_t width;
+    drmGetCap(fd, DRM_CAP_CURSOR_WIDTH, &width);
+    return int(width);
+}
+
+gbm_device* gbm_create_device_checked(int fd)
+{
+    auto device = gbm_create_device(fd);
+    if (!device)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("Failed to create gbm-kms device"));
+    }
+    return device;
+}
+}
+
+mga::Cursor::GBMBOWrapper::GBMBOWrapper(int fd, MirOrientation orientation) :
+    device{gbm_create_device_checked(fd)},
+    buffer{
+        gbm_bo_create(
+            device,
+            get_drm_cursor_width(fd),
+            get_drm_cursor_height(fd),
+            GBM_FORMAT_ARGB8888,
+            GBM_BO_USE_CURSOR | GBM_BO_USE_WRITE)},
+    current_orientation{orientation}
+{
+    if (!buffer) BOOST_THROW_EXCEPTION(std::runtime_error("failed to create gbm-kms buffer"));
+}
+
+inline mga::Cursor::GBMBOWrapper::operator gbm_bo*()
+{
+    return buffer;
+}
+
+inline mga::Cursor::GBMBOWrapper::~GBMBOWrapper()
+{
+    if (device)
+        gbm_device_destroy(device);
+    if (buffer)
+        gbm_bo_destroy(buffer);
+}
+
+mga::Cursor::GBMBOWrapper::GBMBOWrapper(GBMBOWrapper&& from)
+    : device{from.device},
+      buffer{from.buffer},
+      current_orientation{from.current_orientation}
+{
+    from.buffer = nullptr;
+    from.device = nullptr;
+}
+
+auto mga::Cursor::GBMBOWrapper::change_orientation(MirOrientation new_orientation) -> bool
+{
+    if (current_orientation == new_orientation)
+        return false;
+
+    current_orientation = new_orientation;
+    return true;
+}
+
+mga::Cursor::Cursor(
+    KMSOutputContainer& output_container,
+    std::shared_ptr<CurrentConfiguration> const& current_configuration) :
+        output_container(output_container),
+        current_position(),
+        last_set_failed(false),
+        min_buffer_width{std::numeric_limits<uint32_t>::max()},
+        min_buffer_height{std::numeric_limits<uint32_t>::max()},
+        current_configuration(current_configuration)
+{
+    // Generate the buffers for the initial configuration.
+    current_configuration->with_current_configuration_do(
+        [this](KMSDisplayConfiguration const& kms_conf)
+        {
+            kms_conf.for_each_output(
+                [this, &kms_conf](auto const& output)
+                {
+                    // I'm not sure why g++ needs the explicit "this->" but it does - alan_g
+                    this->buffer_for_output(*kms_conf.get_output_for(output.id));
+                });
+        });
+
+    hide();
+    if (last_set_failed)
+        BOOST_THROW_EXCEPTION(std::runtime_error("Initial KMS cursor set failed"));
+}
+
+mga::Cursor::~Cursor() noexcept
+{
+    hide();
+}
+
+void mga::Cursor::write_buffer_data_locked(
+    std::lock_guard<std::mutex> const&,
+    gbm_bo* buffer,
+    void const* data,
+    size_t count)
+{
+    if (auto result = gbm_bo_write(buffer, data, count))
+    {
+        BOOST_THROW_EXCEPTION(
+            ::boost::enable_error_info(std::runtime_error("failed to initialize gbm-kms buffer"))
+                << (boost::error_info<Cursor, decltype(result)>(result)));
+    }
+}
+
+void mga::Cursor::pad_and_write_image_data_locked(
+    std::lock_guard<std::mutex> const& lg,
+    GBMBOWrapper& buffer)
+{
+    auto const orientation = buffer.orientation();
+    bool const sideways = orientation == mir_orientation_left || orientation == mir_orientation_right;
+
+    auto const min_width  = sideways ? min_buffer_width : min_buffer_height;
+    auto const min_height = sideways ? min_buffer_height : min_buffer_width;
+
+    auto const image_width = std::min(min_width, size.width.as_uint32_t());
+    auto const image_height = std::min(min_height, size.height.as_uint32_t());
+    auto const image_stride = size.width.as_uint32_t() * 4;
+
+    auto const buffer_stride = std::max(min_width*4, gbm_bo_get_stride(buffer));  // in bytes
+    auto const buffer_height = std::max(min_height, gbm_bo_get_height(buffer));
+    size_t const padded_size = buffer_stride * buffer_height;
+
+    auto padded = std::unique_ptr<uint8_t[]>(new uint8_t[padded_size]);
+    size_t rhs_padding = buffer_stride - 4*image_width;
+
+    auto const filler = 0; // 0x3f; is useful to make buffer visible for debugging
+    uint8_t const* src = argb8888.data();
+    uint8_t* dest = &padded[0];
+
+    switch (orientation)
+    {
+    case mir_orientation_normal:
+        for (unsigned int y = 0; y < image_height; y++)
+        {
+            memcpy(dest, src, 4*image_width);
+            memset(dest + 4*image_width, filler, rhs_padding);
+            dest += buffer_stride;
+            src += image_stride;
+        }
+
+        memset(dest, 0, buffer_stride * (buffer_height - image_height));
+        break;
+
+    case mir_orientation_inverted:
+        for (unsigned int row = 0; row != image_height; ++row)
+        {
+            memset(dest+row*buffer_stride+4*image_width, filler, rhs_padding);
+
+            for (unsigned int col = 0; col != image_width; ++col)
+            {
+                memcpy(dest+row*buffer_stride+4*col, src + ((image_height-1)-row)*image_stride + 4*((image_width-1)-col), 4);
+            }
+        }
+
+        memset(dest+image_height*buffer_stride, filler, buffer_stride * (buffer_height - image_height));
+        break;
+
+    case mir_orientation_left:
+        for (unsigned int row = 0; row != image_width; ++row)
+        {
+            memset(dest+row*buffer_stride+4*image_height, filler, rhs_padding);
+
+            for (unsigned int col = 0; col != image_height; ++col)
+            {
+                memcpy(dest+row*buffer_stride+4*col, src + ((image_width-1)-row)*4 + image_stride*col, 4);
+            }
+        }
+
+        memset(dest+image_width*buffer_stride, filler, buffer_stride * (buffer_height - image_width));
+        break;
+
+    case mir_orientation_right:
+        for (unsigned int row = 0; row != image_width; ++row)
+        {
+            memset(dest+row*buffer_stride+4*image_height, filler, rhs_padding);
+
+            for (unsigned int col = 0; col != image_height; ++col)
+            {
+                memcpy(dest+row*buffer_stride+4*col, src + row*4 + image_stride*((image_height-1)-col), 4);
+            }
+        }
+
+        memset(dest+image_width*buffer_stride, filler, buffer_stride * (buffer_height - image_width));
+        break;
+    }
+
+    write_buffer_data_locked(lg, buffer, &padded[0], padded_size);
+}
+
+void mga::Cursor::show(CursorImage const& cursor_image)
+{
+    std::lock_guard lg(guard);
+
+    size = cursor_image.size();
+
+    argb8888.resize(size.width.as_uint32_t() * size.height.as_uint32_t() * 4);
+    memcpy(argb8888.data(), cursor_image.as_argb_8888(), argb8888.size());
+
+    hotspot = cursor_image.hotspot();
+    {
+        auto locked_buffers = buffers.lock();
+        for (auto& tuple : *locked_buffers)
+        {
+            pad_and_write_image_data_locked(lg, std::get<2>(tuple));
+        }
+    }
+
+    // Writing the data could throw an exception so let's
+    // hold off on setting visible until after we have succeeded.
+    visible = true;
+    place_cursor_at_locked(lg, current_position, ForceState);
+}
+
+void mga::Cursor::move_to(geometry::Point position)
+{
+    place_cursor_at(position, UpdateState);
+}
+
+void mga::Cursor::suspend()
+{
+    std::lock_guard lg(guard);
+    clear(lg);
+}
+
+void mga::Cursor::clear(std::lock_guard<std::mutex> const&)
+{
+    last_set_failed = false;
+    output_container.for_each_output([&](std::shared_ptr<KMSOutput> const& output)
+        {
+            if (!output->clear_cursor())
+                last_set_failed = true;
+        });
+}
+
+void mga::Cursor::resume()
+{
+    place_cursor_at(current_position, ForceState);
+}
+
+void mga::Cursor::hide()
+{
+    std::lock_guard lg(guard);
+    visible = false;
+    clear(lg);
+}
+
+void mga::Cursor::for_each_used_output(
+    std::function<void(KMSOutput& output, DisplayConfigurationOutput const& conf)> const& f)
+{
+    current_configuration->with_current_configuration_do(
+        [&f](KMSDisplayConfiguration const& kms_conf)
+        {
+            kms_conf.for_each_output([&](DisplayConfigurationOutput const& conf_output)
+            {
+                if (conf_output.used)
+                {
+                    auto output = kms_conf.get_output_for(conf_output.id);
+                    f(*output, conf_output);
+                }
+            });
+        });
+}
+
+void mga::Cursor::place_cursor_at(
+    geometry::Point position,
+    ForceCursorState force_state)
+{
+    std::lock_guard lg(guard);
+    place_cursor_at_locked(lg, position, force_state);
+}
+
+void mga::Cursor::place_cursor_at_locked(
+    std::lock_guard<std::mutex> const& lg,
+    geometry::Point position,
+    ForceCursorState force_state)
+{
+
+    current_position = position;
+
+    if (!visible)
+        return;
+
+    bool set_on_all_outputs = true;
+    auto const cursor_rect = geometry::Rectangle(position - hotspot, size);
+
+    for_each_used_output([&](KMSOutput& output, DisplayConfigurationOutput const& conf)
+    {
+        auto const output_rect = conf.extents();
+
+        if (output_rect.overlaps(cursor_rect))
+        {
+            auto const orientation = conf.orientation;
+            auto const relative_to_extants = position - output_rect.top_left;
+            auto const relative_to_extants_vec = glm::vec2{
+                relative_to_extants.dx.as_int(),
+                relative_to_extants.dy.as_int()};
+
+            // Cursor position scaled such that (-1, -1) is at the bottom left of the logical output extents and (1, 1)
+            // is at the upper right
+            auto const scaled_vec = glm::vec2{
+                relative_to_extants_vec.x / output_rect.size.width.as_int(),
+                relative_to_extants_vec.y / output_rect.size.height.as_int()} * 2.0f - glm::vec2{1};
+
+            // Cursor position on the same (-1, -1) to (1, 1) coordinate system, but with the output transform applied
+            auto const transformed_vec = scaled_vec * conf.transformation();
+
+            auto const output_size_vec = glm::vec2{output.size().width.as_int(), output.size().height.as_int()};
+
+            // Cursor position in actual output pixels
+            auto const output_space_vec = ((transformed_vec + glm::vec2{1}) / 2.0f) * output_size_vec;
+
+            auto const position_on_output = geom::Point{roundf(output_space_vec.x), roundf(output_space_vec.y)};
+
+            auto const hotspot_displacement = transform(geom::Rectangle{{}, size}, hotspot, orientation);
+
+            // It's a little strange that we implement hotspot this way as there is
+            // drmModeSetCursor2 with hotspot support. However, it appears to not actually
+            // work on radeon and intel. There also seems to be precedent in weston for
+            // implementing hotspot in this fashion.
+            output.move_cursor(position_on_output - hotspot_displacement);
+            auto& buffer = buffer_for_output(output);
+
+            auto const changed_orientation = buffer.change_orientation(orientation);
+
+            if (changed_orientation)
+                pad_and_write_image_data_locked(lg, buffer);
+
+            if (force_state || !output.has_cursor() || changed_orientation)
+            {
+                if (!output.set_cursor(buffer) || !output.has_cursor())
+                    set_on_all_outputs = false;
+            }
+        }
+        else
+        {
+            if (force_state || output.has_cursor())
+            {
+                output.clear_cursor();
+            }
+        }
+    });
+
+    last_set_failed = !set_on_all_outputs;
+}
+
+mga::Cursor::GBMBOWrapper& mga::Cursor::buffer_for_output(KMSOutput const& output)
+{
+    auto const drm_fd = output.drm_fd();
+    auto const id = output.id();
+    auto locked_buffers = buffers.lock();
+
+    for (auto& bo : *locked_buffers)
+    {
+        // We use both id and drm_fd as identifier as we're not sure of the uniqueness of either
+        if (std::get<0>(bo) == id && std::get<1>(bo) == drm_fd)
+            return std::get<2>(bo);
+    }
+
+    locked_buffers->push_back(image_buffer{id, drm_fd, GBMBOWrapper{drm_fd, mir_orientation_normal}});
+
+    GBMBOWrapper& bo = std::get<2>(locked_buffers->back());
+    if (gbm_bo_get_width(bo) < min_buffer_width)
+    {
+        min_buffer_width = gbm_bo_get_width(bo);
+    }
+    if (gbm_bo_get_height(bo) < min_buffer_height)
+    {
+        min_buffer_height = gbm_bo_get_height(bo);
+    }
+
+    return bo;
+}

--- a/src/platforms/atomic-kms/server/kms/cursor.h
+++ b/src/platforms/atomic-kms/server/kms/cursor.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef MIR_GRAPHICS_ATOMIC_CURSOR_H_
+#define MIR_GRAPHICS_ATOMIC_CURSOR_H_
+
+#include "mir/graphics/cursor.h"
+
+#include "mir_toolkit/common.h"
+#include "mir/synchronised.h"
+#include "mir/geometry/displacement.h"
+
+#include <gbm.h>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace mir
+{
+namespace graphics
+{
+class CursorImage;
+class DisplayConfigurationOutput;
+
+namespace atomic
+{
+class KMSOutputContainer;
+class KMSOutput;
+class KMSDisplayConfiguration;
+class GBMPlatform;
+
+class CurrentConfiguration
+{
+public:
+    virtual ~CurrentConfiguration() = default;
+
+    virtual void with_current_configuration_do(
+        std::function<void(KMSDisplayConfiguration const&)> const& exec) = 0;
+
+protected:
+    CurrentConfiguration() = default;
+    CurrentConfiguration(CurrentConfiguration const&) = delete;
+    CurrentConfiguration& operator=(CurrentConfiguration const&) = delete;
+};
+
+class Cursor : public graphics::Cursor
+{
+public:
+    Cursor(
+        KMSOutputContainer& output_container,
+        std::shared_ptr<CurrentConfiguration> const& current_configuration);
+
+    ~Cursor() noexcept;
+
+    void show(CursorImage const& cursor_image) override;
+    void hide() override;
+
+    void move_to(geometry::Point position) override;
+
+    void suspend();
+    void resume();
+
+private:
+    enum ForceCursorState { UpdateState, ForceState };
+    struct GBMBOWrapper;
+    void for_each_used_output(std::function<void(KMSOutput& output, DisplayConfigurationOutput const& conf)> const& f);
+    void place_cursor_at(geometry::Point position, ForceCursorState force_state);
+    void place_cursor_at_locked(std::lock_guard<std::mutex> const&, geometry::Point position, ForceCursorState force_state);
+    void write_buffer_data_locked(
+        std::lock_guard<std::mutex> const&,
+        gbm_bo* buffer,
+        void const* data,
+        size_t count);
+    void pad_and_write_image_data_locked(
+        std::lock_guard<std::mutex> const&,
+        GBMBOWrapper& buffer);
+    void clear(std::lock_guard<std::mutex> const&);
+
+    GBMBOWrapper& buffer_for_output(KMSOutput const& output);
+
+    std::mutex guard;
+
+    KMSOutputContainer& output_container;
+    geometry::Point current_position;
+    geometry::Displacement hotspot;
+    geometry::Size size;
+    std::vector<uint8_t> argb8888;
+
+    bool visible;
+    bool last_set_failed;
+
+    struct GBMBOWrapper
+    {
+        GBMBOWrapper(int fd, MirOrientation orientation);
+        operator gbm_bo*();
+
+        auto orientation() const -> MirOrientation { return current_orientation; }
+        auto change_orientation(MirOrientation new_orientation) -> bool;
+
+        ~GBMBOWrapper();
+
+        GBMBOWrapper(GBMBOWrapper&& from);
+    private:
+        gbm_device* device;
+        gbm_bo* buffer;
+        MirOrientation current_orientation;
+        GBMBOWrapper(GBMBOWrapper const&) = delete;
+        GBMBOWrapper& operator=(GBMBOWrapper const&) = delete;
+    };
+
+    using image_buffer = std::tuple<uint32_t, int, GBMBOWrapper>;
+    Synchronised<std::vector<image_buffer>> buffers;
+
+    uint32_t min_buffer_width;
+    uint32_t min_buffer_height;
+
+    std::shared_ptr<CurrentConfiguration> const current_configuration;
+};
+}
+}
+}
+
+
+#endif /* MIR_GRAPHICS_ATOMIC_CURSOR_H_ */

--- a/src/platforms/atomic-kms/server/kms/display.h
+++ b/src/platforms/atomic-kms/server/kms/display.h
@@ -14,16 +14,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GRAPHICS_GBM_DISPLAY_H_
-#define MIR_GRAPHICS_GBM_DISPLAY_H_
+#ifndef MIR_GRAPHICS_ATOMIC_DISPLAY_H_
+#define MIR_GRAPHICS_ATOMIC_DISPLAY_H_
 
+#include "./platform_common.h"
 #include "kms-utils/drm_event_handler.h"
 #include "mir/graphics/display.h"
+#include "mir/graphics/platform.h"
 #include "mir/udev/wrapper.h"
 #include "real_kms_output_container.h"
 #include "real_kms_display_configuration.h"
-#include "platform_common.h"
-#include "mir/graphics/platform.h"
 
 #include <atomic>
 #include <mutex>
@@ -128,4 +128,4 @@ private:
 }
 }
 
-#endif /* MIR_GRAPHICS_GBM_DISPLAY_H_ */
+#endif /* MIR_GRAPHICS_ATOMIC_DISPLAY_H_ */

--- a/src/platforms/atomic-kms/server/platform_common.h
+++ b/src/platforms/atomic-kms/server/platform_common.h
@@ -14,8 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GRAPHICS_GBM_PLATFORM_COMMON_H_
-#define MIR_GRAPHICS_GBM_PLATFORM_COMMON_H_
+#ifndef MIR_GRAPHICS_ATOMIC_PLATFORM_COMMON_H_
+#define MIR_GRAPHICS_ATOMIC_PLATFORM_COMMON_H_
 
 namespace mir
 {
@@ -33,4 +33,4 @@ enum class BypassOption
 }
 }
 }
-#endif /* MIR_GRAPHICS_GBM_PLATFORM_COMMON_H_ */
+#endif /* MIR_GRAPHICS_ATOMIC_PLATFORM_COMMON_H_ */

--- a/src/platforms/common/server/kms-utils/kms_connector.cpp
+++ b/src/platforms/common/server/kms-utils/kms_connector.cpp
@@ -197,7 +197,6 @@ auto mgk::find_crtc_with_primary_plane(
         if (plane->possible_crtcs & (1 << crtc_index))
         {
             ObjectProperties plane_props{drm_fd, plane->plane_id, DRM_MODE_OBJECT_PLANE};
-            std::cerr << "Plane type: " << plane_props["type"] << '\n';
         }
     }
 

--- a/src/platforms/common/server/kms-utils/kms_connector.h
+++ b/src/platforms/common/server/kms-utils/kms_connector.h
@@ -20,7 +20,6 @@
 #include "drm_mode_resources.h"
 
 #include <string>
-#include <vector>
 #include <xf86drmMode.h>
 
 namespace mir
@@ -48,9 +47,8 @@ DRMModeCrtcUPtr find_crtc_for_connector(
     int drm_fd,
     DRMModeConnectorUPtr const& connector);
 
-std::pair<DRMModeCrtcUPtr, DRMModePlaneUPtr> find_crtc_with_primary_plane(
-    int drm_fd,
-    DRMModeConnectorUPtr const& connector);
+auto find_crtc_with_primary_plane(int drm_fd, DRMModeConnectorUPtr const& connector)
+    -> std::tuple<DRMModeCrtcUPtr, DRMModePlaneUPtr, DRMModePlaneUPtr>;
 }
 }
 }

--- a/src/platforms/eglstream-kms/server/egl_output.cpp
+++ b/src/platforms/eglstream-kms/server/egl_output.cpp
@@ -28,7 +28,6 @@
 #include <sys/ioctl.h>
 #include <boost/throw_exception.hpp>
 #include <system_error>
-#include <tuple>
 #include <sys/mman.h>
 
 namespace mg = mir::graphics;
@@ -214,9 +213,7 @@ void mgek::EGLOutput::configure(size_t kms_mode_index)
     mode_index = kms_mode_index;
     refresh_connector(drm_fd, connector);
 
-    mgk::DRMModeCrtcUPtr crtc;
-    mgk::DRMModePlaneUPtr plane;
-    std::tie(crtc, plane) = mgk::find_crtc_with_primary_plane(drm_fd, connector);
+    auto [crtc, plane, _] = mgk::find_crtc_with_primary_plane(drm_fd, connector);
     crtc_id_ = crtc->crtc_id;
     plane_id = plane->plane_id;
     plane_props = std::make_unique<mgk::ObjectProperties>(drm_fd, plane_id, DRM_MODE_OBJECT_PLANE);


### PR DESCRIPTION
Now with 100% more atomic API!

Still a bit broken:
1. If we don't commit on cursor move, the cursor becomes very choppy
2. If we attempt a blocking commit on cursor move, but use , cursor and application window movement become sluggish when dragging a window around.
3. If we attempt a nonblocking commit on cursor move, the kernel/hardware/?? can't keep up and complains a bunch (works best though!).
4. Crashes sometimes (might be related to the input thread calling `set_cursor`, attempting a commit, and the main thread attempting a commit at the same time?)
5. Cursor sometimes disappears when entering or leaving application windows (actual content, drop shadow doesn't affect it)

How to test:
1. Log out of your graphical session
2. Switch to a VT
3. Make sure hardware cursors initialize correctly, this can be done by  running any Mir example with the argument `--platform-display-libs=mir:atomic-kms`  and piping the output to `grep -i 'hardware cursor'`
4. If the hardware cursor initializes correctly, you can go on using your compositor as normal.