### PR TITLE
Workaround for LXQt panel

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2118,6 +2118,13 @@ auto antipodes(MirPlacementGravity rect_gravity) -> MirPlacementGravity
 
 auto constrain_to(mir::geometry::Rectangle const& rect, Point point) -> Point
 {
+    // The LXQt panel items sets anchor rects outside their window geometry,
+    // conditionally allow this as a workaround
+    if (getenv("MIR_ANCHOR_RECTANGLE_UNCONSTRAINED") != nullptr)
+    {
+        return point;
+    }
+
     if (point.x < rect.top_left.x)
         point.x = rect.top_left.x;
 


### PR DESCRIPTION
Provide a way to hack Mir into ignoring protocol constraints on the anchor rectangle

See https://github.com/lxqt/lxqt-wayland-session/pull/40#issuecomment-2668999542 for more discussion