### PR TITLE
mg::SoftwareCursor: Don't `hide()` on destruction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .project
+.cache
 benchmarks/mir_perf_framework_setup.py
 debian/*.log
 include/server/mir/version.h
@@ -9,5 +10,6 @@ build-*
 cmake-*
 build
 benchmarks/build
+compile_commands.json
 
 tools/bot-data.tar.xz

--- a/src/server/graphics/software_cursor.cpp
+++ b/src/server/graphics/software_cursor.cpp
@@ -143,10 +143,7 @@ mg::SoftwareCursor::SoftwareCursor(
 {
 }
 
-mg::SoftwareCursor::~SoftwareCursor()
-{
-    hide();
-}
+mg::SoftwareCursor::~SoftwareCursor() = default;
 
 void mg::SoftwareCursor::show(std::shared_ptr<CursorImage> const& cursor_image)
 {

--- a/tests/unit-tests/graphics/test_software_cursor.cpp
+++ b/tests/unit-tests/graphics/test_software_cursor.cpp
@@ -177,17 +177,6 @@ TEST_F(SoftwareCursor, is_added_to_scene_when_shown)
     cursor.show(stub_cursor_image);
 }
 
-TEST_F(SoftwareCursor, is_removed_from_scene_on_destruction)
-{
-    using namespace testing;
-
-    InSequence s;
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_));
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_));
-
-    cursor.show(stub_cursor_image);
-}
-
 TEST_F(SoftwareCursor, tolerates_being_hidden_while_being_shown)
 {
     using namespace testing;


### PR DESCRIPTION
We only ever destroy `the_cursor()` during teardown, and
*during* teardown work deferred to the `GLibMainLoop` can
get leaked; in this case resulting in the cursor `Renderable`
being leaked (along with the `Scene`).

Since we don't need to release any *hardware* resources,
just don't try to hide the cursor; we're going to stop
drawing it immediately anyway!