### PR TITLE
docs: remove extra brace

### DIFF
--- a/doc/sphinx/how-to/how-to-specify-startup-apps.md
+++ b/doc/sphinx/how-to/how-to-specify-startup-apps.md
@@ -35,7 +35,7 @@ to pass the external client launcher and our configuration option to
 +    {
 +        for(auto const& app : apps)
 +        {
-+            external_client_launcher.launch(std::vector<std::string>{app}});
++            external_client_launcher.launch(std::vector<std::string>{app});
 +        }
 +    };
 +


### PR DESCRIPTION
Removes an extra unmatched closed brace in the "How to Specify Startup Applications" code sample.