### PR TITLE
Disable token creation for a bit on keyboard input

### DIFF
--- a/src/server/shell/token_authority.cpp
+++ b/src/server/shell/token_authority.cpp
@@ -58,6 +58,10 @@ msh::TokenAuthority::TokenAuthority(std::shared_ptr<MainLoop>&& main_loop) :
 
 auto msh::TokenAuthority::issue_token(std::optional<Token::RevocationListener> revocation_listener) -> Token
 {
+    std::scoped_lock lock{mutex};
+
+
+    // Not sure if libuuid is thread safe
     auto token = Token{generate_token(),  revocation_listener};
 
     auto alarm = main_loop->create_alarm(
@@ -68,7 +72,6 @@ auto msh::TokenAuthority::issue_token(std::optional<Token::RevocationListener> r
     alarm->reschedule_in(::timeout_ms);
 
     {
-        std::scoped_lock lock{mutex};
 
         revocation_alarms.emplace_back(std::move(alarm));
         issued_tokens.insert(token);


### PR DESCRIPTION
Fixes apps being activated even while typing.

To test:
1. Run miral-app
2. Open a terminal
3. Run `pluma &`
4. Run `sleep 2 && pluma`
5. Start typing on your keyboard

Without this fix, pluma manages to request an activation token and request activation with this token between keystrokes. This PR adds a small window (100 ms) after each keystroke where token creation is disabled.

Note: To properly test, the session check [here](
https://github.com/canonical/mir/pull/3727/files#diff-b445f58ec25aa464dc1b22558007b0ae65356f06b5e33c70288f3c68b0cc7000R243) should be removed. We're still discussing whether this check should be included or not as it doesn't make sense for unfocused applications to be able to request tokens and activate themselves, but we haven't seen any applications that behave as expected so far.