### PR TITLE
Move the license below the resources, as this is generally less useful to someone reading the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,6 @@ Window management is integrated into Mir with useful default behaviour
 and is extremely customisable by shell authors using a simple high-level
 API.
 
-## License
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 or 3 as
-published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 ## Resources
 The Mir project website is <http://mir-server.io/>,
 the code is [hosted on GitHub](https://github.com/MirServer)
@@ -41,5 +28,17 @@ the [\#mirserver](https://web.libera.chat/?channels=#mir-server) IRC channel on 
 For developer documentation, including installation and build instructions,
 see <https://canonical-mir.readthedocs-hosted.com>.
 
-# Copyright
+## Copyright and License
 Copyright © Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 or 3 as
+published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
Fix the heading of Copyright, which was h1 not h2.