### PR TITLE
Include missing headers to fix compile under musl/libc++

### DIFF
--- a/src/include/server/mir/scene/session_coordinator.h
+++ b/src/include/server/mir/scene/session_coordinator.h
@@ -22,6 +22,8 @@
 
 #include "mir_toolkit/common.h"
 
+#include <unistd.h>
+
 #include <memory>
 
 namespace mir

--- a/src/include/server/mir/shell/shell.h
+++ b/src/include/server/mir/shell/shell.h
@@ -24,6 +24,8 @@
 
 #include "mir_toolkit/common.h"
 
+#include <unistd.h>
+
 #include <memory>
 
 namespace mir

--- a/src/include/server/mir/shell/token_authority.h
+++ b/src/include/server/mir/shell/token_authority.h
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <unordered_set>
 
 namespace mir

--- a/src/miral/config_file.cpp
+++ b/src/miral/config_file.cpp
@@ -29,6 +29,7 @@
 #include <fstream>
 #include <optional>
 #include <string>
+#include <sstream>
 #include <vector>
 
 using namespace std::filesystem;

--- a/src/platforms/common/server/kms-utils/drm_event_handler.h
+++ b/src/platforms/common/server/kms-utils/drm_event_handler.h
@@ -17,6 +17,7 @@
 #ifndef MIR_PLATFORM_KMS_DRM_EVENT_HANDLER_H_
 #define MIR_PLATFORM_KMS_DRM_EVENT_HANDLER_H_
 
+#include <functional>
 #include <future>
 
 namespace mir

--- a/src/platforms/wayland/wl_egl_display_provider.cpp
+++ b/src/platforms/wayland/wl_egl_display_provider.cpp
@@ -6,6 +6,7 @@
 #include <EGL/egl.h>
 #include <wayland-egl-core.h>
 
+#include <mutex>
 #include <optional>
 
 namespace mg = mir::graphics;

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -31,6 +31,7 @@
 #include <codecvt>
 #include <filesystem>
 #include <map>
+#include <mutex>
 
 namespace ms = mir::scene;
 namespace geom = mir::geometry;


### PR DESCRIPTION
Found compile errors such as the following both on v2.19.3 and main (with this PR being verified against the latter):
```
In file included from src/platforms/common/server/kms-utils/threaded_drm_event_handler.cpp:17:
In file included from src/platforms/common/server/kms-utils/threaded_drm_event_handler.h:20:
src/platforms/common/server/kms-utils/drm_event_handler.h:42:14: error: no template named 'function' in namespace 'std'
   42 |         std::function<void(unsigned int frame_number, std::chrono::milliseconds frame_time)> on_flip) = 0;
      |         ~~~~~^

In file included from src/server/server.cpp:39:
In file included from src/server/frontend_wayland/wayland_connector.h:20:
src/include/server/mir/shell/token_authority.h:72:10: error: no type named 'mutex' in namespace 'std'
   72 |     std::mutex mutable mutex;
      |     ~~~~~^

In file included from src/server/scene/session_manager.cpp:17:
In file included from src/server/scene/session_manager.h:20:
src/include/server/mir/scene/session_coordinator.h:47:9: error: unknown type name 'pid_t'
   47 |         pid_t client_pid,
      |         ^

src/miral/config_file.cpp:126:28: error: implicit instantiation of undefined template 'std::basic_istringstream<char>'
  126 |         std::istringstream config_stream{config_dirs};
      |                            ^
/usr/bin/../include/c++/v1/__fwd/sstream.h:26:28: note: template is declared here
   26 | class _LIBCPP_TEMPLATE_VIS basic_istringstream;
      |                            ^
```
Since I already fixed similar issues in #3388 and they seem to keep coming back overtime would it make sense to have CI testbuild against musl paired with LLVM libc++ as well? Using alpine edge as a base with `apk add clang19 lld libc++-dev llvm-libunwind-dev` and adding `--rtlib=compiler-rt` to `CFLAGS`, `-stdlib=libc++ -unwindlib=libunwind` to `CXXFLAGS` and `-fuse-ld=lld` to `LDFLAGS` should more or less replicate my setup (minus using LLVM in place of binutils?)