### PR TITLE
Introduce `InputEventTransformer` to read and synthesize input events

### DIFF
--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -42,6 +42,7 @@ extern char const* const fatal_except_opt;
 extern char const* const debug_opt;
 extern char const* const composite_delay_opt;
 extern char const* const enable_key_repeat_opt;
+extern char const* const enable_mouse_keys_opt;
 extern char const* const x11_display_opt;
 extern char const* const x11_scale_opt;
 extern char const* const wayland_extensions_opt;

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -124,6 +124,7 @@ class CursorImages;
 class Seat;
 class KeyMapper;
 class LedObserverRegistrar;
+class InputEventTransformer;
 namespace receiver
 {
 class XKBMapperRegistrar;
@@ -317,6 +318,7 @@ public:
     virtual std::shared_ptr<input::CompositeEventFilter> the_composite_event_filter();
 
     virtual std::shared_ptr<input::EventFilterChainDispatcher> the_event_filter_chain_dispatcher();
+    virtual std::shared_ptr<input::InputEventTransformer> the_input_event_transformer();
 
     virtual std::shared_ptr<shell::InputTargeter> the_input_targeter();
     virtual std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> the_keyboard_observer_registrar();
@@ -379,6 +381,7 @@ protected:
 
     CachedPtr<input::InputReport> input_report;
     CachedPtr<input::EventFilterChainDispatcher> event_filter_chain_dispatcher;
+    CachedPtr<input::InputEventTransformer> input_event_transformer;
     CachedPtr<input::CompositeEventFilter> composite_event_filter;
     CachedPtr<input::InputManager>    input_manager;
     CachedPtr<input::SurfaceInputDispatcher>    surface_input_dispatcher;

--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -36,17 +36,13 @@ class EventBuilder;
 class InputEventTransformer : public EventFilter
 {
 public:
-    struct EventDispatcher
+    class EventDispatcher
     {
+    public:
         EventDispatcher(
             std::shared_ptr<MainLoop> const main_loop,
             input::InputSink* const sink,
-            input::EventBuilder* const builder) :
-            main_loop{main_loop},
-            sink{sink},
-            builder{builder}
-        {
-        }
+            input::EventBuilder* const builder);
 
         void dispatch_key_event(
             std::optional<std::chrono::nanoseconds> timestamp,
@@ -72,8 +68,9 @@ public:
         input::EventBuilder* const builder;
     };
 
-    struct Transformer
+    class Transformer
     {
+    public:
         virtual ~Transformer() = default;
 
         // Returning true means that the event has been successfully processed and
@@ -89,7 +86,6 @@ public:
     bool handle(MirEvent const&) override;
 
     void append(std::weak_ptr<Transformer> const&);
-    void prepend(std::weak_ptr<Transformer> const&);
 
 private:
     void lazily_init_virtual_input_device();

--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -19,8 +19,10 @@
 
 #include "mir/input/event_filter.h"
 #include "mir/input/event_builder.h"
+#include "mir_toolkit/events/event.h"
 
 #include <chrono>
+#include <functional>
 #include <mutex>
 #include <vector>
 #include <memory>
@@ -37,47 +39,7 @@ class EventBuilder;
 class InputEventTransformer : public EventFilter
 {
 public:
-    class EventDispatcher
-    {
-    public:
-        EventDispatcher(
-            std::shared_ptr<MainLoop> const main_loop,
-            input::InputSink* const sink,
-            input::EventBuilder* const builder);
-
-        void dispatch_key_event(
-            std::optional<std::chrono::nanoseconds> timestamp,
-            MirKeyboardAction action,
-            xkb_keysym_t keysym,
-            int scan_code);
-
-        void dispatch_pointer_event(
-            std::optional<std::chrono::nanoseconds> timestamp,
-            MirPointerAction action,
-            MirPointerButtons buttons,
-            std::optional<mir::geometry::PointF> position,
-            mir::geometry::DisplacementF motion,
-            MirPointerAxisSource axis_source,
-            events::ScrollAxisH h_scroll,
-            events::ScrollAxisV v_scroll);
-
-        void maybe_update(InputSink* maybe_new_sink, EventBuilder* maybe_new_builder);
-
-    private:
-        void dispatch(mir::EventUPtr e);
-
-        std::shared_ptr<MainLoop> const main_loop;
-
-        // Since dispatchers are handed down to transformers which might keep a
-        // reference to them, then we should be careful to not change the
-        // builder as they dispatch an event.
-        std::mutex mutex;
-
-        // Sinks and/or builders are not constant for one virtual device.
-        input::InputSink* sink;
-        input::EventBuilder* builder;
-    };
-
+    using EventDispatcher = std::function<void(std::shared_ptr<MirEvent>)>;
     class Transformer
     {
     public:
@@ -87,7 +49,7 @@ public:
         // shouldn't be handled by later transformers, whether the transformer is
         // accumulating events for later dispatching or has immediately dispatched
         // an event is an implementation detail of the transformer
-        virtual bool transform_input_event(std::shared_ptr<EventDispatcher> const& dispatcher,  MirEvent const&) = 0;
+        virtual bool transform_input_event(EventDispatcher const& dispatcher, EventBuilder*,  MirEvent const&) = 0;
     };
 
     InputEventTransformer(std::shared_ptr<InputDeviceRegistry> const&, std::shared_ptr<MainLoop> const&);
@@ -98,12 +60,10 @@ public:
     void append(std::weak_ptr<Transformer> const&);
 
 private:
-
     std::mutex mutex;
     std::vector<std::weak_ptr<Transformer>> input_transformers;
-    std::shared_ptr<input::VirtualInputDevice> virtual_pointer;
-    std::shared_ptr<EventDispatcher> dispatcher;
 
+    std::shared_ptr<input::VirtualInputDevice> const virtual_pointer;
     std::shared_ptr<input::InputDeviceRegistry> const input_device_registry;
     std::shared_ptr<MainLoop> const main_loop;
 };

--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_INPUT_INPUT_EVENT_TRANSFORMER_H_
+#define MIR_INPUT_INPUT_EVENT_TRANSFORMER_H_
+
+#include "mir/input/event_filter.h"
+#include "mir/input/event_builder.h"
+
+#include <chrono>
+#include <vector>
+#include <memory>
+
+namespace mir
+{
+class MainLoop;
+namespace input
+{
+class VirtualInputDevice;
+class InputDeviceRegistry;
+class InputSink;
+class EventBuilder;
+class InputEventTransformer : public EventFilter
+{
+public:
+    struct EventDispatcher
+    {
+        EventDispatcher(
+            std::shared_ptr<MainLoop> const main_loop,
+            input::InputSink* const sink,
+            input::EventBuilder* const builder) :
+            main_loop{main_loop},
+            sink{sink},
+            builder{builder}
+        {
+        }
+
+        void dispatch_key_event(
+            std::optional<std::chrono::nanoseconds> timestamp,
+            MirKeyboardAction action,
+            xkb_keysym_t keysym,
+            int scan_code);
+
+        void dispatch_pointer_event(
+            std::optional<std::chrono::nanoseconds> timestamp,
+            MirPointerAction action,
+            MirPointerButtons buttons,
+            std::optional<mir::geometry::PointF> position,
+            mir::geometry::DisplacementF motion,
+            MirPointerAxisSource axis_source,
+            events::ScrollAxisH h_scroll,
+            events::ScrollAxisV v_scroll);
+
+    private:
+        void dispatch(mir::EventUPtr e);
+
+        std::shared_ptr<MainLoop> const main_loop;
+        input::InputSink* const sink;
+        input::EventBuilder* const builder;
+    };
+
+    struct Transformer
+    {
+        virtual ~Transformer() = default;
+
+        // Returning true means that the event has been successfully processed and
+        // shouldn't be handled by later transformers, whether the transformer is
+        // accumulating events for later dispatching or has immediately dispatched
+        // an event is an implementation detail of the transformer
+        virtual bool transform_input_event(std::shared_ptr<EventDispatcher> const& dispatcher,  MirEvent const&) = 0;
+    };
+
+    InputEventTransformer(std::shared_ptr<InputDeviceRegistry> const&, std::shared_ptr<MainLoop> const&);
+    ~InputEventTransformer();
+
+    bool handle(MirEvent const&) override;
+
+    void append(std::weak_ptr<Transformer> const&);
+    void prepend(std::weak_ptr<Transformer> const&);
+
+private:
+    void lazily_init_virtual_input_device();
+
+    std::mutex mutex;
+    std::vector<std::weak_ptr<Transformer>> input_transformers;
+    std::shared_ptr<input::VirtualInputDevice> virtual_pointer;
+    std::shared_ptr<EventDispatcher> dispatcher;
+
+    std::shared_ptr<input::InputDeviceRegistry> const input_device_registry;
+    std::shared_ptr<MainLoop> const main_loop;
+};
+}
+}
+
+#endif

--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -88,7 +88,6 @@ public:
     void append(std::weak_ptr<Transformer> const&);
 
 private:
-    void lazily_init_virtual_input_device();
 
     std::mutex mutex;
     std::vector<std::weak_ptr<Transformer>> input_transformers;

--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -58,6 +58,7 @@ public:
     bool handle(MirEvent const&) override;
 
     void append(std::weak_ptr<Transformer> const&);
+    bool remove(std::shared_ptr<Transformer> const&);
 
 private:
     std::mutex mutex;

--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -21,6 +21,7 @@
 #include "mir/input/event_builder.h"
 
 #include <chrono>
+#include <mutex>
 #include <vector>
 #include <memory>
 
@@ -60,12 +61,21 @@ public:
             events::ScrollAxisH h_scroll,
             events::ScrollAxisV v_scroll);
 
+        void maybe_update(InputSink* maybe_new_sink, EventBuilder* maybe_new_builder);
+
     private:
         void dispatch(mir::EventUPtr e);
 
         std::shared_ptr<MainLoop> const main_loop;
-        input::InputSink* const sink;
-        input::EventBuilder* const builder;
+
+        // Since dispatchers are handed down to transformers which might keep a
+        // reference to them, then we should be careful to not change the
+        // builder as they dispatch an event.
+        std::mutex mutex;
+
+        // Sinks and/or builders are not constant for one virtual device.
+        input::InputSink* sink;
+        input::EventBuilder* builder;
     };
 
     class Transformer

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -17,18 +17,27 @@
 #ifndef MIR_SHELL_ACCESSIBILITY_MANAGER_H
 #define MIR_SHELL_ACCESSIBILITY_MANAGER_H
 
+#include "mir/input/input_event_transformer.h"
 #include <memory>
 #include <optional>
 #include <vector>
 
 namespace mir
 {
+namespace options
+{
+class Option;
+}
 namespace shell
 {
 class KeyboardHelper;
 class AccessibilityManager
 {
 public:
+    AccessibilityManager(
+        std::shared_ptr<mir::options::Option> const&,
+        std::shared_ptr<input::InputEventTransformer> const& event_transformer);
+
     void register_keyboard_helper(std::shared_ptr<shell::KeyboardHelper> const&);
 
     std::optional<int> repeat_rate() const;
@@ -36,7 +45,6 @@ public:
 
     void repeat_rate(int new_rate);
     void repeat_delay(int new_rate);
-    void override_key_repeat_settings(bool enable);
 
     void notify_helpers() const;
 
@@ -46,7 +54,12 @@ private:
     // 25 rate and 600 delay are the default in Weston and Sway
     int repeat_rate_{25};
     int repeat_delay_{600};
-    bool enable_key_repeat{true};
+    bool enable_key_repeat;
+
+    bool enable_mouse_keys;
+
+    std::shared_ptr<mir::input::InputEventTransformer> const event_transformer;
+    std::shared_ptr<mir::input::InputEventTransformer::Transformer> const transformer;
 };
 }
 }

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -41,6 +41,7 @@ char const* const mo::fatal_except_opt            = "on-fatal-error-except";
 char const* const mo::debug_opt                   = "debug";
 char const* const mo::composite_delay_opt         = "composite-delay";
 char const* const mo::enable_key_repeat_opt       = "enable-key-repeat";
+char const* const mo::enable_mouse_keys_opt       = "enable-mouse-keys";
 char const* const mo::x11_display_opt             = "enable-x11";
 char const* const mo::x11_scale_opt               = "x11-scale";
 char const* const mo::wayland_extensions_opt      = "wayland-extensions";
@@ -180,6 +181,8 @@ mo::DefaultConfiguration::DefaultConfiguration(
             "Cursor (mouse pointer) to use [{auto,null,software}]")
         (enable_key_repeat_opt, po::value<bool>()->default_value(true),
              "Enable server generated key repeat")
+        (enable_mouse_keys_opt, po::value<bool>()->default_value(false),
+             "Enable mousekeys (controlling the mouse with the numpad)")
         (idle_timeout_opt, po::value<int>()->default_value(0),
             "Time (in seconds) Mir will remain idle before turning off the display "
             "when the session is not locked, or 0 to keep display on forever.")

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -123,6 +123,7 @@ MIR_PLATFORM_2.20 {
     mir::options::drop_wayland_extensions_opt;
     mir::options::enable_input_opt*;
     mir::options::enable_key_repeat_opt*;
+    mir::options::enable_mouse_keys_opt*;
     mir::options::fatal_except_opt*;
     mir::options::idle_timeout_opt;
     mir::options::idle_timeout_when_locked_opt;
@@ -203,11 +204,3 @@ MIR_PLATFORM_2.20 {
  };
  local: *;
 };
-
-MIR_PLATFORM_2.20 {
- global:
-  extern "C++" {
-    mir::options::enable_mouse_keys_opt*;
- };
- local: *;
-} MIR_PLATFORM_2.19;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -123,7 +123,6 @@ MIR_PLATFORM_2.20 {
     mir::options::drop_wayland_extensions_opt;
     mir::options::enable_input_opt*;
     mir::options::enable_key_repeat_opt*;
-    mir::options::enable_mouse_keys_opt*;
     mir::options::fatal_except_opt*;
     mir::options::idle_timeout_opt;
     mir::options::idle_timeout_when_locked_opt;
@@ -204,3 +203,11 @@ MIR_PLATFORM_2.20 {
  };
  local: *;
 };
+
+MIR_PLATFORM_2.20 {
+ global:
+  extern "C++" {
+    mir::options::enable_mouse_keys_opt*;
+ };
+ local: *;
+} MIR_PLATFORM_2.19;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -123,6 +123,7 @@ MIR_PLATFORM_2.20 {
     mir::options::drop_wayland_extensions_opt;
     mir::options::enable_input_opt*;
     mir::options::enable_key_repeat_opt*;
+    mir::options::enable_mouse_keys_opt*;
     mir::options::fatal_except_opt*;
     mir::options::idle_timeout_opt;
     mir::options::idle_timeout_when_locked_opt;

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -367,10 +367,6 @@ std::shared_ptr<mf::Connector>
                 enabled_wayland_extensions.begin(),
                 enabled_wayland_extensions.end()};
 
-            auto accessibility_manager = the_accessibility_manager();
-            auto const enable_repeat = options->get<bool>(options::enable_key_repeat_opt);
-            accessibility_manager->override_key_repeat_settings(enable_repeat);
-
             auto const x11_enabled = options->is_set(mo::x11_display_opt) && options->get<bool>(mo::x11_display_opt);
 
             return std::make_shared<mf::WaylandConnector>(
@@ -399,7 +395,7 @@ std::shared_ptr<mf::Connector>
                     x11_enabled,
                     wayland_extension_hooks),
                 wayland_extension_filter,
-                accessibility_manager,
+                the_accessibility_manager(),
                 the_session_lock(),
                 the_decoration_strategy(),
                 the_session_coordinator(),

--- a/src/server/input/CMakeLists.txt
+++ b/src/server/input/CMakeLists.txt
@@ -28,10 +28,12 @@ set(
   idle_poking_dispatcher.cpp
   virtual_input_device.cpp
   xkb_mapper_registrar.cpp
+  input_event_transformer.cpp
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/seat_observer.h
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/input_dispatcher.h
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/seat.h
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/input_probe.h
+  ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/input_event_transformer.h
 )
 
 set_property(

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -21,6 +21,7 @@
 #include "event_filter_chain_dispatcher.h"
 #include "config_changer.h"
 #include "cursor_controller.h"
+#include "mir/input/input_event_transformer.h"
 #include "touchspot_controller.h"
 #include "null_input_manager.h"
 #include "null_input_dispatcher.h"
@@ -99,6 +100,18 @@ mir::DefaultServerConfiguration::the_event_filter_chain_dispatcher()
             return std::make_shared<mi::EventFilterChainDispatcher>(
                 make_default_filter_list(),
                 the_surface_input_dispatcher());
+        });
+}
+
+std::shared_ptr<mi::InputEventTransformer> mir::DefaultServerConfiguration::the_input_event_transformer()
+{
+    return input_event_transformer(
+        [this]
+        {
+            auto event_transformer =
+                std::make_shared<input::InputEventTransformer>(the_input_device_registry(), the_main_loop());
+            the_composite_event_filter()->prepend(event_transformer);
+            return event_transformer;
         });
 }
 

--- a/src/server/input/input_event_transformer.cpp
+++ b/src/server/input/input_event_transformer.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/input/input_event_transformer.h"
+
+#include "mir/input/device_capability.h"
+#include "mir/input/event_builder.h"
+#include "mir/input/input_device_registry.h"
+#include "mir/input/input_sink.h"
+#include "mir/input/virtual_input_device.h"
+#include "mir/main_loop.h"
+
+#include <memory>
+#include <mutex>
+
+namespace mi = mir::input;
+
+mi::InputEventTransformer::InputEventTransformer(
+    std::shared_ptr<InputDeviceRegistry> const& device_registry, std::shared_ptr<MainLoop> const& main_loop) :
+    input_device_registry{device_registry},
+    main_loop{main_loop}
+{
+}
+
+mir::input::InputEventTransformer::~InputEventTransformer()
+{
+    if(virtual_pointer)
+        input_device_registry->remove_device(virtual_pointer);
+}
+
+bool mi::InputEventTransformer::handle(MirEvent const& event)
+{
+    std::lock_guard lock{mutex};
+
+    if(!virtual_pointer)
+        return false;
+
+    auto handled = false;
+    virtual_pointer->if_started_then(
+        [this, &event, &handled](mir::input::InputSink* sink, mir::input::EventBuilder* builder)
+        {
+            if (!dispatcher)
+                dispatcher = std::make_shared<EventDispatcher>(main_loop, sink, builder);
+
+            for (auto it = input_transformers.begin(); it != input_transformers.end(); ++it)
+            {
+                auto const& t = it->lock();
+                if (!t)
+                {
+                    it = input_transformers.erase(it);
+                    continue;
+                }
+
+                if (t->transform_input_event(dispatcher, event))
+                    handled = true;
+            }
+
+            handled = false;
+        });
+
+    return handled;
+}
+
+void mi::InputEventTransformer::append(std::weak_ptr<mi::InputEventTransformer::Transformer> const& transformer)
+{
+    std::lock_guard lock{mutex};
+    lazily_init_virtual_input_device();
+    input_transformers.push_back(transformer);
+}
+
+void mi::InputEventTransformer::prepend(std::weak_ptr<mi::InputEventTransformer::Transformer> const& transformer)
+{
+    std::lock_guard lock{mutex};
+    lazily_init_virtual_input_device();
+    input_transformers.insert(input_transformers.begin(),transformer);
+}
+
+void mi::InputEventTransformer::lazily_init_virtual_input_device()
+{
+    if (input_transformers.empty())
+    {
+        virtual_pointer =
+            std::make_shared<input::VirtualInputDevice>("mousekey-pointer", mir::input::DeviceCapability::pointer);
+        input_device_registry->add_device(virtual_pointer);
+    }
+}
+
+void mir::input::InputEventTransformer::EventDispatcher::dispatch(mir::EventUPtr e)
+{
+    main_loop->spawn(
+        [e = std::shared_ptr(std::move(e)), this]
+        {
+            sink->handle_input(e);
+        });
+}
+
+void mir::input::InputEventTransformer::EventDispatcher::dispatch_key_event(
+    std::optional<std::chrono::nanoseconds> timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code)
+{
+    dispatch(builder->key_event(timestamp, action, keysym, scan_code));
+}
+
+void mir::input::InputEventTransformer::EventDispatcher::dispatch_pointer_event(
+    std::optional<std::chrono::nanoseconds> timestamp,
+    MirPointerAction action,
+    MirPointerButtons buttons,
+    std::optional<mir::geometry::PointF> position,
+    mir::geometry::DisplacementF motion,
+    MirPointerAxisSource axis_source,
+    events::ScrollAxisH h_scroll,
+    events::ScrollAxisV v_scroll)
+{
+    dispatch(builder->pointer_event(timestamp, action, buttons, position, motion, axis_source, h_scroll, v_scroll));
+}
+

--- a/src/server/input/input_event_transformer.cpp
+++ b/src/server/input/input_event_transformer.cpp
@@ -61,6 +61,8 @@ bool mi::InputEventTransformer::handle(MirEvent const& event)
                 if (!t)
                 {
                     it = input_transformers.erase(it);
+                    if(it == input_transformers.end())
+                        return;
                     continue;
                 }
 

--- a/src/server/input/input_event_transformer.cpp
+++ b/src/server/input/input_event_transformer.cpp
@@ -65,10 +65,11 @@ bool mi::InputEventTransformer::handle(MirEvent const& event)
                 }
 
                 if (t->transform_input_event(dispatcher, event))
+                {
                     handled = true;
+                    break;
+                }
             }
-
-            handled = false;
         });
 
     return handled;

--- a/src/server/input/input_event_transformer.cpp
+++ b/src/server/input/input_event_transformer.cpp
@@ -73,6 +73,13 @@ bool mi::InputEventTransformer::handle(MirEvent const& event)
             }
         });
 
+    // Remove the input device if the last transformer was removed.
+    if (input_transformers.empty())
+    {
+        input_device_registry->remove_device(virtual_pointer);
+        virtual_pointer.reset();
+    }
+
     return handled;
 }
 

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -16,10 +16,8 @@
 
 #include "mir/shell/accessibility_manager.h"
 
-#include "mir/event_printer.h"
 #include "mir/input/event_builder.h"
 #include "mir/input/input_sink.h"
-#include "mir/log.h"
 #include "mir/options/configuration.h"
 #include "mir/shell/keyboard_helper.h"
 
@@ -27,7 +25,6 @@
 
 #include <memory>
 #include <optional>
-#include <sstream>
 
 void mir::shell::AccessibilityManager::register_keyboard_helper(std::shared_ptr<KeyboardHelper> const& helper)
 {
@@ -65,10 +62,6 @@ struct MouseKeysTransformer: public mir::input::InputEventTransformer::Transform
         MirEvent const& event) override
     {
         using namespace mir; // For operator<<
-
-        std::stringstream ss;
-        ss << const_cast<MirEvent&>(event);
-        mir::log_debug("%s", ss.str().c_str());
 
         if (mir_event_get_type(&event) != mir_event_type_input)
             return false;

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -15,9 +15,18 @@
  */
 
 #include "mir/shell/accessibility_manager.h"
+
+#include "mir/event_printer.h"
+#include "mir/input/input_sink.h"
+#include "mir/log.h"
+#include "mir/options/configuration.h"
 #include "mir/shell/keyboard_helper.h"
 
+#include <xkbcommon/xkbcommon-keysyms.h>
+
+#include <memory>
 #include <optional>
+#include <sstream>
 
 void mir::shell::AccessibilityManager::register_keyboard_helper(std::shared_ptr<KeyboardHelper> const& helper)
 {
@@ -42,12 +51,80 @@ void mir::shell::AccessibilityManager::repeat_delay(int new_delay) {
     repeat_delay_ = new_delay;
 }
 
-void mir::shell::AccessibilityManager::override_key_repeat_settings(bool enable)
-{
-    enable_key_repeat = enable;
-}
-
 void mir::shell::AccessibilityManager::notify_helpers() const {
     for(auto const& helper: keyboard_helpers)
         helper->repeat_info_changed(repeat_rate(), repeat_delay());
+}
+
+struct MouseKeysTransformer: public mir::input::InputEventTransformer::Transformer
+{
+    bool transform_input_event(
+        std::shared_ptr<mir::input::InputEventTransformer::EventDispatcher> const& dispatcher,
+        MirEvent const& event) override
+    {
+        using namespace mir; // For operator<<
+
+        std::stringstream ss;
+        ss << const_cast<MirEvent&>(event);
+        mir::log_debug("%s", ss.str().c_str());
+
+        if (mir_event_get_type(&event) != mir_event_type_input)
+            return false;
+
+        MirInputEvent const* input_event = mir_event_get_input_event(&event);
+
+        if (mir_input_event_get_type(input_event) == mir_input_event_type_key)
+        {
+            MirKeyboardEvent const* kev = mir_input_event_get_keyboard_event(input_event);
+            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down &&
+                mir_keyboard_event_action(kev) != mir_keyboard_action_repeat)
+                return false;
+
+            auto offset = geometry::DisplacementF{};
+            switch (mir_keyboard_event_keysym(kev))
+            {
+            case XKB_KEY_KP_2:
+                offset = geometry::DisplacementF{0, 10};
+                break;
+            case XKB_KEY_KP_4:
+                offset = geometry::DisplacementF{-10, 0};
+                break;
+            case XKB_KEY_KP_6:
+                offset = geometry::DisplacementF{10, 0};
+                break;
+            case XKB_KEY_KP_8:
+                offset = geometry::DisplacementF{0, -10};
+                break;
+
+            default:
+                return false;
+            }
+
+            dispatcher->dispatch_pointer_event(
+                std::nullopt,
+                mir_pointer_action_motion,
+                0,
+                std::nullopt,
+                offset,
+                mir_pointer_axis_source_none,
+                mir::events::ScrollAxisH{},
+                mir::events::ScrollAxisV{});
+
+            return true;
+        }
+
+        return false;
+    }
+};
+
+mir::shell::AccessibilityManager::AccessibilityManager(
+    std::shared_ptr<mir::options::Option> const& options,
+    std::shared_ptr<input::InputEventTransformer> const& event_transformer) :
+    enable_key_repeat{options->get<bool>(options::enable_key_repeat_opt)},
+    enable_mouse_keys{options->get<bool>(options::enable_mouse_keys_opt)},
+    event_transformer{event_transformer},
+    transformer{std::make_shared<MouseKeysTransformer>()}
+{
+    if (enable_mouse_keys)
+        event_transformer->append(transformer);
 }

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -17,6 +17,7 @@
 #include "mir/shell/accessibility_manager.h"
 
 #include "mir/event_printer.h"
+#include "mir/input/event_builder.h"
 #include "mir/input/input_sink.h"
 #include "mir/log.h"
 #include "mir/options/configuration.h"
@@ -59,7 +60,8 @@ void mir::shell::AccessibilityManager::notify_helpers() const {
 struct MouseKeysTransformer: public mir::input::InputEventTransformer::Transformer
 {
     bool transform_input_event(
-        std::shared_ptr<mir::input::InputEventTransformer::EventDispatcher> const& dispatcher,
+        mir::input::InputEventTransformer::EventDispatcher const& dispatcher,
+        mir::input::EventBuilder* builder,
         MirEvent const& event) override
     {
         using namespace mir; // For operator<<
@@ -100,7 +102,7 @@ struct MouseKeysTransformer: public mir::input::InputEventTransformer::Transform
                 return false;
             }
 
-            dispatcher->dispatch_pointer_event(
+            dispatcher(builder->pointer_event(
                 std::nullopt,
                 mir_pointer_action_motion,
                 0,
@@ -108,7 +110,7 @@ struct MouseKeysTransformer: public mir::input::InputEventTransformer::Transform
                 offset,
                 mir_pointer_axis_source_none,
                 mir::events::ScrollAxisH{},
-                mir::events::ScrollAxisV{});
+                mir::events::ScrollAxisV{}));
 
             return true;
         }

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -26,7 +26,6 @@
 #include "mir/input/composite_event_filter.h"
 #include "mir/main_loop.h"
 #include "mir/options/configuration.h"
-#include "mir/options/option.h"
 #include "mir/shell/abstract_shell.h"
 #include "mir/shell/accessibility_manager.h"
 #include "mir/shell/system_compositor_window_manager.h"
@@ -188,9 +187,9 @@ mir::DefaultServerConfiguration::the_shell_display_layout()
 auto mir::DefaultServerConfiguration::the_accessibility_manager() -> std::shared_ptr<shell::AccessibilityManager>
 {
     return accessibility_manager(
-        []
+        [this]
         {
-            return std::make_shared<shell::AccessibilityManager>();
+            return std::make_shared<shell::AccessibilityManager>(the_options(), the_input_event_transformer());
         });
 }
 

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1420,6 +1420,7 @@ global:
     mir::input::InputEventTransformer::handle*;
     mir::input::InputEventTransformer::prepend*;
     mir::shell::AbstractShell::is_above*;
+    mir::shell::AccessibilityManager::AccessibilityManager*;
     mir::shell::AccessibilityManager::notify_helpers*;
     mir::shell::AccessibilityManager::override_key_repeat_settings*;
     mir::shell::AccessibilityManager::register_keyboard_helper*;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1423,6 +1423,7 @@ global:
     mir::input::InputEventTransformer::append*;
     mir::input::InputEventTransformer::handle*;
     mir::input::InputEventTransformer::prepend*;
+    mir::input::InputEventTransformer::remove*;
     mir::shell::AbstractShell::is_above*;
     mir::shell::AccessibilityManager::AccessibilityManager*;
     mir::shell::AccessibilityManager::notify_helpers*;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1408,10 +1408,17 @@ MIR_SERVER_INTERNAL_2.20 {
 global:
   extern "C++" {
     mir::DefaultServerConfiguration::the_accessibility_manager*;
+    mir::DefaultServerConfiguration::the_input_event_transformer*;
     mir::DefaultServerConfiguration::the_token_authority*;
     mir::Server::get_activation_token*;
     mir::Server::the_accessibility_manager*;
     mir::Server::the_token_authority*;
+    mir::input::InputEventTransformer::?InputEventTransformer*;
+    mir::input::InputEventTransformer::InputEventTransformer*;
+    mir::input::InputEventTransformer::Transformer::?Transformer*;
+    mir::input::InputEventTransformer::append*;
+    mir::input::InputEventTransformer::handle*;
+    mir::input::InputEventTransformer::prepend*;
     mir::shell::AbstractShell::is_above*;
     mir::shell::AccessibilityManager::notify_helpers*;
     mir::shell::AccessibilityManager::override_key_repeat_settings*;
@@ -1428,16 +1435,24 @@ global:
     mir::shell::TokenAuthority::revoke_all_tokens*;
     mir::shell::TokenAuthority::revoke_token*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_accessibility_manager*;
+    non-virtual?thunk?to?mir::DefaultServerConfiguration::the_input_event_transformer*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_token_authority*;
+    non-virtual?thunk?to?mir::input::InputEventTransformer::?InputEventTransformer*;
+    non-virtual?thunk?to?mir::input::InputEventTransformer::Transformer::?Transformer*;
+    non-virtual?thunk?to?mir::input::InputEventTransformer::handle*;
     non-virtual?thunk?to?mir::shell::AbstractShell::is_above*;
     non-virtual?thunk?to?mir::shell::ShellWrapper::is_above*;
     non-virtual?thunk?to?mir::shell::SurfaceStackWrapper::is_above*;
     typeinfo?for?mir::shell::AccessibilityManager;
+    typeinfo?for?mir::input::InputEventTransformer::Transformer;
+    typeinfo?for?mir::input::InputEventTransformer;
     typeinfo?for?mir::shell::TokenAuthority::Token;
     typeinfo?for?mir::shell::TokenAuthority;
     virtual?thunk?to?mir::DefaultServerConfiguration::the_token_authority*;
     virtual?thunk?to?mir::shell::AbstractShell::is_above*;
     virtual?thunk?to?mir::shell::ShellWrapper::is_above*;
+    vtable?for?mir::input::InputEventTransformer::Transformer;
+    vtable?for?mir::input::InputEventTransformer;
   };
 } MIR_SERVER_INTERNAL_2.19;
 

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1414,6 +1414,9 @@ global:
     mir::Server::the_accessibility_manager*;
     mir::Server::the_token_authority*;
     mir::input::InputEventTransformer::?InputEventTransformer*;
+    mir::input::InputEventTransformer::EventDispatcher::EventDispatcher*;
+    mir::input::InputEventTransformer::EventDispatcher::dispatch_key_event*;
+    mir::input::InputEventTransformer::EventDispatcher::dispatch_pointer_event*;
     mir::input::InputEventTransformer::InputEventTransformer*;
     mir::input::InputEventTransformer::Transformer::?Transformer*;
     mir::input::InputEventTransformer::append*;
@@ -1445,13 +1448,16 @@ global:
     non-virtual?thunk?to?mir::shell::ShellWrapper::is_above*;
     non-virtual?thunk?to?mir::shell::SurfaceStackWrapper::is_above*;
     typeinfo?for?mir::shell::AccessibilityManager;
+    typeinfo?for?mir::input::InputEventTransformer::EventDispatcher;
     typeinfo?for?mir::input::InputEventTransformer::Transformer;
     typeinfo?for?mir::input::InputEventTransformer;
+    typeinfo?for?mir::shell::AccessibilityManager;
     typeinfo?for?mir::shell::TokenAuthority::Token;
     typeinfo?for?mir::shell::TokenAuthority;
     virtual?thunk?to?mir::DefaultServerConfiguration::the_token_authority*;
     virtual?thunk?to?mir::shell::AbstractShell::is_above*;
     virtual?thunk?to?mir::shell::ShellWrapper::is_above*;
+    vtable?for?mir::input::InputEventTransformer::EventDispatcher;
     vtable?for?mir::input::InputEventTransformer::Transformer;
     vtable?for?mir::input::InputEventTransformer;
   };

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1417,6 +1417,7 @@ global:
     mir::input::InputEventTransformer::EventDispatcher::EventDispatcher*;
     mir::input::InputEventTransformer::EventDispatcher::dispatch_key_event*;
     mir::input::InputEventTransformer::EventDispatcher::dispatch_pointer_event*;
+    mir::input::InputEventTransformer::EventDispatcher::maybe_update*;
     mir::input::InputEventTransformer::InputEventTransformer*;
     mir::input::InputEventTransformer::Transformer::?Transformer*;
     mir::input::InputEventTransformer::append*;

--- a/tests/acceptance-tests/test_input_device_hub.cpp
+++ b/tests/acceptance-tests/test_input_device_hub.cpp
@@ -67,6 +67,8 @@ TEST_F(TestInputDeviceHub, notifies_input_device_observer_about_available_device
 {
     using namespace testing;
     InSequence seq;
+    EXPECT_CALL(observer, device_added(_)); // Account for "mousekey-pointer"
+
     EXPECT_CALL(observer, changes_complete())
         .WillOnce(mt::WakeUp(&observer_registered));
 

--- a/tests/acceptance-tests/test_seat_report.cpp
+++ b/tests/acceptance-tests/test_seat_report.cpp
@@ -138,7 +138,7 @@ TEST_F(TestSeatReport, add_device_received)
             devices.push_back(device.id());
         });
 
-    EXPECT_THAT(device_ids_seen, ContainerEq(devices));
+    EXPECT_THAT(device_ids_seen, IsSubsetOf(devices));
 }
 
 TEST_F(TestSeatReport, remove_device_received)

--- a/tests/acceptance-tests/test_seat_report.cpp
+++ b/tests/acceptance-tests/test_seat_report.cpp
@@ -327,9 +327,10 @@ TEST_F(TestSeatReport, key_state_received)
     auto listener = std::make_shared<KeyStateListener>(1);
     server.the_seat_observer_registrar()->register_interest(listener);
 
+    auto const fake_keyboard_name = "fake-keyboard";
     auto fake_keyboard = mtf::add_fake_input_device(
         mi::InputDeviceInfo{
-            "name",
+            fake_keyboard_name,
             "uid",
             mi::DeviceCapability::keyboard | mi::DeviceCapability::alpha_numeric});
 
@@ -345,19 +346,19 @@ TEST_F(TestSeatReport, key_state_received)
         fake_keyboard->emit_key_state(temporary_copy);
     }
 
-    uint64_t device_id{0};
-    bool seen_device{false};
+    std::optional<size_t> fake_keyboard_id = std::nullopt;
     server.the_input_device_hub()->for_each_input_device(
-        [&device_id, &seen_device](auto const& device)
+        [&fake_keyboard_id, fake_keyboard_name](auto const& device)
         {
-            if (seen_device)
-                FAIL() << "Unexpected input device seen";
-            device_id = device.id();
-            seen_device = true;
+            if(device.name() == fake_keyboard_name)
+                fake_keyboard_id = device.id();
         });
+
+    if (!fake_keyboard_id.has_value())
+        FAIL() << "Fake keyboard not found";
 
     listener->wait_for_key_state(
         30s,
-        device_id,
+        *fake_keyboard_id,
         sent_state);
 }

--- a/tests/unit-tests/input/CMakeLists.txt
+++ b/tests/unit-tests/input/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND UNIT_TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_validator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_keymap.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_default_event_builder.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_input_event_transformer.cpp
 )
 
 list(APPEND UMOCK_UNIT_TEST_SOURCES

--- a/tests/unit-tests/input/test_input_event_transformer.cpp
+++ b/tests/unit-tests/input/test_input_event_transformer.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/dispatch/multiplexing_dispatchable.h"
+#include "mir/events/event_builders.h"
+#include "mir/glib_main_loop.h"
+#include "mir/input/input_device_hub.h"
+#include "mir/input/input_device_registry.h"
+#include "mir/input/input_event_transformer.h"
+#include "src/server/input/default_input_device_hub.h"
+
+#include "mir/test/doubles/mock_input_seat.h"
+#include "mir/test/doubles/mock_key_mapper.h"
+#include "mir/test/doubles/mock_led_observer_registrar.h"
+#include "mir/test/doubles/mock_server_status_listener.h"
+#include "mir/test/doubles/advanceable_clock.h"
+#include "mir/test/fake_shared.h"
+
+#include <functional>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <xkbcommon/xkbcommon-compat.h>
+
+namespace mt = mir::test;
+namespace mtd = mt::doubles;
+namespace mev = mir::events;
+
+using namespace testing;
+
+struct TestInputEventTransformer : testing::Test
+{
+    mir::dispatch::MultiplexingDispatchable multiplexer;
+    NiceMock<mtd::MockLedObserverRegistrar> led_observer_registrar;
+    NiceMock<mtd::MockInputSeat> mock_seat;
+    NiceMock<mtd::MockKeyMapper> mock_key_mapper;
+    NiceMock<mtd::MockServerStatusListener> mock_server_status_listener;
+    mtd::AdvanceableClock clock;
+
+    TestInputEventTransformer() :
+        input_device_hub{std::make_shared<mir::input::DefaultInputDeviceHub>(
+            mt::fake_shared(mock_seat),
+            mt::fake_shared(multiplexer),
+            mt::fake_shared(clock),
+            mt::fake_shared(mock_key_mapper),
+            mt::fake_shared(mock_server_status_listener),
+            mt::fake_shared(led_observer_registrar))},
+        input_event_transformer{input_device_hub, std::make_shared<mir::GLibMainLoop>(mt::fake_shared(clock))}
+    {
+    }
+
+    mir::EventUPtr make_key_event()
+    {
+        return mev::make_key_event(
+            MirInputDeviceId{0},
+            clock.now().time_since_epoch(),
+            mir_keyboard_action_up,
+            XKB_KEY_W,
+            0,
+            mir_input_event_modifier_none);
+    }
+
+    std::shared_ptr<mir::input::DefaultInputDeviceHub> const input_device_hub;
+    mir::input::InputEventTransformer input_event_transformer;
+};
+
+struct StubTransformer : public mir::input::InputEventTransformer::Transformer
+{
+    std::function<bool()> const on_event;
+    bool called{false};
+
+    StubTransformer(std::function<bool()> on_event) :
+        on_event{on_event}
+    {
+    }
+
+    virtual bool transform_input_event(
+        mir::input::InputEventTransformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&) override
+    {
+        called = true;
+        return on_event();
+    }
+};
+
+TEST_F(TestInputEventTransformer, virtual_input_device_exists)
+{
+    auto mousekey_pointer_found = false;
+    input_device_hub->for_each_input_device(
+        [&mousekey_pointer_found](mir::input::Device const& dev)
+        {
+            if (dev.name() == "mousekey-pointer")
+                mousekey_pointer_found = true;
+        });
+
+    ASSERT_TRUE(mousekey_pointer_found);
+}
+
+TEST_F(TestInputEventTransformer, transformer_gets_called)
+{
+    auto stub_transformer = std::make_shared<StubTransformer>(
+        []
+        {
+            return false;
+        });
+
+    input_event_transformer.append(stub_transformer);
+
+    input_event_transformer.handle(*make_key_event());
+    ASSERT_TRUE(stub_transformer->called);
+}
+
+TEST_F(TestInputEventTransformer, events_block_correctly)
+{
+    auto stub_transformer_1 = std::make_shared<StubTransformer>(
+        []
+        {
+            return true;
+        });
+    auto stub_transformer_2 = std::make_shared<StubTransformer>(
+        []
+        {
+            // Wont get called since stub_transformer_1 returns `true`,
+            // signalling that it handled the event and no other transformers
+            // should run
+            return true;
+        });
+
+    input_event_transformer.append(stub_transformer_1);
+    input_event_transformer.append(stub_transformer_2);
+
+    input_event_transformer.handle(*make_key_event());
+    ASSERT_TRUE(stub_transformer_1->called && !stub_transformer_2->called);
+}
+
+TEST_F(TestInputEventTransformer, events_cascade_correctly)
+{
+    auto stub_transformer_1 = std::make_shared<StubTransformer>(
+        []
+        {
+            return false;
+        });
+    auto stub_transformer_2 = std::make_shared<StubTransformer>(
+        []
+        {
+            return true;
+        });
+
+    input_event_transformer.append(stub_transformer_1);
+    input_event_transformer.append(stub_transformer_2);
+
+    input_event_transformer.handle(*make_key_event());
+    ASSERT_TRUE(stub_transformer_1->called && stub_transformer_2->called);
+}
+
+TEST_F(TestInputEventTransformer, transformer_not_called_after_removal)
+{
+    // Gotta use an external variable for this one since we're clearing the
+    // shared pointer
+    auto external_called = false;
+    auto stub_transformer = std::make_shared<StubTransformer>(
+        [&external_called]
+        {
+        external_called = true;
+            return false;
+        });
+
+    input_event_transformer.append(stub_transformer);
+    input_event_transformer.handle(*make_key_event());
+    ASSERT_TRUE(stub_transformer->called);
+
+    external_called = false;
+    stub_transformer.reset();
+
+    input_event_transformer.handle(*make_key_event());
+    ASSERT_FALSE(external_called);
+}


### PR DESCRIPTION
Some notes:
1. The latter half of this PR (the accessibility manager demo) is just for making sure its functionality works properly. ~I will move this commit to the mousekeys  PR after this one is approved.~ Well, since that PR is based on this, it doesn't matter if I leave it here or move it there, so...
2. Currently, there's a segfault when shutting down mir thrown somewhere while destructing `SeatInputDeviceTracker::touch_visualizer`. It's not entirely clear what's the cause, but I have a "workaround" for it. ~I'm still trying to find the root cause~ #3768