### PR TITLE
platforms: Use `NativeBufferBase` in `as_texture`

### DIFF
--- a/include/platform/mir/graphics/linux_dmabuf.h
+++ b/include/platform/mir/graphics/linux_dmabuf.h
@@ -83,7 +83,7 @@ public:
     void validate_import(DMABufBuffer const& dma_buf);
 
     auto as_texture(
-        std::shared_ptr<Buffer> buffer)
+        std::shared_ptr<NativeBufferBase> buffer)
         -> std::shared_ptr<gl::Texture>;
 
      auto supported_formats() const -> DmaBufFormatDescriptors const&;

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -1204,7 +1204,7 @@ void mg::DMABufEGLProvider::validate_import(DMABufBuffer const& dma_buf)
     }
 }
 
-auto mg::DMABufEGLProvider::as_texture(std::shared_ptr<Buffer> buffer)
+auto mg::DMABufEGLProvider::as_texture(std::shared_ptr<NativeBufferBase> buffer)
     -> std::shared_ptr<gl::Texture>
 {
     if (auto dmabuf_tex = std::dynamic_pointer_cast<DmabufTexBuffer>(buffer))

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -733,7 +733,8 @@ mge::GLRenderingProvider::~GLRenderingProvider() = default;
 auto mir::graphics::eglstream::GLRenderingProvider::as_texture(std::shared_ptr<Buffer> buffer)
     -> std::shared_ptr<gl::Texture>
 {
-    return std::dynamic_pointer_cast<gl::Texture>(std::move(buffer));
+    std::shared_ptr<NativeBufferBase> native_buffer{buffer, buffer->native_buffer_base()};
+    return std::dynamic_pointer_cast<gl::Texture>(std::move(native_buffer));
 }
 
 auto mge::GLRenderingProvider::surface_for_sink(

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "buffer_allocator.h"
+#include "mir/graphics/buffer.h"
 #include "mir/graphics/gl_config.h"
 #include "mir/graphics/graphic_buffer_allocator.h"
 #include "mir/graphics/linux_dmabuf.h"
@@ -215,11 +216,12 @@ auto mgg::BufferAllocator::shared_egl_context() -> EGLContext
 
 auto mgg::GLRenderingProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std::shared_ptr<gl::Texture>
 {
-    if (auto dmabuf_texture = dmabuf_provider->as_texture(buffer))
+    std::shared_ptr<NativeBufferBase> native_buffer{buffer, buffer->native_buffer_base()};
+    if (auto dmabuf_texture = dmabuf_provider->as_texture(native_buffer))
     {
         return dmabuf_texture;
     }
-    else if (auto tex = std::dynamic_pointer_cast<gl::Texture>(buffer))
+    else if (auto tex = std::dynamic_pointer_cast<gl::Texture>(native_buffer))
     {
         return tex;
     }

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -309,15 +309,16 @@ auto mge::BufferAllocator::shared_egl_context() -> EGLContext
 
 auto mge::GLRenderingProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std::shared_ptr<gl::Texture>
 {
+    std::shared_ptr<NativeBufferBase> native_buffer{buffer, buffer->native_buffer_base()};
     if (dmabuf_provider)
     {
-        if (auto tex = dmabuf_provider->as_texture(buffer))
+        if (auto tex = dmabuf_provider->as_texture(native_buffer))
         {
             return tex;
         }
     }
     // TODO: Should this be abstracted, like dmabuf_provider above?
-    return std::dynamic_pointer_cast<gl::Texture>(buffer);
+    return std::dynamic_pointer_cast<gl::Texture>(native_buffer);
 }
 
 namespace

--- a/tests/include/mir/test/doubles/stub_gl_rendering_provider.h
+++ b/tests/include/mir/test/doubles/stub_gl_rendering_provider.h
@@ -30,7 +30,8 @@ class StubGlRenderingProvider : public graphics::GLRenderingProvider
 public:
     auto as_texture(std::shared_ptr<graphics::Buffer> buffer) -> std::shared_ptr<graphics::gl::Texture> override
     {
-        if (auto existing_buf = std::dynamic_pointer_cast<graphics::gl::Texture>(std::move(buffer)))
+        std::shared_ptr<graphics::NativeBufferBase> native_buffer{buffer, buffer->native_buffer_base()};
+        if (auto existing_buf = std::dynamic_pointer_cast<graphics::gl::Texture>(std::move(native_buffer)))
         {
             return existing_buf;
         }


### PR DESCRIPTION
Users may wish to wrap a `Buffer` in a class with some extra behaviour of their own (notably, tracking when the buffer is no longer used by the rendering pipeline).

In order to allow this wrapping while still having `as_texture` access the *real* buffer type we should be using `NativeBufferBase` so the wrapper can return the underlying buffer.