### PR TITLE
platforms/generic-egl: Correct order of EGL resource destruction

### DIFF
--- a/src/platforms/renderer-generic-egl/rendering_platform.h
+++ b/src/platforms/renderer-generic-egl/rendering_platform.h
@@ -49,8 +49,20 @@ protected:
 private:
     explicit RenderingPlatform(std::tuple<EGLDisplay, bool> dpy);
 
-    EGLDisplay const dpy;
-    bool const owns_dpy;
+    class EGLDisplayHandle
+    {
+    public:
+        EGLDisplayHandle(EGLDisplay dpy, bool owns_dpy);
+        ~EGLDisplayHandle();
+
+        operator EGLDisplay() const;
+
+    private:
+        EGLDisplay const dpy;
+        bool const owns_dpy;
+    };
+
+    EGLDisplayHandle dpy;
     std::unique_ptr<renderer::gl::Context> const ctx;
     std::shared_ptr<DMABufEGLProvider> const dmabuf_provider;
 };

--- a/src/platforms/renderer-generic-egl/rendering_platform.h
+++ b/src/platforms/renderer-generic-egl/rendering_platform.h
@@ -49,6 +49,13 @@ protected:
 private:
     explicit RenderingPlatform(std::tuple<EGLDisplay, bool> dpy);
 
+    /* 
+     * We (sometimes) need to clean up the EGLDisplay with eglTerminate,
+     * but this should happen after cleanup of `ctx` and `dmabuf_provider`
+     * (which both wrap resources on the EGLDisplay).
+     *
+     * Use a trivial handle class to handle cleanup on destruction.
+     */
     class EGLDisplayHandle
     {
     public:


### PR DESCRIPTION
We want `EGLTerminate` to be called *last*, but there are a bunch of member variables that will try cleaning up EGL resources in *their* destructors.

Move `EGLDisplay` handling into a trivial class with its own destructor so we can rely on member ordering to enforce correct destruction order.