### PR TITLE
tests/acceptance-tests/wayland/CMakeLists.txt: Reference expected_wlc…

### DIFF
--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 # Pull list of expected failures
 file(STRINGS
-  expected_wlcs_failures.list
+  ${CMAKE_SOURCE_DIR}/tests/acceptance-tests/wayland/expected_wlcs_failures.list
   RAW_EXPECTED_FAILURES
 )
 


### PR DESCRIPTION
…s_failures.list with full-path relative to builddir, so that autopkgtest's cmake call succeeds in finding the file.