### PR TITLE
decoration-strategy-rework

### DIFF
--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -147,7 +147,7 @@ msd::BasicDecoration::BasicDecoration(
       renderer{std::make_unique<Renderer>(buffer_allocator, decoration_strategy->render_strategy())},
       window_surface{window_surface},
       decoration_surface{create_surface()},
-      window_state{new_window_state()},
+      window_state{decoration_strategy->new_window_state(window_surface, scale)},
       window_surface_observer_manager{std::make_unique<WindowSurfaceObserverManager>(
           window_surface,
           threadsafe_self)},
@@ -193,7 +193,7 @@ msd::BasicDecoration::~BasicDecoration()
 void msd::BasicDecoration::window_state_updated()
 {
     auto previous_window_state = std::move(window_state);
-    window_state = new_window_state();
+    window_state = decoration_strategy->new_window_state(window_surface, scale);
 
     input_manager->update_window_state(*window_state);
 
@@ -257,11 +257,6 @@ void msd::BasicDecoration::set_scale(float new_scale)
 {
     scale = new_scale;
     window_state_updated();
-}
-
-auto msd::BasicDecoration::new_window_state() const -> std::unique_ptr<WindowState>
-{
-    return std::make_unique<WindowState>(static_geometry, window_surface, scale);
 }
 
 auto msd::BasicDecoration::create_surface() const -> std::shared_ptr<scene::Surface>

--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -138,12 +138,11 @@ msd::BasicDecoration::BasicDecoration(
     std::shared_ptr<DecorationStrategy> decoration_strategy)
     : threadsafe_self{std::make_shared<ThreadsafeAccess<BasicDecoration>>(executor)},
       decoration_strategy{decoration_strategy},
-      static_geometry{decoration_strategy->static_geometry()},
       shell{shell},
       buffer_allocator{buffer_allocator},
       cursor_images{cursor_images},
       session{window_surface->session().lock()},
-      buffer_streams{std::make_unique<BufferStreams>(session, static_geometry->buffer_format)},
+      buffer_streams{std::make_unique<BufferStreams>(session, decoration_strategy->buffer_format())},
       renderer{std::make_unique<Renderer>(buffer_allocator, decoration_strategy->render_strategy())},
       window_surface{window_surface},
       decoration_surface{create_surface()},
@@ -275,7 +274,7 @@ auto msd::BasicDecoration::create_surface() const -> std::shared_ptr<scene::Surf
     params.streams = {{
         session->create_buffer_stream(mg::BufferProperties{
             geom::Size{1, 1},
-            static_geometry->buffer_format,
+            decoration_strategy->buffer_format(),
             mg::BufferUsage::software}),
         {},
         }};

--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -56,6 +56,15 @@ struct PropertyComparison
     {
     }
 
+    template<typename TYPE>
+    PropertyComparison(TYPE (OBJ::*member))
+        : comp{[=](OBJ const* a, OBJ const* b)
+        {
+            return (a->*member) == (b->*member);
+        }}
+    {
+    }
+
     auto operator()(OBJ const* a, OBJ const* b) const -> bool
     {
         return comp(a, b);
@@ -312,7 +321,7 @@ void msd::BasicDecoration::update(
     if (input_updated({
             &InputState::input_shape}))
     {
-        spec.input_shape = input_state->input_shape();
+        spec.input_shape = input_state->input_shape;
     }
 
     if (window_updated({

--- a/src/server/shell/decoration/basic_decoration.h
+++ b/src/server/shell/decoration/basic_decoration.h
@@ -57,7 +57,6 @@ class StreamSpecification;
 namespace decoration
 {
 template<typename T> class ThreadsafeAccess;
-class StaticGeometry;
 class WindowState;
 class WindowSurfaceObserverManager;
 class InputManager;

--- a/src/server/shell/decoration/basic_decoration.h
+++ b/src/server/shell/decoration/basic_decoration.h
@@ -103,7 +103,6 @@ protected:
 
     std::shared_ptr<ThreadsafeAccess<BasicDecoration>> const threadsafe_self;
     std::shared_ptr<DecorationStrategy> const decoration_strategy;
-    std::shared_ptr<StaticGeometry> const static_geometry;
 
     std::shared_ptr<shell::Shell> const shell;
     std::shared_ptr<graphics::GraphicBufferAllocator> const buffer_allocator;

--- a/src/server/shell/decoration/basic_decoration.h
+++ b/src/server/shell/decoration/basic_decoration.h
@@ -90,9 +90,6 @@ public:
     void set_scale(float scale) override;
 
 protected:
-    /// Creates an up-to-date WindowState object
-    auto new_window_state() const -> std::unique_ptr<WindowState>;
-
     /// Returns paramaters to create the decoration surface
     auto create_surface() const -> std::shared_ptr<scene::Surface>;
 

--- a/src/server/shell/decoration/basic_manager.cpp
+++ b/src/server/shell/decoration/basic_manager.cpp
@@ -136,22 +136,7 @@ using mir::geometry::Size;
 auto msd::BasicManager::compute_size_with_decorations(Size content_size,
     MirWindowType type, MirWindowState state) -> Size
 {
-    auto const geometry = decoration_strategy->static_geometry();
-
-    switch (border_type_for(type, state))
-    {
-    case msd::BorderType::Full:
-        content_size.width += geometry->side_border_width * 2;
-        content_size.height += geometry->titlebar_height + geometry->bottom_border_height;
-        break;
-    case msd::BorderType::Titlebar:
-        content_size.height += geometry->titlebar_height;
-        break;
-    case msd::BorderType::None:
-        break;
-    }
-
-    return content_size;
+    return decoration_strategy->compute_size_with_decorations(content_size, type, state);
 }
 
 void msd::BasicManager::set_scale(float new_scale)

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -308,7 +308,15 @@ public:
     auto button_placement(unsigned n, const WindowState& ws) const -> mir::geometry::Rectangle override;
     auto compute_size_with_decorations(geom::Size content_size, MirWindowType type, MirWindowState state) const
         -> geom::Size override;
+    auto new_window_state(const std::shared_ptr<mir::scene::Surface>& window_surface,
+        float scale) const -> std::unique_ptr<WindowState> override;
 };
+
+auto DecorationStrategy::new_window_state(const std::shared_ptr<mir::scene::Surface>& window_surface,
+    float scale) const -> std::unique_ptr<WindowState>
+{
+    return std::make_unique<WindowState>(static_geometry(), window_surface, scale);
+}
 
 auto DecorationStrategy::compute_size_with_decorations(
     geom::Size content_size, MirWindowType type, MirWindowState state) const -> geom::Size

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -38,7 +38,6 @@ namespace msh = mir::shell;
 namespace msd = mir::shell::decoration;
 
 using msd::WindowState;
-using msd::Pixel;
 using msd::InputState;
 
 namespace
@@ -237,6 +236,8 @@ struct RendererStrategy : public msd::RendererStrategy
     auto render_bottom_border(msd::BufferMaker const* buffer_maker) -> std::optional<std::shared_ptr<mir::graphics::Buffer>> override;
 
 private:
+    using Pixel = msd::BufferMaker::Pixel;
+
     std::shared_ptr<StaticGeometry> const static_geometry;
 
     /// A visual theme for a decoration
@@ -316,6 +317,8 @@ private:
     void redraw_titlebar_background(geom::Size scaled_titlebar_size);
     void redraw_titlebar_text(geom::Size scaled_titlebar_size);
     void redraw_titlebar_buttons(geom::Size scaled_titlebar_size);
+
+    static auto alloc_pixels(geom::Size size) -> std::unique_ptr<Pixel[]>;
 };
 
 class DecorationStrategy : public msd::DecorationStrategy, public std::enable_shared_from_this<DecorationStrategy>
@@ -388,13 +391,12 @@ auto DecorationStrategy::compute_size_with_decorations(
     return content_size;
 }
 
-auto alloc_pixels(geom::Size size) -> std::unique_ptr<Pixel[]>
+auto RendererStrategy::alloc_pixels(geom::Size size) -> std::unique_ptr<Pixel[]>
 {
-    size_t const buf_size = area(size) * sizeof(Pixel);
-    if (buf_size)
+    if (size_t const buf_size = area(size) * sizeof(Pixel))
         return std::unique_ptr<Pixel[]>{new Pixel[buf_size]};
     else
-        return nullptr;
+        return {};
 }
 }
 

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -308,12 +308,18 @@ public:
     auto button_placement(unsigned n, const WindowState& ws) const -> mir::geometry::Rectangle override;
     auto compute_size_with_decorations(geom::Size content_size, MirWindowType type, MirWindowState state) const
         -> geom::Size override;
+    auto buffer_format() const -> MirPixelFormat override;
     auto new_window_state(const std::shared_ptr<mir::scene::Surface>& window_surface,
-        float scale) const -> std::unique_ptr<WindowState> override;
+                          float scale) const -> std::unique_ptr<WindowState> override;
 };
 
+auto DecorationStrategy::buffer_format() const -> MirPixelFormat
+{
+    return static_geometry()->buffer_format;
+}
+
 auto DecorationStrategy::new_window_state(const std::shared_ptr<mir::scene::Surface>& window_surface,
-    float scale) const -> std::unique_ptr<WindowState>
+                                          float scale) const -> std::unique_ptr<WindowState>
 {
     return std::make_unique<WindowState>(static_geometry(), window_surface, scale);
 }

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -795,11 +795,11 @@ void RendererStrategy::update_state(WindowState const& window_state, InputState 
         needs_titlebar_redraw = true;
     }
 
-    if (input_state.buttons() != buttons)
+    if (input_state.buttons != buttons)
     {
         // If the number of buttons or their location changed, redraw the whole titlebar
         // Otherwise if the buttons are in the same place, just redraw them
-        if (input_state.buttons().size() != buttons.size())
+        if (input_state.buttons.size() != buttons.size())
         {
             needs_titlebar_redraw = true;
         }
@@ -807,11 +807,11 @@ void RendererStrategy::update_state(WindowState const& window_state, InputState 
         {
             for (unsigned i = 0; i < buttons.size(); i++)
             {
-                if (input_state.buttons()[i].rect != buttons[i].rect)
+                if (input_state.buttons[i].rect != buttons[i].rect)
                     needs_titlebar_redraw = true;
             }
         }
-        buttons = input_state.buttons();
+        buttons = input_state.buttons;
         needs_titlebar_buttons_redraw = true;
     }
 }

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -303,7 +303,8 @@ private:
 class DecorationStrategy : public msd::DecorationStrategy
 {
 public:
-    auto static_geometry() const -> std::shared_ptr<StaticGeometry> override;
+
+    auto static_geometry() const -> std::shared_ptr<StaticGeometry>;
     auto render_strategy() const -> std::unique_ptr<mir::shell::decoration::RendererStrategy> override;
     auto button_placement(unsigned n, const WindowState& ws) const -> mir::geometry::Rectangle override;
     auto compute_size_with_decorations(geom::Size content_size, MirWindowType type, MirWindowState state) const
@@ -311,7 +312,13 @@ public:
     auto buffer_format() const -> MirPixelFormat override;
     auto new_window_state(const std::shared_ptr<mir::scene::Surface>& window_surface,
                           float scale) const -> std::unique_ptr<WindowState> override;
+    auto resize_corner_input_size() const -> mir::geometry::Size override;
 };
+
+auto DecorationStrategy::resize_corner_input_size() const -> mir::geometry::Size
+{
+    return static_geometry()->resize_corner_input_size;
+}
 
 auto DecorationStrategy::buffer_format() const -> MirPixelFormat
 {

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -287,7 +287,7 @@ private:
             geom::Width line_width,
             Pixel color)> const render_icon; ///< Draws button's icon to the given buffer
     };
-    std::map<msd::ButtonFunction, Icon const> button_icons;
+    std::map<msd::Button::Function, Icon const> button_icons;
 
     float scale{1.0f};
     std::string name;
@@ -307,7 +307,7 @@ private:
     bool needs_titlebar_redraw{true};
     bool needs_titlebar_buttons_redraw{true};
 
-    std::vector<msd::ButtonInfo> buttons;
+    std::vector<msd::Button> buttons;
 
     void update_solid_color_pixels();
 
@@ -717,17 +717,17 @@ RendererStrategy::RendererStrategy(std::shared_ptr<StaticGeometry> const& static
     current_theme{nullptr},
     text{Text::instance()},
     button_icons{
-        {msd::ButtonFunction::Close, {
+        {msd::Button::Close, {
             default_close_normal_button,
             default_close_active_button,
             default_button_icon,
             render_close_icon}},
-        {msd::ButtonFunction::Maximize, {
+        {msd::Button::Maximize, {
             default_normal_button,
             default_active_button,
             default_button_icon,
             render_maximize_icon}},
-        {msd::ButtonFunction::Minimize, {
+        {msd::Button::Minimize, {
             default_normal_button,
             default_active_button,
             default_button_icon,
@@ -919,7 +919,7 @@ void RendererStrategy::redraw_titlebar_buttons(geom::Size const scaled_titlebar_
         if (icon != button_icons.end())
         {
             Pixel button_color = icon->second.normal_color;
-            if (button.state == msd::ButtonState::Hovered)
+            if (button.state == msd::Button::Hovered)
                 button_color = icon->second.active_color;
             for (geom::Y y{scaled_button_rect.top()}; y < scaled_button_rect.bottom(); y += geom::DeltaY{1})
             {

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -231,10 +231,10 @@ struct RendererStrategy : public msd::RendererStrategy
     RendererStrategy(std::shared_ptr<StaticGeometry> const& static_geometry);
 
     void update_state(WindowState const& window_state, InputState const& input_state) override;
-    auto render_titlebar() -> std::optional<RenderedPixels> override;
-    auto render_left_border() -> std::optional<RenderedPixels> override;
-    auto render_right_border() -> std::optional<RenderedPixels> override;
-    auto render_bottom_border() -> std::optional<RenderedPixels> override;
+    auto render_titlebar(msd::BufferMaker const* buffer_maker) -> std::optional<std::shared_ptr<mir::graphics::Buffer>> override;
+    auto render_left_border(msd::BufferMaker const* buffer_maker) -> std::optional<std::shared_ptr<mir::graphics::Buffer>> override;
+    auto render_right_border(msd::BufferMaker const* buffer_maker) -> std::optional<std::shared_ptr<mir::graphics::Buffer>> override;
+    auto render_bottom_border(msd::BufferMaker const* buffer_maker) -> std::optional<std::shared_ptr<mir::graphics::Buffer>> override;
 
 private:
     std::shared_ptr<StaticGeometry> const static_geometry;
@@ -814,7 +814,7 @@ void RendererStrategy::update_state(WindowState const& window_state, InputState 
     }
 }
 
-auto RendererStrategy::render_titlebar() -> std::optional<RenderedPixels>
+auto RendererStrategy::render_titlebar(msd::BufferMaker const* maker) -> std::optional<std::shared_ptr<mir::graphics::Buffer>>
 {
     auto const scaled_titlebar_size{titlebar_size * scale};
 
@@ -842,34 +842,34 @@ auto RendererStrategy::render_titlebar() -> std::optional<RenderedPixels>
     needs_titlebar_redraw = false;
     needs_titlebar_buttons_redraw = false;
 
-    return RenderedPixels{static_geometry->buffer_format, scaled_titlebar_size, titlebar_pixels.get()};
+    return maker->make_buffer(static_geometry->buffer_format, scaled_titlebar_size, titlebar_pixels.get());
 }
 
-auto RendererStrategy::render_left_border() -> std::optional<RenderedPixels>
+auto RendererStrategy::render_left_border(msd::BufferMaker const* maker) -> std::optional<std::shared_ptr<mir::graphics::Buffer>>
 {
     auto const scaled_left_border_size{left_border_size * scale};
     if (!area(scaled_left_border_size))
         return std::nullopt;
     update_solid_color_pixels();
-    return RenderedPixels{static_geometry->buffer_format, scaled_left_border_size, solid_color_pixels.get()};
+    return maker->make_buffer(static_geometry->buffer_format, scaled_left_border_size, solid_color_pixels.get());
 }
 
-auto RendererStrategy::render_right_border() -> std::optional<RenderedPixels>
+auto RendererStrategy::render_right_border(msd::BufferMaker const* maker) -> std::optional<std::shared_ptr<mir::graphics::Buffer>>
 {
     auto const scaled_right_border_size{right_border_size * scale};
     if (!area(scaled_right_border_size))
         return std::nullopt;
     update_solid_color_pixels();
-    return RenderedPixels{static_geometry->buffer_format, scaled_right_border_size, solid_color_pixels.get()};
+    return maker->make_buffer(static_geometry->buffer_format, scaled_right_border_size, solid_color_pixels.get());
 }
 
-auto RendererStrategy::render_bottom_border() -> std::optional<RenderedPixels>
+auto RendererStrategy::render_bottom_border(msd::BufferMaker const* maker) -> std::optional<std::shared_ptr<mir::graphics::Buffer>>
 {
     auto const scaled_bottom_border_size{bottom_border_size * scale};
     if (!area(scaled_bottom_border_size))
         return std::nullopt;
     update_solid_color_pixels();
-    return RenderedPixels{static_geometry->buffer_format, scaled_bottom_border_size, solid_color_pixels.get()};
+    return maker->make_buffer(static_geometry->buffer_format, scaled_bottom_border_size, solid_color_pixels.get());
 }
 
 void RendererStrategy::update_solid_color_pixels()

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -306,7 +306,28 @@ public:
     auto static_geometry() const -> std::shared_ptr<StaticGeometry> override;
     auto render_strategy() const -> std::unique_ptr<mir::shell::decoration::RendererStrategy> override;
     auto button_placement(unsigned n, const WindowState& ws) const -> mir::geometry::Rectangle override;
+    auto compute_size_with_decorations(geom::Size content_size, MirWindowType type, MirWindowState state) const
+        -> geom::Size override;
 };
+
+auto DecorationStrategy::compute_size_with_decorations(
+    geom::Size content_size, MirWindowType type, MirWindowState state) const -> geom::Size
+{
+    switch (msd::border_type_for(type, state))
+    {
+    case msd::BorderType::Full:
+        content_size.width += static_geometry()->side_border_width * 2;
+        content_size.height += static_geometry()->titlebar_height + static_geometry()->bottom_border_height;
+        break;
+    case msd::BorderType::Titlebar:
+        content_size.height += static_geometry()->titlebar_height;
+        break;
+    case msd::BorderType::None:
+        break;
+    }
+
+    return content_size;
+}
 }
 
 auto msd::border_type_for(MirWindowType type, MirWindowState state) -> msd::BorderType

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -387,6 +387,15 @@ auto DecorationStrategy::compute_size_with_decorations(
 
     return content_size;
 }
+
+auto alloc_pixels(geom::Size size) -> std::unique_ptr<Pixel[]>
+{
+    size_t const buf_size = area(size) * sizeof(Pixel);
+    if (buf_size)
+        return std::unique_ptr<Pixel[]>{new Pixel[buf_size]};
+    else
+        return nullptr;
+}
 }
 
 auto msd::border_type_for(MirWindowType type, MirWindowState state) -> msd::BorderType

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -321,7 +321,7 @@ private:
     static auto alloc_pixels(geom::Size size) -> std::unique_ptr<Pixel[]>;
 };
 
-class DecorationStrategy : public msd::DecorationStrategy, public std::enable_shared_from_this<DecorationStrategy>
+class DecorationStrategy : public msd::DecorationStrategy
 {
 public:
     ~DecorationStrategy() override = default;
@@ -335,25 +335,7 @@ public:
     auto new_window_state(const std::shared_ptr<mir::scene::Surface>& window_surface,
                           float scale) const -> std::unique_ptr<WindowState> override;
     auto resize_corner_input_size() const -> geom::Size override;
-    auto titlebar_height() const -> geom::Height override;
-    auto side_border_width() const -> geom::Width override;
-    auto bottom_border_height() const -> geom::Height override;
 };
-
-auto DecorationStrategy::titlebar_height() const -> geom::Height
-{
-    return static_geometry()->titlebar_height;
-}
-
-auto DecorationStrategy::side_border_width() const -> geom::Width
-{
-    return static_geometry()->side_border_width;
-}
-
-auto DecorationStrategy::bottom_border_height() const -> geom::Height
-{
-    return static_geometry()->bottom_border_height;
-}
 
 auto DecorationStrategy::resize_corner_input_size() const -> geom::Size
 {
@@ -369,7 +351,12 @@ auto DecorationStrategy::new_window_state(const std::shared_ptr<mir::scene::Surf
                                           float scale) const -> std::unique_ptr<WindowState>
 
 {
-    return std::make_unique<WindowState>(shared_from_this(), window_surface, scale);
+    return std::make_unique<WindowState>(
+        window_surface,
+        static_geometry()->titlebar_height,
+        static_geometry()->side_border_width,
+        static_geometry()->bottom_border_height,
+        scale);
 }
 
 auto DecorationStrategy::compute_size_with_decorations(

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -33,20 +33,6 @@ namespace mir::shell::decoration
 {
 using Pixel = uint32_t;
 
-enum class ButtonState
-{
-    Up,         ///< The user is not interacting with this button
-    Hovered,    ///< The user is hovering over this button
-    Down,       ///< The user is currently pressing this button
-};
-
-enum class ButtonFunction
-{
-    Close,
-    Maximize,
-    Minimize,
-};
-
 enum class BorderType
 {
     Full,       ///< Full titlebar and border (for restored windows)
@@ -56,13 +42,30 @@ enum class BorderType
 
 auto border_type_for(MirWindowType type, MirWindowState state) -> BorderType;
 
-struct ButtonInfo
+struct Button
 {
-    ButtonFunction function;
-    ButtonState state;
+    enum class State
+    {
+        Up,         ///< The user is not interacting with this button
+        Hovered,    ///< The user is hovering over this button
+        Down,       ///< The user is currently pressing this button
+    };
+
+    enum class Function
+    {
+        Close,
+        Maximize,
+        Minimize,
+    };
+
+    using enum State;
+    using enum Function;
+
+    Function function;
+    State state;
     geometry::Rectangle rect;
 
-    auto operator==(ButtonInfo const& other) const -> bool
+    auto operator==(Button const& other) const -> bool
     {
         return function == other.function &&
                state == other.state &&
@@ -75,21 +78,21 @@ class InputState
 {
 public:
     InputState(
-        std::vector<ButtonInfo> const& buttons,
+        std::vector<Button> const& buttons,
         std::vector<geometry::Rectangle> const& input_shape)
         : buttons_{buttons},
           input_shape_{input_shape}
     {
     }
 
-    auto buttons() const -> std::vector<ButtonInfo> const& { return buttons_; }
+    auto buttons() const -> std::vector<Button> const& { return buttons_; }
     auto input_shape() const -> std::vector<geometry::Rectangle> const& { return input_shape_; }
 
 private:
     InputState(InputState const&) = delete;
     InputState& operator=(InputState const&) = delete;
 
-    std::vector<ButtonInfo> const buttons_;
+    std::vector<Button> const buttons_;
     std::vector<geometry::Rectangle> const input_shape_;
 };
 

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -42,24 +42,24 @@ enum class BorderType
 
 auto border_type_for(MirWindowType type, MirWindowState state) -> BorderType;
 
+/// Minimize, maximize, and close buttons
 struct Button
 {
-    enum class State
-    {
-        Up,         ///< The user is not interacting with this button
-        Hovered,    ///< The user is hovering over this button
-        Down,       ///< The user is currently pressing this button
-    };
-
     enum class Function
     {
         Close,
         Maximize,
         Minimize,
     };
-
-    using enum State;
     using enum Function;
+
+    enum class State
+    {
+        Up,         ///< The user is not interacting with this button
+        Hovered,    ///< The user is hovering over this button
+        Down,       ///< The user is currently pressing this button
+    };
+    using enum State;
 
     Function function;
     State state;
@@ -141,6 +141,7 @@ private:
     float const scale_;
 };
 
+/// Customization point for rendering
 class RendererStrategy
 {
 public:
@@ -163,6 +164,7 @@ public:
     virtual auto render_bottom_border() -> std::optional<RenderedPixels> = 0;
 };
 
+/// Customization point for decorations
 class DecorationStrategy
 {
 public:
@@ -177,14 +179,16 @@ public:
         std::shared_ptr<scene::Surface> const& window_surface, float scale) const -> std::unique_ptr<WindowState> = 0;
     virtual auto buffer_format() const -> MirPixelFormat = 0;
     virtual auto resize_corner_input_size() const -> geometry::Size = 0;
-    virtual auto titlebar_height() const -> geometry::Height = 0;
-    virtual auto side_border_width() const -> geometry::Width = 0;
-    virtual auto bottom_border_height() const -> geometry::Height = 0;
 
     DecorationStrategy() = default;
     virtual ~DecorationStrategy() = default;
 
 private:
+    virtual auto titlebar_height() const -> geometry::Height = 0;
+    virtual auto side_border_width() const -> geometry::Width = 0;
+    virtual auto bottom_border_height() const -> geometry::Height = 0;
+    friend class WindowState;
+
     DecorationStrategy(DecorationStrategy const&) = delete;
     DecorationStrategy& operator=(DecorationStrategy const&) = delete;
 };

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -135,6 +135,20 @@ private:
     float const scale_;
 };
 
+/// Mixin for creating graphics buffers from raw pixels
+class BufferMaker
+{
+public:
+    virtual auto make_buffer(MirPixelFormat const format, geometry::Size const size, Pixel const* const pixels) const
+    -> std::optional<std::shared_ptr<graphics::Buffer>> = 0;
+
+protected:
+    BufferMaker() = default;
+    virtual ~BufferMaker() = default;
+    BufferMaker(BufferMaker&) = delete;
+    BufferMaker& operator=(BufferMaker const&) = delete;
+};
+
 /// Customization point for rendering
 class RendererStrategy
 {
@@ -142,18 +156,11 @@ public:
     RendererStrategy() = default;
     virtual ~RendererStrategy() = default;
 
-    struct RenderedPixels
-    {
-        MirPixelFormat const format;
-        geometry::Size const size;
-        Pixel const* const pixels;
-    };
-
     virtual void update_state(WindowState const& window_state, InputState const& input_state) = 0;
-    virtual auto render_titlebar() -> std::optional<RenderedPixels> = 0;
-    virtual auto render_left_border() -> std::optional<RenderedPixels> = 0;
-    virtual auto render_right_border() -> std::optional<RenderedPixels> = 0;
-    virtual auto render_bottom_border() -> std::optional<RenderedPixels> = 0;
+    virtual auto render_titlebar(BufferMaker const* buffer_maker) -> std::optional<std::shared_ptr<graphics::Buffer>> = 0;
+    virtual auto render_left_border(BufferMaker const* buffer_maker) -> std::optional<std::shared_ptr<graphics::Buffer>> = 0;
+    virtual auto render_right_border(BufferMaker const* buffer_maker) -> std::optional<std::shared_ptr<graphics::Buffer>> = 0;
+    virtual auto render_bottom_border(BufferMaker const* buffer_maker) -> std::optional<std::shared_ptr<graphics::Buffer>> = 0;
 };
 
 /// Customization point for decorations

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -28,11 +28,10 @@
 #include <vector>
 
 namespace mir::scene { class Surface; }
+namespace mir::graphics { class Buffer; }
 
 namespace mir::shell::decoration
 {
-using Pixel = uint32_t;
-
 enum class BorderType
 {
     Full,       ///< Full titlebar and border (for restored windows)
@@ -139,6 +138,8 @@ private:
 class BufferMaker
 {
 public:
+    using Pixel = uint32_t;
+
     virtual auto make_buffer(MirPixelFormat const format, geometry::Size const size, Pixel const* const pixels) const
     -> std::optional<std::shared_ptr<graphics::Buffer>> = 0;
 

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -183,7 +183,6 @@ public:
 
     static auto default_decoration_strategy() -> std::unique_ptr<DecorationStrategy>;
 
-    virtual auto static_geometry() const -> std::shared_ptr<StaticGeometry> = 0;
     virtual auto render_strategy() const -> std::unique_ptr<RendererStrategy> = 0;
     virtual auto button_placement(unsigned n, WindowState const& ws) const -> geometry::Rectangle = 0;
     virtual auto compute_size_with_decorations(
@@ -191,6 +190,7 @@ public:
     virtual auto new_window_state(
         std::shared_ptr<scene::Surface> const& window_surface, float scale) const -> std::unique_ptr<WindowState> = 0;
     virtual auto buffer_format() const -> MirPixelFormat = 0;
+    virtual auto resize_corner_input_size() const -> geometry::Size = 0;
 
     DecorationStrategy() = default;
     virtual ~DecorationStrategy() = default;

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -65,12 +65,7 @@ struct Button
     State state;
     geometry::Rectangle rect;
 
-    auto operator==(Button const& other) const -> bool
-    {
-        return function == other.function &&
-               state == other.state &&
-               rect == other.rect;
-    }
+    auto operator==(Button const& other) const -> bool = default;
 };
 
 /// Describes the state of the interface (what buttons are pushed, etc)
@@ -131,7 +126,6 @@ public:
 
 private:
     WindowState(WindowState const&) = delete;
-    WindowState& operator=(WindowState const&) = delete;
 
     std::shared_ptr<const DecorationStrategy> const decoration_strategy;
     geometry::Size const window_size_;
@@ -145,8 +139,6 @@ private:
 class RendererStrategy
 {
 public:
-    static auto alloc_pixels(geometry::Size size) -> std::unique_ptr<Pixel[]>;
-
     RendererStrategy() = default;
     virtual ~RendererStrategy() = default;
 

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -188,6 +188,8 @@ public:
     virtual auto button_placement(unsigned n, WindowState const& ws) const -> geometry::Rectangle = 0;
     virtual auto compute_size_with_decorations(
         geometry::Size content_size, MirWindowType type, MirWindowState state) const -> geometry::Size = 0;
+    virtual auto new_window_state(
+        std::shared_ptr<scene::Surface> const& window_surface, float scale) const -> std::unique_ptr<WindowState> = 0;
 
     DecorationStrategy() = default;
     virtual ~DecorationStrategy() = default;

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -82,8 +82,10 @@ class WindowState
 {
 public:
     WindowState(
-        std::shared_ptr<const DecorationStrategy>&& decoration_strategy,
         std::shared_ptr<scene::Surface> const& window_surface,
+        geometry::Height fixed_titlebar_height,
+        geometry::Width fixed_side_border_width,
+        geometry::Height fixed_bottom_border_height,
         float scale);
 
     ~WindowState();
@@ -166,11 +168,6 @@ public:
     virtual ~DecorationStrategy() = default;
 
 private:
-    virtual auto titlebar_height() const -> geometry::Height = 0;
-    virtual auto side_border_width() const -> geometry::Width = 0;
-    virtual auto bottom_border_height() const -> geometry::Height = 0;
-    friend class WindowState;
-
     DecorationStrategy(DecorationStrategy const&) = delete;
     DecorationStrategy& operator=(DecorationStrategy const&) = delete;
 };

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -190,6 +190,7 @@ public:
         geometry::Size content_size, MirWindowType type, MirWindowState state) const -> geometry::Size = 0;
     virtual auto new_window_state(
         std::shared_ptr<scene::Surface> const& window_surface, float scale) const -> std::unique_ptr<WindowState> = 0;
+    virtual auto buffer_format() const -> MirPixelFormat = 0;
 
     DecorationStrategy() = default;
     virtual ~DecorationStrategy() = default;

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -186,6 +186,8 @@ public:
     virtual auto static_geometry() const -> std::shared_ptr<StaticGeometry> = 0;
     virtual auto render_strategy() const -> std::unique_ptr<RendererStrategy> = 0;
     virtual auto button_placement(unsigned n, WindowState const& ws) const -> geometry::Rectangle = 0;
+    virtual auto compute_size_with_decorations(
+        geometry::Size content_size, MirWindowType type, MirWindowState state) const -> geometry::Size = 0;
 
     DecorationStrategy() = default;
     virtual ~DecorationStrategy() = default;

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -86,6 +86,8 @@ public:
         std::shared_ptr<scene::Surface> const& window_surface,
         float scale);
 
+    ~WindowState();
+
     auto window_size() const -> geometry::Size;
     auto border_type() const -> BorderType;
     auto focused_state() const -> MirWindowFocusState;
@@ -110,12 +112,8 @@ public:
 private:
     WindowState(WindowState const&) = delete;
 
-    std::shared_ptr<const DecorationStrategy> const decoration_strategy;
-    geometry::Size const window_size_;
-    BorderType const border_type_;
-    MirWindowFocusState const focus_state_;
-    std::string const window_name_;
-    float const scale_;
+    class Self;
+    std::unique_ptr<Self> const self;
 };
 
 /// Mixin for creating graphics buffers from raw pixels

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -68,26 +68,10 @@ struct Button
 };
 
 /// Describes the state of the interface (what buttons are pushed, etc)
-class InputState
+struct InputState
 {
-public:
-    InputState(
-        std::vector<Button> const& buttons,
-        std::vector<geometry::Rectangle> const& input_shape)
-        : buttons_{buttons},
-          input_shape_{input_shape}
-    {
-    }
-
-    auto buttons() const -> std::vector<Button> const& { return buttons_; }
-    auto input_shape() const -> std::vector<geometry::Rectangle> const& { return input_shape_; }
-
-private:
-    InputState(InputState const&) = delete;
-    InputState& operator=(InputState const&) = delete;
-
-    std::vector<Button> const buttons_;
-    std::vector<geometry::Rectangle> const input_shape_;
+    std::vector<Button> const buttons;
+    std::vector<geometry::Rectangle> const input_shape;
 };
 
 class DecorationStrategy;

--- a/src/server/shell/decoration/decoration_strategy.h
+++ b/src/server/shell/decoration/decoration_strategy.h
@@ -151,8 +151,8 @@ private:
     geometry::Size const window_size_;
     BorderType const border_type_;
     MirWindowFocusState const focus_state_;
-    std::string window_name_;
-    float scale_;
+    std::string const window_name_;
+    float const scale_;
 };
 
 class RendererStrategy

--- a/src/server/shell/decoration/input.cpp
+++ b/src/server/shell/decoration/input.cpp
@@ -127,9 +127,9 @@ msd::InputManager::InputManager(
     observer{std::make_shared<Observer>(this)},
     decoration{decoration},
     widgets{
-        std::make_shared<Widget>(ButtonFunction::Close),
-        std::make_shared<Widget>(ButtonFunction::Maximize),
-        std::make_shared<Widget>(ButtonFunction::Minimize),
+        std::make_shared<Widget>(Button::Close),
+        std::make_shared<Widget>(Button::Maximize),
+        std::make_shared<Widget>(Button::Minimize),
         std::make_shared<Widget>(mir_resize_edge_northwest),
         std::make_shared<Widget>(mir_resize_edge_northeast),
         std::make_shared<Widget>(mir_resize_edge_southwest),
@@ -199,11 +199,11 @@ void msd::InputManager::update_window_state(WindowState const& window_state)
 auto msd::InputManager::state() -> std::unique_ptr<InputState>
 {
     std::lock_guard lock{mutex};
-    std::vector<ButtonInfo> buttons;
+    std::vector<Button> buttons;
     for (auto const& widget : widgets)
     {
         if (widget->button)
-            buttons.push_back(ButtonInfo{
+            buttons.push_back(Button{
                 widget->button.value(),
                 widget->state,
                 widget->rect});
@@ -420,7 +420,7 @@ auto msd::InputManager::widget_at(geom::Point location) -> std::optional<std::sh
 
 void msd::InputManager::widget_enter(Widget& widget)
 {
-    widget.state = ButtonState::Hovered;
+    widget.state = Button::Hovered;
     if (widget.resize_edge)
         set_cursor(widget.resize_edge.value());
     decoration->spawn([](BasicDecoration* decoration)
@@ -431,7 +431,7 @@ void msd::InputManager::widget_enter(Widget& widget)
 
 void msd::InputManager::widget_leave(Widget& widget)
 {
-    widget.state = ButtonState::Up;
+    widget.state = Button::Up;
     set_cursor(mir_resize_edge_none);
     decoration->spawn([](BasicDecoration* decoration)
         {
@@ -441,7 +441,7 @@ void msd::InputManager::widget_leave(Widget& widget)
 
 void msd::InputManager::widget_down(Widget& widget)
 {
-    widget.state = ButtonState::Down;
+    widget.state = Button::Down;
     decoration->spawn([](BasicDecoration* decoration)
         {
             decoration->input_state_updated();
@@ -450,7 +450,7 @@ void msd::InputManager::widget_down(Widget& widget)
 
 void msd::InputManager::widget_up(Widget& widget)
 {
-    if (widget.state == ButtonState::Down)
+    if (widget.state == Button::Down)
     {
         auto const input_ev = mir_event_get_input_event(latest_event.get());
         auto const event_timestamp = std::chrono::nanoseconds{mir_input_event_get_event_time(input_ev)};
@@ -473,21 +473,21 @@ void msd::InputManager::widget_up(Widget& widget)
         {
             switch (widget.button.value())
             {
-            case ButtonFunction::Close:
+            case Button::Close:
                 decoration->spawn([](BasicDecoration* decoration)
                     {
                         decoration->request_close();
                     });
                 break;
 
-            case ButtonFunction::Maximize:
+            case Button::Maximize:
                 decoration->spawn([](BasicDecoration* decoration)
                     {
                         decoration->request_toggle_maximize();
                     });
                 break;
 
-            case ButtonFunction::Minimize:
+            case Button::Minimize:
                 decoration->spawn([](BasicDecoration* decoration)
                     {
                         decoration->request_minimize();
@@ -496,7 +496,7 @@ void msd::InputManager::widget_up(Widget& widget)
             }
         }
     }
-    widget.state = ButtonState::Hovered;
+    widget.state = Button::Hovered;
     decoration->spawn([](BasicDecoration* decoration)
         {
             decoration->input_state_updated();
@@ -505,7 +505,7 @@ void msd::InputManager::widget_up(Widget& widget)
 
 void msd::InputManager::widget_drag(Widget& widget)
 {
-    if (widget.state == ButtonState::Down)
+    if (widget.state == Button::Down)
     {
         if (widget.resize_edge)
         {
@@ -533,7 +533,7 @@ void msd::InputManager::widget_drag(Widget& widget)
                     decoration->request_move(mir_event_get_input_event(event.get()));
                 });
         }
-        widget.state = ButtonState::Up;
+        widget.state = Button::Up;
     }
     decoration->spawn([](BasicDecoration* decoration)
         {

--- a/src/server/shell/decoration/input.cpp
+++ b/src/server/shell/decoration/input.cpp
@@ -123,7 +123,6 @@ msd::InputManager::InputManager(
     WindowState const& window_state,
     std::shared_ptr<ThreadsafeAccess<BasicDecoration>> const& decoration) :
     decoration_strategy{decoration_strategy},
-    static_geometry{decoration_strategy->static_geometry()},
     decoration_surface{decoration_surface},
     observer{std::make_shared<Observer>(this)},
     decoration{decoration},
@@ -165,7 +164,8 @@ void msd::InputManager::update_window_state(WindowState const& window_state)
         }
         else if (widget->resize_edge)
         {
-            widget->rect = resize_edge_rect(window_state, *static_geometry, widget->resize_edge.value());
+            widget->rect = resize_edge_rect(window_state,
+                decoration_strategy->resize_corner_input_size(), widget->resize_edge.value());
         }
         else
         {
@@ -215,7 +215,7 @@ auto msd::InputManager::state() -> std::unique_ptr<InputState>
 
 auto msd::InputManager::resize_edge_rect(
     WindowState const& window_state,
-    StaticGeometry const& static_geometry,
+    geom::Size const& resize_corner_input_size,
     MirResizeEdge resize_edge) -> geom::Rectangle
 {
     switch (resize_edge)
@@ -240,15 +240,15 @@ auto msd::InputManager::resize_edge_rect(
         return window_state.right_border_rect();
 
     case mir_resize_edge_northwest:
-        return {{}, static_geometry.resize_corner_input_size};
+        return {{}, resize_corner_input_size};
 
     case mir_resize_edge_northeast:
     {
         geom::Point top_left{
             as_x(window_state.window_size().width) -
-                as_delta(static_geometry.resize_corner_input_size.width),
+                as_delta(resize_corner_input_size.width),
             0};
-        return {top_left, static_geometry.resize_corner_input_size};
+        return {top_left, resize_corner_input_size};
     }
 
     case mir_resize_edge_southwest:
@@ -256,18 +256,18 @@ auto msd::InputManager::resize_edge_rect(
         geom::Point top_left{
             0,
             as_y(window_state.window_size().height) -
-                as_delta(static_geometry.resize_corner_input_size.height)};
-        return {top_left, static_geometry.resize_corner_input_size};
+                as_delta(resize_corner_input_size.height)};
+        return {top_left, resize_corner_input_size};
     }
 
     case mir_resize_edge_southeast:
     {
         geom::Point top_left{
             as_x(window_state.window_size().width) -
-                as_delta(static_geometry.resize_corner_input_size.width),
+                as_delta(resize_corner_input_size.width),
             as_y(window_state.window_size().height) -
-                as_delta(static_geometry.resize_corner_input_size.height)};
-        return {top_left, static_geometry.resize_corner_input_size};
+                as_delta(resize_corner_input_size.height)};
+        return {top_left, resize_corner_input_size};
     }
 
     default: return {};

--- a/src/server/shell/decoration/input.h
+++ b/src/server/shell/decoration/input.h
@@ -94,7 +94,7 @@ private:
 
     struct Widget
     {
-        Widget(ButtonFunction button)
+        Widget(Button::Function button)
             : button{button}
         {
         }
@@ -105,8 +105,8 @@ private:
         }
 
         geometry::Rectangle rect;
-        ButtonState state{ButtonState::Up};
-        std::optional<ButtonFunction> const button;
+        Button::State state{Button::Up};
+        std::optional<Button::Function> const button;
         // mir_resize_edge_none is used to mean the widget moves the window
         std::optional<MirResizeEdge> const resize_edge;
     };

--- a/src/server/shell/decoration/input.h
+++ b/src/server/shell/decoration/input.h
@@ -47,7 +47,6 @@ namespace decoration
 {
 class WindowState;
 class BasicDecoration;
-class StaticGeometry;
 template<typename T> class ThreadsafeAccess;
 
 /// Manages the observer that listens to user input
@@ -72,7 +71,7 @@ private:
 
     static auto resize_edge_rect(
         WindowState const& window_state,
-        StaticGeometry const& static_geometry,
+        geometry::Size const& resize_corner_input_size,
         MirResizeEdge resize_edge) -> geometry::Rectangle;
     void pointer_event(std::shared_ptr<MirEvent const> const& event, geometry::Point location, bool pressed);
     void pointer_leave(std::shared_ptr<MirEvent const> const& event);
@@ -83,7 +82,6 @@ private:
 
     std::mutex mutex;
     std::shared_ptr<DecorationStrategy> const decoration_strategy;
-    std::shared_ptr<StaticGeometry> const static_geometry;
     std::shared_ptr<scene::Surface> decoration_surface;
     std::shared_ptr<Observer> const observer;
     std::shared_ptr<ThreadsafeAccess<BasicDecoration>> decoration;

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -48,11 +48,10 @@ std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
 {
 }
 
-auto msd::Renderer::make_buffer(
-    uint32_t const* pixels,
-    geometry::Size size,
-    MirPixelFormat buffer_format) -> std::optional<std::shared_ptr<mg::Buffer>>
+auto mir::shell::decoration::Renderer::make_buffer(const MirPixelFormat format, const geometry::Size size,
+    Pixel const* const pixels) const -> std::optional<std::shared_ptr<graphics::Buffer>>
 {
+    MirPixelFormat buffer_format = format;
     if (!area(size))
     {
         log_warning("Failed to draw SSD: tried to create zero size buffer");
@@ -83,50 +82,22 @@ auto msd::Renderer::make_buffer(
 
 auto msd::Renderer::render_titlebar() -> std::optional<std::shared_ptr<mg::Buffer>>
 {
-    if (auto const& rendered_pixels = strategy->render_titlebar())
-    {
-        return make_buffer(rendered_pixels->pixels, rendered_pixels->size, rendered_pixels->format);
-    }
-    else
-    {
-        return std::nullopt;
-    }
+    return strategy->render_titlebar(this);
 }
 
 auto msd::Renderer::render_left_border() -> std::optional<std::shared_ptr<mg::Buffer>>
 {
-    if (auto const& rendered_pixels = strategy->render_left_border())
-    {
-        return make_buffer(rendered_pixels->pixels, rendered_pixels->size, rendered_pixels->format);
-    }
-    else
-    {
-        return std::nullopt;
-    }
+    return strategy->render_left_border(this);
 }
 
 auto msd::Renderer::render_right_border() -> std::optional<std::shared_ptr<mg::Buffer>>
 {
-    if (auto const& rendered_pixels = strategy->render_right_border())
-    {
-        return make_buffer(rendered_pixels->pixels, rendered_pixels->size, rendered_pixels->format);
-    }
-    else
-    {
-        return std::nullopt;
-    }
+    return strategy->render_right_border(this);
 }
 
 auto msd::Renderer::render_bottom_border() -> std::optional<std::shared_ptr<mg::Buffer>>
 {
-    if (auto const& rendered_pixels = strategy->render_bottom_border())
-    {
-        return make_buffer(rendered_pixels->pixels, rendered_pixels->size, rendered_pixels->format);
-    }
-    else
-    {
-        return std::nullopt;
-    }
+    return strategy->render_bottom_border(this);
 }
 
 

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -134,13 +134,3 @@ void msd::Renderer::update_state(WindowState const& window_state, InputState con
 {
     strategy->update_state(window_state, input_state);
 }
-
-
-auto msd::RendererStrategy::alloc_pixels(geometry::Size size) -> std::unique_ptr<Pixel[]>
-{
-    size_t const buf_size = area(size) * sizeof(Pixel);
-    if (buf_size)
-        return std::unique_ptr<Pixel[]>{new Pixel[buf_size]};
-    else
-        return nullptr;
-}

--- a/src/server/shell/decoration/renderer.h
+++ b/src/server/shell/decoration/renderer.h
@@ -41,7 +41,7 @@ class WindowState;
 class InputState;
 struct StaticGeometry;
 
-class Renderer
+class Renderer : BufferMaker
 {
 public:
     Renderer(
@@ -58,10 +58,8 @@ private:
     std::shared_ptr<graphics::GraphicBufferAllocator> const buffer_allocator;
     std::unique_ptr<RendererStrategy> const strategy;
 
-    auto make_buffer(
-        Pixel const* pixels,
-        geometry::Size size,
-        MirPixelFormat buffer_format) -> std::optional<std::shared_ptr<graphics::Buffer>>;
+    auto make_buffer(const MirPixelFormat format, const geometry::Size size,
+        Pixel const* const pixels) const -> std::optional<std::shared_ptr<graphics::Buffer>> override;
 };
 }
 }

--- a/src/server/shell/decoration/window.cpp
+++ b/src/server/shell/decoration/window.cpp
@@ -30,36 +30,51 @@ class msd::WindowState::Self
 {
 public:
     Self(
-    std::shared_ptr<const DecorationStrategy>&& decoration_strategy,
-    std::shared_ptr<scene::Surface> const& surface,
-    float scale);
+        std::shared_ptr<scene::Surface> const& surface,
+        geometry::Height fixed_titlebar_height,
+        geometry::Width fixed_side_border_width,
+        geometry::Height fixed_bottom_border_height,
+        float scale);
 
-    std::shared_ptr<const DecorationStrategy> const decoration_strategy;
-    geometry::Size const window_size_;
-    BorderType const border_type_;
-    MirWindowFocusState const focus_state_;
-    std::string const window_name_;
-    float const scale_;
+    geometry::Height const fixed_titlebar_height;
+    geometry::Width const fixed_side_border_width;
+    geometry::Height const fixed_bottom_border_height;
+    geometry::Size const window_size;
+    BorderType const border_type;
+    MirWindowFocusState const focus_state;
+    std::string const window_name;
+    float const scale;
 };
 
 msd::WindowState::Self::Self(
-    std::shared_ptr<const DecorationStrategy>&& decoration_strategy,
     std::shared_ptr<scene::Surface> const& surface,
+    geometry::Height fixed_titlebar_height,
+    geometry::Width fixed_side_border_width,
+    geometry::Height fixed_bottom_border_height,
     float scale)
-    : decoration_strategy{std::move(decoration_strategy)},
-      window_size_{surface->window_size()},
-      border_type_{border_type_for(surface->type(), surface->state())},
-      focus_state_{surface->focus_state()},
-      window_name_{surface->name()},
-      scale_{scale}
+    : fixed_titlebar_height(fixed_titlebar_height),
+      fixed_side_border_width(fixed_side_border_width),
+      fixed_bottom_border_height(fixed_bottom_border_height),
+      window_size{surface->window_size()},
+      border_type{border_type_for(surface->type(), surface->state())},
+      focus_state{surface->focus_state()},
+      window_name{surface->name()},
+      scale{scale}
 {
 }
 
 msd::WindowState::WindowState(
-    std::shared_ptr<const DecorationStrategy>&& decoration_strategy,
     std::shared_ptr<scene::Surface> const& surface,
+    geometry::Height fixed_titlebar_height,
+    geometry::Width fixed_side_border_width,
+    geometry::Height fixed_bottom_border_height,
     float scale)
-    : self{std::make_unique<Self>(std::move(decoration_strategy), surface, scale)}
+    : self{std::make_unique<Self>(
+        surface,
+        fixed_titlebar_height,
+        fixed_side_border_width,
+        fixed_bottom_border_height,
+        scale)}
 {
 }
 
@@ -67,27 +82,27 @@ mir::shell::decoration::WindowState::~WindowState() = default;
 
 auto msd::WindowState::window_size() const -> geom::Size
 {
-    return self->window_size_;
+    return self->window_size;
 }
 
 auto msd::WindowState::border_type() const -> BorderType
 {
-    return self->border_type_;
+    return self->border_type;
 }
 
 auto msd::WindowState::focused_state() const -> MirWindowFocusState
 {
-    return self->focus_state_;
+    return self->focus_state;
 }
 
 auto msd::WindowState::window_name() const -> std::string
 {
-    return self->window_name_;
+    return self->window_name;
 }
 
 auto msd::WindowState::titlebar_width() const -> geom::Width
 {
-    switch (self->border_type_)
+    switch (self->border_type)
     {
     case BorderType::Full:
     case BorderType::Titlebar:
@@ -102,11 +117,11 @@ auto msd::WindowState::titlebar_width() const -> geom::Width
 
 auto msd::WindowState::titlebar_height() const -> geom::Height
 {
-    switch (self->border_type_)
+    switch (self->border_type)
     {
     case BorderType::Full:
     case BorderType::Titlebar:
-        return self->decoration_strategy->titlebar_height();
+        return self->fixed_titlebar_height;
     case BorderType::None:
         return {};
     }
@@ -117,10 +132,10 @@ auto msd::WindowState::titlebar_height() const -> geom::Height
 
 auto msd::WindowState::side_border_width() const -> geom::Width
 {
-    switch (self->border_type_)
+    switch (self->border_type)
     {
     case BorderType::Full:
-        return self->decoration_strategy->side_border_width();
+        return self->fixed_side_border_width;
     case BorderType::Titlebar:
     case BorderType::None:
         return {};
@@ -132,7 +147,7 @@ auto msd::WindowState::side_border_width() const -> geom::Width
 
 auto msd::WindowState::side_border_height() const -> geom::Height
 {
-    switch (self->border_type_)
+    switch (self->border_type)
     {
     case BorderType::Full:
         return window_size().height - as_delta(titlebar_height()) - as_delta(bottom_border_height());
@@ -152,10 +167,10 @@ auto msd::WindowState::bottom_border_width() const -> geom::Width
 
 auto msd::WindowState::bottom_border_height() const -> geom::Height
 {
-    switch (self->border_type_)
+    switch (self->border_type)
     {
     case BorderType::Full:
-        return self->decoration_strategy->bottom_border_height();
+        return self->fixed_bottom_border_height;
     case BorderType::Titlebar:
     case BorderType::None:
         return {};
@@ -195,7 +210,7 @@ auto msd::WindowState::bottom_border_rect() const -> geom::Rectangle
 
 auto msd::WindowState::scale() const -> float
 {
-    return self->scale_;
+    return self->scale;
 }
 
 class msd::WindowSurfaceObserverManager::Observer

--- a/src/server/shell/decoration/window.cpp
+++ b/src/server/shell/decoration/window.cpp
@@ -26,7 +26,23 @@ namespace ms = mir::scene;
 namespace geom = mir::geometry;
 namespace msd = mir::shell::decoration;
 
-msd::WindowState::WindowState(
+class msd::WindowState::Self
+{
+public:
+    Self(
+    std::shared_ptr<const DecorationStrategy>&& decoration_strategy,
+    std::shared_ptr<scene::Surface> const& surface,
+    float scale);
+
+    std::shared_ptr<const DecorationStrategy> const decoration_strategy;
+    geometry::Size const window_size_;
+    BorderType const border_type_;
+    MirWindowFocusState const focus_state_;
+    std::string const window_name_;
+    float const scale_;
+};
+
+msd::WindowState::Self::Self(
     std::shared_ptr<const DecorationStrategy>&& decoration_strategy,
     std::shared_ptr<scene::Surface> const& surface,
     float scale)
@@ -39,29 +55,39 @@ msd::WindowState::WindowState(
 {
 }
 
+msd::WindowState::WindowState(
+    std::shared_ptr<const DecorationStrategy>&& decoration_strategy,
+    std::shared_ptr<scene::Surface> const& surface,
+    float scale)
+    : self{std::make_unique<Self>(std::move(decoration_strategy), surface, scale)}
+{
+}
+
+mir::shell::decoration::WindowState::~WindowState() = default;
+
 auto msd::WindowState::window_size() const -> geom::Size
 {
-    return window_size_;
+    return self->window_size_;
 }
 
 auto msd::WindowState::border_type() const -> BorderType
 {
-    return border_type_;
+    return self->border_type_;
 }
 
 auto msd::WindowState::focused_state() const -> MirWindowFocusState
 {
-    return focus_state_;
+    return self->focus_state_;
 }
 
 auto msd::WindowState::window_name() const -> std::string
 {
-    return window_name_;
+    return self->window_name_;
 }
 
 auto msd::WindowState::titlebar_width() const -> geom::Width
 {
-    switch (border_type_)
+    switch (self->border_type_)
     {
     case BorderType::Full:
     case BorderType::Titlebar:
@@ -76,11 +102,11 @@ auto msd::WindowState::titlebar_width() const -> geom::Width
 
 auto msd::WindowState::titlebar_height() const -> geom::Height
 {
-    switch (border_type_)
+    switch (self->border_type_)
     {
     case BorderType::Full:
     case BorderType::Titlebar:
-        return decoration_strategy->titlebar_height();
+        return self->decoration_strategy->titlebar_height();
     case BorderType::None:
         return {};
     }
@@ -91,10 +117,10 @@ auto msd::WindowState::titlebar_height() const -> geom::Height
 
 auto msd::WindowState::side_border_width() const -> geom::Width
 {
-    switch (border_type_)
+    switch (self->border_type_)
     {
     case BorderType::Full:
-        return decoration_strategy->side_border_width();
+        return self->decoration_strategy->side_border_width();
     case BorderType::Titlebar:
     case BorderType::None:
         return {};
@@ -106,7 +132,7 @@ auto msd::WindowState::side_border_width() const -> geom::Width
 
 auto msd::WindowState::side_border_height() const -> geom::Height
 {
-    switch (border_type_)
+    switch (self->border_type_)
     {
     case BorderType::Full:
         return window_size().height - as_delta(titlebar_height()) - as_delta(bottom_border_height());
@@ -126,10 +152,10 @@ auto msd::WindowState::bottom_border_width() const -> geom::Width
 
 auto msd::WindowState::bottom_border_height() const -> geom::Height
 {
-    switch (border_type_)
+    switch (self->border_type_)
     {
     case BorderType::Full:
-        return decoration_strategy->bottom_border_height();
+        return self->decoration_strategy->bottom_border_height();
     case BorderType::Titlebar:
     case BorderType::None:
         return {};
@@ -169,7 +195,7 @@ auto msd::WindowState::bottom_border_rect() const -> geom::Rectangle
 
 auto msd::WindowState::scale() const -> float
 {
-    return scale_;
+    return self->scale_;
 }
 
 class msd::WindowSurfaceObserverManager::Observer

--- a/src/server/shell/decoration/window.cpp
+++ b/src/server/shell/decoration/window.cpp
@@ -27,10 +27,10 @@ namespace geom = mir::geometry;
 namespace msd = mir::shell::decoration;
 
 msd::WindowState::WindowState(
-    std::shared_ptr<StaticGeometry> const& static_geometry,
+    std::shared_ptr<const DecorationStrategy>&& decoration_strategy,
     std::shared_ptr<scene::Surface> const& surface,
     float scale)
-    : static_geometry{static_geometry},
+    : decoration_strategy{std::move(decoration_strategy)},
       window_size_{surface->window_size()},
       border_type_{border_type_for(surface->type(), surface->state())},
       focus_state_{surface->focus_state()},
@@ -80,7 +80,7 @@ auto msd::WindowState::titlebar_height() const -> geom::Height
     {
     case BorderType::Full:
     case BorderType::Titlebar:
-        return static_geometry->titlebar_height;
+        return decoration_strategy->titlebar_height();
     case BorderType::None:
         return {};
     }
@@ -94,7 +94,7 @@ auto msd::WindowState::side_border_width() const -> geom::Width
     switch (border_type_)
     {
     case BorderType::Full:
-        return static_geometry->side_border_width;
+        return decoration_strategy->side_border_width();
     case BorderType::Titlebar:
     case BorderType::None:
         return {};
@@ -129,7 +129,7 @@ auto msd::WindowState::bottom_border_height() const -> geom::Height
     switch (border_type_)
     {
     case BorderType::Full:
-        return static_geometry->bottom_border_height;
+        return decoration_strategy->bottom_border_height();
     case BorderType::Titlebar:
     case BorderType::None:
         return {};


### PR DESCRIPTION
Improves the interface between the decoration strategies and the rest of the subsystem:

1. Encapsulates the StaticGeometry
2. Moves the Button enums into the struct (with a few renames)
3. Adds some documentation
4. Simplifies buffer creation API
5. Make InputState a struct
6. Simplify use of WindowState

Generally, making the decoration strategy simpler and easier to customise