### PR TITLE
testing: adding tests for output updates

### DIFF
--- a/examples/tests/test_floating_window_manager.cpp
+++ b/examples/tests/test_floating_window_manager.cpp
@@ -58,12 +58,12 @@ public:
         };
     }
 
-    auto get_output_rectangles() -> std::vector<mir::geometry::Rectangle> override
+    auto get_initial_output_configs() -> std::vector<mir::graphics::DisplayConfigurationOutput> override
     {
-        return {
+        return output_configs_from_output_rectangles({
             mir::geometry::Rectangle{{0, 0}, {800, 600}},
             mir::geometry::Rectangle{{800, 0}, {800, 600}}
-        };
+        });
     }
 
 private:

--- a/include/test/mir/test/doubles/fake_display.h
+++ b/include/test/mir/test/doubles/fake_display.h
@@ -40,6 +40,8 @@ public:
 
     explicit FakeDisplay(std::vector<geometry::Rectangle> const& output_rects);
 
+    explicit FakeDisplay(std::vector<mir::graphics::DisplayConfigurationOutput> const& output_configs);
+
     void for_each_display_sync_group(std::function<void(mir::graphics::DisplaySyncGroup&)> const& f) override;
 
     std::unique_ptr<mir::graphics::DisplayConfiguration> configuration() const override;

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -350,12 +350,12 @@ public:
 
     auto the_decoration_strategy() -> std::shared_ptr<DecorationStrategy> override;
     void set_the_decoration_strategy(std::shared_ptr<DecorationStrategy> strategy) override;
+    auto the_display_configuration_observer() -> std::shared_ptr<graphics::DisplayConfigurationObserver>;
 
 protected:
     std::shared_ptr<options::Option> the_options() const;
     auto the_options_provider() const -> std::shared_ptr<options::Configuration>;
     std::shared_ptr<input::DefaultInputDeviceHub>  the_default_input_device_hub();
-    std::shared_ptr<graphics::DisplayConfigurationObserver> the_display_configuration_observer();
     std::shared_ptr<input::SeatObserver> the_seat_observer();
 
     virtual std::shared_ptr<scene::MediatingDisplayChanger> the_mediating_display_changer();

--- a/src/include/server/mir/server.h
+++ b/src/include/server/mir/server.h
@@ -430,6 +430,10 @@ public:
     auto the_display_configuration_observer_registrar() const ->
         std::shared_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>>;
 
+    /// \return the DisplayConfigurationObserver
+    auto the_display_configuration_observer() const ->
+        std::shared_ptr<graphics::DisplayConfigurationObserver>;
+
     /// \return a registrar to add and remove SeatObservers
     auto the_seat_observer_registrar() const ->
         std::shared_ptr<ObserverRegistrar<input::SeatObserver>>;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -138,7 +138,8 @@ struct TemporaryCompositeEventFilter : public mi::CompositeEventFilter
     MACRO(the_input_device_registry)\
     MACRO(the_idle_handler)\
     MACRO(the_token_authority)\
-    MACRO(the_accessibility_manager)
+    MACRO(the_accessibility_manager)\
+    MACRO(the_display_configuration_observer)
 
 #define MIR_SERVER_BUILDER(name)\
     std::function<std::invoke_result_t<decltype(&mir::DefaultServerConfiguration::the_##name),mir::DefaultServerConfiguration*>()> name##_builder;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -204,6 +204,7 @@ global:
     mir::Server::the_decoration_strategy*;
     mir::Server::the_display*;
     mir::Server::the_display_configuration_controller*;
+    mir::Server::the_display_configuration_observer*;
     mir::Server::the_display_configuration_observer_registrar*;
     mir::Server::the_display_platforms*;
     mir::Server::the_focus_controller*;
@@ -1416,3 +1417,4 @@ global:
   };
 local: *;
 };
+

--- a/tests/include/mir_test_framework/window_management_test_harness.h
+++ b/tests/include/mir_test_framework/window_management_test_harness.h
@@ -22,6 +22,7 @@
 #include <miral/application.h>
 #include <miral/window_manager_tools.h>
 #include <mir/events/event.h>
+#include <mir/graphics/display_configuration.h>
 #include "mir_test_framework/headless_in_process_server.h"
 
 namespace mir::scene
@@ -64,8 +65,18 @@ public:
     auto tools() const -> miral::WindowManagerTools&;
     auto is_above(miral::Window const& a, miral::Window const& b) const -> bool;
 
+    void for_each_output(std::function<void(miral::Output const&)> const& f) const;
+
+    /// Simulates an update to the displays with the provided list of output configurations.
+    void update_outputs(std::vector<mir::graphics::DisplayConfigurationOutput> const&) const;
+
+    /// Helper method that transforms a list of output rectangles into a list of display configurations.
+    /// This is useful for creating a list of simple, connected outputs quickly.
+    static auto output_configs_from_output_rectangles(std::vector<mir::geometry::Rectangle> const& output_rects)
+        -> std::vector<mir::graphics::DisplayConfigurationOutput>;
+
     virtual auto get_builder() -> WindowManagementPolicyBuilder = 0;
-    virtual auto get_output_rectangles() -> std::vector<mir::geometry::Rectangle> = 0;
+    virtual auto get_initial_output_configs() -> std::vector<mir::graphics::DisplayConfigurationOutput> = 0;
 private:
     class Self;
     std::unique_ptr<Self> const self;

--- a/tests/window_management_tests/test_minimal_window_manager.cpp
+++ b/tests/window_management_tests/test_minimal_window_manager.cpp
@@ -14,9 +14,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "mir/geometry/forward.h"
 #define MIR_LOG_COMPONENT "test_minimal_window_manager"
+
+#include "mir/geometry/forward.h"
+#include "mir_test_framework/window_management_test_harness.h"
 #include <miral/minimal_window_manager.h>
+#include <miral/output.h>
 #include <mir/scene/session.h>
 #include <mir/wayland/weak.h>
 #include <mir/scene/surface.h>
@@ -25,10 +28,14 @@
 #include <mir/events/pointer_event.h>
 #include <mir/compositor/buffer_stream.h>
 #include <mir/log.h>
-
-#include "mir_test_framework/window_management_test_harness.h"
+#include <mir/graphics/default_display_configuration_policy.h>
+#include <mir/shell/shell.h>
 #include <linux/input.h>
 #include <mir/shell/shell.h>
+
+#include <gtest/gtest.h>
+#include <gtest/gtest-spi.h>
+#include <gmock/gmock.h>
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
@@ -121,6 +128,15 @@ CreateSurfaceSpecFunc create_bottom_attached()
 class MinimalWindowManagerTest : public mir_test_framework::WindowManagementTestHarness
 {
 public:
+    MinimalWindowManagerTest() : WindowManagementTestHarness()
+    {
+        server.wrap_display_configuration_policy([&](std::shared_ptr<mg::DisplayConfigurationPolicy> const&)
+            -> std::shared_ptr<mg::DisplayConfigurationPolicy>
+        {
+            return std::make_shared<mir::graphics::SideBySideDisplayConfigurationPolicy>();
+        });
+    }
+
     auto get_builder() -> mir_test_framework::WindowManagementPolicyBuilder override
     {
         return [&](miral::WindowManagerTools const& tools)
@@ -129,12 +145,12 @@ public:
         };
     }
 
-    auto get_output_rectangles() -> std::vector<mir::geometry::Rectangle> override
+    auto get_initial_output_configs() -> std::vector<mir::graphics::DisplayConfigurationOutput> override
     {
-        return {
+        return output_configs_from_output_rectangles({
             mir::geometry::Rectangle{{0, 0}, {800, 600}},
-            mir::geometry::Rectangle{{800, 0}, {800, 600}}
-        };
+            mir::geometry::Rectangle{{800, 0}, {1000, 600}}
+        });
     }
 
     virtual miral::FocusStealing focus_stealing() const
@@ -716,7 +732,7 @@ TEST_F(MinimalWindowManagerTest,
 TEST_F(MinimalWindowManagerTest, closing_attached_window_causes_maximized_to_resize)
 {
     // Setup: Create one app with a maximized window and one app with a top attached window
-    auto const output_rectangle =  get_output_rectangles()[0];
+    auto const output_rectangle =  get_initial_output_configs()[0];
     auto const app = open_application("app1");
     miral::WindowSpecification spec;
     spec.size() = { geom::Width {100}, geom::Height{100} };
@@ -725,10 +741,10 @@ TEST_F(MinimalWindowManagerTest, closing_attached_window_causes_maximized_to_res
     auto const window = create_window(app, spec);
 
     auto const top_spec = create_top_attached();
-    auto const attached = create_window(app, top_spec(output_rectangle.size));
+    auto const attached = create_window(app, top_spec(output_rectangle.extents().size));
     EXPECT_THAT(window.size(), Eq(geom::Size(
-        output_rectangle.size.width.as_int(),
-        output_rectangle.size.height.as_int() - exclusive_surface_size
+        output_rectangle.extents().size.width.as_int(),
+        output_rectangle.extents().size.height.as_int() - exclusive_surface_size
     )));
 
     // Act: Close the attached window
@@ -736,8 +752,8 @@ TEST_F(MinimalWindowManagerTest, closing_attached_window_causes_maximized_to_res
 
     // Expect: the window now takes up the full dimensions
     EXPECT_THAT(window.size(), Eq(geom::Size(
-        output_rectangle.size.width.as_int(),
-        output_rectangle.size.height.as_int()
+        output_rectangle.extents().size.width.as_int(),
+        output_rectangle.extents().size.height.as_int()
     )));
 }
 
@@ -832,12 +848,12 @@ TEST_P(MinimalWindowManagerAttachedTest, attached_window_positioning)
 {
     auto const app = open_application("test");
     auto const& placements = GetParam().placements;
-    auto const output_rectangles = get_output_rectangles();
+    auto const output_rectangles = get_initial_output_configs();
 
     std::vector<miral::Window> windows;
     auto const& output_rectangle = output_rectangles[0];
     for (const auto& placement : placements)
-        windows.push_back(create_window(app, placement.create(output_rectangle.size)));
+        windows.push_back(create_window(app, placement.create(output_rectangle.extents().size)));
 
     EXPECT_EQ(windows.size(), placements.size());
     for (size_t i = 0; i < windows.size(); i++)
@@ -845,7 +861,7 @@ TEST_P(MinimalWindowManagerAttachedTest, attached_window_positioning)
         auto const& window = windows[i];
         const auto& expected_rect = placements[i].expected_rect;
 
-        auto const expected = expected_rect(output_rectangle.size);
+        auto const expected = expected_rect(output_rectangle.extents().size);
         EXPECT_EQ(window.top_left(), expected.top_left);
         EXPECT_EQ(window.size(), expected.size);
     }
@@ -1081,19 +1097,19 @@ TEST_P(MinimalWindowManagerMaximizedSurfaceExclusionZoneTest, maximized_windows_
 {
     auto const app = open_application("test");
     auto const param = GetParam();
-    auto const output_rectangles = get_output_rectangles();
+    auto const output_rectangles = get_initial_output_configs();
 
     std::vector<miral::Window> windows;
     auto const& output_rectangle = output_rectangles[0];
     for (const auto& create : param.exclusive_surface_create_func)
-        windows.push_back(create_window(app, create(output_rectangle.size)));
+        windows.push_back(create_window(app, create(output_rectangle.extents().size)));
 
     EXPECT_EQ(windows.size(), param.exclusive_surface_create_func.size());
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_maximized;
     spec.depth_layer() = mir_depth_layer_application;
     auto const window = create_window(app, spec);
-    auto const expected = param.expected_rectangle(output_rectangle);
+    auto const expected = param.expected_rectangle(output_rectangle.extents());
 
     EXPECT_EQ(window.top_left(), expected.top_left);
     EXPECT_EQ(window.size(), expected.size);
@@ -1200,3 +1216,158 @@ INSTANTIATE_TEST_SUITE_P(MinimalWindowManagerMaximizedSurfaceExclusionZoneTest,
         }
     )
 );
+
+TEST_F(MinimalWindowManagerTest, when_no_surface_is_focused_then_window_is_placed_on_output_of_cursor)
+{
+    // Move the cursor to the second output
+    auto const second_rectangle = get_initial_output_configs()[1].extents();
+    geom::PointF const new_cursor_position{
+        second_rectangle.top_left.x.as_int() + static_cast<int>(
+            static_cast<float>(second_rectangle.size.width.as_int()) / 2.f),
+        second_rectangle.top_left.y.as_int() + static_cast<int>(
+            static_cast<float>(second_rectangle.size.height.as_int()) / 2.f)
+    };
+    tools().move_cursor_to(new_cursor_position);
+    EXPECT_THAT(tools().active_output(), second_rectangle);
+
+    auto const app = open_application("test");
+    miral::WindowSpecification spec;
+    spec.size() = geom::Size(100, 100);
+    auto const window = create_window(app, spec);
+
+    // Expect that the new window is centered in the X-axis and that the Y is at the expected poisition.
+    EXPECT_THAT(window.top_left(), Eq(
+        mir::geometry::Point(
+            second_rectangle.top_left.x.as_int() + (second_rectangle.size.width.as_int() - spec.size().value().width.as_int()) / 2.f,
+            167
+        )
+    ));
+}
+
+TEST_F(MinimalWindowManagerTest, window_can_be_maximized_on_new_output)
+{
+    // Add a third output
+    auto const new_output_configs = output_configs_from_output_rectangles({
+        mir::geometry::Rectangle{{0, 0}, {800, 600}},
+        mir::geometry::Rectangle{{800, 0}, {1000, 600}},
+        mir::geometry::Rectangle{{1800, 0}, {500, 500}},
+    });
+
+    update_outputs(new_output_configs);
+    std::vector<miral::Output> outputs;
+    for_each_output([&](miral::Output const& output)
+    {
+        outputs.push_back(output);
+    });
+
+    EXPECT_THAT(outputs.size(), Eq(3));
+
+    // Move the cursor to the third output
+    geom::PointF const new_cursor_position(1900, 100);
+    tools().move_cursor_to(new_cursor_position);
+    EXPECT_THAT(tools().active_output(), new_output_configs[2].extents());
+
+    auto const app = open_application("test");
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_maximized;
+    spec.size() = geom::Size(100, 100);
+    auto const window = create_window(app, spec);
+
+    // Expect that the new window is on the third output
+    EXPECT_THAT(window.top_left(), Eq(new_output_configs[2].extents().top_left));
+}
+
+TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_resize)
+{
+    auto const app = open_application("test");
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_maximized;
+    spec.size() = geom::Size(100, 100);
+    auto const window = create_window(app, spec);
+
+    auto const new_output_configs = output_configs_from_output_rectangles({
+        mir::geometry::Rectangle{{0, 0}, {1000, 1000}},
+        mir::geometry::Rectangle{{1000, 0}, {1000, 600}}
+    });
+    update_outputs(new_output_configs);
+    EXPECT_THAT(window.top_left(), Eq(new_output_configs[0].extents().top_left));
+    EXPECT_THAT(window.size(), Eq(new_output_configs[0].extents().size));
+}
+
+TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_removal)
+{
+    tools().move_cursor_to(geom::PointF(900, 100));
+
+    auto const app = open_application("test");
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_maximized;
+    spec.size() = geom::Size(100, 100);
+    auto const window = create_window(app, spec);
+
+    auto const outputs = get_initial_output_configs();
+    EXPECT_THAT(window.top_left(), Eq(outputs[1].extents().top_left));
+    EXPECT_THAT(window.size(), Eq(outputs[1].extents().size));
+
+    auto const new_output_configs = output_configs_from_output_rectangles({
+        mir::geometry::Rectangle{{0, 0}, {1000, 1000}}
+    });
+    update_outputs(new_output_configs);
+    EXPECT_THAT(window.top_left(), Eq(new_output_configs[0].extents().top_left));
+    EXPECT_THAT(window.size(), Eq(new_output_configs[0].extents().size));
+}
+
+TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_unused)
+{
+    EXPECT_NONFATAL_FAILURE({
+        this->tools().move_cursor_to(geom::PointF(0, 0));
+        auto const app = this->open_application("test");
+        miral::WindowSpecification spec;
+        spec.state() = mir_window_state_maximized;
+        spec.size() = geom::Size(100, 100);
+        auto const window = this->create_window(app, spec);
+
+        auto new_output_configs = this->get_initial_output_configs();
+        new_output_configs[0].used = false;
+        this->update_outputs(new_output_configs);
+        geom::Rectangle const window_rect(window.top_left(), window.size());
+        EXPECT_THAT(window_rect, Eq(new_output_configs[1].extents()));
+    }, "");
+}
+
+TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_disconnected)
+{
+    EXPECT_NONFATAL_FAILURE({
+        this->tools().move_cursor_to(geom::PointF(0, 0));
+        auto const app = this->open_application("test");
+        miral::WindowSpecification spec;
+        spec.state() = mir_window_state_maximized;
+        spec.size() = geom::Size(100, 100);
+        auto const window = this->create_window(app, spec);
+
+        auto new_output_configs = this->get_initial_output_configs();
+        new_output_configs[0].connected = false;
+        this->update_outputs(new_output_configs);
+
+        geom::Rectangle const window_rect(window.top_left(), window.size());
+        EXPECT_THAT(window_rect, Eq(new_output_configs[1].extents()));
+    }, "");
+}
+
+TEST_F(MinimalWindowManagerTest, windows_on_removed_output_are_placed_on_next_available_output)
+{
+    EXPECT_NONFATAL_FAILURE({
+        this->tools().move_cursor_to(geom::PointF(900, 100));
+
+        auto const app = this->open_application("test");
+        miral::WindowSpecification spec;
+        spec.size() = geom::Size(100, 100);
+        auto const window = this->create_window(app, spec);
+
+        auto const new_output_configs = this->output_configs_from_output_rectangles({
+            mir::geometry::Rectangle{{0, 0}, {1000, 1000}}
+        });
+        this->update_outputs(new_output_configs);
+        geom::Rectangle const window_rect(window.top_left(), window.size());
+        EXPECT_THAT(window_rect.overlaps(new_output_configs[0].extents()), Eq(true));
+    }, "");
+}


### PR DESCRIPTION
## What's new?

- Exposed `the_display_configuration_observer` from the configuration so that we can trigger display updates
- Added `WindowManagementTestHarness::for_each_output` and `WindowManagementTestHarness::update_outputs`
- Refactored `WindowManagementTestHarness::get_output_rectangles` to `WindowManagementTestHarness::get_initial_output_configs`
- Updated `NotifyingWindowManagerToolsImplementation::move_cursor_to` to be linear
- Wrote some new tests for the `MinimalWindowManager` with how surfaces should behave on new outputs