### PR TITLE
Fix leak of `LinuxDmaBufUnstable` resources

### DIFF
--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -139,30 +139,7 @@ void mgg::BufferAllocator::bind_display(wl_display* display, std::shared_ptr<Exe
         if (dmabuf_provider)
         {
             mg::EGLExtensions::EXTImageDmaBufImportModifiers modifier_ext{dpy};
-            dmabuf_extension =
-                std::unique_ptr<LinuxDmaBufUnstable, std::function<void(LinuxDmaBufUnstable*)>>(
-                    new LinuxDmaBufUnstable{
-                        display,
-                        dmabuf_provider,
-                    },
-                    [wayland_executor](LinuxDmaBufUnstable* global)
-                    {
-                        // The global must be destroyed on the Wayland thread
-                        wayland_executor->spawn(
-                            [global]()
-                            {
-                                /* This is safe against double-frees, as the WaylandExecutor
-                                 * guarantees that work scheduled will only run while the Wayland
-                                 * event loop is running, and the main loop is stopped before
-                                 * wl_display_destroy() frees any globals
-                                 *
-                                 * This will, however, leak the global if the main loop is destroyed
-                                 * before the buffer allocator. Fixing that requires work in the
-                                 * wrapper generator.
-                                 */
-                                delete global;
-                            });
-                    });
+            dmabuf_extension = std::make_unique<LinuxDmaBufUnstable>(display, dmabuf_provider);
             mir::log_info("Enabled linux-dmabuf import support");
         }
     }
@@ -182,15 +159,16 @@ void mgg::BufferAllocator::bind_display(wl_display* display, std::shared_ptr<Exe
 
 void mgg::BufferAllocator::unbind_display(wl_display* display)
 {
+    auto context_guard = mir::raii::paired_calls(
+        [this]() { ctx->make_current(); },
+        [this]() { ctx->release_current(); });
+    auto dpy = eglGetCurrentDisplay();
+
     if (egl_display_bound)
     {
-        auto context_guard = mir::raii::paired_calls(
-            [this]() { ctx->make_current(); },
-            [this]() { ctx->release_current(); });
-        auto dpy = eglGetCurrentDisplay();
-
         mg::wayland::unbind_display(dpy, display, *egl_extensions);
     }
+    dmabuf_extension.reset();
 }
 
 std::shared_ptr<mg::Buffer> mgg::BufferAllocator::buffer_from_resource(

--- a/src/platforms/gbm-kms/server/buffer_allocator.h
+++ b/src/platforms/gbm-kms/server/buffer_allocator.h
@@ -80,7 +80,7 @@ private:
     std::unique_ptr<renderer::gl::Context> const ctx;
     std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
     std::shared_ptr<Executor> wayland_executor;
-    std::unique_ptr<LinuxDmaBufUnstable, std::function<void(LinuxDmaBufUnstable*)>> dmabuf_extension;
+    std::unique_ptr<LinuxDmaBufUnstable> dmabuf_extension;
     std::shared_ptr<EGLExtensions> const egl_extensions;
     std::shared_ptr<DMABufEGLProvider> const dmabuf_provider;
     bool egl_display_bound{false};

--- a/src/platforms/renderer-generic-egl/buffer_allocator.h
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.h
@@ -76,7 +76,7 @@ private:
     std::unique_ptr<renderer::gl::Context> const ctx;
     std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
     std::shared_ptr<Executor> wayland_executor;
-    std::unique_ptr<LinuxDmaBufUnstable, std::function<void(LinuxDmaBufUnstable*)>> dmabuf_extension;
+    std::unique_ptr<LinuxDmaBufUnstable> dmabuf_extension;
     std::shared_ptr<EGLExtensions> const egl_extensions;
     std::shared_ptr<DMABufEGLProvider> const dmabuf_provider;
     bool egl_display_bound{false};


### PR DESCRIPTION
Fix `mf::WaylandConnector` to always call `GraphicsBufferAllocator::unbind_display`
on the Wayland eventloop (or directly, if the eventloop isn't running), and then
use this to clean up `LinuxDmaBufUnstable` resources synchronously rather than
deferring them to the `WaylandExecutor` which may never execute that work.