### PR TITLE
tests/UdevWrapper: Drop test relying on UDev behaviour that has changed.

### DIFF
--- a/tests/unit-tests/test_udev_wrapper.cpp
+++ b/tests/unit-tests/test_udev_wrapper.cpp
@@ -317,19 +317,6 @@ TEST_F(UdevWrapperTest, MemberDereferenceWorks)
     EXPECT_STREQ("drm", iter->subsystem());
 }
 
-TEST_F(UdevWrapperTest, UdevMonitorDoesNotTriggerBeforeEnabling)
-{
-    mir::udev::Monitor monitor{mir::udev::Context()};
-    bool event_handler_called = false;
-
-    udev_environment.add_device("drm", "control64D", NULL, {}, {});
-
-    monitor.process_events([&event_handler_called](mir::udev::Monitor::EventType,
-                                                   mir::udev::Device const&) {event_handler_called = true;});
-
-    EXPECT_FALSE(event_handler_called);
-}
-
 TEST_F(UdevWrapperTest, UdevMonitorTriggersAfterEnabling)
 {
     mir::udev::Monitor monitor{mir::udev::Context()};


### PR DESCRIPTION
None of our code *really* cares that we don't want to get events before calling `monitor.enable()`, and UDev in Ubuntu 25.04 has changed behaviour so that events *are* received before enabling the monitor, so just drop the test.

Fixes: #3850 