### PR TITLE
Move `~WindowManagementPolicy` to its source file.

### DIFF
--- a/include/miral/miral/window_management_policy.h
+++ b/include/miral/miral/window_management_policy.h
@@ -276,7 +276,7 @@ public:
     virtual void advise_application_zone_delete(Zone const& application_zone);
     /** @} */
 
-    virtual ~WindowManagementPolicy() = default;
+    virtual ~WindowManagementPolicy();
     WindowManagementPolicy() = default;
     WindowManagementPolicy(WindowManagementPolicy const&) = delete;
     WindowManagementPolicy& operator=(WindowManagementPolicy const&) = delete;

--- a/src/miral/window_management_policy.cpp
+++ b/src/miral/window_management_policy.cpp
@@ -36,3 +36,4 @@ void miral::WindowManagementPolicy::advise_output_delete(Output const& /*output*
 void miral::WindowManagementPolicy::advise_application_zone_create(Zone const& /*application_zone*/) {}
 void miral::WindowManagementPolicy::advise_application_zone_update(Zone const& /*updated*/, Zone const& /*original*/) {}
 void miral::WindowManagementPolicy::advise_application_zone_delete(Zone const& /*application_zone*/) {}
+miral::WindowManagementPolicy::~WindowManagementPolicy() = default;


### PR DESCRIPTION
Helps fix spurious debian symbol errors in CI.