### PR TITLE
CMake: Don't error on some GCC warnings with high false-positive rates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,10 +68,22 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--as-needed")
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--as-needed")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--as-needed")
 
+
 set(MIR_FATAL_COMPILE_WARNINGS ON CACHE BOOL "Should compiler warnings fail the build")
 if(MIR_FATAL_COMPILE_WARNINGS)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  # Disable maybe-uninitialized errors on GCC when optimisation is enabled
+  # They are notorious for false-positives
+  # Also, disable array-bounds errors, they are likewise significantly
+  # false-positivey
+  # (We particularly hit https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111415)
+  if ((CMAKE_C_COMPILER_ID MATCHES "GNU") AND NOT (CMAKE_BUILD_TYPE MATCHES "Debug"))
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=maybe-uninitialized -Wno-error=array-bounds")
+  endif()
+  if ((CMAKE_CXX_COMPILER_ID MATCHES "GNU") AND NOT (CMAKE_BUILD_TYPE MATCHES "Debug"))
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=maybe-uninitialized -Wno-error=array-bounds")
+  endif()
 endif()
 
 set(MIR_COMPILER_QUIRKS "" CACHE STRING "Semicolon-separated list of compiler quirks to enable")


### PR DESCRIPTION
`-Warray-bounds` and `-Wmaybe-uninitialized` have been known since GCC 11 to generate false positives. They come and go, as optimisations change, but we hit these sufficiently often to make it not useful to error on them.

Particularly: we get hit by [this specific array-bounds issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111415)

(Meta bugs on the GCC bugtracker for these are [array-bounds](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56456) and [list for maybe-uninitialized](https://gcc.gnu.org/bugzilla/buglist.cgi?quicksearch=maybe%20uninitialized%20false%20positive))