### PR TITLE
(#3843) Excluding a test from miral-test runs

### DIFF
--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -92,6 +92,11 @@ target_link_libraries(miral-test
 option(MIR_RUN_MIRAL_TESTS "Run miral tests as part of testsuite" ON)
 
 if(MIR_RUN_MIRAL_TESTS)
+    set(MIR_EXCLUDE_TESTS
+      TestConfigFile.with_reload_on_change_after_a_config_in_xdg_conf_dir0_is_loaded_a_new_config_in_xdg_conf_home_is_loaded
+    )
     mir_discover_tests_with_fd_leak_detection(miral-test)
+    
+    set(MIR_EXCLUDE_TESTS)
     mir_discover_tests_with_fd_leak_detection(miral-test-internal)
 endif()


### PR DESCRIPTION
Is this evil? I am setting `MIR_EXCLUDE_TESTS`. It is local to the test, and fairly easy to control.