### PR TITLE
Remove unused `InputPanelV1::display`

### DIFF
--- a/src/server/frontend_wayland/input_method_v1.cpp
+++ b/src/server/frontend_wayland/input_method_v1.cpp
@@ -576,7 +576,6 @@ mf::InputPanelV1::InputPanelV1(
     OutputManager* const output_manager,
     std::shared_ptr<scene::TextInputHub> const text_input_hub)
     : Global(display, Version<1>()),
-      display{display},
       wayland_executor{wayland_executor},
       shell{shell},
       seat{seat},

--- a/src/server/frontend_wayland/input_method_v1.h
+++ b/src/server/frontend_wayland/input_method_v1.h
@@ -72,7 +72,6 @@ private:
     class Instance;
     void bind(wl_resource* new_zwp_input_panel_v1) override;
 
-    wl_display* display;
     std::shared_ptr<Executor> const wayland_executor;
     std::shared_ptr<shell::Shell> const shell;
     WlSeat* seat;


### PR DESCRIPTION
After an update, clang-20 started marking `InputPanelV1::display` as unused, which is true as there is no need to store it. This still happens with clang-20 (20250112081750+42da12063f49-1\~exp1\~20250112081925.659)