### PR TITLE
Ignore invalid display config files and boot normally.

### DIFF
--- a/src/miral/display_configuration_option.cpp
+++ b/src/miral/display_configuration_option.cpp
@@ -225,9 +225,21 @@ void miral::display_configuration_options(mir::Server& server)
                 {
                     mir::fatal_error("Display scale option can't be used with static display configuration");
                 }
-                auto sdc = std::make_shared<StaticDisplayConfig>(display_layout.substr(strlen(static_opt_val)));
-                server.add_init_callback([sdc, &server]{ sdc->init_auto_reload(server); });
-                layout_selector = std::move(sdc);
+
+                try
+                {
+                    auto sdc = std::make_shared<StaticDisplayConfig>(display_layout.substr(strlen(static_opt_val)));
+                    server.add_init_callback(
+                        [sdc, &server]
+                        {
+                            sdc->init_auto_reload(server);
+                        });
+                    layout_selector = std::move(sdc);
+                }
+                catch (miral::StaticDisplayConfig::InvalidConfig& e)
+                {
+                    mir::log_error("%s. Using defaults", e.what());
+                }
             }
 
             if (scale != 1.0)

--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -121,6 +121,15 @@ class StaticDisplayConfig : public ReloadingYamlFileDisplayConfig
 {
 public:
     StaticDisplayConfig(std::string const& filename);
+
+    class InvalidConfig : public std::runtime_error
+    {
+    public:
+        InvalidConfig(std::string const& what) :
+            std::runtime_error(what)
+        {
+        }
+    };
 };
 }
 


### PR DESCRIPTION
Closes #3628 

Adds a new exception type `StaticDsiplayConfig::InvalidConfig`, which is now used inside `YamlFileDisplayConfig::load_config` to signal a failure in parsing. When this exception is caught, we skip the rest of config parsing and the remaining code that depends on it and run as if `--display-config=static=path/to/invalid/file.display` was not provided.