### PR TITLE
Fix X11 dropdowns persisting for too long on unfocus

### DIFF
--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -771,11 +771,6 @@ void mf::XWaylandWM::handle_unmap_notify(xcb_unmap_notify_event_t *event)
     if (connection->is_ours(event->window))
         return;
 
-    // We just ignore the ICCCM 4.1.4 synthetic unmap notify
-    // as it may come in after we've destroyed the window
-    if (event->response_type & ~0x80)
-        return;
-
     if (auto const surface = get_wm_surface(event->window))
     {
         surface.value()->close();


### PR DESCRIPTION
For some reason, our code ignored synthetic unmap requests, even though [ICCCM 4.1.4](https://tronche.com/gui/x/icccm/sec-4.html) doesn't mention that it should be ignored. I tried commenting out the couple of lines responsible for ignoring the request and tested with gimp, qtcreator, and imagemagick. All seem to work better, especially gimp and qtcreator where this bug is most apparent.