### PR TITLE
Don't leak VirtualInputDevice keyboards

### DIFF
--- a/src/server/frontend_wayland/text_input_v3.cpp
+++ b/src/server/frontend_wayland/text_input_v3.cpp
@@ -333,6 +333,7 @@ mf::TextInputV3::TextInputV3(
 mf::TextInputV3::~TextInputV3()
 {
     seat.remove_focus_listener(client, this);
+    ctx->device_registry->remove_device(keyboard_device);
     ctx->text_input_hub->deactivate_handler(handler);
 }
 


### PR DESCRIPTION
Every time an app supporting text-input-v3 starts we allocate a "virtual-keyboard", we should also deallocate it as appropriate.

This was identified while investigating #3710, and is part of the fix (possibly all the fix - still testing)