### PR TITLE
Do not crash when pcmanfm-qt does DnD 

### DIFF
--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -374,8 +374,11 @@ mf::WlDataDevice::DragIconSurface::DragIconSurface(WlSurface* icon, std::shared_
     icon->set_role(this);
 
     auto spec = shell::SurfaceSpecification();
-    spec.width = surface.value().buffer_size()->width;
-    spec.height = surface.value().buffer_size()->height;
+    if (auto const size = surface.value().buffer_size())
+    {
+        spec.width = size->width;
+        spec.height = size->height;
+    }
     spec.streams = std::vector<shell::StreamSpecification>{};
     spec.input_shape = std::vector<Rectangle>{};
     spec.depth_layer = mir_depth_layer_overlay;


### PR DESCRIPTION
I.e.  check we have a buffer size before using it

Fixes: #3765
