### PR TITLE
(#3843) bugfix: increase timeout to 1 second in TestConfigFile 

### DIFF
--- a/src/miral/config_file.cpp
+++ b/src/miral/config_file.cpp
@@ -170,11 +170,13 @@ void Watcher::register_handler(miral::MirRunner& runner)
 {
     if (directory_watch_descriptor)
     {
+        mir::log_debug("Registering the signal handler for %d", directory_watch_descriptor.value());
         auto const weak_this = weak_from_this();
         fd_handle = runner.register_fd_handler(inotify_fd, [weak_this] (int fd)
         {
             if (auto const strong_this = weak_this.lock())
             {
+                mir::log_debug("Calling signal handler callback for %d", fd);
                 strong_this->handler(fd);
             }
             else
@@ -183,6 +185,8 @@ void Watcher::register_handler(miral::MirRunner& runner)
             }
         });
     }
+    else
+        mir::log_debug("Not registering the signal handler for %d", directory_watch_descriptor.value());
 }
 
 void Watcher::handler(int) const

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -95,6 +95,8 @@ struct TestConfigFile : PendingLoad, miral::TestServer
         mark_pending();
         std::ofstream file(path/config_file);
         file << "some content";
+
+        std::cout << "write_config_in: wrote config file to: " << path << std::endl;
     }
 
     void SetUp() override

--- a/tests/miral/config_file.cpp
+++ b/tests/miral/config_file.cpp
@@ -44,9 +44,19 @@ public:
     {
         std::unique_lock lock{mutex};
 
-        if (!cv.wait_for(lock, std::chrono::milliseconds{10}, [this] { return !pending_loads; }))
+        if (!cv.wait_for(lock, std::chrono::milliseconds{100}, [this] { return !pending_loads; }))
         {
             std::cerr << "wait_for_load() timed out" << std::endl;
+        }
+    }
+
+    void wait_for_nothing()
+    {
+        std::unique_lock lock{mutex};
+
+        if (!cv.wait_for(lock, std::chrono::milliseconds{10}, [this] { return !pending_loads; }))
+        {
+            std::cerr << "wait_for_nothing() timed out" << std::endl;
         }
     }
 
@@ -419,7 +429,7 @@ TEST_F(TestConfigFile, with_no_reloading_when_a_file_is_written_nothing_is_loade
     EXPECT_CALL(*this, load).Times(0);
 
     write_a_file();
-    wait_for_load();
+    wait_for_nothing();
 }
 
 TEST_F(TestConfigFile, with_no_reloading_when_a_file_is_rewritten_nothing_is_reloaded)
@@ -439,7 +449,7 @@ TEST_F(TestConfigFile, with_no_reloading_when_a_file_is_rewritten_nothing_is_rel
 
     wait_for_load();
     write_a_file();
-    wait_for_load();
+    wait_for_nothing();
 }
 
 TEST_F(TestConfigFile, with_no_reloading_when_config_home_unset_a_file_in_home_config_is_loaded)
@@ -507,7 +517,7 @@ TEST_F(TestConfigFile, with_no_reloading_a_file_in_xdg_config_home_is_not_reload
     write_config_in(xdg_conf_dir0);
     write_config_in(xdg_conf_home);
     write_config_in(home_config);
-    wait_for_load();
+    wait_for_nothing();
 }
 
 TEST_F(TestConfigFile, with_no_reloading_a_config_in_xdg_conf_dir0_is_loaded)
@@ -553,7 +563,7 @@ TEST_F(TestConfigFile, with_no_reloading_after_a_config_in_xdg_conf_dir0_is_load
     wait_for_load();
 
     write_config_in(xdg_conf_home);
-    wait_for_load();
+    wait_for_nothing();
 }
 
 TEST_F(TestConfigFile, with_no_reloading_a_config_in_xdg_conf_dir0_is_loaded_in_preference_to_dir1_or_2)


### PR DESCRIPTION
fixes #3843 

So this test (and its kin) rely on a bit of a timing. The order of events is:

1. Start monitoring the config file on the main thread. This enqueues a task onto the fd monitor thread.
2. Write the config file on the main thread.
3. Wait on the config to be written on main thread (timeout is 10ms)
4. Expect that the fd thread fires in the meantime telling us that the file has changed

Steps 3 and 4 currently have to happen within 10ms. This is likely to happen more often than not. However, if a machine has a slow moment, this could be too little time. My recommendation here is to increase that timeout.

## What's new?
- Increase test timeout from 10ms to 1s to increase chance of success on slow machines
