### PR TITLE
feature: throwing an invalid_stride error when the size provided to wl_shm::create_pool is less than or equal to zero

### DIFF
--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -332,5 +332,13 @@ mf::Shm::Shm(wl_resource* resource, std::shared_ptr<Executor> wayland_executor)
 
 void mf::Shm::create_pool(wl_resource* id, Fd fd, int32_t size)
 {
+    if (size <= 0)
+    {
+        throw wayland::ProtocolError{
+            resource,
+            wayland::Shm::Error::invalid_stride,
+            "Invalid requested size"};
+    }
+
     new ShmPool{id, wayland_executor, fd, size};
 }


### PR DESCRIPTION
I encountered this while running `cosmic-bg` on Mir. It still doesn't fix the problems there, but it avoids us blowing up in mmap