### PR TITLE
bugfix: always sending an initial output enter if we fail to send one otherwise

### DIFF
--- a/src/include/server/mir/scene/surface.h
+++ b/src/include/server/mir/scene/surface.h
@@ -49,6 +49,9 @@ class Surface :
     public ObserverRegistrar<SurfaceObserver>
 {
 public:
+    /// Called after the initial position and size has been set for the surface
+    virtual void initial_placement_done() = 0;
+
     // resolve ambiguous member function names
 
     std::string name() const override = 0;

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -281,6 +281,11 @@ void ms::BasicSurface::unregister_interest(SurfaceObserver const& observer)
     observers->unregister_interest(observer);
 }
 
+void ms::BasicSurface::initial_placement_done()
+{
+    linearised_track_outputs();
+}
+
 std::string ms::BasicSurface::name() const
 {
     return synchronised_state.lock()->surface_name;

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -87,6 +87,7 @@ public:
     void register_early_observer(std::weak_ptr<SurfaceObserver> const& observer, Executor& executor) override;
     void unregister_interest(SurfaceObserver const& observer) override;
 
+    virtual void initial_placement_done() override;
     std::string name() const override;
     void move_to(geometry::Point const& top_left) override;
 

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -262,6 +262,8 @@ auto msh::AbstractShell::create_surface(
     {
         decoration_manager->decorate(result);
     }
+
+    result->initial_placement_done();
     return result;
 }
 

--- a/tests/include/mir/test/doubles/stub_surface.h
+++ b/tests/include/mir/test/doubles/stub_surface.h
@@ -28,6 +28,7 @@ namespace doubles
 // scene::Surface is a horribly wide interface to expose from Mir
 struct StubSurface : scene::Surface
 {
+    void initial_placement_done() override { }
     std::string name() const override { return ""; }
     void move_to(geometry::Point const&) override {}
     geometry::Size window_size() const override { return {}; }


### PR DESCRIPTION
## What's new?
- Added a method called `Surface::initial_placement_done` that is called after the surface has been placed properly
- `BasicSurface` sends the output enter event after creation.


This makes `cosmic-bg` work!