### PR TITLE
Ctrl+Alt+{t,T,x,X} now prevent other event filters from running.

### DIFF
--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -110,12 +110,12 @@ int main(int argc, char const* argv[])
             case XKB_KEY_t:
             case XKB_KEY_T:
                 external_client_launcher.launch({terminal_cmd});
-                return false;
+                return true;
 
             case XKB_KEY_x:
             case XKB_KEY_X:
                 external_client_launcher.launch_using_x11({"xterm"});
-                return false;
+                return true;
 
             default:
                 return false;


### PR DESCRIPTION
This fixes terminals failing to activate themselves due to the key listener immediately revoking their token in response to the terminal launch shortcut being pressed.