### PR TITLE
miral::TestDisplayServer: Allow using real `RenderingPlatform`s in tests

### DIFF
--- a/tests/include/mir/test/doubles/stub_buffer.h
+++ b/tests/include/mir/test/doubles/stub_buffer.h
@@ -55,7 +55,7 @@ public:
                   size,
                   mir_pixel_format_abgr_8888,
                   graphics::BufferUsage::hardware},
-              geometry::Stride{}}
+              geometry::Stride{size.width.as_uint32_t() * MIR_BYTES_PER_PIXEL(mir_pixel_format_abgr_8888)}}
 
     {
     }
@@ -66,8 +66,7 @@ public:
                   size,
                   pixel_format,
                   graphics::BufferUsage::hardware},
-                  geometry::Stride{}}
-
+                  geometry::Stride{size.width.as_uint32_t() * MIR_BYTES_PER_PIXEL(pixel_format)}}
     {
     }
 

--- a/tests/include/mir/test/doubles/stub_display_sink.h
+++ b/tests/include/mir/test/doubles/stub_display_sink.h
@@ -17,8 +17,13 @@
 #ifndef MIR_TEST_DOUBLES_STUB_DISPLAY_BUFFER_H_
 #define MIR_TEST_DOUBLES_STUB_DISPLAY_BUFFER_H_
 
+#include "mir/graphics/drm_formats.h"
+#include "mir/graphics/platform.h"
 #include "mir/test/doubles/null_display_sink.h"
 #include "mir/geometry/rectangle.h"
+#include "mir/test/doubles/stub_buffer.h"
+#include "mir_toolkit/common.h"
+#include <drm_fourcc.h>
 
 namespace mir
 {
@@ -27,15 +32,90 @@ namespace test
 namespace doubles
 {
 
+class DummyCPUAddressableDisplayAllocator : public graphics::CPUAddressableDisplayAllocator
+{
+    class MappableFB : public graphics::CPUAddressableDisplayAllocator::MappableFB
+    {
+    public:
+        MappableFB(geometry::Size size, graphics::DRMFormat format)
+            : buffer{std::make_unique<StubBuffer>(size, format.as_mir_format().value())}
+        {
+        }
+
+        auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override
+        {
+            return buffer->map_writeable();
+        }
+
+        auto format() const -> MirPixelFormat override
+        {
+            return buffer->format();
+        }
+
+        auto stride() const -> geometry::Stride override
+        {
+            return buffer->stride();
+        }
+        auto size() const -> geometry::Size override
+        {
+            return buffer->size();
+        }
+    private:
+        std::unique_ptr<StubBuffer> const buffer;
+    };
+
+public:
+    DummyCPUAddressableDisplayAllocator(geometry::Size size)
+        : size{size}
+    {
+    }
+
+    auto supported_formats() const -> std::vector<graphics::DRMFormat> override
+    {
+        return {graphics::DRMFormat{DRM_FORMAT_ARGB8888}};
+    }
+    auto alloc_fb(graphics::DRMFormat format) -> std::unique_ptr<graphics::CPUAddressableDisplayAllocator::MappableFB> override
+    {
+        return std::make_unique<MappableFB>(size, format);
+    }
+    auto output_size() const -> geometry::Size override
+    {
+        return size;
+    }
+
+private:
+    geometry::Size const size;
+};
+
 class StubDisplaySink : public NullDisplaySink
 {
 public:
-    StubDisplaySink(geometry::Rectangle const& view_area_) : view_area_(view_area_) {}
-    StubDisplaySink(StubDisplaySink const& s) : view_area_(s.view_area_) {}
+    StubDisplaySink(geometry::Rectangle const& view_area_)
+        : view_area_(view_area_),
+          allocator{view_area_.size}
+    {
+    }
+
+    StubDisplaySink(StubDisplaySink const& s)
+        : StubDisplaySink(s.view_area_)
+    {
+    }
+
     geometry::Rectangle view_area() const override { return view_area_; }
 
 private:
+    auto maybe_create_allocator(graphics::DisplayAllocator::Tag const& tag)
+        -> graphics::DisplayAllocator* override
+    {
+        if (dynamic_cast<graphics::CPUAddressableDisplayAllocator::Tag const*>(&tag))
+        {
+            return &allocator;
+        }
+        return nullptr;
+    }
+
     geometry::Rectangle view_area_;
+    DummyCPUAddressableDisplayAllocator allocator;
 };
 
 }

--- a/tests/mir_test_framework/stubbed_graphics_platform.cpp
+++ b/tests/mir_test_framework/stubbed_graphics_platform.cpp
@@ -100,9 +100,16 @@ auto mtf::StubGraphicPlatform::maybe_create_provider(
     return nullptr;
 }
 
-auto mtf::StubGraphicPlatform::maybe_create_provider(mg::DisplayProvider::Tag const&)
+auto mtf::StubGraphicPlatform::maybe_create_provider(mg::DisplayProvider::Tag const& tag)
     -> std::shared_ptr<mg::DisplayProvider>
 {
+    class NullCPUAddressableDisplayProvider : public mg::CPUAddressableDisplayProvider
+    {
+    };
+    if (dynamic_cast<mg::CPUAddressableDisplayProvider::Tag const*>(&tag))
+    {
+        return std::make_shared<NullCPUAddressableDisplayProvider>();
+    }
     return nullptr;
 }
 

--- a/tests/mir_test_framework/test_display_server.cpp
+++ b/tests/mir_test_framework/test_display_server.cpp
@@ -61,7 +61,6 @@ miral::TestDisplayServer::TestDisplayServer(int argc, char const** argv) :
     unsetenv("WAYLAND_DISPLAY");    // We don't want to conflict with any existing server
     add_to_environment("MIR_SERVER_PLATFORM_PATH", mtf::server_platform_path().c_str());
     add_to_environment("MIR_SERVER_PLATFORM_DISPLAY_LIBS", "mir:stub-graphics");
-    add_to_environment("MIR_SERVER_PLATFORM_RENDERING_LIBS", "mir:stub-graphics");
     add_to_environment("MIR_SERVER_PLATFORM_INPUT_LIB", "mir:stub-input");
     add_to_environment("MIR_SERVER_CONSOLE_PROVIDER", "none");
 }


### PR DESCRIPTION
We want to be able to test platform-specific interfaces
(particularly: linux-drm-syncobj) that require a particular
`RenderingPlatform` to be loaded.

This implements `CPUAddressableDisplay*` in the stub
display platform, which then allows a non-stub
`RenderingPlatform` to be loaded and used.

With that, stop forcing the use of the stub rendering
platform in `miral::TestDisplayServer`.