### PR TITLE
mg::SoftwareCursor: Synchronously clean up in destructor

### DIFF
--- a/src/server/graphics/software_cursor.cpp
+++ b/src/server/graphics/software_cursor.cpp
@@ -145,7 +145,16 @@ mg::SoftwareCursor::SoftwareCursor(
 
 mg::SoftwareCursor::~SoftwareCursor()
 {
-    hide();
+    /* We don't have to worry about locking here, so we can directly
+     * call into the scene.
+     *
+     * This also avoids punting cleanup work to the executor that
+     * might be already stopped
+     */
+    if (visible && renderable)
+    {
+        scene->remove_input_visualization(renderable);
+    }
 }
 
 void mg::SoftwareCursor::show(std::shared_ptr<CursorImage> const& cursor_image)


### PR DESCRIPTION
During `hide()` we defer work to the `scene_executor` in order to avoid calling into the scene while holding a lock, but in the destructor we don't need to *hold* a lock, so just call in directly.

Resolves a leak of `cursor_renderable` during teardown, where the `scene_executor` may no longer be dispatching tasks, resulting in the cleanup never being performed.