### PR TITLE
Introduce mir::shell::BasicAccessibilityManager::MousekeyPointer

### DIFF
--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -17,8 +17,6 @@
 #ifndef MIR_INPUT_INPUT_EVENT_TRANSFORMER_H_
 #define MIR_INPUT_INPUT_EVENT_TRANSFORMER_H_
 
-#include "mir/input/event_filter.h"
-#include "mir/input/event_builder.h"
 #include "mir_toolkit/events/event.h"
 
 #include <chrono>
@@ -36,7 +34,7 @@ class VirtualInputDevice;
 class InputDeviceRegistry;
 class InputSink;
 class EventBuilder;
-class InputEventTransformer : public EventFilter
+class InputEventTransformer
 {
 public:
     using EventDispatcher = std::function<void(std::shared_ptr<MirEvent>)>;
@@ -52,10 +50,13 @@ public:
         virtual bool transform_input_event(EventDispatcher const&, EventBuilder*,  MirEvent const&) = 0;
     };
 
-    InputEventTransformer(std::shared_ptr<InputDeviceRegistry> const&, std::shared_ptr<MainLoop> const&);
+    InputEventTransformer();
     ~InputEventTransformer();
 
-    bool handle(MirEvent const&) override;
+    bool transform(
+        MirEvent const& event,
+        EventBuilder* builder,
+        EventDispatcher const& dispatcher);
 
     void append(std::weak_ptr<Transformer> const&);
     bool remove(std::shared_ptr<Transformer> const&);
@@ -63,10 +64,6 @@ public:
 private:
     std::mutex mutex;
     std::vector<std::weak_ptr<Transformer>> input_transformers;
-
-    std::shared_ptr<input::VirtualInputDevice> const virtual_pointer;
-    std::shared_ptr<input::InputDeviceRegistry> const input_device_registry;
-    std::shared_ptr<MainLoop> const main_loop;
 };
 }
 }

--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -26,7 +26,6 @@
 
 namespace mir
 {
-class MainLoop;
 namespace input
 {
 class EventBuilder;

--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -19,7 +19,6 @@
 
 #include "mir_toolkit/events/event.h"
 
-#include <chrono>
 #include <functional>
 #include <mutex>
 #include <vector>
@@ -30,9 +29,6 @@ namespace mir
 class MainLoop;
 namespace input
 {
-class VirtualInputDevice;
-class InputDeviceRegistry;
-class InputSink;
 class EventBuilder;
 class InputEventTransformer
 {

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -106,7 +106,7 @@ mir::DefaultServerConfiguration::the_event_filter_chain_dispatcher()
 std::shared_ptr<mi::InputEventTransformer> mir::DefaultServerConfiguration::the_input_event_transformer()
 {
     return input_event_transformer(
-        [this]
+        []
         {
             return std::make_shared<input::InputEventTransformer>();
         });

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -21,7 +21,6 @@
 #include "event_filter_chain_dispatcher.h"
 #include "config_changer.h"
 #include "cursor_controller.h"
-#include "mir/input/input_event_transformer.h"
 #include "touchspot_controller.h"
 #include "null_input_manager.h"
 #include "null_input_dispatcher.h"
@@ -40,6 +39,7 @@
 #include "mir/input/xkb_mapper_registrar.h"
 #include "mir/input/vt_filter.h"
 #include "mir/input/device.h"
+#include "mir/input/input_event_transformer.h"
 #include "mir/options/configuration.h"
 #include "mir/options/option.h"
 #include "mir/dispatch/multiplexing_dispatchable.h"
@@ -108,10 +108,7 @@ std::shared_ptr<mi::InputEventTransformer> mir::DefaultServerConfiguration::the_
     return input_event_transformer(
         [this]
         {
-            auto event_transformer =
-                std::make_shared<input::InputEventTransformer>(the_input_device_registry(), the_main_loop());
-            the_composite_event_filter()->prepend(event_transformer);
-            return event_transformer;
+            return std::make_shared<input::InputEventTransformer>();
         });
 }
 

--- a/src/server/input/input_event_transformer.cpp
+++ b/src/server/input/input_event_transformer.cpp
@@ -16,15 +16,9 @@
 
 #include "mir/input/input_event_transformer.h"
 
-#include "mir/input/input_sink.h"
-#include "mir/input/virtual_input_device.h"
 #include "mir/log.h"
 
 #include <algorithm>
-#include <boost/throw_exception.hpp>
-#include <cassert>
-#include <memory>
-#include <mutex>
 
 namespace mi = mir::input;
 

--- a/src/server/shell/basic_accessibility_manager.cpp
+++ b/src/server/shell/basic_accessibility_manager.cpp
@@ -98,26 +98,33 @@ void mir::shell::BasicAccessibilityManager::repeat_rate_and_delay(
 
 void mir::shell::BasicAccessibilityManager::mousekeys_enabled(bool on)
 {
-    auto state = this->mutable_state.lock();
     if (on)
     {
-        if (!state->mousekey_pointer)
+        main_loop->spawn([this]
         {
-            state->mousekey_pointer = std::make_shared<MousekeyPointer>(main_loop, event_transformer);
+            auto state = this->mutable_state.lock();
+            if (!state->mousekey_pointer)
+            {
+                state->mousekey_pointer = std::make_shared<MousekeyPointer>(main_loop, event_transformer);
 
-            event_transformer->append(transformer);
-            input_device_registry->add_device(state->mousekey_pointer);
-            the_composite_event_filter->prepend(state->mousekey_pointer);
-        }
+                event_transformer->append(transformer);
+                input_device_registry->add_device(state->mousekey_pointer);
+                the_composite_event_filter->prepend(state->mousekey_pointer);
+            }
+        });
     }
     else
     {
-        if (state->mousekey_pointer)
+        main_loop->spawn([this]
         {
-            input_device_registry->remove_device(state->mousekey_pointer);
-            event_transformer->remove(transformer);
-            state->mousekey_pointer.reset();
-        }
+            auto state = this->mutable_state.lock();
+            if (state->mousekey_pointer)
+            {
+                input_device_registry->remove_device(state->mousekey_pointer);
+                event_transformer->remove(transformer);
+                state->mousekey_pointer.reset();
+            }
+        });
     }
 }
 

--- a/src/server/shell/basic_accessibility_manager.cpp
+++ b/src/server/shell/basic_accessibility_manager.cpp
@@ -15,10 +15,15 @@
  */
 
 #include "basic_accessibility_manager.h"
-#include "mir/graphics/cursor.h"
 #include "mouse_keys_transformer.h"
 
+#include "mir/graphics/cursor.h"
+#include "mir/input/composite_event_filter.h"
+#include "mir/input/event_filter.h"
+#include "mir/input/input_device_registry.h"
 #include "mir/input/input_event_transformer.h"
+#include "mir/input/input_sink.h"
+#include "mir/input/virtual_input_device.h"
 #include "mir/main_loop.h"
 #include "mir/shell/keyboard_helper.h"
 
@@ -26,6 +31,34 @@
 
 #include <memory>
 #include <optional>
+
+class mir::shell::BasicAccessibilityManager::MousekeyPointer : public mir::input::VirtualInputDevice, public input::EventFilter
+{
+public:
+    MousekeyPointer(std::shared_ptr<MainLoop> main_loop, std::shared_ptr<input::InputEventTransformer> iet) :
+        mir::input::VirtualInputDevice{"mousekey-pointer", mir::input::DeviceCapability::pointer},
+        main_loop{std::move(main_loop)},
+        iet{std::move(iet)}
+    {
+    }
+
+    bool handle(MirEvent const& event) override
+    {
+        auto handled = false;
+        if_started_then([this, &event, &handled](auto* sink, auto* builder)
+        {
+            handled = iet->transform(event, builder, [this, sink](auto event)
+                {
+                    main_loop->spawn([sink, event]{ sink->handle_input(event); });
+                });
+        });
+        return handled;
+    }
+
+private:
+    std::shared_ptr<MainLoop> const main_loop;
+    std::shared_ptr<input::InputEventTransformer> const iet;
+};
 
 void mir::shell::BasicAccessibilityManager::register_keyboard_helper(std::shared_ptr<KeyboardHelper> const& helper)
 {
@@ -65,21 +98,44 @@ void mir::shell::BasicAccessibilityManager::repeat_rate_and_delay(
 
 void mir::shell::BasicAccessibilityManager::mousekeys_enabled(bool on)
 {
+    auto state = this->mutable_state.lock();
     if (on)
-        event_transformer->append(transformer);
+    {
+        if (!state->mousekey_pointer)
+        {
+            state->mousekey_pointer = std::make_shared<MousekeyPointer>(main_loop, event_transformer);
+
+            event_transformer->append(transformer);
+            input_device_registry->add_device(state->mousekey_pointer);
+            the_composite_event_filter->prepend(state->mousekey_pointer);
+        }
+    }
     else
-        event_transformer->remove(transformer);
+    {
+        if (state->mousekey_pointer)
+        {
+            input_device_registry->remove_device(state->mousekey_pointer);
+            event_transformer->remove(transformer);
+            state->mousekey_pointer.reset();
+        }
+    }
 }
 
 mir::shell::BasicAccessibilityManager::BasicAccessibilityManager(
+    std::shared_ptr<MainLoop> main_loop,
+    std::shared_ptr<input::CompositeEventFilter> the_composite_event_filter,
     std::shared_ptr<input::InputEventTransformer> const& event_transformer,
     bool enable_key_repeat,
     std::shared_ptr<mir::graphics::Cursor> const& cursor,
-    std::shared_ptr<shell::MouseKeysTransformer> const& mousekeys_transformer) :
+    std::shared_ptr<shell::MouseKeysTransformer> const& mousekeys_transformer,
+    std::shared_ptr<input::InputDeviceRegistry> const& input_device_registry) :
+    main_loop{std::move(main_loop)},
+    the_composite_event_filter{std::move(the_composite_event_filter)},
     enable_key_repeat{enable_key_repeat},
     cursor{cursor},
     event_transformer{event_transformer},
-    transformer{mousekeys_transformer}
+    transformer{mousekeys_transformer},
+    input_device_registry{input_device_registry}
 {
 }
 

--- a/src/server/shell/basic_accessibility_manager.h
+++ b/src/server/shell/basic_accessibility_manager.h
@@ -31,7 +31,10 @@ class Cursor;
 }
 namespace input
 {
+class CompositeEventFilter;
 class InputEventTransformer;
+class VirtualInputDevice;
+class InputDeviceRegistry;
 }
 namespace shell
 {
@@ -51,10 +54,13 @@ class BasicAccessibilityManager : public AccessibilityManager
 {
 public:
     BasicAccessibilityManager(
+        std::shared_ptr<MainLoop> main_loop,
+        std::shared_ptr<input::CompositeEventFilter> the_composite_event_filter,
         std::shared_ptr<input::InputEventTransformer> const& event_transformer,
         bool enable_key_repeat,
         std::shared_ptr<mir::graphics::Cursor> const& cursor,
-        std::shared_ptr<shell::MouseKeysTransformer> const& mousekeys_transformer);
+        std::shared_ptr<shell::MouseKeysTransformer> const& mousekeys_transformer,
+        std::shared_ptr<input::InputDeviceRegistry> const& input_device_registry);
 
     void register_keyboard_helper(std::shared_ptr<shell::KeyboardHelper> const&) override;
 
@@ -70,20 +76,26 @@ public:
     void max_speed(double x_axis, double y_axis) override;
 
 private:
+    class MousekeyPointer;
+
     struct MutableState {
         // 25 rate and 600 delay are the default in Weston and Sway
         int repeat_rate{25};
         int repeat_delay{600};
 
         std::vector<std::shared_ptr<shell::KeyboardHelper>> keyboard_helpers;
+        std::shared_ptr<MousekeyPointer> mousekey_pointer;
     };
 
     Synchronised<MutableState> mutable_state;
 
+    std::shared_ptr<MainLoop> const main_loop;
+    std::shared_ptr<input::CompositeEventFilter> const the_composite_event_filter;
     bool const enable_key_repeat;
     std::shared_ptr<graphics::Cursor> const cursor;
     std::shared_ptr<mir::input::InputEventTransformer> const event_transformer;
     std::shared_ptr<mir::shell::MouseKeysTransformer> const transformer;
+    std::shared_ptr<mir::input::InputDeviceRegistry> const input_device_registry;
 };
 }
 }

--- a/src/server/shell/basic_accessibility_manager.h
+++ b/src/server/shell/basic_accessibility_manager.h
@@ -33,7 +33,6 @@ namespace input
 {
 class CompositeEventFilter;
 class InputEventTransformer;
-class VirtualInputDevice;
 class InputDeviceRegistry;
 }
 namespace shell

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -191,9 +191,12 @@ auto mir::DefaultServerConfiguration::the_accessibility_manager() -> std::shared
         [this]
         {
             return std::make_shared<shell::BasicAccessibilityManager>(
+                the_main_loop(),
+                the_composite_event_filter(),
                 the_input_event_transformer(),
                 the_options()->get<bool>(mir::options::enable_key_repeat_opt),
                 the_cursor(),
-                std::make_shared<shell::BasicMouseKeysTransformer>(the_main_loop(), the_clock()));
+                std::make_shared<shell::BasicMouseKeysTransformer>(the_main_loop(), the_clock()),
+                the_input_device_registry());
         });
 }

--- a/src/server/shell/mouse_keys_transformer.cpp
+++ b/src/server/shell/mouse_keys_transformer.cpp
@@ -17,11 +17,11 @@
 #include "mouse_keys_transformer.h"
 
 #include "mir/geometry/forward.h"
+#include "mir/input/event_builder.h"
+#include "mir/input/mousekeys_keymap.h"
 #include "mir/log.h"
 #include "mir/main_loop.h"
 #include "mir/time/alarm.h"
-#include "mir/input/mousekeys_keymap.h"
-
 #include "mir/time/clock.h"
 #include "mir_toolkit/events/enums.h"
 #include "mir_toolkit/events/input/keyboard_event.h"

--- a/src/server/shell/mouse_keys_transformer.h
+++ b/src/server/shell/mouse_keys_transformer.h
@@ -25,6 +25,7 @@
 
 namespace mir
 {
+class MainLoop;
 namespace options
 {
 class Option;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -377,7 +377,6 @@ global:
     mir::input::InputEventTransformer::InputEventTransformer*;
     mir::input::InputEventTransformer::Transformer::?Transformer*;
     mir::input::InputEventTransformer::append*;
-    mir::input::InputEventTransformer::handle*;
     mir::input::InputEventTransformer::remove*;
     mir::input::InputEventTransformer::transform*;
     mir::input::InputManager::?InputManager*;
@@ -885,7 +884,6 @@ global:
     non-virtual?thunk?to?mir::input::InputDispatcher::?InputDispatcher*;
     non-virtual?thunk?to?mir::input::InputEventTransformer::?InputEventTransformer*;
     non-virtual?thunk?to?mir::input::InputEventTransformer::Transformer::?Transformer*;
-    non-virtual?thunk?to?mir::input::InputEventTransformer::handle*;
     non-virtual?thunk?to?mir::input::InputManager::?InputManager*;
     non-virtual?thunk?to?mir::input::KeyboardObserver::?KeyboardObserver*;
     non-virtual?thunk?to?mir::input::Scene::?Scene*;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -379,6 +379,7 @@ global:
     mir::input::InputEventTransformer::append*;
     mir::input::InputEventTransformer::handle*;
     mir::input::InputEventTransformer::remove*;
+    mir::input::InputEventTransformer::transform*;
     mir::input::InputManager::?InputManager*;
     mir::input::InputManager::InputManager*;
     mir::input::InputManager::operator*;
@@ -1416,3 +1417,4 @@ global:
   };
 local: *;
 };
+

--- a/tests/acceptance-tests/test_input_device_hub.cpp
+++ b/tests/acceptance-tests/test_input_device_hub.cpp
@@ -67,8 +67,6 @@ TEST_F(TestInputDeviceHub, notifies_input_device_observer_about_available_device
 {
     using namespace testing;
     InSequence seq;
-    EXPECT_CALL(observer, device_added(_)); // Account for "mousekey-pointer"
-
     EXPECT_CALL(observer, changes_complete())
         .WillOnce(mt::WakeUp(&observer_registered));
 


### PR DESCRIPTION
Reassign some of the responsibilities from `InputEventTransformer`

Alternative to #3861

Fixes: #3854