### PR TITLE
bugfix: wlr layer shell surface are guaranteed to have a nonzero size

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -409,7 +409,7 @@ auto mf::LayerSurfaceV1::vert_padding(Anchors const& anchors, Margin const& marg
 
 auto mf::LayerSurfaceV1::unpadded_requested_size() const -> geom::Size
 {
-    auto size = requested_window_size().value_or(current_size());
+    auto size = requested_window_size().value_or(current_size().value_or(geom::Size(640, 480)));
     size.width -= horiz_padding(anchors.committed(), margin.committed());
     size.height -= vert_padding(anchors.committed(), margin.committed());
     return size;

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -119,8 +119,8 @@ protected:
     /// The size the window will be after the next commit
     auto pending_size() const -> geometry::Size;
 
-    /// The size the window currently is (the committed size, or a reasonable default if it has never committed)
-    auto current_size() const -> geometry::Size;
+    /// The size the window currently is (the committed size, or std::nullopt if it has never committed)
+    auto current_size() const -> std::optional<geometry::Size>;
 
     /// Window size requested by Mir
     auto requested_window_size() const -> std::optional<geometry::Size>;


### PR DESCRIPTION
## What's new?
- Layer shell surfaces are guaranteed to have a requested size of 640x480 in the event that no size is found. This requests clients from making the mistake of allocating a zero-sized buffer
- `WindowWlSurfaceRole::current_size()` now returns std::nullopt when it cannot reasonably resolve a size

## To test
- Install cosmic-bg
- Run it
- Note that you do not crash