### PR TITLE
Only initialize `AccessibilityManager::transformer` if mousekeys are enabled

### DIFF
--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -68,7 +68,7 @@ private:
     bool const enable_mouse_keys;
 
     std::shared_ptr<mir::input::InputEventTransformer> const event_transformer;
-    std::shared_ptr<mir::input::InputEventTransformer::Transformer> transformer;
+    std::shared_ptr<mir::input::InputEventTransformer::Transformer> const transformer;
 };
 }
 }

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -65,7 +65,6 @@ private:
     Synchronised<MutableState> mutable_state;
 
     bool const enable_key_repeat;
-    bool const enable_mouse_keys;
 
     std::shared_ptr<mir::input::InputEventTransformer> const event_transformer;
     std::shared_ptr<mir::input::InputEventTransformer::Transformer> const transformer;

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -66,7 +66,7 @@ private:
     bool const enable_mouse_keys;
 
     std::shared_ptr<mir::input::InputEventTransformer> const event_transformer;
-    std::shared_ptr<mir::input::InputEventTransformer::Transformer> const transformer;
+    std::shared_ptr<mir::input::InputEventTransformer::Transformer> transformer;
 };
 }
 }

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -40,6 +40,8 @@ public:
         std::shared_ptr<mir::options::Option> const&,
         std::shared_ptr<input::InputEventTransformer> const& event_transformer);
 
+    ~AccessibilityManager();
+
     void register_keyboard_helper(std::shared_ptr<shell::KeyboardHelper> const&);
 
     std::optional<int> repeat_rate() const;

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -116,22 +116,18 @@ mir::shell::AccessibilityManager::AccessibilityManager(
     std::shared_ptr<mir::options::Option> const& options,
     std::shared_ptr<input::InputEventTransformer> const& event_transformer) :
     enable_key_repeat{options->get<bool>(options::enable_key_repeat_opt)},
-    enable_mouse_keys{options->get<bool>(options::enable_mouse_keys_opt)},
     event_transformer{event_transformer},
     transformer{[&]
                 {
-                    if (enable_mouse_keys)
-                    {
-                        auto const t = std::make_shared<MouseKeysTransformer>();
-                        event_transformer->append(transformer);
-                        return t;
-                    }
-
-                    return std::shared_ptr<MouseKeysTransformer>{};
+                    return (options->get<bool>(options::enable_mouse_keys_opt)) ?
+                               std::make_shared<MouseKeysTransformer>() :
+                               std::shared_ptr<MouseKeysTransformer>{};
                 }()
 
     }
 {
+    if (transformer)
+        event_transformer->append(transformer);
 }
 
 mir::shell::AccessibilityManager::~AccessibilityManager()

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -117,13 +117,21 @@ mir::shell::AccessibilityManager::AccessibilityManager(
     std::shared_ptr<input::InputEventTransformer> const& event_transformer) :
     enable_key_repeat{options->get<bool>(options::enable_key_repeat_opt)},
     enable_mouse_keys{options->get<bool>(options::enable_mouse_keys_opt)},
-    event_transformer{event_transformer}
-{
-    if (enable_mouse_keys)
-    {
-        transformer = std::make_shared<MouseKeysTransformer>();
-        event_transformer->append(transformer);
+    event_transformer{event_transformer},
+    transformer{[&]
+                {
+                    if (enable_mouse_keys)
+                    {
+                        auto const t = std::make_shared<MouseKeysTransformer>();
+                        event_transformer->append(transformer);
+                        return t;
+                    }
+
+                    return std::shared_ptr<MouseKeysTransformer>{};
+                }()
+
     }
+{
 }
 
 mir::shell::AccessibilityManager::~AccessibilityManager()

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -125,3 +125,9 @@ mir::shell::AccessibilityManager::AccessibilityManager(
         event_transformer->append(transformer);
     }
 }
+
+mir::shell::AccessibilityManager::~AccessibilityManager()
+{
+    if(transformer)
+        event_transformer->remove(transformer);
+}

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -132,6 +132,6 @@ mir::shell::AccessibilityManager::AccessibilityManager(
 
 mir::shell::AccessibilityManager::~AccessibilityManager()
 {
-    if(transformer)
+    if (transformer)
         event_transformer->remove(transformer);
 }

--- a/src/server/shell/accessibility_manager.cpp
+++ b/src/server/shell/accessibility_manager.cpp
@@ -117,9 +117,11 @@ mir::shell::AccessibilityManager::AccessibilityManager(
     std::shared_ptr<input::InputEventTransformer> const& event_transformer) :
     enable_key_repeat{options->get<bool>(options::enable_key_repeat_opt)},
     enable_mouse_keys{options->get<bool>(options::enable_mouse_keys_opt)},
-    event_transformer{event_transformer},
-    transformer{std::make_shared<MouseKeysTransformer>()}
+    event_transformer{event_transformer}
 {
     if (enable_mouse_keys)
+    {
+        transformer = std::make_shared<MouseKeysTransformer>();
         event_transformer->append(transformer);
+    }
 }


### PR DESCRIPTION
Split out from https://github.com/canonical/mir/pull/3861#issuecomment-2758295300