### PR TITLE
static_display_config: add display properties to output

### DIFF
--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -119,6 +119,8 @@ private:
 
     static void serialize_output_configuration(
         std::ostream& out, mir::graphics::UserDisplayConfigurationOutput const& conf_output);
+    static void serialize_display_info(
+        std::ostream& out, mir::graphics::UserDisplayConfigurationOutput const& conf_output);
 };
 
 class ReloadingYamlFileDisplayConfig : public YamlFileDisplayConfig

--- a/tests/miral/static_display_config.cpp
+++ b/tests/miral/static_display_config.cpp
@@ -656,7 +656,7 @@ TEST_F(StaticDisplayConfig, empty_display_is_error)
     EXPECT_THROW((sdc.load_config(stream, "")), mir::AbnormalExit);
 }
 
-struct PropertyValueTest : public StaticDisplayConfig, public WithParamInterface<std::string>
+struct PropertyValueTest : public StaticDisplayConfig, public WithParamInterface<std::pair<std::string, std::string>>
 {
 };
 
@@ -666,7 +666,7 @@ TEST_P(PropertyValueTest, invalid_display_property_value_is_error)
         "layouts:\n"
         "  default:\n"
         "    displays:\n"
-        "    - " + GetParam() + ": null\n"};
+        "    - " + GetParam().first + ": null\n"};
 
     EXPECT_THROW((sdc.load_config(stream, "")), mir::AbnormalExit);
 }
@@ -677,15 +677,10 @@ TEST_P(PropertyValueTest, empty_display_property_value_is_error)
         "layouts:\n"
         "  default:\n"
         "    displays:\n"
-        "    - " + GetParam() + ": ""\n"};
+        "    - " + GetParam().first + ": ""\n"};
 
     EXPECT_THROW((sdc.load_config(stream, "")), mir::AbnormalExit);
 }
-
-INSTANTIATE_TEST_SUITE_P(
-    EDIDValues,
-    PropertyValueTest,
-    Values("vendor", "product", "model", "serial"));
 
 TEST_F(StaticDisplayConfig, no_matcher_matches_all)
 {
@@ -889,3 +884,34 @@ TEST_F(StaticDisplayConfig, cards_apply_on_unmatched_displays)
     EXPECT_THAT(hdmi1.orientation, Eq(mir_orientation_left));
     EXPECT_THAT(vga1.orientation, Eq(mir_orientation_right));
 }
+
+TEST_F(StaticDisplayConfig, serialize_output_with_no_edids)
+{
+    std::ostringstream out;
+
+    miral::YamlFileDisplayConfig::serialize_configuration(out, dc);
+
+    ASSERT_THAT(out.str(), HasSubstr("# No display properties could be determined."));
+}
+
+TEST_P(PropertyValueTest, serialize_properties_for_outputs)
+{
+    std::ostringstream out;
+
+    hdmi1.edid = basic_edid;
+
+    miral::YamlFileDisplayConfig::serialize_configuration(out, dc);
+
+    ASSERT_THAT(out.str(), ContainsRegex("# [ -] " + GetParam().first + ": " + GetParam().second));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EDIDValues,
+    PropertyValueTest,
+    Values(
+        std::make_pair("vendor", "APP"),
+        std::make_pair("model", "Color LCD"),
+        std::make_pair("product", "40178"),
+        std::make_pair("serial", "0")
+    )
+);


### PR DESCRIPTION
Adds to the default config:

```yaml
    # displays:
    # A list of display configurations matched by the displays' properties
    #
    # These take the same display options as above,
    # and take precedence over the port-based configuration.
    #
    # - vendor: BOE
    #   model: 
    #   product: 2399
    #   serial: 0
```