### PR TITLE
std::wstring_convert is deprecated, but there's no obvious replacement. Yet

### DIFF
--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -59,7 +59,10 @@ struct Printer
     void printhelp(BackgroundInfo const& region);
 
 private:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     std::wstring_convert<preferred_codecvt> converter;
+#pragma GCC diagnostic pop
 
     bool working = false;
     FT_Library lib;

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -686,7 +686,12 @@ auto RendererStrategy::Text::Impl::font_path() -> std::string
 
 auto RendererStrategy::Text::Impl::utf8_to_utf32(std::string const& text) -> std::u32string
 {
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
+#pragma GCC diagnostic pop
+
     std::u32string utf32_text;
     try {
         utf32_text = converter.from_bytes(text);


### PR DESCRIPTION
This is "Appendix D" and slated for removal in C++26, hopefully there will be an obvious replacement by then  