### PR TITLE
Add `BasicAccessibilityManager::Registration`

### DIFF
--- a/src/server/shell/basic_accessibility_manager.cpp
+++ b/src/server/shell/basic_accessibility_manager.cpp
@@ -32,7 +32,7 @@ inline Transformer* mir::shell::BasicAccessibilityManager::Registration<Transfor
 }
 
 template <typename Transformer>
-inline void mir::shell::BasicAccessibilityManager::Registration<Transformer>::remove_registration()
+inline void mir::shell::BasicAccessibilityManager::Registration<Transformer>::remove_registration() const
 {
     // atomic::compare_exchange_strong(expected, desired) checks the atomic
     // value against the "expected" value. If they're equal, it returns `true`
@@ -46,7 +46,7 @@ inline void mir::shell::BasicAccessibilityManager::Registration<Transformer>::re
 }
 
 template <typename Transformer>
-inline void mir::shell::BasicAccessibilityManager::Registration<Transformer>::add_registration()
+inline void mir::shell::BasicAccessibilityManager::Registration<Transformer>::add_registration() const
 {
     auto expected = false;
     if (registered.compare_exchange_strong(expected, true))

--- a/src/server/shell/basic_accessibility_manager.h
+++ b/src/server/shell/basic_accessibility_manager.h
@@ -85,8 +85,8 @@ private:
             std::shared_ptr<Transformer> const& transformer,
             std::shared_ptr<input::InputEventTransformer> const& event_transformer);
 
-        void add_registration();
-        void remove_registration();
+        void add_registration() const;
+        void remove_registration() const;
 
         Transformer* operator->() const noexcept;
 
@@ -96,14 +96,14 @@ private:
 
         std::shared_ptr<Transformer> const transformer;
         std::shared_ptr<input::InputEventTransformer> const event_transformer;
-        std::atomic<bool> registered{false};
+        std::atomic<bool> mutable registered{false};
     };
 
     Synchronised<MutableState> mutable_state;
 
     bool const enable_key_repeat;
     std::shared_ptr<graphics::Cursor> const cursor;
-    Registration<MouseKeysTransformer> transformer;
+    Registration<MouseKeysTransformer> const transformer;
 };
 }
 }


### PR DESCRIPTION
Just a simple wrapper over a boolean + a transformer to prevent double-registrations and erroneous `on_{enabled,disabled}` calls.