### PR TITLE
feature: implementation of xdg_activation_v1 because I want my auto focuses

### DIFF
--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -65,6 +65,7 @@ set(
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/frontend/buffer_stream.h
   wp_viewporter.cpp             wp_viewporter.h
   fractional_scale_v1.cpp           fractional_scale_v1.h
+  xdg_activation_v1.cpp         xdg_activation_v1.h
 )
 
 add_custom_command(

--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -114,5 +114,6 @@ target_link_libraries(mirfrontend-wayland
     mircore
   PRIVATE
     PkgConfig::GIOUnix
+    PkgConfig::UUID
 )
 

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -330,7 +330,8 @@ mf::WaylandConnector::WaylandConnector(
         desktop_file_manager,
         session_lock_,
         decoration_strategy,
-        focus_controller});
+        focus_controller,
+        keyboard_observer_registrar});
 
     shm_global = std::make_unique<WlShm>(display.get(), executor);
 

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -241,7 +241,8 @@ mf::WaylandConnector::WaylandConnector(
     WaylandProtocolExtensionFilter const& extension_filter,
     bool enable_key_repeat,
     std::shared_ptr<scene::SessionLock> const& session_lock,
-    std::shared_ptr<mir::DecorationStrategy> const& decoration_strategy)
+    std::shared_ptr<mir::DecorationStrategy> const& decoration_strategy,
+    std::shared_ptr<shell::FocusController> const& focus_controller)
     : extension_filter{extension_filter},
       display{wl_display_create(), &cleanup_display},
       pause_signal{eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE)},
@@ -328,7 +329,8 @@ mf::WaylandConnector::WaylandConnector(
         main_loop,
         desktop_file_manager,
         session_lock_,
-        decoration_strategy});
+        decoration_strategy,
+        focus_controller});
 
     shm_global = std::make_unique<WlShm>(display.get(), executor);
 

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -242,7 +242,7 @@ mf::WaylandConnector::WaylandConnector(
     bool enable_key_repeat,
     std::shared_ptr<scene::SessionLock> const& session_lock,
     std::shared_ptr<mir::DecorationStrategy> const& decoration_strategy,
-    std::shared_ptr<shell::FocusController> const& focus_controller)
+    std::shared_ptr<scene::SessionCoordinator> const& session_coordinator)
     : extension_filter{extension_filter},
       display{wl_display_create(), &cleanup_display},
       pause_signal{eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE)},
@@ -330,7 +330,7 @@ mf::WaylandConnector::WaylandConnector(
         desktop_file_manager,
         session_lock_,
         decoration_strategy,
-        focus_controller,
+        session_coordinator,
         keyboard_observer_registrar});
 
     shm_global = std::make_unique<WlShm>(display.get(), executor);

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -59,6 +59,7 @@ class DisplayConfigurationObserver;
 namespace shell
 {
 class Shell;
+class FocusController;
 }
 namespace scene
 {
@@ -113,6 +114,7 @@ public:
         std::shared_ptr<DesktopFileManager> desktop_file_manager;
         std::shared_ptr<scene::SessionLock> session_lock;
         std::shared_ptr<mir::DecorationStrategy> decoration_strategy;
+        std::shared_ptr<shell::FocusController> focus_controller;
     };
 
     WaylandExtensions() = default;
@@ -165,7 +167,8 @@ public:
         WaylandProtocolExtensionFilter const& extension_filter,
         bool enable_key_repeat,
         std::shared_ptr<scene::SessionLock> const& session_lock,
-        std::shared_ptr<DecorationStrategy> const& decoration_strategy);
+        std::shared_ptr<DecorationStrategy> const& decoration_strategy,
+        std::shared_ptr<shell::FocusController> const& focus_controller);
 
     ~WaylandConnector() override;
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -59,7 +59,6 @@ class DisplayConfigurationObserver;
 namespace shell
 {
 class Shell;
-class FocusController;
 }
 namespace scene
 {
@@ -68,6 +67,7 @@ class IdleHub;
 class Surface;
 class TextInputHub;
 class SessionLock;
+class SessionCoordinator;
 }
 namespace time
 {
@@ -114,7 +114,7 @@ public:
         std::shared_ptr<DesktopFileManager> desktop_file_manager;
         std::shared_ptr<scene::SessionLock> session_lock;
         std::shared_ptr<mir::DecorationStrategy> decoration_strategy;
-        std::shared_ptr<shell::FocusController> focus_controller;
+        std::shared_ptr<scene::SessionCoordinator> session_coordinator;
         std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> keyboard_observer_registrar;
     };
 
@@ -169,7 +169,7 @@ public:
         bool enable_key_repeat,
         std::shared_ptr<scene::SessionLock> const& session_lock,
         std::shared_ptr<DecorationStrategy> const& decoration_strategy,
-        std::shared_ptr<shell::FocusController> const& focus_controller);
+        std::shared_ptr<scene::SessionCoordinator> const& session_coordinator);
 
     ~WaylandConnector() override;
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -115,6 +115,7 @@ public:
         std::shared_ptr<scene::SessionLock> session_lock;
         std::shared_ptr<mir::DecorationStrategy> decoration_strategy;
         std::shared_ptr<shell::FocusController> focus_controller;
+        std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> keyboard_observer_registrar;
     };
 
     WaylandExtensions() = default;

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -43,6 +43,7 @@
 #include "wl_seat.h"
 #include "wl_shell.h"
 #include "wlr_screencopy_v1.h"
+#include "xdg_activation_v1.h"
 #include "xdg-decoration-unstable-v1_wrapper.h"
 #include "xdg_decoration_unstable_v1.h"
 #include "xdg_output_v1.h"
@@ -226,6 +227,10 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
         {
             return mf::create_fractional_scale_v1(ctx.display);
         }),
+    make_extension_builder<mw::XdgActivationV1>([](auto const& ctx)
+        {
+            return mf::create_xdg_activation_v1(ctx.display, ctx.shell, ctx.focus_controller, ctx.main_loop);
+        }),
 };
 
 ExtensionBuilder const xwayland_builder {
@@ -384,7 +389,8 @@ std::shared_ptr<mf::Connector>
                 wayland_extension_filter,
                 enable_repeat,
                 the_session_lock(),
-                the_decoration_strategy());
+                the_decoration_strategy(),
+                the_focus_controller());
         });
 }
 

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -338,6 +338,7 @@ auto mf::get_standard_extensions() -> std::vector<std::string>
         mw::TextInputManagerV3::interface_name,
         mw::MirShellV1::interface_name,
         mw::XdgDecorationManagerV1::interface_name,
+        mw::XdgActivationV1::interface_name,
         mw::FractionalScaleManagerV1::interface_name};
 }
 

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -232,7 +232,7 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
             return mf::create_xdg_activation_v1(
                 ctx.display,
                 ctx.shell,
-                ctx.focus_controller,
+                ctx.session_coordinator,
                 ctx.main_loop,
                 ctx.keyboard_observer_registrar,
                 *ctx.wayland_executor);
@@ -396,7 +396,7 @@ std::shared_ptr<mf::Connector>
                 enable_repeat,
                 the_session_lock(),
                 the_decoration_strategy(),
-                the_focus_controller());
+                the_session_coordinator());
         });
 }
 

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -229,7 +229,13 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
         }),
     make_extension_builder<mw::XdgActivationV1>([](auto const& ctx)
         {
-            return mf::create_xdg_activation_v1(ctx.display, ctx.shell, ctx.focus_controller, ctx.main_loop);
+            return mf::create_xdg_activation_v1(
+                ctx.display,
+                ctx.shell,
+                ctx.focus_controller,
+                ctx.main_loop,
+                ctx.keyboard_observer_registrar,
+                *ctx.wayland_executor);
         }),
 };
 

--- a/src/server/frontend_wayland/xdg_activation_v1.cpp
+++ b/src/server/frontend_wayland/xdg_activation_v1.cpp
@@ -1,0 +1,312 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "xdg_activation_v1.h"
+#include "wl_surface.h"
+#include "wl_seat.h"
+#include "mir/main_loop.h"
+#include "mir/scene/surface.h"
+#include "mir/shell/shell.h"
+#include "mir/shell/focus_controller.h"
+#include "mir/log.h"
+#include <random>
+#include <chrono>
+
+namespace mf = mir::frontend;
+namespace mw = mir::wayland;
+namespace msh = mir::shell;
+
+namespace mir::frontend
+{
+/// Time in milliseconds that the compositor will wait before invalidating a token
+auto constexpr TIMEOUT_MS = std::chrono::milliseconds(3000);
+
+std::string generate_token()
+{
+    std::string str("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+    std::random_device rd;
+    std::mt19937 generator(rd());
+    std::shuffle(str.begin(), str.end(), generator);
+    return str.substr(0, 32);
+}
+
+class XdgActivationV1 : public wayland::XdgActivationV1::Global
+{
+public:
+    XdgActivationV1(
+        struct wl_display* display,
+        std::shared_ptr<msh::Shell> const& shell,
+        std::shared_ptr<msh::FocusController> const& focus_controller,
+        std::shared_ptr<MainLoop> const& main_loop);
+
+    std::string const& create_token();
+    bool try_consume_token(std::string const& token);
+
+private:
+    class Instance : public wayland::XdgActivationV1
+    {
+    public:
+        Instance(
+            struct wl_resource* resource,
+            mf::XdgActivationV1* xdg_activation_v1,
+            std::shared_ptr<msh::Shell> const& shell,
+            std::shared_ptr<msh::FocusController> const& focus_controller,
+            std::shared_ptr<MainLoop> const& main_loop);
+
+    private:
+        void get_activation_token(struct wl_resource* id) override;
+        void activate(std::string const& token, struct wl_resource* surface) override;
+
+        mf::XdgActivationV1* xdg_activation_v1;
+        std::shared_ptr<msh::Shell> shell;
+        std::shared_ptr<msh::FocusController> const focus_controller;
+        std::shared_ptr<MainLoop> main_loop;
+    };
+
+    struct Token
+    {
+        std::string token;
+        std::unique_ptr<time::Alarm> alarm;
+    };
+
+    void bind(wl_resource* resource) override;
+
+    std::shared_ptr<msh::Shell> shell;
+    std::shared_ptr<msh::FocusController> const focus_controller;
+    std::shared_ptr<MainLoop> main_loop;
+    std::vector<Token> pending_tokens;
+    std::mutex lock;
+};
+
+class XdgActivationTokenV1 : public wayland::XdgActivationTokenV1
+{
+public:
+    XdgActivationTokenV1(
+        struct wl_resource* resource,
+        std::string const& token,
+        std::shared_ptr<msh::FocusController> const& focus_controller);
+
+private:
+    void set_serial(uint32_t serial, struct wl_resource* seat) override;
+    void set_app_id(std::string const& app_id) override;
+    void set_surface(struct wl_resource* surface) override;
+    void commit() override;
+
+    std::string token;
+    std::shared_ptr<msh::FocusController> const focus_controller;
+    std::optional<uint32_t> serial;
+    std::optional<struct wl_resource*> seat;
+    std::optional<std::string> app_id;
+    std::optional<struct wl_resource*> requesting_surface;
+};
+}
+
+auto mf::create_xdg_activation_v1(
+    struct wl_display* display,
+    std::shared_ptr<msh::Shell> const& shell,
+    std::shared_ptr<msh::FocusController> const& focus_controller,
+    std::shared_ptr<MainLoop> const& main_loop)
+    -> std::shared_ptr<mw::XdgActivationV1::Global>
+{
+    return std::make_shared<mf::XdgActivationV1>(display, shell, focus_controller, main_loop);
+}
+
+mf::XdgActivationV1::XdgActivationV1(
+    struct wl_display* display,
+    std::shared_ptr<msh::Shell> const& shell,
+    std::shared_ptr<msh::FocusController> const& focus_controller,
+    std::shared_ptr<MainLoop> const& main_loop)
+    : Global(display, Version<1>()),
+      shell{shell},
+      focus_controller{focus_controller},
+      main_loop{main_loop}
+{
+
+}
+
+std::string const& mf::XdgActivationV1::create_token()
+{
+    auto generated = generate_token();
+    Token token{generated, main_loop->create_alarm([this, generated]()
+    {
+        try_consume_token(generated);
+    })};
+    token.alarm->reschedule_in(TIMEOUT_MS);
+
+    std::lock_guard guard(lock);
+    pending_tokens.emplace_back(std::move(token));
+    return pending_tokens[pending_tokens.size() - 1].token;
+}
+
+bool mf::XdgActivationV1::try_consume_token(std::string const& token)
+{
+    std::lock_guard guard(lock);
+    for (auto it = pending_tokens.begin(); it != pending_tokens.end(); it++)
+    {
+        if (it->token == token)
+        {
+            pending_tokens.erase(it);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void mf::XdgActivationV1::bind(struct wl_resource* resource)
+{
+    new Instance{resource, this, shell, focus_controller, main_loop};
+}
+
+mf::XdgActivationV1::Instance::Instance(
+    struct wl_resource* resource,
+    mf::XdgActivationV1* xdg_activation_v1,
+    std::shared_ptr<msh::Shell> const& shell,
+    std::shared_ptr<msh::FocusController> const& focus_controller,
+    std::shared_ptr<MainLoop> const& main_loop)
+    : XdgActivationV1(resource, Version<1>()),
+      xdg_activation_v1{xdg_activation_v1},
+      shell{shell},
+      focus_controller{focus_controller},
+      main_loop{main_loop}
+{
+}
+
+void mf::XdgActivationV1::Instance::get_activation_token(struct wl_resource* id)
+{
+    new XdgActivationTokenV1(id, xdg_activation_v1->create_token(), focus_controller);
+}
+
+void mf::XdgActivationV1::Instance::activate(std::string const& token, struct wl_resource* surface)
+{
+    if (!xdg_activation_v1->try_consume_token(token))
+    {
+        mir::log_error("XdgActivationV1::activate invalid token: %s", token.c_str());
+        return;
+    }
+
+    main_loop->enqueue(this, [surface=surface, shell=shell]
+    {
+        auto const wl_surface = mf::WlSurface::from(surface);
+        if (!wl_surface)
+        {
+            mir::log_error("XdgActivationV1::activate wl_surface not found");
+            return;
+        }
+
+        auto const scene_surface_opt = wl_surface->scene_surface();
+        if (!scene_surface_opt)
+        {
+            mir::log_error("XdgActivationV1::activate scene_surface_opt not found");
+            return;
+        }
+
+        auto const& scene_surface = scene_surface_opt.value();
+        auto const now = std::chrono::steady_clock::now().time_since_epoch();
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds >(now).count();
+        shell->raise_surface(wl_surface->session, scene_surface, ns);
+    });
+}
+
+mf::XdgActivationTokenV1::XdgActivationTokenV1(
+    struct wl_resource* resource,
+    std::string const& token,
+    std::shared_ptr<msh::FocusController> const& focus_controller)
+    : wayland::XdgActivationTokenV1(resource, Version<1>()),
+      token{token},
+      focus_controller{focus_controller}
+{
+}
+
+void mf::XdgActivationTokenV1::set_serial(uint32_t serial_, struct wl_resource* seat_)
+{
+    serial = serial_;
+    seat = seat_;
+}
+
+void mf::XdgActivationTokenV1::set_app_id(std::string const& app_id_)
+{
+    app_id = app_id_;
+}
+
+void mf::XdgActivationTokenV1::set_surface(struct wl_resource* surface)
+{
+    requesting_surface = surface;
+}
+
+void mf::XdgActivationTokenV1::commit()
+{
+    // In the event of a failure, we send 'done' with a new, invalid token
+    // which cannot be used later.
+
+    if (seat && serial)
+    {
+        // First, assert that the seat still exists.
+        auto const wl_seat = mf::WlSeat::from(seat.value());
+        if (!wl_seat)
+        {
+            mir::log_error("XdgActivationTokenV1::commit wl_seat not found");
+            send_done_event(generate_token());
+            return;
+        }
+
+        // TODO:
+        // Next, verify that the serial belongs to the seat
+    }
+
+    if (app_id)
+    {
+        // Check that the focused application has app_id
+        auto const& focused = focus_controller->focused_surface();
+        if (!focused)
+        {
+            mir::log_error("XdgActivationTokenV1::commit cannot find the focused surface");
+            send_done_event(generate_token());
+            return;
+        }
+
+        if (focused->application_id() != app_id)
+        {
+            mir::log_error("XdgActivationTokenV1::commit app_id != focused application id");
+            send_done_event(generate_token());
+            return;
+        }
+    }
+
+    if (requesting_surface)
+    {
+        // Check that the focused surface is the requesting_surface
+        auto const wl_surface = mf::WlSurface::from(requesting_surface.value());
+        auto const scene_surface_opt = wl_surface->scene_surface();
+        if (!scene_surface_opt)
+        {
+            mir::log_error("XdgActivationTokenV1::commit cannot find the provided scene surface");
+            send_done_event(generate_token());
+            return;
+        }
+
+        auto const& scene_surface = scene_surface_opt.value();
+
+        if (focus_controller->focused_surface() != scene_surface)
+        {
+            mir::log_error("XdgActivationTokenV1::commit the focused surface is not the surface that requesteda ctivation");
+            send_done_event(generate_token());
+            return;
+        }
+    }
+
+    send_done_event(token);
+}

--- a/src/server/frontend_wayland/xdg_activation_v1.cpp
+++ b/src/server/frontend_wayland/xdg_activation_v1.cpp
@@ -31,8 +31,6 @@
 #include <uuid.h>
 #include <mir/events/keyboard_event.h>
 
-#include "../../../examples/client/wayland_runner.h"
-
 namespace mf = mir::frontend;
 namespace mw = mir::wayland;
 namespace ms = mir::scene;
@@ -411,11 +409,10 @@ void mf::XdgActivationTokenV1::set_app_id(std::string const& app_id)
 
 void mf::XdgActivationTokenV1::set_surface(struct wl_resource* surface)
 {
-    // TODO: This is the application id of the requesting surface.
-    //  Until it presents itself as a problem, we will ignore it or now.
-    //  Instead, we only ensure that the same same session is focused
-    //  between token request and activation. Or we simply ensure
-    //  that focus hasn't changed at all.
+    // TODO: This is the requesting surface. Until it presents itself
+    //  as a problem, we will ignore it or now. Instead, we only ensure
+    //  that the same same session is focused between token request
+    //  and activation. Or we simply ensure that focus hasn't changed at all.
     (void)surface;
 }
 

--- a/src/server/frontend_wayland/xdg_activation_v1.h
+++ b/src/server/frontend_wayland/xdg_activation_v1.h
@@ -18,6 +18,7 @@
 #define MIR_FRONTEND_XDG_ACTIVATION_UNSTABLE_V1_H
 
 #include "xdg-activation-v1_wrapper.h"
+#include "mir/observer_registrar.h"
 
 struct wl_display;
 
@@ -29,6 +30,10 @@ namespace shell
 class Shell;
 class FocusController;
 }
+namespace input
+{
+class KeyboardObserver;
+}
 
 namespace frontend
 {
@@ -36,7 +41,9 @@ auto create_xdg_activation_v1(
     struct wl_display* display,
     std::shared_ptr<shell::Shell> const&,
     std::shared_ptr<shell::FocusController> const&,
-    std::shared_ptr<MainLoop> const&) ->
+    std::shared_ptr<MainLoop> const&,
+    std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const&,
+    Executor& wayland_executor) ->
     std::shared_ptr<wayland::XdgActivationV1::Global>;
 }
 }

--- a/src/server/frontend_wayland/xdg_activation_v1.h
+++ b/src/server/frontend_wayland/xdg_activation_v1.h
@@ -28,7 +28,10 @@ class MainLoop;
 namespace shell
 {
 class Shell;
-class FocusController;
+}
+namespace scene
+{
+class SessionCoordinator;
 }
 namespace input
 {
@@ -40,7 +43,7 @@ namespace frontend
 auto create_xdg_activation_v1(
     struct wl_display* display,
     std::shared_ptr<shell::Shell> const&,
-    std::shared_ptr<shell::FocusController> const&,
+    std::shared_ptr<scene::SessionCoordinator> const&,
     std::shared_ptr<MainLoop> const&,
     std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const&,
     Executor& wayland_executor) ->

--- a/src/server/frontend_wayland/xdg_activation_v1.h
+++ b/src/server/frontend_wayland/xdg_activation_v1.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_FRONTEND_XDG_ACTIVATION_UNSTABLE_V1_H
+#define MIR_FRONTEND_XDG_ACTIVATION_UNSTABLE_V1_H
+
+#include "xdg-activation-v1_wrapper.h"
+
+struct wl_display;
+
+namespace mir
+{
+class MainLoop;
+namespace shell
+{
+class Shell;
+class FocusController;
+}
+
+namespace frontend
+{
+auto create_xdg_activation_v1(
+    struct wl_display* display,
+    std::shared_ptr<shell::Shell> const&,
+    std::shared_ptr<shell::FocusController> const&,
+    std::shared_ptr<MainLoop> const&) ->
+    std::shared_ptr<wayland::XdgActivationV1::Global>;
+}
+}
+
+
+#endif //MIR_FRONTEND_XDG_ACTIVATION_UNSTABLE_V1_H

--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -39,6 +39,7 @@ mir_generate_protocol_wrapper(mirwayland "zmir_" mir-shell-unstable-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "z" xdg-decoration-unstable-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "wp_" viewporter.xml)
 mir_generate_protocol_wrapper(mirwayland "wp_" fractional-scale-v1.xml)
+mir_generate_protocol_wrapper(mirwayland "z" xdg-activation-v1.xml)
 
 target_link_libraries(mirwayland
   PUBLIC

--- a/wayland-protocols/xdg-activation-v1.xml
+++ b/wayland-protocols/xdg-activation-v1.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_activation_v1">
+
+    <copyright>
+        Copyright © 2020 Aleix Pol Gonzalez &lt;aleixpol@kde.org&gt;
+        Copyright © 2020 Carlos Garnacho &lt;carlosg@gnome.org&gt;
+
+        Permission is hereby granted, free of charge, to any person obtaining a
+        copy of this software and associated documentation files (the "Software"),
+        to deal in the Software without restriction, including without limitation
+        the rights to use, copy, modify, merge, publish, distribute, sublicense,
+        and/or sell copies of the Software, and to permit persons to whom the
+        Software is furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice (including the next
+        paragraph) shall be included in all copies or substantial portions of the
+        Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+        DEALINGS IN THE SOFTWARE.
+    </copyright>
+
+    <description summary="Protocol for requesting activation of surfaces">
+        The way for a client to pass focus to another toplevel is as follows.
+
+        The client that intends to activate another toplevel uses the
+        xdg_activation_v1.get_activation_token request to get an activation token.
+        This token is then forwarded to the client, which is supposed to activate
+        one of its surfaces, through a separate band of communication.
+
+        One established way of doing this is through the XDG_ACTIVATION_TOKEN
+        environment variable of a newly launched child process. The child process
+        should unset the environment variable again right after reading it out in
+        order to avoid propagating it to other child processes.
+
+        Another established way exists for Applications implementing the D-Bus
+        interface org.freedesktop.Application, which should get their token under
+        activation-token on their platform_data.
+
+        In general activation tokens may be transferred across clients through
+        means not described in this protocol.
+
+        The client to be activated will then pass the token
+        it received to the xdg_activation_v1.activate request. The compositor can
+        then use this token to decide how to react to the activation request.
+
+        The token the activating client gets may be ineffective either already at
+        the time it receives it, for example if it was not focused, for focus
+        stealing prevention. The activating client will have no way to discover
+        the validity of the token, and may still forward it to the to be activated
+        client.
+
+        The created activation token may optionally get information attached to it
+        that can be used by the compositor to identify the application that we
+        intend to activate. This can for example be used to display a visual hint
+        about what application is being started.
+
+        Warning! The protocol described in this file is currently in the testing
+        phase. Backward compatible changes may be added together with the
+        corresponding interface version bump. Backward incompatible changes can
+        only be done by creating a new major version of the extension.
+    </description>
+
+    <interface name="xdg_activation_v1" version="1">
+        <description summary="interface for activating surfaces">
+            A global interface used for informing the compositor about applications
+            being activated or started, or for applications to request to be
+            activated.
+        </description>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the xdg_activation object">
+                Notify the compositor that the xdg_activation object will no longer be
+                used.
+
+                The child objects created via this interface are unaffected and should
+                be destroyed separately.
+            </description>
+        </request>
+
+        <request name="get_activation_token">
+            <description summary="requests a token">
+                Creates an xdg_activation_token_v1 object that will provide
+                the initiating client with a unique token for this activation. This
+                token should be offered to the clients to be activated.
+            </description>
+
+            <arg name="id" type="new_id" interface="xdg_activation_token_v1"/>
+        </request>
+
+        <request name="activate">
+            <description summary="notify new interaction being available">
+                Requests surface activation. It's up to the compositor to display
+                this information as desired, for example by placing the surface above
+                the rest.
+
+                The compositor may know who requested this by checking the activation
+                token and might decide not to follow through with the activation if it's
+                considered unwanted.
+
+                Compositors can ignore unknown activation tokens when an invalid
+                token is passed.
+            </description>
+            <arg name="token" type="string" summary="the activation token of the initiating client"/>
+            <arg name="surface" type="object" interface="wl_surface"
+                 summary="the wl_surface to activate"/>
+        </request>
+    </interface>
+
+    <interface name="xdg_activation_token_v1" version="1">
+        <description summary="an exported activation handle">
+            An object for setting up a token and receiving a token handle that can
+            be passed as an activation token to another client.
+
+            The object is created using the xdg_activation_v1.get_activation_token
+            request. This object should then be populated with the app_id, surface
+            and serial information and committed. The compositor shall then issue a
+            done event with the token. In case the request's parameters are invalid,
+            the compositor will provide an invalid token.
+        </description>
+
+        <enum name="error">
+            <entry name="already_used" value="0"
+                   summary="The token has already been used previously"/>
+        </enum>
+
+        <request name="set_serial">
+            <description summary="specifies the seat and serial of the activating event">
+                Provides information about the seat and serial event that requested the
+                token.
+
+                The serial can come from an input or focus event. For instance, if a
+                click triggers the launch of a third-party client, the launcher client
+                should send a set_serial request with the serial and seat from the
+                wl_pointer.button event.
+
+                Some compositors might refuse to activate toplevels when the token
+                doesn't have a valid and recent enough event serial.
+
+                Must be sent before commit. This information is optional.
+            </description>
+            <arg name="serial" type="uint"
+                 summary="the serial of the event that triggered the activation"/>
+            <arg name="seat" type="object" interface="wl_seat"
+                 summary="the wl_seat of the event"/>
+        </request>
+
+        <request name="set_app_id">
+            <description summary="specifies the application being activated">
+                The requesting client can specify an app_id to associate the token
+                being created with it.
+
+                Must be sent before commit. This information is optional.
+            </description>
+            <arg name="app_id" type="string"
+                 summary="the application id of the client being activated."/>
+        </request>
+
+        <request name="set_surface">
+            <description summary="specifies the surface requesting activation">
+                This request sets the surface requesting the activation. Note, this is
+                different from the surface that will be activated.
+
+                Some compositors might refuse to activate toplevels when the token
+                doesn't have a requesting surface.
+
+                Must be sent before commit. This information is optional.
+            </description>
+            <arg name="surface" type="object" interface="wl_surface"
+                 summary="the requesting surface"/>
+        </request>
+
+        <request name="commit">
+            <description summary="issues the token request">
+                Requests an activation token based on the different parameters that
+                have been offered through set_serial, set_surface and set_app_id.
+            </description>
+        </request>
+
+        <event name="done">
+            <description summary="the exported activation token">
+                The 'done' event contains the unique token of this activation request
+                and notifies that the provider is done.
+            </description>
+            <arg name="token" type="string" summary="the exported activation token"/>
+        </event>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the xdg_activation_token_v1 object">
+                Notify the compositor that the xdg_activation_token_v1 object will no
+                longer be used. The received token stays valid.
+            </description>
+        </request>
+    </interface>
+</protocol>


### PR DESCRIPTION
[Screencast from 2024-10-16 16-21-05.webm](https://github.com/user-attachments/assets/86f9b0bf-181c-4aab-acfd-4ceb1e4e2c38)


## What's new?
- Added the xdg_activation_v1 protocol
- Implemented the xdg_activation_v1 protocol

## To test
- Run `miral-shell`
- Open `gnome-terminal`
- Run `gedit`
- Focus `gnome-terminal` again
- Run `gedit` again
- Note that `gedit` gets focus :magic_wand: 

Similarly:
- Open up `emacs`
- Open up `firefox`
- In emacs, write `https://google.com`
- Ctrl + Click the link
- Watch as firefox gets focus!

## Open questions
- The "timeout" is not configurable at the moment, but perhaps it should be. However, I don't think we do per-protocol options AFAICT

## Todos
- I should probably write some WLCS tests!