### PR TITLE
debian: tighten LTO-disabling rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -39,8 +39,10 @@ endif
 
 # Disable LTO on broken binutils
 # https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/2070302
-ifneq ($(shell ld --version | grep '2.43.1$$'),)
-	DEB_BUILD_MAINT_OPTIONS += optimize=-lto
+ifeq ($(filter arm64,$(DEB_HOST_ARCH)),arm64)
+	ifneq ($(shell ld --version | grep -E '2.4(4|3.1)$$'),)
+		DEB_BUILD_MAINT_OPTIONS += optimize=-lto
+	endif
 endif
 
 # We can't guarantee non-Ubuntu builds will build against WLCS packages we


### PR DESCRIPTION
Only see those issues in plucky,oracular/arm64 at the moment.