### PR TITLE
Don't try to refocus on an app of the same client.

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -288,9 +288,6 @@ void miral::BasicWindowManager::refocus(
     if (hint && select_active_window(hint))
         return;
 
-    if (can_activate_window_for_session_in_workspace(application, workspaces_containing_window))
-        return;
-
     // Try to activate to recently active window of any application in a shared workspace
     {
         miral::Window new_focus;


### PR DESCRIPTION
Fixes #3309 

Note that this bug only occurs with apps that can have multiple windows running under the same process (example: gnome-terminal, pluma)