### PR TITLE
miral: Avoid exception when looking up sessions & windows

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -474,12 +474,24 @@ auto miral::BasicWindowManager::find_application(std::function<bool(ApplicationI
 auto miral::BasicWindowManager::info_for(std::weak_ptr<scene::Session> const& session) const
 -> ApplicationInfo&
 {
+    if (app_info.find(session) == app_info.end())
+    {
+        static ApplicationInfo const null_app_info;
+        return const_cast<ApplicationInfo&>(null_app_info);
+    }
+
     return const_cast<ApplicationInfo&>(app_info.at(session));
 }
 
 auto miral::BasicWindowManager::info_for(std::weak_ptr<scene::Surface> const& surface) const
 -> WindowInfo&
 {
+    if (window_info.find(surface) == window_info.end())
+    {
+        static WindowInfo const null_surface_info;
+        return const_cast<WindowInfo&>(null_surface_info);
+    }
+
     return const_cast<WindowInfo&>(window_info.at(surface));
 }
 


### PR DESCRIPTION
The way miral::BasicWindowManager::info_for() methods are used is without additional error checking whether those ApplicationInfos & WindowInfos actually exist.

Instead of triggering an exception in std::map::at() for out of bounds access, just check whether those are there and return empty informations otherwise.

Fixes a crash in Lomiri where destruction of an xdg_toplevel leads to looking up a non-existing session.

Reference: #3824