### PR TITLE
testing: adding MinimalWindowManager tests for preparing a movement gesture

### DIFF
--- a/tests/include/mir_test_framework/window_management_test_harness.h
+++ b/tests/include/mir_test_framework/window_management_test_harness.h
@@ -59,7 +59,7 @@ public:
     void request_focus(miral::Window const&);
 
     auto focused_surface() -> std::shared_ptr<mir::scene::Surface>;
-    auto tools() -> miral::WindowManagerTools const&;
+    auto tools() -> miral::WindowManagerTools&;
     auto is_above(miral::Window const& a, miral::Window const& b) const -> bool;
 
     virtual auto get_builder() -> WindowManagementPolicyBuilder = 0;

--- a/tests/mir_test_framework/window_management_test_harness.cpp
+++ b/tests/mir_test_framework/window_management_test_harness.cpp
@@ -200,7 +200,7 @@ auto mir_test_framework::WindowManagementTestHarness::focused_surface() -> std::
     return server.the_shell()->focused_surface();
 }
 
-auto mir_test_framework::WindowManagementTestHarness::tools() -> miral::WindowManagerTools const&
+auto mir_test_framework::WindowManagementTestHarness::tools() -> miral::WindowManagerTools&
 {
     return self->tools;
 }


### PR DESCRIPTION
## What's new?
- Adding tests for windows transitioning states when they are moved