### PR TITLE
WIP: gbm-kms: do not pass invalid mode index as current mode

### DIFF
--- a/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
+++ b/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
@@ -593,7 +593,10 @@ void mgg::RealKMSOutput::update_from_hardware_state(
     // There's no need to warn about failing to find a current display mode on a disconnected display.
     if (connected && (current_mode_index == invalid_mode_index)) {
         mir::log_warning(
-            "Unable to determine the current display mode.");
+            "Unable to determine the current display mode, setting to preferred mode");
+        if (preferred_mode_index != invalid_mode_index) {
+            current_mode_index = preferred_mode_index;
+        }
     }
 
     output.type = type;


### PR DESCRIPTION
If preferred mode exists then pass it as a current mode if current mode is not set. This fixes the coredump in lomiri when one tries to connect HDMI display, because of invalid current mode index.