### PR TITLE
feature: add the ability to associate a layout with custom user data

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -504,13 +504,6 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, miral::FocusStealing)@MIRAL_5.0" 5.2.0
  (c++)"miral::WindowManagementPolicy::~WindowManagementPolicy()@MIRAL_5.0" 5.2.0
  MIRAL_5.3@MIRAL_5.3 5.3.0
- (c++)"miral::InputConfiguration::Keyboard::merge(miral::InputConfiguration::Keyboard const&)@MIRAL_5.3" 5.3.0
- (c++)"miral::InputConfiguration::Keyboard::repeat_delay() const@MIRAL_5.3" 5.3.0
- (c++)"miral::InputConfiguration::Keyboard::repeat_rate() const@MIRAL_5.3" 5.3.0
- (c++)"miral::InputConfiguration::Mouse::merge(miral::InputConfiguration::Mouse const&)@MIRAL_5.3" 5.3.0
- (c++)"miral::InputConfiguration::Touchpad::merge(miral::InputConfiguration::Touchpad const&)@MIRAL_5.3" 5.3.0
- (c++)"miral::InputConfiguration::Touchpad::middle_mouse_button_emulation() const@MIRAL_5.3" 5.3.0
- (c++)"miral::InputConfiguration::Touchpad::middle_mouse_button_emulation(std::optional<bool> const&)@MIRAL_5.3" 5.3.0
  (c++)"miral::CursorScale::CursorScale()@MIRAL_5.3" 5.3.0
  (c++)"miral::CursorScale::CursorScale(float)@MIRAL_5.3" 5.3.0
  (c++)"miral::CursorScale::apply_scale() const@MIRAL_5.3" 5.3.0
@@ -518,6 +511,24 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::CursorScale::scale(float) const@MIRAL_5.3" 5.3.0
  (c++)"miral::CursorScale::set_scale(float) const@MIRAL_5.3" 5.3.0
  (c++)"miral::CursorScale::~CursorScale()@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::Node::Node(miral::DisplayConfiguration::Node&&)@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::Node::Node(std::unique_ptr<miral::DisplayConfiguration::Node::Self, std::default_delete<miral::DisplayConfiguration::Node::Self> >&&)@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::Node::as_int() const@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::Node::as_string[abi:cxx11]() const@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::Node::at(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::Node::for_each(std::function<void (miral::DisplayConfiguration::Node const&)> const&) const@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::Node::has(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::Node::type() const@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::Node::~Node()@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::layout_userdata(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const@MIRAL_5.3" 5.3.0
+ (c++)"miral::DisplayConfiguration::layout_userdata_builder(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<std::any (miral::DisplayConfiguration::Node const&)> const&) const@MIRAL_5.3" 5.3.0
+ (c++)"miral::InputConfiguration::Keyboard::merge(miral::InputConfiguration::Keyboard const&)@MIRAL_5.3" 5.3.0
+ (c++)"miral::InputConfiguration::Keyboard::repeat_delay() const@MIRAL_5.3" 5.3.0
+ (c++)"miral::InputConfiguration::Keyboard::repeat_rate() const@MIRAL_5.3" 5.3.0
+ (c++)"miral::InputConfiguration::Mouse::merge(miral::InputConfiguration::Mouse const&)@MIRAL_5.3" 5.3.0
+ (c++)"miral::InputConfiguration::Touchpad::merge(miral::InputConfiguration::Touchpad const&)@MIRAL_5.3" 5.3.0
+ (c++)"miral::InputConfiguration::Touchpad::middle_mouse_button_emulation() const@MIRAL_5.3" 5.3.0
+ (c++)"miral::InputConfiguration::Touchpad::middle_mouse_button_emulation(std::optional<bool> const&)@MIRAL_5.3" 5.3.0
  (c++)"miral::MouseKeysConfig::MouseKeysConfig(bool)@MIRAL_5.3" 5.3.0
  (c++)"miral::MouseKeysConfig::ToggleMouseKeys(bool)@MIRAL_5.3" 5.3.0
  (c++)"miral::MouseKeysConfig::enabled(bool) const@MIRAL_5.3" 5.3.0

--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <optional>
 #include <set>
+#include <any>
 
 namespace YAML
 {
@@ -41,6 +42,8 @@ class MainLoop;
 class Server;
 namespace shell { class DisplayConfigurationController; }
 }
+
+namespace YAML { class Node; }
 
 namespace miral
 {
@@ -56,7 +59,13 @@ public:
 
     auto list_layouts() const -> std::vector<std::string>;
 
+    auto layout_userdata(std::string const& key) -> std::optional<std::any const>;
+
     void add_output_attribute(std::string const& key);
+
+    void layout_userdata_builder(
+        std::string const& key,
+        std::function<std::any(YAML::Node const&)> const& builder);
 
     static void serialize_configuration(std::ostream& out, mir::graphics::DisplayConfiguration& conf);
 
@@ -85,15 +94,24 @@ private:
         Product,
         Serial,
     };
+
     // Workaround for not allowing static initialization in class
     static std::map<Property, std::string const> const display_matching_properties();
 
     using Matchers = std::map<Property, std::string>;
     using Matchers2Config = std::vector<std::pair<Matchers, Config>>;
-    using Layout2Matchers2Config = std::map<std::string, Matchers2Config>;
-    Layout2Matchers2Config config;
+    struct LayoutConfig
+    {
+        Matchers2Config matchers2config;
+        std::map<std::string, std::any> userdata;
+    };
+
+    std::map<std::string, LayoutConfig> config;
 
     std::set<std::string> custom_output_attributes;
+
+    using LayoutUserDataBuilder = std::function<std::any(YAML::Node const& value)>;
+    std::map<std::string, LayoutUserDataBuilder> layout_userdata_builder_funcs;
 
     void parse_configuration(YAML::Node const& node, Config& config, std::string const& error_prefix, std::string const& identifier);
 

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -499,10 +499,10 @@ global:
     typeinfo?for?miral::ConfigFile;
     typeinfo?for?miral::Decorations;
     typeinfo?for?miral::IdleListener;
+    typeinfo?for?miral::IdleListener;
     typeinfo?for?miral::InputConfiguration::Mouse;
     typeinfo?for?miral::InputConfiguration::Touchpad;
     typeinfo?for?miral::InputConfiguration;
-    typeinfo?for?miral::IdleListener;
   };
 } MIRAL_5.0;
 
@@ -526,21 +526,34 @@ global:
   extern "C++" {
     miral::CursorScale::?CursorScale*;
     miral::CursorScale::CursorScale*;
-    miral::CursorScale::scale*;
     miral::CursorScale::operator*;
+    miral::CursorScale::scale*;
+    miral::DisplayConfiguration::Node::?Node*;
+    miral::DisplayConfiguration::Node::Node*;
+    miral::DisplayConfiguration::Node::as_int*;
+    miral::DisplayConfiguration::Node::as_string*;
+    miral::DisplayConfiguration::Node::at*;
+    miral::DisplayConfiguration::Node::for_each*;
+    miral::DisplayConfiguration::Node::has*;
+    miral::DisplayConfiguration::Node::operator*;
+    miral::DisplayConfiguration::Node::type*;
+    miral::DisplayConfiguration::layout_userdata*;
+    miral::DisplayConfiguration::layout_userdata_builder*;
     miral::InputConfiguration::Keyboard::merge*;
+    miral::InputConfiguration::Keyboard::repeat_delay*;
+    miral::InputConfiguration::Keyboard::repeat_rate*;
     miral::InputConfiguration::Mouse::merge*;
     miral::InputConfiguration::Touchpad::merge*;
     miral::InputConfiguration::Touchpad::middle_mouse_button_emulation*;
-    miral::InputConfiguration::Keyboard::repeat_delay*;
-    miral::InputConfiguration::Keyboard::repeat_rate*;
     miral::MouseKeysConfig::MouseKeysConfig*;
+    miral::MouseKeysConfig::enabled*;
     miral::MouseKeysConfig::operator*;
     miral::MouseKeysConfig::set_acceleration_factors*;
     miral::MouseKeysConfig::set_keymap*;
     miral::MouseKeysConfig::set_max_speed*;
-    miral::MouseKeysConfig::enabled*;
     typeinfo?for?miral::CursorScale;
+    typeinfo?for?miral::DisplayConfiguration::Node;
     typeinfo?for?miral::MouseKeysConfig;
   };
 } MIRAL_5.2;
+

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -35,6 +35,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     modify_window_state.cpp
     modify_window_specification.cpp
     display_reconfiguration.cpp
+    display_configuration.cpp
     raise_tree.cpp
     static_display_config.cpp
     test_window_manager_tools.cpp           test_window_manager_tools.h

--- a/tests/miral/display_configuration.cpp
+++ b/tests/miral/display_configuration.cpp
@@ -1,0 +1,140 @@
+/*
+* Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "miral/display_configuration.h"
+#include "miral/test_server.h"
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace miral;
+using namespace testing;
+namespace mt = mir::test;
+
+struct BaseTestDisplayConfiguration : TestDisplayServer, Test
+{
+    void SetUp() override
+    {
+        // Set environment variables such that we'll always read the display
+        // configuration from the temporary directory.
+        setenv("XDG_CONFIG_HOME", "/tmp", 1);
+        unsetenv("XDG_CONFIG_DIRS");
+        unsetenv("HOME");
+
+        invoke_runner([&](MirRunner const& runner)
+        {
+            configuration = std::make_shared<DisplayConfiguration>(runner);
+
+            add_server_init([&](mir::Server& server)
+            {
+                before_read("/tmp/" + runner.display_config_file());
+                (*configuration)(server);
+            });
+        });
+
+        start_server();
+    }
+
+    void TearDown() override
+    {
+        stop_server();
+    }
+
+    /// Called before the display configuration is read. Implementers should
+    /// use this method to write the yaml file that they would like to test
+    /// and set up any callbacks that they expect to be triggered as a result
+    /// of reading.
+    virtual void before_read(std::string const& filepath) = 0;
+
+    std::shared_ptr<DisplayConfiguration> configuration;
+};
+
+struct TestCustomLayoutKeysDisplayConfiguration : BaseTestDisplayConfiguration
+{
+    void before_read(std::string const& filepath) override
+    {
+        // First, write the yaml payload to the file
+        std::ofstream file(filepath);
+        std::string yaml{
+            "layouts:\n"
+            "  first:\n"
+            "    cards:\n"
+            "    - VGA-1:\n"
+            "        state: disabled\n"
+            "    - HDMI-A-1:\n"
+            "        state: disabled\n"
+            "    custom_string: value\n"
+            "    custom_int: 10\n"
+            "    custom_sequence:\n"
+            "        - first\n"
+            "    custom_map:\n"
+            "        key: value\n"
+            "  second:\n"
+            "    cards:\n"
+            "    - VGA-1:\n"
+            "        orientation: inverted\n"
+            "    - HDMI-A-1:\n"
+            "        position: [1280, 0]\n"};
+        file << yaml;
+
+        // Next, establish all of the expected keys
+        configuration->layout_userdata_builder("custom_string", [](DisplayConfiguration::Node const& node)
+        {
+            EXPECT_THAT(node.type(), Eq(miral::DisplayConfiguration::Node::Type::string));
+            return node.as_string();
+        });
+        configuration->layout_userdata_builder("custom_int", [](DisplayConfiguration::Node const& node)
+        {
+            EXPECT_THAT(node.type(), Eq(miral::DisplayConfiguration::Node::Type::integer));
+            return node.as_int();
+        });
+        configuration->layout_userdata_builder("custom_sequence", [](DisplayConfiguration::Node const& node)
+        {
+            EXPECT_THAT(node.type(), Eq(miral::DisplayConfiguration::Node::Type::sequence));
+            std::string value;
+            node.for_each([&](DisplayConfiguration::Node const& sub_node)
+            {
+                value = sub_node.as_string();
+            });
+            return value;
+        });
+        configuration->layout_userdata_builder("custom_map", [](DisplayConfiguration::Node const& node)
+        {
+            EXPECT_THAT(node.type(), Eq(miral::DisplayConfiguration::Node::Type::map));
+            EXPECT_TRUE(node.has("key"));
+            return node.at("key").value().as_string();
+        });
+    }
+};
+
+TEST_F(TestCustomLayoutKeysDisplayConfiguration, can_read_custom_keys_of_all_types_for_a_layout)
+{
+    configuration->select_layout("first");
+    EXPECT_THAT(std::any_cast<std::string>(configuration->layout_userdata("custom_string").value()), Eq("value"));
+    EXPECT_THAT(std::any_cast<int>(configuration->layout_userdata("custom_int").value()), Eq(10));
+    EXPECT_THAT(std::any_cast<std::string>(configuration->layout_userdata("custom_sequence").value()), Eq("first"));
+    EXPECT_THAT(std::any_cast<std::string>(configuration->layout_userdata("custom_map").value()), Eq("value"));
+}
+
+TEST_F(TestCustomLayoutKeysDisplayConfiguration, unseen_keys_are_set_to_nullopt)
+{
+    configuration->select_layout("second");
+    EXPECT_THAT(configuration->layout_userdata("custom_string").has_value(), Eq(false));
+    EXPECT_THAT(configuration->layout_userdata("custom_int").has_value(), Eq(false));
+    EXPECT_THAT(configuration->layout_userdata("custom_sequence").has_value(), Eq(false));
+    EXPECT_THAT(configuration->layout_userdata("custom_map").has_value(), Eq(false));
+}


### PR DESCRIPTION
## What's new?
- Add `DisplayConfiguration::layout_userdata` and `DisplayConfiguration::set_layout_userdata_builder` so that callers can get/set an arbitrary `shared_ptr<void>` user-defined data member on a per layout basis.
- Bumped the minor version of miral from 5.2 to 5.3
- Wrote a test for setting/getting the userdata for a layout
- Added a new stanza to the `symbols.map` file