### PR TITLE
Make key repeat and delay configurable

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -492,6 +492,14 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::InputConfiguration::~InputConfiguration()@MIRAL_5.1" 5.1.0
  (c++)"miral::WindowManagerTools::move_cursor_to(mir::geometry::generic::Point<float>)@MIRAL_5.1" 5.1.0
  MIRAL_5.2@MIRAL_5.2 5.2.0
+ (c++)"miral::InputConfiguration::Keyboard::Keyboard()@MIRAL_5.2" 5.2.0
+ (c++)"miral::InputConfiguration::Keyboard::Keyboard(miral::InputConfiguration::Keyboard const&)@MIRAL_5.2" 5.2.0
+ (c++)"miral::InputConfiguration::Keyboard::operator=(miral::InputConfiguration::Keyboard)@MIRAL_5.2" 5.2.0
+ (c++)"miral::InputConfiguration::Keyboard::set_repeat_delay(int)@MIRAL_5.2" 5.2.0
+ (c++)"miral::InputConfiguration::Keyboard::set_repeat_rate(int)@MIRAL_5.2" 5.2.0
+ (c++)"miral::InputConfiguration::Keyboard::~Keyboard()@MIRAL_5.2" 5.2.0
+ (c++)"miral::InputConfiguration::keyboard()@MIRAL_5.2" 5.2.0
+ (c++)"miral::InputConfiguration::keyboard(miral::InputConfiguration::Keyboard const&)@MIRAL_5.2" 5.2.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, MirInputEventModifier, miral::FocusStealing)@MIRAL_5.0" 5.2.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, miral::FocusStealing)@MIRAL_5.0" 5.2.0
  (c++)"miral::WindowManagementPolicy::~WindowManagementPolicy()@MIRAL_5.0" 5.2.0

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -121,15 +121,15 @@ try
     miral::MirRunner runner{argc, argv, "mir/mir_demo_server.config"};
 
     miral::InputConfiguration input_configuration;
+    auto mouse = input_configuration.mouse();
+    auto touchpad = input_configuration.touchpad();
+    auto keyboard = input_configuration.keyboard();
 
     miral::ConfigFile test{runner, "mir_demo_server.input", miral::ConfigFile::Mode::reload_on_change,
-        [&input_configuration](auto& in, auto path)
+        [&](auto& in, auto path)
     {
         std::cout << "** Reloading: " << path << std::endl;
 
-        auto mouse = input_configuration.mouse();
-        auto touchpad = input_configuration.touchpad();
-        auto keyboard = input_configuration.keyboard();
 
         for (std::string line; std::getline(in, line);)
         {
@@ -189,6 +189,14 @@ try
         input_configuration.touchpad(touchpad);
         input_configuration.keyboard(keyboard);
     }};
+
+    runner.add_start_callback(
+        [&]
+        {
+            input_configuration.mouse(mouse);
+            input_configuration.touchpad(touchpad);
+            input_configuration.keyboard(keyboard);
+        });
 
     runner.set_exception_handler(exception_handler);
 

--- a/include/miral/miral/input_configuration.h
+++ b/include/miral/miral/input_configuration.h
@@ -40,11 +40,14 @@ public:
 
     class Mouse;
     class Touchpad;
+    class Keyboard;
 
     auto mouse() -> Mouse;
     void mouse(Mouse const& val);
     auto touchpad() -> Touchpad;
     void touchpad(Touchpad const& val);
+    auto keyboard() -> Keyboard;
+    void keyboard(Keyboard const& val);
 
 private:
     class Self;
@@ -114,6 +117,27 @@ public:
     void click_mode(std::optional<MirTouchpadClickMode>const& val);
     void scroll_mode(std::optional<MirTouchpadScrollMode>const& val);
     void tap_to_click(std::optional<bool>const& val);
+
+private:
+    friend class InputConfiguration::Self;
+    class Self;
+    std::shared_ptr<Self> self;
+};
+
+/** Input configuration for keyboard devices
+ * \remark Since MirAL 5.3
+ */
+class InputConfiguration::Keyboard
+{
+public:
+    Keyboard();
+    ~Keyboard();
+
+    Keyboard(Keyboard const& that);
+    auto operator=(Keyboard that) -> Keyboard&;
+
+    void set_repeat_rate(int new_rate);
+    void set_repeat_delay(int new_delay);
 
 private:
     friend class InputConfiguration::Self;

--- a/include/server/mir/shell/keyboard_helper.h
+++ b/include/server/mir/shell/keyboard_helper.h
@@ -17,6 +17,7 @@
 #ifndef MIR_SHELL_KEYBOARD_HELPER_
 #define MIR_SHELL_KEYBOARD_HELPER_
 
+#include <optional>
 namespace mir
 {
 namespace shell
@@ -25,7 +26,7 @@ class KeyboardHelper
 {
 public:
     virtual ~KeyboardHelper() = default;
-    virtual void repeat_info_changed(int rate, int delay) const = 0;
+    virtual void repeat_info_changed(std::optional<int> rate, int delay) const = 0;
 };
 }
 }

--- a/include/server/mir/shell/keyboard_helper.h
+++ b/include/server/mir/shell/keyboard_helper.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_SHELL_KEYBOARD_HELPER_
+#define MIR_SHELL_KEYBOARD_HELPER_
+
+namespace mir
+{
+namespace shell
+{
+class KeyboardHelper
+{
+public:
+    virtual ~KeyboardHelper() = default;
+    virtual void repeat_info_changed(int rate, int delay) const = 0;
+};
+}
+}
+
+#endif

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -64,6 +64,7 @@ class SurfaceStack;
 
 namespace shell
 {
+class AccessibilityManager;
 class DisplayConfigurationController;
 class InputTargeter;
 class FocusController;
@@ -281,6 +282,7 @@ public:
 
     virtual std::shared_ptr<shell::PersistentSurfaceStore> the_persistent_surface_store();
     virtual std::shared_ptr<shell::ShellReport>         the_shell_report();
+    virtual std::shared_ptr<shell::AccessibilityManager> the_accessibility_manager();
     /** @} */
 
     /** @name internal scene configuration
@@ -430,6 +432,7 @@ protected:
     CachedPtr<SharedLibraryProberReport> shared_library_prober_report;
     CachedPtr<shell::Shell> shell;
     CachedPtr<shell::ShellReport> shell_report;
+    CachedPtr<shell::AccessibilityManager> accessibility_manager;
     CachedPtr<shell::decoration::Manager> decoration_manager;
     CachedPtr<scene::ApplicationNotRespondingDetector> application_not_responding_detector;
     CachedPtr<cookie::Authority> cookie_authority;

--- a/src/include/server/mir/server.h
+++ b/src/include/server/mir/server.h
@@ -43,6 +43,7 @@ class SessionAuthorizer;
 }
 namespace shell
 {
+class AccessibilityManager;
 class DisplayLayout;
 class DisplayConfigurationController;
 class FocusController;
@@ -438,6 +439,9 @@ public:
 
     auto the_token_authority() const ->
         std::shared_ptr<shell::TokenAuthority>;
+
+    auto the_accessibility_manager() const ->
+        std::shared_ptr<shell::AccessibilityManager>;
 /** @} */
 
 /** @name Client side support

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -18,6 +18,7 @@
 #define MIR_SHELL_ACCESSIBILITY_MANAGER_H
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace mir
@@ -30,11 +31,12 @@ class AccessibilityManager
 public:
     void register_keyboard_helper(std::shared_ptr<shell::KeyboardHelper>);
 
-    int repeat_rate() const;
+    std::optional<int> repeat_rate() const;
     int repeat_delay() const;
 
     void repeat_rate(int new_rate);
     void repeat_delay(int new_rate);
+    void override_key_repeat_settings(bool enable);
 
     void notify_helpers() const;
 
@@ -44,6 +46,7 @@ private:
     // 25 rate and 600 delay are the default in Weston and Sway
     int repeat_rate_{25};
     int repeat_delay_{600};
+    bool enable_key_repeat{true};
 };
 }
 }

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_SHELL_ACCESSIBILITY_MANAGER_H
+#define MIR_SHELL_ACCESSIBILITY_MANAGER_H
+
+#include <memory>
+#include <vector>
+
+namespace mir
+{
+namespace shell
+{
+class KeyboardHelper;
+class AccessibilityManager
+{
+public:
+    void register_keyboard_helper(std::shared_ptr<shell::KeyboardHelper>);
+
+    int repeat_rate() const;
+    int repeat_delay() const;
+
+    void repeat_rate(int new_rate);
+    void repeat_delay(int new_rate);
+
+    void notify_helpers() const;
+
+private:
+    std::vector<std::shared_ptr<shell::KeyboardHelper>> keyboard_helpers;
+
+    // 25 rate and 600 delay are the default in Weston and Sway
+    int repeat_rate_{25};
+    int repeat_delay_{600};
+};
+}
+}
+
+#endif

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -29,7 +29,7 @@ class KeyboardHelper;
 class AccessibilityManager
 {
 public:
-    void register_keyboard_helper(std::shared_ptr<shell::KeyboardHelper>);
+    void register_keyboard_helper(std::shared_ptr<shell::KeyboardHelper> const&);
 
     std::optional<int> repeat_rate() const;
     int repeat_delay() const;

--- a/src/miral/input_device_config.cpp
+++ b/src/miral/input_device_config.cpp
@@ -322,6 +322,11 @@ auto miral::InputDeviceConfig::touchpad() const -> TouchpadInputConfiguration
     return touchpad_config;
 }
 
+auto miral::InputDeviceConfig::keyboard() const -> KeyboardInputConfiguration
+{
+    return keyboard_config;
+}
+
 void miral::InputDeviceConfig::mouse(MouseInputConfiguration const& val)
 {
     mouse_config = val;
@@ -330,6 +335,11 @@ void miral::InputDeviceConfig::mouse(MouseInputConfiguration const& val)
 void miral::InputDeviceConfig::touchpad(TouchpadInputConfiguration const& val)
 {
     touchpad_config = val;
+}
+
+void miral::InputDeviceConfig::keyboard(KeyboardInputConfiguration const& val)
+{
+    keyboard_config = val;
 }
 
 void miral::TouchpadInputConfiguration::apply_to(mi::Device& device) const

--- a/src/miral/input_device_config.h
+++ b/src/miral/input_device_config.h
@@ -54,6 +54,13 @@ public:
     std::optional<bool> middle_button_emulation;
 };
 
+class KeyboardInputConfiguration
+{
+public:
+    std::optional<int> repeat_rate;
+    std::optional<int> repeat_delay;
+};
+
 class InputDeviceConfig : public mir::input::InputDeviceObserver
 {
 public:
@@ -67,14 +74,17 @@ public:
 
     auto mouse() const -> MouseInputConfiguration;
     auto touchpad() const -> TouchpadInputConfiguration;
+    auto keyboard() const -> KeyboardInputConfiguration;
 
     void mouse(MouseInputConfiguration const& val);
     void touchpad(TouchpadInputConfiguration const& val);
+    void keyboard(KeyboardInputConfiguration const& val);
 private:
     explicit InputDeviceConfig(std::shared_ptr<mir::options::Option> const& options);
 
     MouseInputConfiguration mouse_config;
     TouchpadInputConfiguration touchpad_config;
+    KeyboardInputConfiguration keyboard_config;
 };
 
 }

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -506,3 +506,16 @@ global:
   };
 } MIRAL_5.0;
 
+MIRAL_5.2 {
+global:
+  extern "C++" {
+    miral::InputConfiguration::Keyboard::?Keyboard*;
+    miral::InputConfiguration::Keyboard::Keyboard*;
+    miral::InputConfiguration::Keyboard::config_changed*;
+    miral::InputConfiguration::Keyboard::operator*;
+    miral::InputConfiguration::Keyboard::set_repeat_delay*;
+    miral::InputConfiguration::Keyboard::set_repeat_rate*;
+    miral::InputConfiguration::keyboard*;
+    typeinfo?for?miral::InputConfiguration::Keyboard;
+  };
+} MIRAL_5.1;

--- a/src/server/frontend_wayland/input_method_grab_keyboard_v2.h
+++ b/src/server/frontend_wayland/input_method_grab_keyboard_v2.h
@@ -54,7 +54,7 @@ private:
     class Handler;
 
     std::shared_ptr<Handler> const handler;
-    std::unique_ptr<KeyboardHelper> const helper;
+    std::shared_ptr<KeyboardHelper> const helper;
     wayland::Weak<wayland::Client> wl_client;
 
     /// KeyboardImpl overrides

--- a/src/server/frontend_wayland/keyboard_helper.cpp
+++ b/src/server/frontend_wayland/keyboard_helper.cpp
@@ -33,7 +33,8 @@ mf::KeyboardHelper::KeyboardHelper(
     KeyboardCallbacks* callbacks,
     std::shared_ptr<mi::Keymap> const& initial_keymap,
     std::shared_ptr<input::Seat> const& seat,
-    bool enable_key_repeat)
+    int default_repeat_rate,
+    int default_repeat_delay)
     : callbacks{callbacks},
       mir_seat{seat},
       current_keymap{nullptr}, // will be set later in the constructor by set_keymap()
@@ -51,9 +52,7 @@ mf::KeyboardHelper::KeyboardHelper(
      */
     set_keymap(initial_keymap);
 
-    // 25 rate and 600 delay are the default in Weston and Sway
-    // At some point we will want to make this configurable
-    callbacks->send_repeat_info(enable_key_repeat ? 25 : 0, 600);
+    callbacks->send_repeat_info(default_repeat_rate, default_repeat_delay);
 }
 
 mf::KeyboardHelper::~KeyboardHelper() = default;

--- a/src/server/frontend_wayland/keyboard_helper.cpp
+++ b/src/server/frontend_wayland/keyboard_helper.cpp
@@ -33,7 +33,7 @@ mf::KeyboardHelper::KeyboardHelper(
     KeyboardCallbacks* callbacks,
     std::shared_ptr<mi::Keymap> const& initial_keymap,
     std::shared_ptr<input::Seat> const& seat,
-    int default_repeat_rate,
+    std::optional<int> default_repeat_rate,
     int default_repeat_delay)
     : callbacks{callbacks},
       mir_seat{seat},
@@ -52,7 +52,7 @@ mf::KeyboardHelper::KeyboardHelper(
      */
     set_keymap(initial_keymap);
 
-    callbacks->send_repeat_info(default_repeat_rate, default_repeat_delay);
+    repeat_info_changed(default_repeat_rate, default_repeat_delay);
 }
 
 mf::KeyboardHelper::~KeyboardHelper() = default;
@@ -103,9 +103,9 @@ void mf::KeyboardHelper::refresh_modifiers()
     set_modifiers(mir_seat->xkb_modifiers());
 }
 
-void mf::KeyboardHelper::repeat_info_changed(int rate, int delay) const
+void mf::KeyboardHelper::repeat_info_changed(std::optional<int> rate, int delay) const
 {
-    callbacks->send_repeat_info(rate, delay);
+    callbacks->send_repeat_info(rate.value_or(0), delay);
 }
 
 void mf::KeyboardHelper::handle_keyboard_event(std::shared_ptr<MirKeyboardEvent const> const& event)

--- a/src/server/frontend_wayland/keyboard_helper.cpp
+++ b/src/server/frontend_wayland/keyboard_helper.cpp
@@ -56,6 +56,8 @@ mf::KeyboardHelper::KeyboardHelper(
     callbacks->send_repeat_info(enable_key_repeat ? 25 : 0, 600);
 }
 
+mf::KeyboardHelper::~KeyboardHelper() = default;
+
 void mf::KeyboardHelper::handle_event(std::shared_ptr<MirEvent const> const& event)
 {
     switch (mir_input_event_get_type(mir_event_get_input_event(event.get())))
@@ -100,6 +102,11 @@ auto mf::KeyboardHelper::pressed_key_scancodes() const -> std::vector<uint32_t>
 void mf::KeyboardHelper::refresh_modifiers()
 {
     set_modifiers(mir_seat->xkb_modifiers());
+}
+
+void mf::KeyboardHelper::repeat_info_changed(int rate, int delay) const
+{
+    callbacks->send_repeat_info(rate, delay);
 }
 
 void mf::KeyboardHelper::handle_keyboard_event(std::shared_ptr<MirKeyboardEvent const> const& event)

--- a/src/server/frontend_wayland/keyboard_helper.h
+++ b/src/server/frontend_wayland/keyboard_helper.h
@@ -41,6 +41,7 @@ class Seat;
 
 namespace frontend
 {
+class WlSeat;
 class KeyboardCallbacks
 {
 public:
@@ -60,12 +61,6 @@ private:
 class KeyboardHelper
 {
 public:
-    KeyboardHelper(
-        KeyboardCallbacks* keybaord_impl,
-        std::shared_ptr<mir::input::Keymap> const& initial_keymap,
-        std::shared_ptr<input::Seat> const& seat,
-        bool enable_key_repeat);
-
     void handle_event(std::shared_ptr<MirEvent const> const& event);
 
     /// Returns the scancodes of pressed keys
@@ -74,6 +69,13 @@ public:
     void refresh_modifiers();
 
 private:
+    friend class mir::frontend::WlSeat;
+    KeyboardHelper(
+        KeyboardCallbacks* keybaord_impl,
+        std::shared_ptr<mir::input::Keymap> const& initial_keymap,
+        std::shared_ptr<input::Seat> const& seat,
+        bool enable_key_repeat);
+
     void handle_keyboard_event(std::shared_ptr<MirKeyboardEvent const> const& event);
     void set_keymap(std::shared_ptr<mir::input::Keymap> const& new_keymap);
     void set_modifiers(MirXkbModifiers const& new_modifiers);

--- a/src/server/frontend_wayland/keyboard_helper.h
+++ b/src/server/frontend_wayland/keyboard_helper.h
@@ -21,6 +21,7 @@
 #include "wayland_wrapper.h"
 #include "mir/events/xkb_modifiers.h"
 
+#include <optional>
 #include <vector>
 #include <functional>
 
@@ -75,7 +76,7 @@ public:
     /// Updates the modifiers from the seat
     void refresh_modifiers();
 
-    void repeat_info_changed(int rate, int delay) const override;
+    void repeat_info_changed(std::optional<int> rate, int delay) const override;
 
 private:
     friend class mir::frontend::WlSeat;
@@ -84,7 +85,7 @@ private:
         KeyboardCallbacks* keybaord_impl,
         std::shared_ptr<mir::input::Keymap> const& initial_keymap,
         std::shared_ptr<input::Seat> const& seat,
-        int default_repeat_rate,
+        std::optional<int> default_repeat_rate,
         int default_repeat_delay);
 
     void handle_keyboard_event(std::shared_ptr<MirKeyboardEvent const> const& event);

--- a/src/server/frontend_wayland/keyboard_helper.h
+++ b/src/server/frontend_wayland/keyboard_helper.h
@@ -39,6 +39,10 @@ namespace input
 class Keymap;
 class Seat;
 }
+namespace shell
+{
+class AccessibilityManager;
+}
 
 namespace frontend
 {
@@ -75,6 +79,7 @@ public:
 
 private:
     friend class mir::frontend::WlSeat;
+    friend class mir::shell::AccessibilityManager;
     KeyboardHelper(
         KeyboardCallbacks* keybaord_impl,
         std::shared_ptr<mir::input::Keymap> const& initial_keymap,

--- a/src/server/frontend_wayland/keyboard_helper.h
+++ b/src/server/frontend_wayland/keyboard_helper.h
@@ -17,6 +17,7 @@
 #ifndef MIR_FRONTEND_KEYBOARD_HELPER_H
 #define MIR_FRONTEND_KEYBOARD_HELPER_H
 
+#include "mir/shell/keyboard_helper.h"
 #include "wayland_wrapper.h"
 #include "mir/events/xkb_modifiers.h"
 
@@ -58,15 +59,19 @@ private:
     KeyboardCallbacks& operator=(KeyboardCallbacks const&) = delete;
 };
 
-class KeyboardHelper
+class KeyboardHelper : public mir::shell::KeyboardHelper
 {
 public:
+    ~KeyboardHelper() override;
+
     void handle_event(std::shared_ptr<MirEvent const> const& event);
 
     /// Returns the scancodes of pressed keys
     auto pressed_key_scancodes() const -> std::vector<uint32_t>;
     /// Updates the modifiers from the seat
     void refresh_modifiers();
+
+    void repeat_info_changed(int rate, int delay) const override;
 
 private:
     friend class mir::frontend::WlSeat;

--- a/src/server/frontend_wayland/keyboard_helper.h
+++ b/src/server/frontend_wayland/keyboard_helper.h
@@ -84,7 +84,8 @@ private:
         KeyboardCallbacks* keybaord_impl,
         std::shared_ptr<mir::input::Keymap> const& initial_keymap,
         std::shared_ptr<input::Seat> const& seat,
-        bool enable_key_repeat);
+        int default_repeat_rate,
+        int default_repeat_delay);
 
     void handle_keyboard_event(std::shared_ptr<MirKeyboardEvent const> const& event);
     void set_keymap(std::shared_ptr<mir::input::Keymap> const& new_keymap);

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -241,7 +241,7 @@ mf::WaylandConnector::WaylandConnector(
     bool arw_socket,
     std::unique_ptr<WaylandExtensions> extensions_,
     WaylandProtocolExtensionFilter const& extension_filter,
-    bool enable_key_repeat,
+    std::shared_ptr<shell::AccessibilityManager> const& accessibility_manager,
     std::shared_ptr<scene::SessionLock> const& session_lock,
     std::shared_ptr<mir::DecorationStrategy> const& decoration_strategy,
     std::shared_ptr<scene::SessionCoordinator> const& session_coordinator,
@@ -297,7 +297,7 @@ mf::WaylandConnector::WaylandConnector(
         input_hub,
         keyboard_observer_registrar,
         seat,
-        enable_key_repeat);
+        accessibility_manager);
     output_manager = std::make_unique<mf::OutputManager>(
         display.get(),
         executor,

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -60,6 +60,7 @@ class DisplayConfigurationObserver;
 namespace shell
 {
 class Shell;
+class AccessibilityManager;
 }
 namespace scene
 {
@@ -168,7 +169,7 @@ public:
         bool arw_socket,
         std::unique_ptr<WaylandExtensions> extensions,
         WaylandProtocolExtensionFilter const& extension_filter,
-        bool enable_key_repeat,
+        std::shared_ptr<shell::AccessibilityManager> const& accessibility_manager,
         std::shared_ptr<scene::SessionLock> const& session_lock,
         std::shared_ptr<DecorationStrategy> const& decoration_strategy,
         std::shared_ptr<scene::SessionCoordinator> const& session_coordinator,

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -366,7 +366,8 @@ std::shared_ptr<mf::Connector>
                 enabled_wayland_extensions.begin(),
                 enabled_wayland_extensions.end()};
 
-            auto const enable_repeat = options->get<bool>(options::enable_key_repeat_opt);
+            // TODO pass this to the accessibility manager
+            /* auto const enable_repeat = options->get<bool>(options::enable_key_repeat_opt); */
             auto const x11_enabled = options->is_set(mo::x11_display_opt) && options->get<bool>(mo::x11_display_opt);
 
             return std::make_shared<mf::WaylandConnector>(
@@ -395,7 +396,7 @@ std::shared_ptr<mf::Connector>
                     x11_enabled,
                     wayland_extension_hooks),
                 wayland_extension_filter,
-                enable_repeat,
+                the_accessibility_manager(),
                 the_session_lock(),
                 the_decoration_strategy(),
                 the_session_coordinator(),

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -29,6 +29,7 @@
 #include "input_method_v1.h"
 #include "input_method_v2.h"
 #include "layer_shell_v1.h"
+#include "mir/shell/accessibility_manager.h"
 #include "mir_shell.h"
 #include "pointer_constraints_unstable_v1.h"
 #include "primary_selection_v1.h"
@@ -366,8 +367,9 @@ std::shared_ptr<mf::Connector>
                 enabled_wayland_extensions.begin(),
                 enabled_wayland_extensions.end()};
 
-            // TODO pass this to the accessibility manager
-            /* auto const enable_repeat = options->get<bool>(options::enable_key_repeat_opt); */
+            auto const enable_repeat = options->get<bool>(options::enable_key_repeat_opt);
+            the_accessibility_manager()->override_key_repeat_settings(enable_repeat);
+
             auto const x11_enabled = options->is_set(mo::x11_display_opt) && options->get<bool>(mo::x11_display_opt);
 
             return std::make_shared<mf::WaylandConnector>(

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -44,7 +44,7 @@ public:
     void focus_on(WlSurface* surface);
 
 private:
-    std::unique_ptr<KeyboardHelper> const helper;
+    std::shared_ptr<KeyboardHelper> const helper;
     wayland::Weak<WlSurface> focused_surface;
 
     /// KeyboardCallbacks overrides

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -35,6 +35,7 @@
 #include "mir/input/mir_keyboard_config.h"
 #include "mir/input/keyboard_observer.h"
 #include "mir/scene/surface.h"
+#include "mir/shell/accessibility_manager.h"
 #include "mir_toolkit/events/input/pointer_event.h"
 
 #include <mutex>
@@ -194,7 +195,7 @@ mf::WlSeat::WlSeat(
     std::shared_ptr<mi::InputDeviceHub> const& input_hub,
     std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const& keyboard_observer_registrar,
     std::shared_ptr<mi::Seat> const& seat,
-    bool enable_key_repeat)
+    std::shared_ptr<shell::AccessibilityManager> const& accessibility_manager)
     :   Global(display, Version<8>()),
         keymap{std::make_shared<input::ParameterKeymap>()},
         config_observer{
@@ -213,7 +214,7 @@ mf::WlSeat::WlSeat(
         clock{clock},
         input_hub{input_hub},
         seat{seat},
-        enable_key_repeat{enable_key_repeat}
+        accessibility_manager{accessibility_manager}
 {
     input_hub->add_observer(config_observer);
     keyboard_observer_registrar->register_interest(keyboard_observer, wayland_executor);
@@ -252,7 +253,10 @@ void mf::WlSeat::for_each_listener(mw::Client* client, std::function<void(WlTouc
 
 auto mf::WlSeat::make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::shared_ptr<KeyboardHelper>
 {
-    auto const keyboard_helper = std::shared_ptr<KeyboardHelper>(new KeyboardHelper(callbacks, keymap, seat, enable_key_repeat));
+    auto const default_repeat_rate = accessibility_manager->repeat_rate();
+    auto const default_repeat_delay = accessibility_manager->repeat_delay();
+    auto const keyboard_helper = std::shared_ptr<KeyboardHelper>(new KeyboardHelper(callbacks, keymap, seat, default_repeat_rate, default_repeat_delay));
+    accessibility_manager->register_keyboard_helper(keyboard_helper);
     return keyboard_helper;
 }
 

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -250,9 +250,10 @@ void mf::WlSeat::for_each_listener(mw::Client* client, std::function<void(WlTouc
     touch_listeners->for_each(client, func);
 }
 
-auto mf::WlSeat::make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::unique_ptr<KeyboardHelper>
+auto mf::WlSeat::make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::shared_ptr<KeyboardHelper>
 {
-    return std::unique_ptr<KeyboardHelper>(new KeyboardHelper(callbacks, keymap, seat, enable_key_repeat));
+    auto const keyboard_helper = std::shared_ptr<KeyboardHelper>(new KeyboardHelper(callbacks, keymap, seat, enable_key_repeat));
+    return keyboard_helper;
 }
 
 void mf::WlSeat::bind(wl_resource* new_wl_seat)

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -252,7 +252,7 @@ void mf::WlSeat::for_each_listener(mw::Client* client, std::function<void(WlTouc
 
 auto mf::WlSeat::make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::unique_ptr<KeyboardHelper>
 {
-    return std::make_unique<KeyboardHelper>(callbacks, keymap, seat, enable_key_repeat);
+    return std::unique_ptr<KeyboardHelper>(new KeyboardHelper(callbacks, keymap, seat, enable_key_repeat));
 }
 
 void mf::WlSeat::bind(wl_resource* new_wl_seat)

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -253,7 +253,10 @@ void mf::WlSeat::for_each_listener(mw::Client* client, std::function<void(WlTouc
 
 auto mf::WlSeat::make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::shared_ptr<KeyboardHelper>
 {
-    auto const default_repeat_rate = accessibility_manager->repeat_rate();
+    // https://wayland.app/protocols/wayland#wl_keyboard:event:repeat_info
+    // " A rate of zero will disable any repeating (regardless of the value of
+    // delay)."
+    auto const default_repeat_rate = accessibility_manager->repeat_rate().value_or(0);
     auto const default_repeat_delay = accessibility_manager->repeat_delay();
     auto const keyboard_helper = std::shared_ptr<KeyboardHelper>(new KeyboardHelper(callbacks, keymap, seat, default_repeat_rate, default_repeat_delay));
     accessibility_manager->register_keyboard_helper(keyboard_helper);

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -256,7 +256,7 @@ auto mf::WlSeat::make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::shar
     // https://wayland.app/protocols/wayland#wl_keyboard:event:repeat_info
     // " A rate of zero will disable any repeating (regardless of the value of
     // delay)."
-    auto const default_repeat_rate = accessibility_manager->repeat_rate().value_or(0);
+    auto const default_repeat_rate = accessibility_manager->repeat_rate();
     auto const default_repeat_delay = accessibility_manager->repeat_delay();
     auto const keyboard_helper = std::shared_ptr<KeyboardHelper>(new KeyboardHelper(callbacks, keymap, seat, default_repeat_rate, default_repeat_delay));
     accessibility_manager->register_keyboard_helper(keyboard_helper);

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -36,6 +36,10 @@ class Seat;
 class Keymap;
 class KeyboardObserver;
 }
+namespace shell
+{
+class AccessibilityManager;
+}
 namespace time
 {
 class Clock;
@@ -74,7 +78,7 @@ public:
         std::shared_ptr<mir::input::InputDeviceHub> const& input_hub,
         std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const& keyboard_observer_registrar,
         std::shared_ptr<mir::input::Seat> const& seat,
-        bool enable_key_repeat);
+        std::shared_ptr<shell::AccessibilityManager> const& accessibility_manager);
 
     ~WlSeat();
 
@@ -131,7 +135,8 @@ private:
     std::shared_ptr<time::Clock> const clock;
     std::shared_ptr<input::InputDeviceHub> const input_hub;
     std::shared_ptr<input::Seat> const seat;
-    bool const enable_key_repeat;
+
+    std::shared_ptr<shell::AccessibilityManager> const accessibility_manager;
 
     void bind(wl_resource* new_wl_seat) override;
 };

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -20,8 +20,6 @@
 #include "wayland_wrapper.h"
 #include "mir/wayland/weak.h"
 
-#include <unordered_map>
-#include <vector>
 #include <functional>
 
 struct MirPointerEvent;
@@ -99,7 +97,7 @@ public:
         FocusListener& operator=(FocusListener const&) = delete;
     };
 
-    auto make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::unique_ptr<KeyboardHelper>;
+    auto make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::shared_ptr<KeyboardHelper>;
 
     /// Adds the listener for future use, and makes a call into it to inform of initial state
     void add_focus_listener(wayland::Client* client, FocusListener* listener);

--- a/src/server/report/default_server_configuration.cpp
+++ b/src/server/report/default_server_configuration.cpp
@@ -112,4 +112,3 @@ auto mir::DefaultServerConfiguration::the_shell_report() -> std::shared_ptr<shel
             return report_factory(options::shell_report_opt)->create_shell_report();
         });
 }
-

--- a/src/server/report/default_server_configuration.cpp
+++ b/src/server/report/default_server_configuration.cpp
@@ -112,3 +112,4 @@ auto mir::DefaultServerConfiguration::the_shell_report() -> std::shared_ptr<shel
             return report_factory(options::shell_report_opt)->create_shell_report();
         });
 }
+

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -134,7 +134,8 @@ struct TemporaryCompositeEventFilter : public mi::CompositeEventFilter
     MACRO(the_decoration_strategy)\
     MACRO(the_input_device_registry)\
     MACRO(the_idle_handler)\
-    MACRO(the_token_authority)
+    MACRO(the_token_authority)\
+    MACRO(the_accessibility_manager)
 
 #define MIR_SERVER_BUILDER(name)\
     std::function<std::invoke_result_t<decltype(&mir::DefaultServerConfiguration::the_##name),mir::DefaultServerConfiguration*>()> name##_builder;

--- a/src/server/shell/CMakeLists.txt
+++ b/src/server/shell/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
   surface_stack_wrapper.cpp ${CMAKE_SOURCE_DIR}/src/include/server/mir/shell/surface_stack_wrapper.h
   basic_idle_handler.cpp ${CMAKE_SOURCE_DIR}/src/include/server/mir/shell/idle_handler.h
   token_authority.cpp ${CMAKE_SOURCE_DIR}/src/include/server/mir/shell/token_authority.h
+  accessibility_manager.cpp ${CMAKE_SOURCE_DIR}/src/include/server/mir/shell/accessibility_manager.h
 )
 
 add_library(

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/shell/accessibility_manager.h"
+#include "mir/shell/keyboard_helper.h"
+
+void mir::shell::AccessibilityManager::register_keyboard_helper(std::shared_ptr<KeyboardHelper> helper)
+{
+    keyboard_helpers.push_back(helper);
+}
+
+int mir::shell::AccessibilityManager::repeat_rate() const {
+    return repeat_rate_;
+}
+
+int mir::shell::AccessibilityManager::repeat_delay() const {
+    return repeat_delay_;
+}
+
+void mir::shell::AccessibilityManager::repeat_rate(int new_rate) {
+    repeat_rate_ = new_rate;
+}
+
+void mir::shell::AccessibilityManager::repeat_delay(int new_delay) {
+    repeat_delay_ = new_delay;
+}
+
+void mir::shell::AccessibilityManager::notify_helpers() const {
+    for(auto const& helper: keyboard_helpers)
+        helper->repeat_info_changed(repeat_rate_, repeat_delay_);
+}

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -19,7 +19,7 @@
 
 #include <optional>
 
-void mir::shell::AccessibilityManager::register_keyboard_helper(std::shared_ptr<KeyboardHelper> helper)
+void mir::shell::AccessibilityManager::register_keyboard_helper(std::shared_ptr<KeyboardHelper> const& helper)
 {
     keyboard_helpers.push_back(helper);
 }

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -17,12 +17,16 @@
 #include "mir/shell/accessibility_manager.h"
 #include "mir/shell/keyboard_helper.h"
 
+#include <optional>
+
 void mir::shell::AccessibilityManager::register_keyboard_helper(std::shared_ptr<KeyboardHelper> helper)
 {
     keyboard_helpers.push_back(helper);
 }
 
-int mir::shell::AccessibilityManager::repeat_rate() const {
+std::optional<int> mir::shell::AccessibilityManager::repeat_rate() const {
+    if(!enable_key_repeat)
+        return {};
     return repeat_rate_;
 }
 
@@ -36,6 +40,11 @@ void mir::shell::AccessibilityManager::repeat_rate(int new_rate) {
 
 void mir::shell::AccessibilityManager::repeat_delay(int new_delay) {
     repeat_delay_ = new_delay;
+}
+
+void mir::shell::AccessibilityManager::override_key_repeat_settings(bool enable)
+{
+    enable_key_repeat = enable;
 }
 
 void mir::shell::AccessibilityManager::notify_helpers() const {

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -49,5 +49,5 @@ void mir::shell::AccessibilityManager::override_key_repeat_settings(bool enable)
 
 void mir::shell::AccessibilityManager::notify_helpers() const {
     for(auto const& helper: keyboard_helpers)
-        helper->repeat_info_changed(repeat_rate_, repeat_delay_);
+        helper->repeat_info_changed(repeat_rate(), repeat_delay());
 }

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -14,20 +14,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <mir/shell/system_compositor_window_manager.h>
-#include <mir/main_loop.h>
 #include "mir/default_server_configuration.h"
-#include "mir/abnormal_exit.h"
 
-#include "mir/input/composite_event_filter.h"
-#include "mir/shell/abstract_shell.h"
-#include "mir/options/configuration.h"
-#include "mir/options/option.h"
+#include "basic_idle_handler.h"
+#include "decoration/basic_decoration.h"
+#include "decoration/basic_manager.h"
 #include "default_persistent_surface_store.h"
 #include "graphics_display_layout.h"
-#include "decoration/basic_manager.h"
-#include "decoration/basic_decoration.h"
-#include "basic_idle_handler.h"
+
+#include "mir/abnormal_exit.h"
+#include "mir/input/composite_event_filter.h"
+#include "mir/main_loop.h"
+#include "mir/options/configuration.h"
+#include "mir/options/option.h"
+#include "mir/shell/abstract_shell.h"
+#include "mir/shell/accessibility_manager.h"
+#include "mir/shell/system_compositor_window_manager.h"
 #include "mir/shell/token_authority.h"
 
 namespace ms = mir::scene;
@@ -182,3 +184,13 @@ mir::DefaultServerConfiguration::the_shell_display_layout()
             return std::make_shared<msh::GraphicsDisplayLayout>(the_display());
         });
 }
+
+auto mir::DefaultServerConfiguration::the_accessibility_manager() -> std::shared_ptr<shell::AccessibilityManager>
+{
+    return accessibility_manager(
+        []
+        {
+            return std::make_shared<shell::AccessibilityManager>();
+        });
+}
+

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -19,6 +19,7 @@ global:
     mir::DefaultServerConfiguration::set_enabled_wayland_extensions*;
     mir::DefaultServerConfiguration::set_the_decoration_strategy*;
     mir::DefaultServerConfiguration::set_wayland_extension_filter*;
+    mir::DefaultServerConfiguration::the_accessibility_manager*;
     mir::DefaultServerConfiguration::the_application_not_responding_detector*;
     mir::DefaultServerConfiguration::the_buffer_allocator*;
     mir::DefaultServerConfiguration::the_clock*;
@@ -190,6 +191,7 @@ global:
     mir::Server::set_wayland_extension_filter*;
     mir::Server::stop*;
     mir::Server::supported_pixel_formats*;
+    mir::Server::the_accessibility_manager*;
     mir::Server::the_application_not_responding_detector*;
     mir::Server::the_composite_event_filter*;
     mir::Server::the_compositor*;
@@ -621,6 +623,10 @@ global:
     mir::shell::AbstractShell::surface_at*;
     mir::shell::AbstractShell::surface_ready*;
     mir::shell::AbstractShell::swap_z_order*;
+    mir::shell::AccessibilityManager::notify_helpers*;
+    mir::shell::AccessibilityManager::register_keyboard_helper*;
+    mir::shell::AccessibilityManager::repeat_delay*;
+    mir::shell::AccessibilityManager::repeat_rate*;
     mir::shell::DefaultWindowManager::handle_keyboard_event*;
     mir::shell::DisplayConfigurationController::?DisplayConfigurationController*;
     mir::shell::DisplayConfigurationController::DisplayConfigurationController*;
@@ -710,6 +716,7 @@ global:
     non-virtual?thunk?to?mir::DefaultServerConfiguration::set_enabled_wayland_extensions*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::set_the_decoration_strategy*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::set_wayland_extension_filter*;
+    non-virtual?thunk?to?mir::DefaultServerConfiguration::the_accessibility_manager*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_application_not_responding_detector*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_buffer_allocator*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_clock*;
@@ -1194,6 +1201,7 @@ global:
     typeinfo?for?mir::scene::TextInputState;
     typeinfo?for?mir::scene::TextInputStateObserver;
     typeinfo?for?mir::shell::AbstractShell;
+    typeinfo?for?mir::shell::AccessibilityManager;
     typeinfo?for?mir::shell::DefaultWindowManager;
     typeinfo?for?mir::shell::DisplayConfigurationController;
     typeinfo?for?mir::shell::DisplayLayout;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -624,6 +624,7 @@ global:
     mir::shell::AbstractShell::surface_ready*;
     mir::shell::AbstractShell::swap_z_order*;
     mir::shell::AccessibilityManager::notify_helpers*;
+    mir::shell::AccessibilityManager::override_key_repeat_settings*;
     mir::shell::AccessibilityManager::register_keyboard_helper*;
     mir::shell::AccessibilityManager::repeat_delay*;
     mir::shell::AccessibilityManager::repeat_rate*;


### PR DESCRIPTION
How to test:
- Create a file at `~/.config/mir_demo_server.input` with the following content:
```
repeat_rate=25
repeat_delay=600
```
- Run mir demo server
- Run a wayland compatible text editor or terminal (`kgx`), or and X application (`xterm`)
- press and hold any key
- Change `repeat_rate` to a higher or lower value and watch as the repeat rate speeds or slows down
- Change `repeat_delay` to a higher or lower value and watch as the duration you need to hold the key down increases or decreases.