### PR TITLE
Use PkgConfig to find development headers

### DIFF
--- a/src/common/events/CMakeLists.txt
+++ b/src/common/events/CMakeLists.txt
@@ -39,4 +39,5 @@ add_library(
 target_link_libraries(mirevents
   PUBLIC
     mircore
+    PkgConfig::XKBCOMMON
 )

--- a/src/platforms/evdev/CMakeLists.txt
+++ b/src/platforms/evdev/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(mirevdevutilsobjects
   PUBLIC
     mircommon
     mircore
+    PkgConfig::LIBINPUT
 )
 
 add_library(mirplatforminputevdevobjects OBJECT
@@ -27,6 +28,7 @@ target_link_libraries(mirplatforminputevdevobjects
     mirplatform
     mircommon
     mircore
+    PkgConfig::LIBINPUT
 )
 
 add_library(mirplatforminputevdev MODULE

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -187,6 +187,7 @@ target_link_libraries(
   mircommon
 
   Boost::system
+  PkgConfig::LIBINPUT
   PkgConfig::WAYLAND_SERVER
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.
 )


### PR DESCRIPTION
openSUSE puts it's xkbcommon and libinput development headers in a non-standard location, which isn't Mir's problem, but it also doesn't implement PkgConfig properly to find those headers.

This is what I did to get it to package for openSUSE, but this should benefit any distribution that uses PkgConfig to find development files.