### PR TITLE
Use old DRM cursor API as a placeholder for the atomic KMS hardware cursor

### DIFF
--- a/src/platforms/atomic-kms/server/kms/CMakeLists.txt
+++ b/src/platforms/atomic-kms/server/kms/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   atomic_kms_output.cpp
   atomic_kms_output.h
   bypass.cpp
+  cursor.cpp
   display.cpp
   display_buffer.cpp
   platform.cpp

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
@@ -491,11 +491,12 @@ void mga::AtomicKMSOutput::wait_for_page_flip()
 bool mga::AtomicKMSOutput::set_cursor(gbm_bo* buffer)
 {
     int result = 0;
-    if (configuration.lock()->current_crtc)
+    auto conf = configuration.lock();
+    if (conf->current_crtc)
     {
         result = drmModeSetCursor(
             drm_fd_,
-            configuration.lock()->current_crtc->crtc_id,
+            conf->current_crtc->crtc_id,
             gbm_bo_get_handle(buffer).u32,
             gbm_bo_get_width(buffer),
             gbm_bo_get_height(buffer));
@@ -509,10 +510,11 @@ bool mga::AtomicKMSOutput::set_cursor(gbm_bo* buffer)
 
 void mga::AtomicKMSOutput::move_cursor(geometry::Point destination)
 {
-    if (configuration.lock()->current_crtc)
+    auto conf = configuration.lock();
+    if (conf->current_crtc)
     {
         if (auto result =
-                drmModeMoveCursor(drm_fd_, configuration.lock()->current_crtc->crtc_id, destination.x.as_int(), destination.y.as_int()))
+                drmModeMoveCursor(drm_fd_, conf->current_crtc->crtc_id, destination.x.as_int(), destination.y.as_int()))
         {
             mir::log_warning("move_cursor: drmModeMoveCursor failed (%s)", strerror(-result));
         }
@@ -522,9 +524,10 @@ void mga::AtomicKMSOutput::move_cursor(geometry::Point destination)
 bool mga::AtomicKMSOutput::clear_cursor()
 {
     int result = 0;
-    if (configuration.lock()->current_crtc)
+    auto conf = configuration.lock()
+    if (conf->current_crtc)
     {
-        result = drmModeSetCursor(drm_fd_, configuration.lock()->current_crtc->crtc_id, 0, 0, 0);
+        result = drmModeSetCursor(drm_fd_, conf->current_crtc->crtc_id, 0, 0, 0);
 
         if (result)
             mir::log_warning("clear_cursor: drmModeSetCursor failed (%s)",

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
@@ -487,9 +487,8 @@ void mga::AtomicKMSOutput::wait_for_page_flip()
     pending_page_flip.get();
 }
 
-bool mga::AtomicKMSOutput::set_cursor(gbm_bo* buffer)
+void mga::AtomicKMSOutput::set_cursor(gbm_bo* buffer)
 {
-    int result = 0;
     if (auto conf = configuration.lock(); conf->current_crtc)
     {
         if (auto result = drmModeSetCursor(
@@ -502,7 +501,6 @@ bool mga::AtomicKMSOutput::set_cursor(gbm_bo* buffer)
             mir::log_warning("set_cursor: drmModeSetCursor failed (%s)", strerror(-result));
         }
     }
-    return !result;
 }
 
 void mga::AtomicKMSOutput::move_cursor(geometry::Point destination)

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
@@ -524,7 +524,7 @@ void mga::AtomicKMSOutput::move_cursor(geometry::Point destination)
 bool mga::AtomicKMSOutput::clear_cursor()
 {
     int result = 0;
-    auto conf = configuration.lock()
+    auto conf = configuration.lock();
     if (conf->current_crtc)
     {
         result = drmModeSetCursor(drm_fd_, conf->current_crtc->crtc_id, 0, 0, 0);

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
@@ -210,8 +210,7 @@ mga::AtomicKMSOutput::AtomicKMSOutput(
 
     kms::DRMModeResources resources{drm_fd_};
 
-    auto conf = configuration.lock();
-    if (conf->connector->encoder_id)
+    if (auto conf = configuration.lock(); conf->connector->encoder_id)
     {
         auto encoder = resources.encoder(conf->connector->encoder_id);
         if (encoder->crtc_id)
@@ -491,16 +490,14 @@ void mga::AtomicKMSOutput::wait_for_page_flip()
 bool mga::AtomicKMSOutput::set_cursor(gbm_bo* buffer)
 {
     int result = 0;
-    auto conf = configuration.lock();
-    if (conf->current_crtc)
+    if (auto conf = configuration.lock(); conf->current_crtc)
     {
-        result = drmModeSetCursor(
+        if (auto result = drmModeSetCursor(
             drm_fd_,
             conf->current_crtc->crtc_id,
             gbm_bo_get_handle(buffer).u32,
             gbm_bo_get_width(buffer),
-            gbm_bo_get_height(buffer));
-        if (result)
+            gbm_bo_get_height(buffer)))
         {
             mir::log_warning("set_cursor: drmModeSetCursor failed (%s)", strerror(-result));
         }
@@ -510,8 +507,7 @@ bool mga::AtomicKMSOutput::set_cursor(gbm_bo* buffer)
 
 void mga::AtomicKMSOutput::move_cursor(geometry::Point destination)
 {
-    auto conf = configuration.lock();
-    if (conf->current_crtc)
+    if (auto conf = configuration.lock(); conf->current_crtc)
     {
         if (auto result =
                 drmModeMoveCursor(drm_fd_, conf->current_crtc->crtc_id, destination.x.as_int(), destination.y.as_int()))
@@ -524,14 +520,12 @@ void mga::AtomicKMSOutput::move_cursor(geometry::Point destination)
 bool mga::AtomicKMSOutput::clear_cursor()
 {
     int result = 0;
-    auto conf = configuration.lock();
-    if (conf->current_crtc)
+    if (auto conf = configuration.lock(); conf->current_crtc)
     {
         result = drmModeSetCursor(drm_fd_, conf->current_crtc->crtc_id, 0, 0, 0);
 
         if (result)
-            mir::log_warning("clear_cursor: drmModeSetCursor failed (%s)",
-                             strerror(-result));
+            mir::log_warning("clear_cursor: drmModeSetCursor failed (%s)", strerror(-result));
     }
 
     return !result;
@@ -564,8 +558,7 @@ bool mga::AtomicKMSOutput::ensure_crtc(Configuration& to_update)
 
 void mga::AtomicKMSOutput::restore_saved_crtc()
 {
-    auto conf = configuration.lock();
-    if (!using_saved_crtc)
+    if (auto conf = configuration.lock(); !using_saved_crtc)
     {
         drmModeSetCrtc(drm_fd_, saved_crtc.crtc_id, saved_crtc.buffer_id,
                        saved_crtc.x, saved_crtc.y,
@@ -579,8 +572,7 @@ void mga::AtomicKMSOutput::set_power_mode(MirPowerMode mode)
 {
     bool should_be_active = mode == mir_power_mode_on;
 
-    auto conf = configuration.lock();
-    if (conf->current_crtc)
+    if (auto conf = configuration.lock(); conf->current_crtc)
     {
         AtomicUpdate update;
         update.add_property(*conf->crtc_props, "ACTIVE", should_be_active);

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.h
@@ -60,7 +60,7 @@ public:
     bool schedule_page_flip(FBHandle const& fb) override;
     void wait_for_page_flip() override;
 
-    bool set_cursor(gbm_bo* buffer) override;
+    void set_cursor(gbm_bo* buffer) override;
     void move_cursor(geometry::Point destination) override;
     bool clear_cursor() override;
     bool has_cursor() const override;

--- a/src/platforms/atomic-kms/server/kms/cursor.cpp
+++ b/src/platforms/atomic-kms/server/kms/cursor.cpp
@@ -1,0 +1,438 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cursor.h"
+#include "platform.h"
+#include "kms_output.h"
+#include "kms_output_container.h"
+#include "kms_display_configuration.h"
+#include "mir/geometry/rectangle.h"
+#include "mir/graphics/cursor_image.h"
+
+#include <xf86drm.h>
+
+#include <boost/exception/errinfo_errno.hpp>
+
+#include <stdexcept>
+#include <vector>
+
+namespace mg = mir::graphics;
+namespace mga = mg::atomic;
+namespace geom = mir::geometry;
+
+namespace
+{
+// Transforms a relative position within the display bounds described by \a rect which is rotated with \a orientation
+geom::Displacement transform(geom::Rectangle const& rect, geom::Displacement const& vector, MirOrientation orientation)
+{
+    switch(orientation)
+    {
+    case mir_orientation_left:
+        return {vector.dy.as_int(), rect.size.width.as_int() -vector.dx.as_int()};
+    case mir_orientation_inverted:
+        return {rect.size.width.as_int() -vector.dx.as_int(), rect.size.height.as_int() - vector.dy.as_int()};
+    case mir_orientation_right:
+        return {rect.size.height.as_int() -vector.dy.as_int(), vector.dx.as_int()};
+    default:
+    case mir_orientation_normal:
+        return vector;
+    }
+}
+
+int get_drm_cursor_height(int fd)
+{
+    uint64_t height;
+    drmGetCap(fd, DRM_CAP_CURSOR_HEIGHT, &height);
+    return static_cast<int>(height);
+}
+
+int get_drm_cursor_width(int fd)
+{
+    uint64_t width;
+    drmGetCap(fd, DRM_CAP_CURSOR_WIDTH, &width);
+    return static_cast<int>(width);
+}
+
+gbm_device* gbm_create_device_checked(int fd)
+{
+    auto device = gbm_create_device(fd);
+    if (!device)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("Failed to create gbm-kms device"));
+    }
+    return device;
+}
+}
+
+mga::Cursor::GBMBOWrapper::GBMBOWrapper(int fd, MirOrientation orientation) :
+    device{gbm_create_device_checked(fd)},
+    buffer{
+        gbm_bo_create(
+            device,
+            get_drm_cursor_width(fd),
+            get_drm_cursor_height(fd),
+            GBM_FORMAT_ARGB8888,
+            GBM_BO_USE_CURSOR | GBM_BO_USE_WRITE)},
+    current_orientation{orientation}
+{
+    if (!buffer) BOOST_THROW_EXCEPTION(std::runtime_error("failed to create gbm-kms buffer"));
+}
+
+inline mga::Cursor::GBMBOWrapper::operator gbm_bo*()
+{
+    return buffer;
+}
+
+inline mga::Cursor::GBMBOWrapper::~GBMBOWrapper()
+{
+    if (device)
+        gbm_device_destroy(device);
+    if (buffer)
+        gbm_bo_destroy(buffer);
+}
+
+mga::Cursor::GBMBOWrapper::GBMBOWrapper(GBMBOWrapper&& from)
+    : device{from.device},
+      buffer{from.buffer},
+      current_orientation{from.current_orientation}
+{
+    from.buffer = nullptr;
+    from.device = nullptr;
+}
+
+auto mga::Cursor::GBMBOWrapper::change_orientation(MirOrientation new_orientation) -> bool
+{
+    if (current_orientation == new_orientation)
+        return false;
+
+    current_orientation = new_orientation;
+    return true;
+}
+
+mga::Cursor::Cursor(
+    KMSOutputContainer& output_container,
+    std::shared_ptr<CurrentConfiguration> const& current_configuration) :
+        output_container(output_container),
+        current_position(),
+        last_set_failed(false),
+        min_buffer_width{std::numeric_limits<uint32_t>::max()},
+        min_buffer_height{std::numeric_limits<uint32_t>::max()},
+        current_configuration(current_configuration)
+{
+    // Generate the buffers for the initial configuration.
+    current_configuration->with_current_configuration_do(
+        [this](KMSDisplayConfiguration const& kms_conf)
+        {
+            kms_conf.for_each_output(
+                [this, &kms_conf](auto const& output)
+                {
+                    // I'm not sure why g++ needs the explicit "this->" but it does - alan_g
+                    this->buffer_for_output(*kms_conf.get_output_for(output.id));
+                });
+        });
+
+    hide();
+    if (last_set_failed)
+        BOOST_THROW_EXCEPTION(std::runtime_error("Initial KMS cursor set failed"));
+}
+
+mga::Cursor::~Cursor() noexcept
+{
+    hide();
+}
+
+void mga::Cursor::write_buffer_data_locked(
+    std::lock_guard<std::mutex> const&,
+    gbm_bo* buffer,
+    void const* data,
+    size_t count)
+{
+    if (auto result = gbm_bo_write(buffer, data, count))
+    {
+        BOOST_THROW_EXCEPTION(
+            ::boost::enable_error_info(std::runtime_error("failed to initialize gbm-kms buffer"))
+                << (boost::error_info<Cursor, decltype(result)>(result)));
+    }
+}
+
+void mga::Cursor::pad_and_write_image_data_locked(
+    std::lock_guard<std::mutex> const& lg,
+    GBMBOWrapper& buffer)
+{
+    auto const orientation = buffer.orientation();
+    bool const sideways = orientation == mir_orientation_left || orientation == mir_orientation_right;
+
+    auto const min_width  = sideways ? min_buffer_width : min_buffer_height;
+    auto const min_height = sideways ? min_buffer_height : min_buffer_width;
+
+    auto const image_width = std::min(min_width, size.width.as_uint32_t());
+    auto const image_height = std::min(min_height, size.height.as_uint32_t());
+    auto const image_stride = size.width.as_uint32_t() * 4;
+
+    auto const buffer_stride = std::max(min_width*4, gbm_bo_get_stride(buffer));  // in bytes
+    auto const buffer_height = std::max(min_height, gbm_bo_get_height(buffer));
+    size_t const padded_size = buffer_stride * buffer_height;
+
+    auto padded = std::unique_ptr<uint8_t[]>(new uint8_t[padded_size]);
+    size_t rhs_padding = buffer_stride - 4*image_width;
+
+    auto const filler = 0; // 0x3f; is useful to make buffer visible for debugging
+    uint8_t const* src = argb8888.data();
+    uint8_t* dest = &padded[0];
+
+    switch (orientation)
+    {
+    case mir_orientation_normal:
+        for (unsigned int y = 0; y < image_height; y++)
+        {
+            memcpy(dest, src, 4*image_width);
+            memset(dest + 4*image_width, filler, rhs_padding);
+            dest += buffer_stride;
+            src += image_stride;
+        }
+
+        memset(dest, 0, buffer_stride * (buffer_height - image_height));
+        break;
+
+    case mir_orientation_inverted:
+        for (unsigned int row = 0; row != image_height; ++row)
+        {
+            memset(dest+row*buffer_stride+4*image_width, filler, rhs_padding);
+
+            for (unsigned int col = 0; col != image_width; ++col)
+            {
+                memcpy(dest+row*buffer_stride+4*col, src + ((image_height-1)-row)*image_stride + 4*((image_width-1)-col), 4);
+            }
+        }
+
+        memset(dest+image_height*buffer_stride, filler, buffer_stride * (buffer_height - image_height));
+        break;
+
+    case mir_orientation_left:
+        for (unsigned int row = 0; row != image_width; ++row)
+        {
+            memset(dest+row*buffer_stride+4*image_height, filler, rhs_padding);
+
+            for (unsigned int col = 0; col != image_height; ++col)
+            {
+                memcpy(dest+row*buffer_stride+4*col, src + ((image_width-1)-row)*4 + image_stride*col, 4);
+            }
+        }
+
+        memset(dest+image_width*buffer_stride, filler, buffer_stride * (buffer_height - image_width));
+        break;
+
+    case mir_orientation_right:
+        for (unsigned int row = 0; row != image_width; ++row)
+        {
+            memset(dest+row*buffer_stride+4*image_height, filler, rhs_padding);
+
+            for (unsigned int col = 0; col != image_height; ++col)
+            {
+                memcpy(dest+row*buffer_stride+4*col, src + row*4 + image_stride*((image_height-1)-col), 4);
+            }
+        }
+
+        memset(dest+image_width*buffer_stride, filler, buffer_stride * (buffer_height - image_width));
+        break;
+    }
+
+    write_buffer_data_locked(lg, buffer, &padded[0], padded_size);
+}
+
+void mga::Cursor::show(CursorImage const& cursor_image)
+{
+    std::lock_guard lg(guard);
+
+    size = cursor_image.size();
+
+    argb8888.resize(size.width.as_uint32_t() * size.height.as_uint32_t() * 4);
+    memcpy(argb8888.data(), cursor_image.as_argb_8888(), argb8888.size());
+
+    hotspot = cursor_image.hotspot();
+    {
+        auto locked_buffers = buffers.lock();
+        for (auto& tuple : *locked_buffers)
+        {
+            pad_and_write_image_data_locked(lg, std::get<2>(tuple));
+        }
+    }
+
+    // Writing the data could throw an exception so let's
+    // hold off on setting visible until after we have succeeded.
+    visible = true;
+    place_cursor_at_locked(lg, current_position, ForceState);
+}
+
+void mga::Cursor::move_to(geometry::Point position)
+{
+    place_cursor_at(position, UpdateState);
+}
+
+void mga::Cursor::suspend()
+{
+    std::lock_guard lg(guard);
+    clear(lg);
+}
+
+void mga::Cursor::clear(std::lock_guard<std::mutex> const&)
+{
+    last_set_failed = false;
+    output_container.for_each_output([&](std::shared_ptr<KMSOutput> const& output)
+        {
+            if (!output->clear_cursor())
+                last_set_failed = true;
+        });
+}
+
+void mga::Cursor::resume()
+{
+    place_cursor_at(current_position, ForceState);
+}
+
+void mga::Cursor::hide()
+{
+    std::lock_guard lg(guard);
+    visible = false;
+    clear(lg);
+}
+
+void mga::Cursor::for_each_used_output(
+    std::function<void(KMSOutput& output, DisplayConfigurationOutput const& conf)> const& f)
+{
+    current_configuration->with_current_configuration_do(
+        [&f](KMSDisplayConfiguration const& kms_conf)
+        {
+            kms_conf.for_each_output([&](DisplayConfigurationOutput const& conf_output)
+            {
+                if (conf_output.used)
+                {
+                    auto output = kms_conf.get_output_for(conf_output.id);
+                    f(*output, conf_output);
+                }
+            });
+        });
+}
+
+void mga::Cursor::place_cursor_at(
+    geometry::Point position,
+    ForceCursorState force_state)
+{
+    std::lock_guard lg(guard);
+    place_cursor_at_locked(lg, position, force_state);
+}
+
+void mga::Cursor::place_cursor_at_locked(
+    std::lock_guard<std::mutex> const& lg,
+    geometry::Point position,
+    ForceCursorState force_state)
+{
+
+    current_position = position;
+
+    if (!visible)
+        return;
+
+    bool set_on_all_outputs = true;
+    auto const cursor_rect = geometry::Rectangle(position - hotspot, size);
+
+    for_each_used_output([&](KMSOutput& output, DisplayConfigurationOutput const& conf)
+    {
+        auto const output_rect = conf.extents();
+
+        if (output_rect.overlaps(cursor_rect))
+        {
+            auto const orientation = conf.orientation;
+            auto const relative_to_extants = position - output_rect.top_left;
+            auto const relative_to_extants_vec = glm::vec2{
+                relative_to_extants.dx.as_int(),
+                relative_to_extants.dy.as_int()};
+
+            // Cursor position scaled such that (-1, -1) is at the bottom left of the logical output extents and (1, 1)
+            // is at the upper right
+            auto const scaled_vec = glm::vec2{
+                relative_to_extants_vec.x / output_rect.size.width.as_int(),
+                relative_to_extants_vec.y / output_rect.size.height.as_int()} * 2.0f - glm::vec2{1};
+
+            // Cursor position on the same (-1, -1) to (1, 1) coordinate system, but with the output transform applied
+            auto const transformed_vec = scaled_vec * conf.transformation();
+
+            auto const output_size_vec = glm::vec2{output.size().width.as_int(), output.size().height.as_int()};
+
+            // Cursor position in actual output pixels
+            auto const output_space_vec = ((transformed_vec + glm::vec2{1}) / 2.0f) * output_size_vec;
+
+            auto const position_on_output = geom::Point{roundf(output_space_vec.x), roundf(output_space_vec.y)};
+
+            auto const hotspot_displacement = transform(geom::Rectangle{{}, size}, hotspot, orientation);
+
+            // It's a little strange that we implement hotspot this way as there is
+            // drmModeSetCursor2 with hotspot support. However, it appears to not actually
+            // work on radeon and intel. There also seems to be precedent in weston for
+            // implementing hotspot in this fashion.
+            output.move_cursor(position_on_output - hotspot_displacement);
+            auto& buffer = buffer_for_output(output);
+
+            auto const changed_orientation = buffer.change_orientation(orientation);
+
+            if (changed_orientation)
+                pad_and_write_image_data_locked(lg, buffer);
+
+            if (force_state || !output.has_cursor() || changed_orientation)
+            {
+                if (!output.set_cursor(buffer) || !output.has_cursor())
+                    set_on_all_outputs = false;
+            }
+        }
+        else
+        {
+            if (force_state || output.has_cursor())
+            {
+                output.clear_cursor();
+            }
+        }
+    });
+
+    last_set_failed = !set_on_all_outputs;
+}
+
+mga::Cursor::GBMBOWrapper& mga::Cursor::buffer_for_output(KMSOutput const& output)
+{
+    auto const drm_fd = output.drm_fd();
+    auto const id = output.id();
+    auto locked_buffers = buffers.lock();
+
+    for (auto& bo : *locked_buffers)
+    {
+        // We use both id and drm_fd as identifier as we're not sure of the uniqueness of either
+        if (std::get<0>(bo) == id && std::get<1>(bo) == drm_fd)
+            return std::get<2>(bo);
+    }
+
+    locked_buffers->push_back(image_buffer{id, drm_fd, GBMBOWrapper{drm_fd, mir_orientation_normal}});
+
+    GBMBOWrapper& bo = std::get<2>(locked_buffers->back());
+    if (gbm_bo_get_width(bo) < min_buffer_width)
+    {
+        min_buffer_width = gbm_bo_get_width(bo);
+    }
+    if (gbm_bo_get_height(bo) < min_buffer_height)
+    {
+        min_buffer_height = gbm_bo_get_height(bo);
+    }
+
+    return bo;
+}

--- a/src/platforms/atomic-kms/server/kms/cursor.cpp
+++ b/src/platforms/atomic-kms/server/kms/cursor.cpp
@@ -393,7 +393,8 @@ void mga::Cursor::place_cursor_at_locked(
 
             if (force_state || !output.has_cursor() || changed_orientation)
             {
-                if (!output.set_cursor(buffer) || !output.has_cursor())
+                output.set_cursor(buffer);
+                if (!output.has_cursor())
                     set_on_all_outputs = false;
             }
         }

--- a/src/platforms/atomic-kms/server/kms/cursor.h
+++ b/src/platforms/atomic-kms/server/kms/cursor.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef MIR_GRAPHICS_ATOMIC_CURSOR_H_
+#define MIR_GRAPHICS_ATOMIC_CURSOR_H_
+
+#include "mir/graphics/cursor.h"
+
+#include "mir_toolkit/common.h"
+#include "mir/synchronised.h"
+#include "mir/geometry/displacement.h"
+
+#include <gbm.h>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace mir
+{
+namespace graphics
+{
+class CursorImage;
+class DisplayConfigurationOutput;
+
+namespace atomic
+{
+class KMSOutputContainer;
+class KMSOutput;
+class KMSDisplayConfiguration;
+class GBMPlatform;
+
+class CurrentConfiguration
+{
+public:
+    virtual ~CurrentConfiguration() = default;
+
+    virtual void with_current_configuration_do(
+        std::function<void(KMSDisplayConfiguration const&)> const& exec) = 0;
+
+protected:
+    CurrentConfiguration() = default;
+    CurrentConfiguration(CurrentConfiguration const&) = delete;
+    CurrentConfiguration& operator=(CurrentConfiguration const&) = delete;
+};
+
+class Cursor : public graphics::Cursor
+{
+public:
+    Cursor(
+        KMSOutputContainer& output_container,
+        std::shared_ptr<CurrentConfiguration> const& current_configuration);
+
+    ~Cursor() noexcept;
+
+    void show(CursorImage const& cursor_image) override;
+    void hide() override;
+
+    void move_to(geometry::Point position) override;
+
+    void suspend();
+    void resume();
+
+private:
+    enum ForceCursorState { UpdateState, ForceState };
+    struct GBMBOWrapper;
+    void for_each_used_output(std::function<void(KMSOutput& output, DisplayConfigurationOutput const& conf)> const& f);
+    void place_cursor_at(geometry::Point position, ForceCursorState force_state);
+    void place_cursor_at_locked(std::lock_guard<std::mutex> const&, geometry::Point position, ForceCursorState force_state);
+    void write_buffer_data_locked(
+        std::lock_guard<std::mutex> const&,
+        gbm_bo* buffer,
+        void const* data,
+        size_t count);
+    void pad_and_write_image_data_locked(
+        std::lock_guard<std::mutex> const&,
+        GBMBOWrapper& buffer);
+    void clear(std::lock_guard<std::mutex> const&);
+
+    GBMBOWrapper& buffer_for_output(KMSOutput const& output);
+
+    std::mutex guard;
+
+    KMSOutputContainer& output_container;
+    geometry::Point current_position;
+    geometry::Displacement hotspot;
+    geometry::Size size;
+    std::vector<uint8_t> argb8888;
+
+    bool visible;
+    bool last_set_failed;
+
+    struct GBMBOWrapper
+    {
+        GBMBOWrapper(int fd, MirOrientation orientation);
+        operator gbm_bo*();
+
+        auto orientation() const -> MirOrientation { return current_orientation; }
+        auto change_orientation(MirOrientation new_orientation) -> bool;
+
+        ~GBMBOWrapper();
+
+        GBMBOWrapper(GBMBOWrapper&& from);
+    private:
+        gbm_device* device;
+        gbm_bo* buffer;
+        MirOrientation current_orientation;
+        GBMBOWrapper(GBMBOWrapper const&) = delete;
+        GBMBOWrapper& operator=(GBMBOWrapper const&) = delete;
+    };
+
+    using image_buffer = std::tuple<uint32_t, int, GBMBOWrapper>;
+    Synchronised<std::vector<image_buffer>> buffers;
+
+    uint32_t min_buffer_width;
+    uint32_t min_buffer_height;
+
+    std::shared_ptr<CurrentConfiguration> const current_configuration;
+};
+}
+}
+}
+
+
+#endif /* MIR_GRAPHICS_ATOMIC_CURSOR_H_ */

--- a/src/platforms/atomic-kms/server/kms/display.cpp
+++ b/src/platforms/atomic-kms/server/kms/display.cpp
@@ -15,31 +15,28 @@
  */
 
 #include "display.h"
-#include "kms-utils/threaded_drm_event_handler.h"
-#include "kms/egl_helper.h"
-#include "mir/graphics/platform.h"
-#include "platform.h"
+#include "atomic_kms_output.h"
+#include "cursor.h"
 #include "display_sink.h"
+#include "kms-utils/threaded_drm_event_handler.h"
+#include "mir/graphics/platform.h"
 #include "kms_display_configuration.h"
 #include "kms_output.h"
 #include "mir/console_services.h"
 #include "mir/graphics/overlapping_output_grouping.h"
 #include "mir/graphics/event_handler_register.h"
 
-#include "kms_framebuffer.h"
 #include "mir/graphics/display_report.h"
 #include "mir/graphics/display_configuration_policy.h"
-#include "mir/graphics/transformation.h"
 #include "mir/geometry/rectangle.h"
-#include "mir/renderer/gl/context.h"
-#include "mir/graphics/drm_formats.h"
-#include "mir/graphics/egl_error.h"
 
 #include <boost/throw_exception.hpp>
 #include <boost/exception/get_error_info.hpp>
 
 #include <boost/exception/errinfo_errno.hpp>
 #include <gbm.h>
+#include <iostream>
+#include <memory>
 #include <system_error>
 #include <xf86drm.h>
 #include "mir/log.h"
@@ -52,8 +49,6 @@
 #include <sys/mman.h>
 
 #include <stdexcept>
-#include <algorithm>
-#include <unordered_map>
 
 namespace mga = mir::graphics::atomic;
 namespace mg = mir::graphics;
@@ -255,7 +250,41 @@ void mga::Display::resume()
 
 auto mga::Display::create_hardware_cursor() -> std::shared_ptr<graphics::Cursor>
 {
-    return {};
+    std::shared_ptr<mga::Cursor> locked_cursor = cursor.lock();
+    if (!locked_cursor)
+    {
+        class AtomicKmsCurrentConfiguration : public CurrentConfiguration
+        {
+        public:
+            AtomicKmsCurrentConfiguration(Display& display) :
+                display(display)
+            {
+            }
+
+            void with_current_configuration_do(std::function<void(KMSDisplayConfiguration const&)> const& exec)
+            {
+                std::lock_guard lg{display.configuration_mutex};
+                exec(display.current_display_configuration);
+            }
+
+        private:
+            Display& display;
+        };
+
+        try
+        {
+            locked_cursor = std::make_shared<mga::Cursor>(
+                *output_container, std::make_shared<AtomicKmsCurrentConfiguration>(*this));
+        }
+        catch (std::runtime_error const&)
+        {
+            // That's OK, we don't need a hardware cursor. Returning null
+            // is allowed and will trigger a fallback to software.
+        }
+        cursor = locked_cursor;
+    }
+
+    return locked_cursor;
 }
 
 void mga::Display::clear_connected_unused_outputs()

--- a/src/platforms/atomic-kms/server/kms/display.h
+++ b/src/platforms/atomic-kms/server/kms/display.h
@@ -19,11 +19,11 @@
 
 #include "kms-utils/drm_event_handler.h"
 #include "mir/graphics/display.h"
+#include "mir/graphics/platform.h"
 #include "mir/udev/wrapper.h"
+#include "platform_common.h"
 #include "real_kms_output_container.h"
 #include "real_kms_display_configuration.h"
-#include "platform_common.h"
-#include "mir/graphics/platform.h"
 
 #include <atomic>
 #include <mutex>

--- a/src/platforms/atomic-kms/server/kms/kms_output.h
+++ b/src/platforms/atomic-kms/server/kms/kms_output.h
@@ -48,7 +48,7 @@ public:
      * this may want to be an opaque class Id + operator== in future.
      */
     virtual uint32_t id() const = 0;
-    
+
     virtual void reset() = 0;
     virtual void configure(geometry::Displacement fb_offset, size_t kms_mode_index) = 0;
     virtual geometry::Size size() const = 0;
@@ -73,7 +73,7 @@ public:
     virtual bool schedule_page_flip(FBHandle const& fb) = 0;
     virtual void wait_for_page_flip() = 0;
 
-    virtual bool set_cursor(gbm_bo* buffer) = 0;
+    virtual void set_cursor(gbm_bo* buffer) = 0;
     virtual void move_cursor(geometry::Point destination) = 0;
     virtual bool clear_cursor() = 0;
     virtual bool has_cursor() const = 0;

--- a/src/platforms/atomic-kms/server/platform_common.h
+++ b/src/platforms/atomic-kms/server/platform_common.h
@@ -14,8 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GRAPHICS_GBM_PLATFORM_COMMON_H_
-#define MIR_GRAPHICS_GBM_PLATFORM_COMMON_H_
+#ifndef MIR_GRAPHICS_ATOMIC_PLATFORM_COMMON_H_
+#define MIR_GRAPHICS_ATOMIC_PLATFORM_COMMON_H_
 
 namespace mir
 {
@@ -33,4 +33,4 @@ enum class BypassOption
 }
 }
 }
-#endif /* MIR_GRAPHICS_GBM_PLATFORM_COMMON_H_ */
+#endif /* MIR_GRAPHICS_ATOMIC_PLATFORM_COMMON_H_ */

--- a/src/platforms/eglstream-kms/server/egl_output.cpp
+++ b/src/platforms/eglstream-kms/server/egl_output.cpp
@@ -28,7 +28,6 @@
 #include <sys/ioctl.h>
 #include <boost/throw_exception.hpp>
 #include <system_error>
-#include <tuple>
 #include <sys/mman.h>
 
 namespace mg = mir::graphics;
@@ -214,9 +213,7 @@ void mgek::EGLOutput::configure(size_t kms_mode_index)
     mode_index = kms_mode_index;
     refresh_connector(drm_fd, connector);
 
-    mgk::DRMModeCrtcUPtr crtc;
-    mgk::DRMModePlaneUPtr plane;
-    std::tie(crtc, plane) = mgk::find_crtc_with_primary_plane(drm_fd, connector);
+    auto [crtc, plane] = mgk::find_crtc_with_primary_plane(drm_fd, connector);
     crtc_id_ = crtc->crtc_id;
     plane_id = plane->plane_id;
     plane_props = std::make_unique<mgk::ObjectProperties>(drm_fd, plane_id, DRM_MODE_OBJECT_PLANE);


### PR DESCRIPTION
This code will act as a placeholder temporarily until we implement damage, at which point, the real atomic KMS cursor  code (#3615) can be updated and merged.