### PR TITLE
Protect `AccessibilityManager` data member from racy mutations

### DIFF
--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -55,9 +55,9 @@ private:
     std::mutex mutable state_mutex;
     int repeat_rate_{25};
     int repeat_delay_{600};
-    bool enable_key_repeat;
 
-    bool enable_mouse_keys;
+    bool const enable_key_repeat;
+    bool const enable_mouse_keys;
 
     std::shared_ptr<mir::input::InputEventTransformer> const event_transformer;
     std::shared_ptr<mir::input::InputEventTransformer::Transformer> const transformer;

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -18,6 +18,8 @@
 #define MIR_SHELL_ACCESSIBILITY_MANAGER_H
 
 #include "mir/input/input_event_transformer.h"
+#include "mir/synchronised.h"
+
 #include <memory>
 #include <optional>
 #include <vector>
@@ -49,12 +51,16 @@ public:
     void notify_helpers() const;
 
 private:
-    std::vector<std::shared_ptr<shell::KeyboardHelper>> keyboard_helpers;
 
-    // 25 rate and 600 delay are the default in Weston and Sway
-    std::mutex mutable state_mutex;
-    int repeat_rate_{25};
-    int repeat_delay_{600};
+    struct MutableState {
+        // 25 rate and 600 delay are the default in Weston and Sway
+        int repeat_rate{25};
+        int repeat_delay{600};
+
+        std::vector<std::shared_ptr<shell::KeyboardHelper>> keyboard_helpers;
+    };
+
+    Synchronised<MutableState> mutable_state;
 
     bool const enable_key_repeat;
     bool const enable_mouse_keys;

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -52,6 +52,7 @@ private:
     std::vector<std::shared_ptr<shell::KeyboardHelper>> keyboard_helpers;
 
     // 25 rate and 600 delay are the default in Weston and Sway
+    std::mutex mutable state_mutex;
     int repeat_rate_{25};
     int repeat_delay_{600};
     bool enable_key_repeat;

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -32,20 +32,24 @@ void mir::shell::AccessibilityManager::register_keyboard_helper(std::shared_ptr<
 }
 
 std::optional<int> mir::shell::AccessibilityManager::repeat_rate() const {
+    std::lock_guard guard{state_mutex};
     if(!enable_key_repeat)
         return {};
     return repeat_rate_;
 }
 
 int mir::shell::AccessibilityManager::repeat_delay() const {
+    std::lock_guard guard{state_mutex};
     return repeat_delay_;
 }
 
 void mir::shell::AccessibilityManager::repeat_rate(int new_rate) {
+    std::lock_guard guard{state_mutex};
     repeat_rate_ = new_rate;
 }
 
 void mir::shell::AccessibilityManager::repeat_delay(int new_delay) {
+    std::lock_guard guard{state_mutex};
     repeat_delay_ = new_delay;
 }
 

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -28,33 +28,29 @@
 
 void mir::shell::AccessibilityManager::register_keyboard_helper(std::shared_ptr<KeyboardHelper> const& helper)
 {
-    keyboard_helpers.push_back(helper);
+    mutable_state.lock()->keyboard_helpers.push_back(helper);
 }
 
 std::optional<int> mir::shell::AccessibilityManager::repeat_rate() const {
-    std::lock_guard guard{state_mutex};
     if(!enable_key_repeat)
         return {};
-    return repeat_rate_;
+    return mutable_state.lock()->repeat_rate;
 }
 
 int mir::shell::AccessibilityManager::repeat_delay() const {
-    std::lock_guard guard{state_mutex};
-    return repeat_delay_;
+    return mutable_state.lock()->repeat_delay;
 }
 
 void mir::shell::AccessibilityManager::repeat_rate(int new_rate) {
-    std::lock_guard guard{state_mutex};
-    repeat_rate_ = new_rate;
+    mutable_state.lock()->repeat_rate = new_rate;
 }
 
 void mir::shell::AccessibilityManager::repeat_delay(int new_delay) {
-    std::lock_guard guard{state_mutex};
-    repeat_delay_ = new_delay;
+    mutable_state.lock()->repeat_delay = new_delay;
 }
 
 void mir::shell::AccessibilityManager::notify_helpers() const {
-    for(auto const& helper: keyboard_helpers)
+    for(auto const& helper: mutable_state.lock()->keyboard_helpers)
         helper->repeat_info_changed(repeat_rate(), repeat_delay());
 }
 


### PR DESCRIPTION
Addresses https://github.com/canonical/mir/pull/3735#discussion_r1999090513
Didn't really fit with either #3735 nor #3830, so I made it into its own PR.