### PR TITLE
Deprecate "persistent" surface IDs

### DIFF
--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -115,14 +115,18 @@ public:
      * @param id        the persistent surface id
      * @return          the metadata
      * @throw           invalid_argument or runtime_error if the id is badly formatted/doesn't identify a current window
+     * \deprecated      'Persistent' surface IDs were part of mirclient API
      */
+    [[deprecated("'Persistent' surface IDs were part of mirclient API")]]
     auto info_for_window_id(std::string const& id) const -> WindowInfo&;
 
     /** retrieve the persistent surface id for a window
      *
      * @param window    the window
      * @return          the persistent surface id
+     * \deprecated      'Persistent' surface IDs were part of mirclient API
      */
+    [[deprecated("'Persistent' surface IDs were part of mirclient API")]]
     auto id_for_window(Window const& window) const -> std::string;
 
     /// Send close request to the window

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -489,6 +489,8 @@ try {
 }
 MIRAL_TRACE_EXCEPTION
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 auto miral::WindowManagementTrace::info_for_window_id(std::string const& id) const -> WindowInfo&
 try {
     log_input();
@@ -508,6 +510,7 @@ try {
     return result;
 }
 MIRAL_TRACE_EXCEPTION
+#pragma GCC diagnostic pop
 
 void miral::WindowManagementTrace::place_and_size_for_state(
     WindowSpecification& modifications, WindowInfo const& window_info) const


### PR DESCRIPTION

IMO the `PersistentSurfaceStore` and associated infrastructure are zombie code: Mark the corresponding APIs as deprecated before removal