### PR TITLE
kms: skip `simple-framebuffer` devices

### DIFF
--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -158,8 +158,12 @@ private:
      *
      * At least as of drivers ≤ version 550, the NVIDIA atomic implementation is buggy in a way that prevents
      * Mir from working. Quirk off atomic-kms on NVIDIA.
+     *
+     * Simple-framebuffer should be evicted before Mir even gets there.
+     * https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084046
+     * https://github.com/canonical/mir/issues/3710
      */
-    std::unordered_set<std::string> drivers_to_skip = { "nvidia", "ast" };
+    std::unordered_set<std::string> drivers_to_skip = { "nvidia", "ast", "simple-framebuffer"};
     std::unordered_set<std::string> devnodes_to_skip;
     // We know this is currently useful for virtio_gpu, vc4-drm and v3d
     std::unordered_set<std::string> skip_modesetting_support = { "virtio_gpu", "vc4-drm", "v3d" };

--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -158,8 +158,12 @@ private:
      *
      * At least as of drivers ≤ version 550, the NVIDIA gbm implementation is buggy in a way that prevents
      * Mir from working. Quirk off gbm-kms on NVIDIA.
+     *
+     * Simple-framebuffer should be evicted before Mir even gets there.
+     * https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084046
+     * https://github.com/canonical/mir/issues/3710
      */
-    std::unordered_set<std::string> drivers_to_skip = { "nvidia", "ast" };
+    std::unordered_set<std::string> drivers_to_skip = { "nvidia", "ast", "simple-framebuffer"};
     std::unordered_set<std::string> devnodes_to_skip;
     // We know this is currently useful for virtio_gpu, vc4-drm and v3d
     std::unordered_set<std::string> skip_modesetting_support = { "virtio_gpu", "vc4-drm", "v3d" };


### PR DESCRIPTION
They should never be there in the first place.
https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084046 https://github.com/canonical/mir/issues/3710

Closes #3710