### PR TITLE
tests: drop `MIR_COMPILER_QUIRKS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,6 @@ if(MIR_FATAL_COMPILE_WARNINGS)
   endif()
 endif()
 
-set(MIR_COMPILER_QUIRKS "" CACHE STRING "Semicolon-separated list of compiler quirks to enable")
-
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-Wmismatched-tags HAS_W_MISMATCHED_TAGS)
 

--- a/debian/rules
+++ b/debian/rules
@@ -30,13 +30,6 @@ COMMON_CONFIGURE_OPTIONS = \
   -DCMAKE_INSTALL_LIBEXECDIR="lib/$(DEB_HOST_MULTIARCH)/mir"\
   -DMIR_BUILD_INTERPROCESS_TESTS=OFF\
 
-ifeq ($(filter ppc64el,$(DEB_HOST_ARCH)),ppc64el)
-	# Disable spurious error on GCC>=12
-	ifneq ($(shell gcc --version | grep '1[34].[[:digit:]]\+.[[:digit:]]\+$$'),)
-		COMMON_CONFIGURE_OPTIONS += -DMIR_COMPILER_QUIRKS="test_touchspot_controller.cpp:array-bounds"
-	endif
-endif
-
 # Disable LTO on broken binutils
 # https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/2070302
 ifneq ($(shell ld --version | grep '2.43.1$$'),)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -150,13 +150,6 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "AddressSanitizer")
     PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
 endif()
 
-if ("test_touchspot_controller.cpp:array-bounds" IN_LIST MIR_COMPILER_QUIRKS)
-  set_property(
-    SOURCE input/test_touchspot_controller.cpp
-    PROPERTY COMPILE_OPTIONS -Wno-error=array-bounds    # ppc64el spuriously warns here
-  )
-endif()
-
 if (MIR_USE_PRECOMPILED_HEADERS)
   target_precompile_headers(
     mir_unit_tests


### PR DESCRIPTION
(https://github.com/canonical/mir/pull/3842) disabled `array-bounds` errors in optimized builds, that was the
only remaining quirk.