### PR TITLE
Extend the lifetime of the accessibility manager to keep enable-key-repeat

### DIFF
--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -142,8 +142,8 @@ private:
     miral::InputConfiguration::Mouse mouse = input_configuration.mouse();
     miral::InputConfiguration::Touchpad touchpad = input_configuration.touchpad();
     miral::InputConfiguration::Keyboard keyboard = input_configuration.keyboard();
-    miral::ConfigFile config_file;
     std::mutex config_mutex;
+    miral::ConfigFile config_file;
 
     void apply_config()
     {

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -367,8 +367,9 @@ std::shared_ptr<mf::Connector>
                 enabled_wayland_extensions.begin(),
                 enabled_wayland_extensions.end()};
 
+            auto accessibility_manager = the_accessibility_manager();
             auto const enable_repeat = options->get<bool>(options::enable_key_repeat_opt);
-            the_accessibility_manager()->override_key_repeat_settings(enable_repeat);
+            accessibility_manager->override_key_repeat_settings(enable_repeat);
 
             auto const x11_enabled = options->is_set(mo::x11_display_opt) && options->get<bool>(mo::x11_display_opt);
 
@@ -398,7 +399,7 @@ std::shared_ptr<mf::Connector>
                     x11_enabled,
                     wayland_extension_hooks),
                 wayland_extension_filter,
-                the_accessibility_manager(),
+                accessibility_manager,
                 the_session_lock(),
                 the_decoration_strategy(),
                 the_session_coordinator(),


### PR DESCRIPTION
closes #3743 