### PR TITLE
Make sure the config file mutex is initialized before being used

### DIFF
--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -138,12 +138,12 @@ public:
     }
 
 private:
+    std::mutex config_mutex;
     miral::InputConfiguration input_configuration;
     miral::InputConfiguration::Mouse mouse = input_configuration.mouse();
     miral::InputConfiguration::Touchpad touchpad = input_configuration.touchpad();
     miral::InputConfiguration::Keyboard keyboard = input_configuration.keyboard();
     miral::ConfigFile config_file;
-    std::mutex config_mutex;
 
     void apply_config()
     {


### PR DESCRIPTION
Since the order of initialization is the same as the order of declaration, the config file was initialized before the mutex. But it would use the mutex during its construction since it loads on construction, causing an error to be thrown and the application to crash.