### PR TITLE
miral: fix missing dsi enumeration

### DIFF
--- a/include/miral/miral/output.h
+++ b/include/miral/miral/output.h
@@ -53,7 +53,10 @@ public:
         hdmia,
         hdmib,
         tv,
-        edp
+        edp,
+        virt,
+        dsi,
+        dpi
     };
 
     explicit Output(const mir::graphics::DisplayConfigurationOutput &output);


### PR DESCRIPTION
* Display output types are enumerated in multiple places across mir. In all of them except for this file, Virtual, DSI, and DPI are enumerated. make miral's output enumeration consistent with rest of mir graphics.