### PR TITLE
Fix deadlock in `BasicAccessibilityManager::notify_helpers`

### DIFF
--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -38,10 +38,8 @@ public:
     virtual std::optional<int> repeat_rate() const = 0;
     virtual int repeat_delay() const = 0;
 
-    virtual void repeat_rate(int new_rate) = 0;
-    virtual void repeat_delay(int new_rate) = 0;
-
-    virtual void notify_helpers() const = 0;
+    // Setting one option to `std::nullopt` signals that it didn't change.
+    virtual void repeat_rate_and_delay(std::optional<int> new_rate, std::optional<int> new_delay) = 0;
 
     virtual void cursor_scale(float new_scale) = 0;
 

--- a/src/miral/input_configuration.cpp
+++ b/src/miral/input_configuration.cpp
@@ -87,12 +87,7 @@ public:
     {
         if(auto const& am = accessibility_manager.lock())
         {
-            if (k.self->repeat_rate)
-                am->repeat_rate(*k.self->repeat_rate);
-            if (k.self->repeat_delay)
-                am->repeat_delay(*k.self->repeat_delay);
-
-            am->notify_helpers();
+            am->repeat_rate_and_delay(k.self->repeat_rate, k.self->repeat_delay);
         }
         keyboard(k);
     }

--- a/src/server/shell/basic_accessibility_manager.cpp
+++ b/src/server/shell/basic_accessibility_manager.cpp
@@ -51,7 +51,8 @@ void mir::shell::BasicAccessibilityManager::repeat_delay(int new_delay) {
 }
 
 void mir::shell::BasicAccessibilityManager::notify_helpers() const {
-    for (auto const& helper: mutable_state.lock()->keyboard_helpers)
+    auto const keyboard_helpers = mutable_state.lock()->keyboard_helpers;
+    for (auto const& helper: keyboard_helpers)
         helper->repeat_info_changed(repeat_rate(), repeat_delay());
 }
 

--- a/src/server/shell/basic_accessibility_manager.cpp
+++ b/src/server/shell/basic_accessibility_manager.cpp
@@ -42,18 +42,25 @@ int mir::shell::BasicAccessibilityManager::repeat_delay() const {
     return mutable_state.lock()->repeat_delay;
 }
 
-void mir::shell::BasicAccessibilityManager::repeat_rate(int new_rate) {
-    mutable_state.lock()->repeat_rate = new_rate;
-}
+void mir::shell::BasicAccessibilityManager::repeat_rate_and_delay(
+    std::optional<int> new_rate, std::optional<int> new_delay)
+{
+    auto const state = mutable_state.lock();
 
-void mir::shell::BasicAccessibilityManager::repeat_delay(int new_delay) {
-    mutable_state.lock()->repeat_delay = new_delay;
-}
+    auto const maybe_new_rate = new_rate.value_or(state->repeat_rate);
+    auto const maybe_new_delay = new_delay.value_or(state->repeat_delay);
 
-void mir::shell::BasicAccessibilityManager::notify_helpers() const {
-    auto const keyboard_helpers = mutable_state.lock()->keyboard_helpers;
-    for (auto const& helper: keyboard_helpers)
-        helper->repeat_info_changed(repeat_rate(), repeat_delay());
+    auto const changed = maybe_new_rate != state->repeat_rate || maybe_new_delay != state->repeat_delay;
+
+    state->repeat_rate = maybe_new_rate;
+    state->repeat_delay = maybe_new_delay;
+
+    if (changed)
+    {
+        for (auto const& helper : state->keyboard_helpers)
+            helper->repeat_info_changed(
+                enable_key_repeat ? state->repeat_rate : std::optional<int>{}, state->repeat_delay);
+    }
 }
 
 void mir::shell::BasicAccessibilityManager::mousekeys_enabled(bool on)

--- a/src/server/shell/basic_accessibility_manager.h
+++ b/src/server/shell/basic_accessibility_manager.h
@@ -60,10 +60,7 @@ public:
 
     std::optional<int> repeat_rate() const override;
     int repeat_delay() const override;
-    void repeat_rate(int new_rate) override;
-    void repeat_delay(int new_rate) override;
-
-    void notify_helpers() const override;
+    void repeat_rate_and_delay(std::optional<int> new_rate, std::optional<int> new_delay) override;
 
     void cursor_scale(float new_scale) override;
 

--- a/tests/miral/test_mousekeys_config.cpp
+++ b/tests/miral/test_mousekeys_config.cpp
@@ -33,8 +33,7 @@ public:
     MOCK_METHOD(void, register_keyboard_helper, (std::shared_ptr<mir::shell::KeyboardHelper> const&), (override));
     MOCK_METHOD(std::optional<int>, repeat_rate, (), (const override));
     MOCK_METHOD(int, repeat_delay, (), (const override));
-    MOCK_METHOD(void, repeat_rate, (int new_rate), (override));
-    MOCK_METHOD(void, repeat_delay, (int new_rate), (override));
+    MOCK_METHOD(void, repeat_rate_and_delay, (std::optional<int> new_rate, std::optional<int> new_delay), (override));
     MOCK_METHOD(void, notify_helpers, (), (const override));
     MOCK_METHOD(void, cursor_scale, (float), (override));
     MOCK_METHOD(void, mousekeys_enabled, (bool on), (override));


### PR DESCRIPTION
The deadlock was caused by the for loop extending the lifetime of the state lock to cover the duration of the whole loop. In the loop, we also locked the state to read some data, which would cause the deadlock.

Why did this decide to come up now? I have no idea, it used to work before (and should've failed in CI), but now it deadlocks...