### PR TITLE
(#3729) disconnected display outputs do not show up in DisplaySink::for_each_display_sink

### DIFF
--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -146,6 +146,14 @@ bool mgg::DisplaySink::overlay(std::vector<DisplayElement> const& renderable_lis
 
 void mgg::DisplaySink::for_each_display_sink(std::function<void(graphics::DisplaySink&)> const& f)
 {
+    // When an output is disconnected, its sink will have a size of 0x0.
+    // This may cause us to allocate a buffer of zero size, which leads
+    // to all sorts of problems (e.g. an error during eglSwapBuffers
+    // because the back buffer is empty). To avoid this, we don't iterate
+    // over display sinks that refer to disconnected outputs.
+    if (!outputs.front()->connected())
+        return;
+
     f(*this);
 }
 

--- a/src/platforms/gbm-kms/server/kms/kms_output.h
+++ b/src/platforms/gbm-kms/server/kms/kms_output.h
@@ -96,6 +96,9 @@ public:
     virtual void update_from_hardware_state(DisplayConfigurationOutput& to_update) const = 0;
 
     virtual int drm_fd() const = 0;
+
+    /// Returns true if the connector is connected, otherwise false.
+    virtual bool connected() const = 0;
 protected:
     KMSOutput() = default;
     KMSOutput(const KMSOutput&) = delete;

--- a/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
+++ b/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
@@ -612,3 +612,9 @@ int mgg::RealKMSOutput::drm_fd() const
 {
     return drm_fd_;
 }
+
+bool mgg::RealKMSOutput::connected() const
+{
+    return connector->connection == DRM_MODE_CONNECTED;
+}
+

--- a/src/platforms/gbm-kms/server/kms/real_kms_output.h
+++ b/src/platforms/gbm-kms/server/kms/real_kms_output.h
@@ -66,6 +66,7 @@ public:
     void update_from_hardware_state(DisplayConfigurationOutput& output) const override;
 
     int drm_fd() const override;
+    bool connected() const override;
 
 private:
     bool ensure_crtc();

--- a/tests/unit-tests/platforms/gbm-kms/kms/mock_kms_output.h
+++ b/tests/unit-tests/platforms/gbm-kms/kms/mock_kms_output.h
@@ -67,6 +67,7 @@ struct MockKMSOutput : public graphics::gbm::KMSOutput
     MOCK_CONST_METHOD1(fb_for, std::shared_ptr<graphics::FBHandle const>(graphics::DMABufBuffer const&));
     MOCK_CONST_METHOD1(buffer_requires_migration, bool(gbm_bo*));
     MOCK_CONST_METHOD0(drm_fd, int());
+    MOCK_CONST_METHOD0(connected, bool());
 };
 
 } // namespace test


### PR DESCRIPTION
fixes #3729 

## What's the problem? 
If a display sink is associated with a disconnected output, `mgg::RealKMSOutput::size()` returns a 0-size. This size is then used to size a buffer, which causes `eglSwapBuffers` to be upset.

## What's the fix?
If this `DisplaySink` references a disconnected output, we shouldn't include it when we're iterating over the list of sinks, as it will assuredly lead to the allocation of a 0-sized buffer.

## As a side note...
The atomic kms platform does not suffer from the same issue as the non-atomic platform, so I have not made changes there.