### PR TITLE
Remove regenerate-mirserver-internal-debian-symbols because it does nothing

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -208,8 +208,3 @@ add_custom_target(
       --include-dirs "$<JOIN:$<TARGET_PROPERTY:mirserver,INCLUDE_DIRECTORIES>,:>"
       --diff
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
-
-add_custom_target(regenerate-mirserver-internal-debian-symbols
-    COMMAND ${PROJECT_SOURCE_DIR}/tools/symbols_map_generator/run.sh --library mir_server_internal --version ${MIR_VERSION_MAJOR}.${MIR_VERSION_MINOR} --output_symbols
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    VERBATIM)


### PR DESCRIPTION
fixes https://github.com/canonical/mir/issues/3571

## What's new?
- This is a dead cmake target