### PR TITLE
ci: rename symbols check job

### DIFF
--- a/.github/workflows/symbols-check.yml
+++ b/.github/workflows/symbols-check.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -12,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Run:
+  CheckSymbols:
     runs-on: ubuntu-24.04
 
     timeout-minutes: 10


### PR DESCRIPTION
Otherwise can't make it required.