### PR TITLE
We broke the platform ABI since 2.18

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -77,7 +77,7 @@ Description: Display server for Ubuntu - server library
  .
  Contains the shared library needed by server applications for Mir.
 
-Package: libmirplatform29
+Package: libmirplatform30
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -140,7 +140,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirplatform29 (= ${binary:Version}),
+Depends: libmirplatform30 (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libboost-program-options-dev,
          ${misc:Depends},

--- a/debian/libmirplatform29.install
+++ b/debian/libmirplatform29.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirplatform.so.29

--- a/debian/libmirplatform30.install
+++ b/debian/libmirplatform30.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirplatform.so.30

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # We need MIRPLATFORM_ABI in both libmirplatform and the platform implementations.
-set(MIRPLATFORM_ABI 29)
+set(MIRPLATFORM_ABI 30)
 
 set(MIRAL_VERSION_MAJOR 5)
 set(MIRAL_VERSION_MINOR 1)

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -1,4 +1,4 @@
-MIR_PLATFORM_2.18 {
+MIR_PLATFORM_2.19 {
  global:
   extern "C++" {
     mir::graphics::AtomicFrame::increment*;
@@ -125,6 +125,7 @@ MIR_PLATFORM_2.18 {
     mir::options::enable_key_repeat_opt*;
     mir::options::fatal_except_opt*;
     mir::options::idle_timeout_opt;
+    mir::options::idle_timeout_when_locked_opt;
     mir::options::input_report_opt*;
     mir::options::log_opt_value*;
     mir::options::logind_console;
@@ -200,12 +201,5 @@ MIR_PLATFORM_2.18 {
     vtable?for?mir::options::Option;
     vtable?for?mir::options::ProgramOption;
  };
-};
-
-MIR_PLATFORM_2.19 {
- global:
-  extern "C++" {
-    mir::options::idle_timeout_when_locked_opt;
- };
  local: *;
-} MIR_PLATFORM_2.18;
+};

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1,4 +1,4 @@
-MIR_SERVER_INTERNAL_2.18 {
+MIR_SERVER_INTERNAL_2.19 {
 global:
   extern "C++" {
     VTT?for?mir::DefaultServerConfiguration;


### PR DESCRIPTION

As noted in https://github.com/canonical/mir/pull/3590#pullrequestreview-2299754528