### PR TITLE
mgc::ShmBuffer: Fix texture setup synchronisation

### DIFF
--- a/include/test/mir/test/doubles/mock_gl.h
+++ b/include/test/mir/test/doubles/mock_gl.h
@@ -65,6 +65,7 @@ public:
     MOCK_METHOD(void, glEnable, (GLenum));
     MOCK_METHOD(void, glEnableVertexAttribArray, (GLuint));
     MOCK_METHOD(void, glFinish, ());
+    MOCK_METHOD(void, glFlush, ());
     MOCK_METHOD(void, glFramebufferRenderbuffer,
                  (GLenum, GLenum, GLenum, GLuint));
     MOCK_METHOD(void, glFramebufferTexture2D,

--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -122,6 +122,16 @@ auto get_tex_id_on_context(mgc::EGLContextExecutor& egl_executor) -> std::shared
 
             // ...and then restore the previous GL state.
             glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(previous_texture));
+
+            /* We need these commands to be in the driver command stream before
+             * anything which uses them can be executed (which will likely be
+             * on another thread, in another EGLContext).
+             *
+             * glFlush() before the promise synchronisation point will ensure
+             * those commands are visible to the driver before we try and use
+             * their results.
+             */
+            glFlush();
             tex_promise->set_value(tex);
         });
     return tex_promise->get_future();

--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -111,7 +111,7 @@ auto get_tex_id_on_context(mgc::EGLContextExecutor& egl_executor) -> std::shared
 
             // Paranoia: Save the current value for the GL state that we're modifying...
             GLint previous_texture;
-            glGetIntegerv(GL_TEXTURE_2D, &previous_texture);
+            glGetIntegerv(GL_TEXTURE_BINDING_2D, &previous_texture);
 
             glBindTexture(GL_TEXTURE_2D, tex);
             // The ShmBuffer *should* be immutable, so we can just set up the properties once

--- a/tests/mir_test_doubles/mock_gl.cpp
+++ b/tests/mir_test_doubles/mock_gl.cpp
@@ -450,6 +450,12 @@ void glFinish()
     global_mock_gl->glFinish();
 }
 
+void glFlush()
+{
+    CHECK_GLOBAL_VOID_MOCK();
+    global_mock_gl->glFlush();
+}
+
 void glGenerateMipmap(GLenum target)
 {
     CHECK_GLOBAL_VOID_MOCK();


### PR DESCRIPTION
Because we're on an `EGLContextExecutor` we're probably on a different
thread to where the GL state is going to be used, *and* we don't
have implicit flushing with `eglMakeCurrent` happening (because
the context just stays current on the `EGLContextExecutor`.

If the GL implementation has per-thread execution queues (for example,
amdgpu by default), this might mean that the texture setup commands
aren't visible to command stream that's actually using the
texture.

Explicitly `glFlush()` after our texture setup, to ensure
these commands are visible to any `EGLContext` that might
need them.

Closes: #3792