### PR TITLE
Fix OSK issues on electron

### DIFF
--- a/src/server/frontend_wayland/text_input_v1.cpp
+++ b/src/server/frontend_wayland/text_input_v1.cpp
@@ -371,7 +371,7 @@ void TextInputV1::deactivate(wl_resource *seat)
     pending_state.reset();
 }
 
-/// Electron appears to call show_input_panel() when commit_state() should be called. 
+/// Electron appears to call show_input_panel() when commit_state() should be called.
 void TextInputV1::show_input_panel()
 {
     commit_state(0);
@@ -386,7 +386,7 @@ void TextInputV1::hide_input_panel()
 
 void TextInputV1::reset()
 {
-    pending_state.reset();
+    pending_state.emplace();
 }
 
 void TextInputV1::set_surrounding_text(const std::string &text, uint32_t cursor, uint32_t anchor)

--- a/src/server/frontend_wayland/text_input_v1.cpp
+++ b/src/server/frontend_wayland/text_input_v1.cpp
@@ -21,9 +21,6 @@
 #include "mir/executor.h"
 #include "mir/scene/text_input_hub.h"
 
-#define MIR_LOG_COMPONENT "TextInputV1"
-#include "mir/log.h"
-
 #include <memory>
 #include <boost/throw_exception.hpp>
 #include <deque>
@@ -369,6 +366,7 @@ void TextInputV1::activate(wl_resource *seat_resource, wl_resource *surface)
     {
         on_new_input_field = true;
         state = State::active;
+        pending_state = {};
     }
 }
 
@@ -394,11 +392,6 @@ void TextInputV1::hide_input_panel()
 
 void TextInputV1::reset()
 {
-    if(state == State::inactive)
-    {
-        mir::log_warning("Attempted to reset state while inactive");
-        return;
-    }
     pending_state = {};
 }
 


### PR DESCRIPTION
Closes #3580. 

Fixes a few issues:
1. The "Interval" field showing the OSK for a split second

2. The "Interval" field (and similar fields) didn't get input changes as you used the OSK

3. Tabbing from the interval field to the minutes/hours/days field to its right opened the OSK in number mode.
This was due to `reset` being called between the content type being set in the state and the state being actually committed, causing Mir to lose the state and not commit it to the handler, leading to the previous mode (numbers) carrying over to the new field