### PR TITLE
feature: implement xdg toplevel tiled states

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -536,4 +536,7 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::MouseKeysConfig::set_acceleration_factors(double, double, double) const@MIRAL_5.3" 5.3.0
  (c++)"miral::MouseKeysConfig::set_keymap(mir::input::MouseKeysKeymap const&) const@MIRAL_5.3" 5.3.0
  (c++)"miral::MouseKeysConfig::set_max_speed(double, double) const@MIRAL_5.3" 5.3.0
+ (c++)"miral::WindowInfo::tiled_edges() const@MIRAL_5.3" 5.3.0
+ (c++)"miral::WindowSpecification::tiled_edges() const@MIRAL_5.3" 5.3.0
+ (c++)"miral::WindowSpecification::tiled_edges()@MIRAL_5.3" 5.3.0
  (c++)"miral::WindowSpecification::to_surface_specification() const@MIRAL_5.3" 5.3.0

--- a/include/core/mir_toolkit/common.h
+++ b/include/core/mir_toolkit/common.h
@@ -423,4 +423,17 @@ typedef enum MirFocusMode
                                       leaving it as long as it has this mode */
 } MirFocusMode;
 
+/**
+ * Hints describing which edges of a surface are considered adjacent
+ * to another part of the tiling grid.
+ */
+typedef enum MirTiledEdge
+{
+    mir_tiled_edge_none = 0,
+    mir_tiled_edge_north = 1 << 0,
+    mir_tiled_edge_east = 1 << 1,
+    mir_tiled_edge_south = 1 << 2,
+    mir_tiled_edge_west = 1 << 3
+} MirTiledEdge;
+
 #endif

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -22,6 +22,7 @@
 
 #include <mir/geometry/rectangles.h>
 #include <mir/optional_value.h>
+#include <mir/flags.h>
 
 #include <algorithm>
 
@@ -143,6 +144,11 @@ struct WindowInfo
     /// \remark Since MirAL 3.9
     auto visible_on_lock_screen() const -> bool;
 
+    /// Used when the surface is in a tiled layout to describe the
+    /// edges that are touching another part of the tiling grid.
+    /// \remark Since MirAL 5.3
+    auto tiled_edges() const -> mir::Flags<MirTiledEdge>;
+
 private:
     friend class BasicWindowManager;
     void name(std::string const& name);
@@ -170,6 +176,7 @@ private:
     void application_id(std::string const& application_id);
     void focus_mode(MirFocusMode focus_mode);
     void visible_on_lock_screen(bool visible);
+    void tiled_edges(mir::Flags<MirTiledEdge> flags);
 
     struct Self;
     std::unique_ptr<Self> self;

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -23,6 +23,7 @@
 #include <mir/geometry/rectangles.h>
 #include <mir/optional_value.h>
 #include <mir/int_wrapper.h>
+#include <mir/flags.h>
 
 #include <memory>
 
@@ -182,9 +183,17 @@ public:
     auto visible_on_lock_screen() -> mir::optional_value<bool>&;
     ///@}
 
+    /// Describes which edges are touching part of the tiling grid
+    /// \remark Since MirAL 5.3
+    ///@{
+    auto tiled_edges() const -> mir::optional_value<mir::Flags<MirTiledEdge>> const&;
+    auto tiled_edges() -> mir::optional_value<mir::Flags<MirTiledEdge>>&;
+    ///@}
+
     /// Create a [mir::shell::SurfaceSpecification] from this window spec.
     /// \remark Since MirAL 5.3
     auto to_surface_specification() const -> mir::shell::SurfaceSpecification;
+
 private:
     friend auto make_surface_spec(WindowSpecification const& miral_spec) -> mir::shell::SurfaceSpecification;
     struct Self;

--- a/src/include/server/mir/scene/null_surface_observer.h
+++ b/src/include/server/mir/scene/null_surface_observer.h
@@ -50,6 +50,7 @@ public:
     void entered_output(Surface const* surf, graphics::DisplayConfigurationOutputId const& id) override;
     void left_output(Surface const* surf, graphics::DisplayConfigurationOutputId const& id) override;
     void rescale_output(Surface const* surf, graphics::DisplayConfigurationOutputId const& id) override;
+    void tiled_edges(Surface const* surf, Flags<MirTiledEdge> edges) override;
 
 protected:
     NullSurfaceObserver(NullSurfaceObserver const&) = delete;

--- a/src/include/server/mir/scene/surface.h
+++ b/src/include/server/mir/scene/surface.h
@@ -21,6 +21,7 @@
 #include "mir/input/surface.h"
 #include "mir/frontend/surface.h"
 #include "mir/compositor/compositor_id.h"
+#include "mir/flags.h"
 #include "mir/optional_value.h"
 #include "mir/observer_registrar.h"
 #include "surface_state_tracker.h"
@@ -156,6 +157,13 @@ public:
     ///@{
     virtual auto focus_mode() const -> MirFocusMode = 0;
     virtual void set_focus_mode(MirFocusMode focus_mode) = 0;
+    ///@}
+
+    /// Used when the surface is in a tiled layout to describe the
+    /// edges that are touching another part of the tiling grid.
+    /// @{
+    virtual auto tiled_edges() const -> Flags<MirTiledEdge> = 0;
+    virtual void set_tiled_edges(Flags<MirTiledEdge> flags) = 0;
     ///@}
 };
 }

--- a/src/include/server/mir/scene/surface_observer.h
+++ b/src/include/server/mir/scene/surface_observer.h
@@ -23,6 +23,7 @@
 #include "mir/input/input_reception_mode.h"
 #include "mir/geometry/rectangle.h"
 #include "mir/graphics/display_configuration.h"
+#include "mir/flags.h"
 
 #include <glm/glm.hpp>
 #include <string>
@@ -65,6 +66,7 @@ public:
     virtual void entered_output(Surface const* surf, graphics::DisplayConfigurationOutputId const& id) = 0;
     virtual void left_output(Surface const* surf, graphics::DisplayConfigurationOutputId const& id) = 0;
     virtual void rescale_output(Surface const* surf, graphics::DisplayConfigurationOutputId const& id) = 0;
+    virtual void tiled_edges(Surface const* surf, Flags<MirTiledEdge> edges) = 0;
 
 protected:
     SurfaceObserver() = default;

--- a/src/include/server/mir/shell/surface_specification.h
+++ b/src/include/server/mir/shell/surface_specification.h
@@ -17,6 +17,7 @@
 #ifndef MIR_SHELL_SURFACE_SPECIFICATION_H_
 #define MIR_SHELL_SURFACE_SPECIFICATION_H_
 
+#include "mir/flags.h"
 #include "mir/optional_value.h"
 #include "mir_toolkit/common.h"
 #include "mir/frontend/surface_id.h"
@@ -109,6 +110,9 @@ struct SurfaceSpecification
 
     /// How the surface should gain and lose focus
     optional_value<MirFocusMode> focus_mode;
+
+    /// Describes which edges are touching part of the tiling grid
+    optional_value<Flags<MirTiledEdge>> tiled_edges;
 };
 bool operator==(SurfaceSpecification const& lhs, SurfaceSpecification const& rhs);
 bool operator!=(SurfaceSpecification const& lhs, SurfaceSpecification const& rhs);

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -551,6 +551,8 @@ global:
     miral::MouseKeysConfig::set_acceleration_factors*;
     miral::MouseKeysConfig::set_keymap*;
     miral::MouseKeysConfig::set_max_speed*;
+    miral::WindowInfo::tiled_edges*;
+    miral::WindowSpecification::tiled_edges*;
     miral::WindowSpecification::to_surface_specification*;
     typeinfo?for?miral::CursorScale;
     typeinfo?for?miral::DisplayConfiguration::Node;

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -490,3 +490,9 @@ auto miral::WindowInfo::visible_on_lock_screen() const -> bool
     std::shared_ptr<mir::scene::Surface> const surface = self->window;
     return surface ? surface->visible_on_lock_screen() : false;
 }
+
+auto miral::WindowInfo::tiled_edges() const -> mir::Flags<MirTiledEdge>
+{
+    std::shared_ptr<mir::scene::Surface> const surface = self->window;
+    return surface ? surface->tiled_edges() : mir::Flags(mir_tiled_edge_none);
+}

--- a/src/miral/window_info_internal.cpp
+++ b/src/miral/window_info_internal.cpp
@@ -235,3 +235,9 @@ void miral::WindowInfo::visible_on_lock_screen(bool visible)
     if (std::shared_ptr<mir::scene::Surface> const surface = self->window)
         surface->set_visible_on_lock_screen(visible);
 }
+
+void miral::WindowInfo::tiled_edges(mir::Flags<MirTiledEdge> edges)
+{
+    if (std::shared_ptr<mir::scene::Surface> const surface = self->window)
+        surface->set_tiled_edges(edges);
+}

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -56,7 +56,8 @@ miral::WindowSpecification::Self::Self(mir::shell::SurfaceSpecification const& s
     application_id(spec.application_id),
     server_side_decorated(spec.server_side_decorated),
     focus_mode(spec.focus_mode),
-    visible_on_lock_screen(spec.visible_on_lock_screen)
+    visible_on_lock_screen(spec.visible_on_lock_screen),
+    tiled_edges(spec.tiled_edges)
 {
     if (spec.aux_rect_placement_offset_x.is_set() && spec.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{spec.aux_rect_placement_offset_x.value(), spec.aux_rect_placement_offset_y.value()};
@@ -461,6 +462,16 @@ auto miral::WindowSpecification::visible_on_lock_screen() const -> mir::optional
 auto miral::WindowSpecification::visible_on_lock_screen() -> mir::optional_value<bool>&
 {
     return self->visible_on_lock_screen;
+}
+
+auto miral::WindowSpecification::tiled_edges() const -> mir::optional_value<mir::Flags<MirTiledEdge>> const&
+{
+    return self->tiled_edges;
+}
+
+auto miral::WindowSpecification::tiled_edges() -> mir::optional_value<mir::Flags<MirTiledEdge>>&
+{
+    return self->tiled_edges;
 }
 
 auto miral::WindowSpecification::userdata() -> mir::optional_value<std::shared_ptr<void>>&

--- a/src/miral/window_specification_internal.cpp
+++ b/src/miral/window_specification_internal.cpp
@@ -99,6 +99,7 @@ auto miral::make_surface_spec(WindowSpecification const& miral_spec) -> mir::she
     copy_if_set(result.server_side_decorated, spec.server_side_decorated);
     copy_if_set(result.focus_mode, spec.focus_mode);
     copy_if_set(result.visible_on_lock_screen, spec.visible_on_lock_screen);
+    copy_if_set(result.tiled_edges, spec.tiled_edges);
 
     if (spec.size.is_set())
     {

--- a/src/miral/window_specification_internal.h
+++ b/src/miral/window_specification_internal.h
@@ -74,6 +74,7 @@ struct WindowSpecification::Self
     mir::optional_value<bool> server_side_decorated;
     mir::optional_value<MirFocusMode> focus_mode;
     mir::optional_value<bool> visible_on_lock_screen;
+    mir::optional_value<mir::Flags<MirTiledEdge>> tiled_edges;
     mir::optional_value<std::shared_ptr<void>> userdata;
 };
 

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -60,6 +60,7 @@ public:
   void entered_output(mir::scene::Surface const* surf, mir::graphics::DisplayConfigurationOutputId const& id) override;
   void left_output(mir::scene::Surface const* surf, mir::graphics::DisplayConfigurationOutputId const& id) override;
   void rescale_output(mir::scene::Surface const* surf, mir::graphics::DisplayConfigurationOutputId const& id) override;
+  void tiled_edges(mir::scene::Surface const* surf, mir::Flags<MirTiledEdge> edges) override;
 
 private:
   std::shared_ptr<miroil::SurfaceObserver> listener;
@@ -175,6 +176,12 @@ void miroil::SurfaceObserverImpl::left_output(
 void miroil::SurfaceObserverImpl::rescale_output(
     mir::scene::Surface const* /*surf*/,
     mir::graphics::DisplayConfigurationOutputId const& /*id*/)
+{
+}
+
+void miroil::SurfaceObserverImpl::tiled_edges(
+    mir::scene::Surface const* /*surf*/,
+    mir::Flags<MirTiledEdge> /*edges*/)
 {
 }
 

--- a/src/server/frontend_wayland/input_method_v1.cpp
+++ b/src/server/frontend_wayland/input_method_v1.cpp
@@ -471,6 +471,7 @@ private:
             std::optional<geometry::Point> const& /*new_top_left*/,
             geometry::Size const& /*new_size*/) override {};
         virtual void handle_close_request() override {};
+        virtual void handle_tiled_edges(Flags<MirTiledEdge> /*tiled_edges*/) override {}
         virtual void handle_commit() override
         {
             auto surface_opt = scene_surface();

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -189,6 +189,7 @@ private:
         std::optional<geometry::Point> const& /*new_top_left*/,
         geometry::Size const& /*new_size*/) override;
     void handle_close_request() override;
+    void handle_tiled_edges(Flags<MirTiledEdge> /*tiled_edges*/) override {}
     void surface_destroyed() override;
 
     void destroy_role() const override

--- a/src/server/frontend_wayland/session_lock_v1.cpp
+++ b/src/server/frontend_wayland/session_lock_v1.cpp
@@ -104,6 +104,7 @@ private:
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(std::optional<geometry::Point> const&, geometry::Size const& new_size) override;
     void handle_close_request() override {};
+    void handle_tiled_edges(Flags<MirTiledEdge> /*tiled_edges*/) override {}
 
     void destroy_role() const override
     {

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -153,6 +153,15 @@ void mf::WaylandSurfaceObserver::rescale_output(ms::Surface const*, graphics::Di
         });
 }
 
+void mir::frontend::WaylandSurfaceObserver::tiled_edges(scene::Surface const*, Flags<MirTiledEdge> edges)
+{
+    run_on_wayland_thread_unless_window_destroyed(
+        [edges](Impl* impl, WindowWlSurfaceRole*)
+        {
+            impl->window.value().handle_tiled_edges(edges);
+        });
+}
+
 void mf::WaylandSurfaceObserver::run_on_wayland_thread_unless_window_destroyed(
     std::function<void(Impl* impl, WindowWlSurfaceRole* window)>&& work)
 {

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -58,6 +58,7 @@ public:
     void entered_output(scene::Surface const*, graphics::DisplayConfigurationOutputId const& id) override;
     void left_output(scene::Surface const*, graphics::DisplayConfigurationOutputId const& id) override;
     void rescale_output(scene::Surface const*, graphics::DisplayConfigurationOutputId const& id) override;
+    void tiled_edges(scene::Surface const*, Flags<MirTiledEdge> edges) override;
     ///@}
 
     /// Should only be called from the Wayland thread

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -20,6 +20,7 @@
 #include "output_manager.h"
 #include "wl_surface_role.h"
 
+#include "mir/flags.h"
 #include "mir/wayland/weak.h"
 #include "mir/wayland/lifetime_tracker.h"
 #include "mir/geometry/displacement.h"
@@ -114,6 +115,7 @@ public:
         std::optional<geometry::Point> const& new_top_left,
         geometry::Size const& new_size) = 0;
     virtual void handle_close_request() = 0;
+    virtual void handle_tiled_edges(Flags<MirTiledEdge> tiled_edges) = 0;
 
 protected:
     /// The size the window will be after the next commit

--- a/src/server/frontend_wayland/wl_shell.cpp
+++ b/src/server/frontend_wayland/wl_shell.cpp
@@ -97,6 +97,8 @@ protected:
         // It seems there is no way to request close of a wl_shell_surface
     }
 
+    void handle_tiled_edges(Flags<MirTiledEdge> /*tiled_edges*/) override {}
+
     void set_fullscreen(
         uint32_t /*method*/,
         uint32_t /*framerate*/,

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -598,6 +598,11 @@ void mf::XdgToplevelStable::handle_resize(
     send_toplevel_configure();
 }
 
+void mf::XdgToplevelStable::handle_tiled_edges(Flags<MirTiledEdge> /*tiled_edges*/)
+{
+    send_toplevel_configure();
+}
+
 void mf::XdgToplevelStable::handle_close_request()
 {
     send_close_event();
@@ -630,6 +635,28 @@ void mf::XdgToplevelStable::send_toplevel_configure()
         {
             if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
                 *state = State::fullscreen;
+        }
+
+        auto tiled_edges = surface.value()->tiled_edges();
+        if (tiled_edges & mir_tiled_edge_north)
+        {
+            if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
+                *state = State::tiled_top;
+        }
+        if (tiled_edges & mir_tiled_edge_east)
+        {
+            if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
+                *state = State::tiled_right;
+        }
+        if (tiled_edges & mir_tiled_edge_south)
+        {
+            if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
+                *state = State::tiled_bottom;
+        }
+        if (tiled_edges & mir_tiled_edge_west)
+        {
+            if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
+                *state = State::tiled_left;
         }
 
         // TODO: plumb resizing state through Mir?

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -81,6 +81,7 @@ public:
         std::optional<geometry::Point> const& new_top_left,
         geometry::Size const& new_size) override;
     void handle_close_request() override;
+    void handle_tiled_edges(Flags<MirTiledEdge> /*tiled_edges*/) override {}
 
     static auto from(wl_resource* resource) -> XdgPopupStable*;
 
@@ -128,6 +129,7 @@ public:
     void handle_active_change(bool /*is_now_active*/) override;
     void handle_resize(std::optional<geometry::Point> const& new_top_left, geometry::Size const& new_size) override;
     void handle_close_request() override;
+    void handle_tiled_edges(Flags<MirTiledEdge> tiled_edges) override;
 
     static XdgToplevelStable* from(wl_resource* surface);
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -87,6 +87,7 @@ public:
         std::optional<geometry::Point> const& new_top_left,
         geometry::Size const& new_size) override;
     void handle_close_request() override;
+    void handle_tiled_edges(Flags<MirTiledEdge> /*tiled_edges*/) override {}
 
 private:
     std::optional<geom::Point> cached_top_left;
@@ -123,6 +124,7 @@ public:
         std::optional<geometry::Point> const& new_top_left,
         geometry::Size const& new_size) override;
     void handle_close_request() override;
+    void handle_tiled_edges(Flags<MirTiledEdge> /*tiled_edges*/) override;
 
 private:
     static XdgToplevelV6* from(wl_resource* surface);
@@ -515,6 +517,11 @@ void mf::XdgToplevelV6::handle_resize(
     geometry::Size const& /*new_size*/)
 {
     send_toplevel_configure();
+}
+
+void mf::XdgToplevelV6::handle_tiled_edges(Flags<MirTiledEdge> /*tiled_edges*/)
+{
+    // Tiled edges are not supported
 }
 
 void mf::XdgToplevelV6::handle_close_request()

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -144,6 +144,8 @@ auto ms::ApplicationSession::create_surface(
         surface->set_focus_mode(params.focus_mode.value());
     if (params.visible_on_lock_screen.is_set())
         surface->set_visible_on_lock_screen(params.visible_on_lock_screen.value());
+    if (params.tiled_edges.is_set())
+        surface->set_tiled_edges(params.tiled_edges.value());
 
     return surface;
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -174,6 +174,11 @@ public:
     {
         for_each_observer(&SurfaceObserver::rescale_output, surf, id);
     }
+
+    void tiled_edges(Surface const* surf, Flags<MirTiledEdge> edges) override
+    {
+        for_each_observer(&SurfaceObserver::tiled_edges, surf, edges);
+    }
 };
 
 namespace
@@ -957,6 +962,17 @@ auto mir::scene::BasicSurface::focus_mode() const -> MirFocusMode
 void mir::scene::BasicSurface::set_focus_mode(MirFocusMode focus_mode)
 {
     synchronised_state.lock()->focus_mode = focus_mode;
+}
+
+auto mir::scene::BasicSurface::tiled_edges() const -> Flags<MirTiledEdge>
+{
+    return synchronised_state.lock()->tiled_edges;
+}
+
+void mir::scene::BasicSurface::set_tiled_edges(Flags<MirTiledEdge> edges)
+{
+    synchronised_state.lock()->tiled_edges = edges;
+    observers->tiled_edges(this, edges);
 }
 
 void mir::scene::BasicSurface::clear_frame_posted_callbacks(State& state)

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -175,6 +175,9 @@ public:
     auto focus_mode() const -> MirFocusMode override;
     void set_focus_mode(MirFocusMode focus_mode) override;
 
+    Flags<MirTiledEdge> tiled_edges() const override;
+    void set_tiled_edges(Flags<MirTiledEdge> flags) override;
+
 private:
     struct State;
     class DisplayConfigurationEarlyListener;
@@ -228,6 +231,7 @@ private:
         } margins{};
 
         MirFocusMode focus_mode = mir_focus_mode_focusable;
+        Flags<MirTiledEdge> tiled_edges = Flags(mir_tiled_edge_none);
     };
     mir::Synchronised<State> synchronised_state;
 

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -40,3 +40,5 @@ void ms::NullSurfaceObserver::application_id_set_to(Surface const*, std::string 
 void ms::NullSurfaceObserver::entered_output(Surface const*, graphics::DisplayConfigurationOutputId const&) {}
 void ms::NullSurfaceObserver::left_output(Surface const*, graphics::DisplayConfigurationOutputId const&) {}
 void ms::NullSurfaceObserver::rescale_output(Surface const*, graphics::DisplayConfigurationOutputId const&){}
+void ms::NullSurfaceObserver::tiled_edges(Surface const*, Flags<MirTiledEdge>) {}
+

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -155,6 +155,8 @@ void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
         focus_mode = that.focus_mode;
     if (that.visible_on_lock_screen.is_set())
         visible_on_lock_screen = that.visible_on_lock_screen;
+    if (that.tiled_edges.is_set())
+        tiled_edges = that.tiled_edges;
 }
 
 bool msh::operator==(
@@ -205,7 +207,8 @@ bool msh::operator==(
         lhs.application_id == rhs.application_id &&
         lhs.server_side_decorated == rhs.server_side_decorated &&
         lhs.focus_mode == rhs.focus_mode &&
-        lhs.visible_on_lock_screen == rhs.visible_on_lock_screen;
+        lhs.visible_on_lock_screen == rhs.visible_on_lock_screen &&
+        lhs.tiled_edges == rhs.tiled_edges;
 }
 
 bool msh::operator!=(

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -495,6 +495,7 @@ global:
     mir::scene::NullSurfaceObserver::reception_mode_set_to*;
     mir::scene::NullSurfaceObserver::renamed*;
     mir::scene::NullSurfaceObserver::rescale_output*;
+    mir::scene::NullSurfaceObserver::tiled_edges*;
     mir::scene::NullSurfaceObserver::transformation_set_to*;
     mir::scene::NullSurfaceObserver::window_resized_to*;
     mir::scene::Observer::?Observer*;
@@ -959,6 +960,7 @@ global:
     non-virtual?thunk?to?mir::scene::NullSurfaceObserver::reception_mode_set_to*;
     non-virtual?thunk?to?mir::scene::NullSurfaceObserver::renamed*;
     non-virtual?thunk?to?mir::scene::NullSurfaceObserver::rescale_output*;
+    non-virtual?thunk?to?mir::scene::NullSurfaceObserver::tiled_edges*;
     non-virtual?thunk?to?mir::scene::NullSurfaceObserver::transformation_set_to*;
     non-virtual?thunk?to?mir::scene::NullSurfaceObserver::window_resized_to*;
     non-virtual?thunk?to?mir::scene::Observer::?Observer*;

--- a/tests/include/mir/test/doubles/stub_surface.h
+++ b/tests/include/mir/test/doubles/stub_surface.h
@@ -91,6 +91,8 @@ struct StubSurface : scene::Surface
         geometry::DeltaX) override {}
     auto focus_mode() const -> MirFocusMode override { return mir_focus_mode_focusable; }
     void set_focus_mode(MirFocusMode) override {}
+    auto tiled_edges() const -> Flags<MirTiledEdge> { return Flags(mir_tiled_edge_none); }
+    void set_tiled_edges(Flags<MirTiledEdge>) {}
 };
 }
 }


### PR DESCRIPTION
## What's new?
- Added tiled edge hints per the [xdg shell spec](https://wayland.app/protocols/xdg-shell#xdg_toplevel:enum:state:entry:tiled_left)
- Piped it through `WindowInfo`, `WindowSpecification`, `SurfaceObserver`, `Surface`, `SurfaceSpecification`, and ultimately `XdgToplevelStable` to notify the client of the state

## How To Test
- You can do something like this in `FloatingWindowManagerPolicy::place_new_window`:

```c++
parameters.tiled_edges() = mir::Flags<MirTiledEdge>(mir_tiled_edge_north | mir_tiled_edge_south);
```

Then you should be able to use `WAYLAND_DEBUG=1` to see the flag going by. I don't really know of any clients that use this in a significant way, but it gets to them