### PR TITLE
Simplify MinimalWindowManagerTests

### DIFF
--- a/tests/window_management_tests/test_minimal_window_manager.cpp
+++ b/tests/window_management_tests/test_minimal_window_manager.cpp
@@ -1390,13 +1390,13 @@ TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_removal)
 TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_unused)
 {
     tools().move_cursor_to(geom::PointF(0, 0));
-    auto const app = this->open_application("test");
+    auto const app = open_application("test");
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_maximized;
     spec.size() = geom::Size(100, 100);
-    auto const window = this->create_window(app, spec);
+    auto const window = create_window(app, spec);
 
-    auto new_output_configs = this->get_initial_output_configs();
+    auto new_output_configs = get_initial_output_configs();
     new_output_configs[0].used = false;
     update_outputs(new_output_configs);
     geom::Rectangle const window_rect(window.top_left(), window.size());
@@ -1406,13 +1406,13 @@ TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_unused)
 TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_disconnected)
 {
     tools().move_cursor_to(geom::PointF(0, 0));
-    auto const app = this->open_application("test");
+    auto const app = open_application("test");
     miral::WindowSpecification spec;
     spec.state() = mir_window_state_maximized;
     spec.size() = geom::Size(100, 100);
-    auto const window = this->create_window(app, spec);
+    auto const window = create_window(app, spec);
 
-    auto new_output_configs = this->get_initial_output_configs();
+    auto new_output_configs = get_initial_output_configs();
     new_output_configs[0].connected = false;
     update_outputs(new_output_configs);
 
@@ -1424,12 +1424,12 @@ TEST_F(MinimalWindowManagerTest, windows_on_removed_output_are_placed_on_next_av
 {
     tools().move_cursor_to(geom::PointF(900, 100));
 
-    auto const app = this->open_application("test");
+    auto const app = open_application("test");
     miral::WindowSpecification spec;
     spec.size() = geom::Size(100, 100);
-    auto const window = this->create_window(app, spec);
+    auto const window = create_window(app, spec);
 
-    auto const new_output_configs = this->output_configs_from_output_rectangles({
+    auto const new_output_configs = output_configs_from_output_rectangles({
         mir::geometry::Rectangle{{0, 0}, {1000, 1000}}
     });
     update_outputs(new_output_configs);

--- a/tests/window_management_tests/test_minimal_window_manager.cpp
+++ b/tests/window_management_tests/test_minimal_window_manager.cpp
@@ -1389,56 +1389,50 @@ TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_removal)
 
 TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_unused)
 {
-    EXPECT_NONFATAL_FAILURE({
-        this->tools().move_cursor_to(geom::PointF(0, 0));
-        auto const app = this->open_application("test");
-        miral::WindowSpecification spec;
-        spec.state() = mir_window_state_maximized;
-        spec.size() = geom::Size(100, 100);
-        auto const window = this->create_window(app, spec);
+    tools().move_cursor_to(geom::PointF(0, 0));
+    auto const app = this->open_application("test");
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_maximized;
+    spec.size() = geom::Size(100, 100);
+    auto const window = this->create_window(app, spec);
 
-        auto new_output_configs = this->get_initial_output_configs();
-        new_output_configs[0].used = false;
-        this->update_outputs(new_output_configs);
-        geom::Rectangle const window_rect(window.top_left(), window.size());
-        EXPECT_THAT(window_rect, Eq(new_output_configs[1].extents()));
-    }, "");
+    auto new_output_configs = this->get_initial_output_configs();
+    new_output_configs[0].used = false;
+    update_outputs(new_output_configs);
+    geom::Rectangle const window_rect(window.top_left(), window.size());
+    EXPECT_THAT(window_rect, Ne(new_output_configs[1].extents()));
 }
 
 TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_disconnected)
 {
-    EXPECT_NONFATAL_FAILURE({
-        this->tools().move_cursor_to(geom::PointF(0, 0));
-        auto const app = this->open_application("test");
-        miral::WindowSpecification spec;
-        spec.state() = mir_window_state_maximized;
-        spec.size() = geom::Size(100, 100);
-        auto const window = this->create_window(app, spec);
+    tools().move_cursor_to(geom::PointF(0, 0));
+    auto const app = this->open_application("test");
+    miral::WindowSpecification spec;
+    spec.state() = mir_window_state_maximized;
+    spec.size() = geom::Size(100, 100);
+    auto const window = this->create_window(app, spec);
 
-        auto new_output_configs = this->get_initial_output_configs();
-        new_output_configs[0].connected = false;
-        this->update_outputs(new_output_configs);
+    auto new_output_configs = this->get_initial_output_configs();
+    new_output_configs[0].connected = false;
+    update_outputs(new_output_configs);
 
-        geom::Rectangle const window_rect(window.top_left(), window.size());
-        EXPECT_THAT(window_rect, Eq(new_output_configs[1].extents()));
-    }, "");
+    geom::Rectangle const window_rect(window.top_left(), window.size());
+    EXPECT_THAT(window_rect, Ne(new_output_configs[1].extents()));
 }
 
 TEST_F(MinimalWindowManagerTest, windows_on_removed_output_are_placed_on_next_available_output)
 {
-    EXPECT_NONFATAL_FAILURE({
-        this->tools().move_cursor_to(geom::PointF(900, 100));
+    tools().move_cursor_to(geom::PointF(900, 100));
 
-        auto const app = this->open_application("test");
-        miral::WindowSpecification spec;
-        spec.size() = geom::Size(100, 100);
-        auto const window = this->create_window(app, spec);
+    auto const app = this->open_application("test");
+    miral::WindowSpecification spec;
+    spec.size() = geom::Size(100, 100);
+    auto const window = this->create_window(app, spec);
 
-        auto const new_output_configs = this->output_configs_from_output_rectangles({
-            mir::geometry::Rectangle{{0, 0}, {1000, 1000}}
-        });
-        this->update_outputs(new_output_configs);
-        geom::Rectangle const window_rect(window.top_left(), window.size());
-        EXPECT_THAT(window_rect.overlaps(new_output_configs[0].extents()), Eq(true));
-    }, "");
+    auto const new_output_configs = this->output_configs_from_output_rectangles({
+        mir::geometry::Rectangle{{0, 0}, {1000, 1000}}
+    });
+    update_outputs(new_output_configs);
+    geom::Rectangle const window_rect(window.top_left(), window.size());
+    EXPECT_FALSE(window_rect.overlaps(new_output_configs[0].extents()));
 }

--- a/tests/window_management_tests/test_minimal_window_manager.cpp
+++ b/tests/window_management_tests/test_minimal_window_manager.cpp
@@ -1387,7 +1387,7 @@ TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_removal)
     EXPECT_THAT(window.size(), Eq(new_output_configs[0].extents().size));
 }
 
-TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_unused)
+TEST_F(MinimalWindowManagerTest, DISABLED_maximized_window_respects_output_unused)
 {
     tools().move_cursor_to(geom::PointF(0, 0));
     auto const app = open_application("test");
@@ -1400,10 +1400,10 @@ TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_unused)
     new_output_configs[0].used = false;
     update_outputs(new_output_configs);
     geom::Rectangle const window_rect(window.top_left(), window.size());
-    EXPECT_THAT(window_rect, Ne(new_output_configs[1].extents()));
+    EXPECT_THAT(window_rect, Eq(new_output_configs[1].extents()));
 }
 
-TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_disconnected)
+TEST_F(MinimalWindowManagerTest, DISABLED_maximized_window_respects_output_disconnected)
 {
     tools().move_cursor_to(geom::PointF(0, 0));
     auto const app = open_application("test");
@@ -1417,10 +1417,10 @@ TEST_F(MinimalWindowManagerTest, maximized_window_respects_output_disconnected)
     update_outputs(new_output_configs);
 
     geom::Rectangle const window_rect(window.top_left(), window.size());
-    EXPECT_THAT(window_rect, Ne(new_output_configs[1].extents()));
+    EXPECT_THAT(window_rect, Eq(new_output_configs[1].extents()));
 }
 
-TEST_F(MinimalWindowManagerTest, windows_on_removed_output_are_placed_on_next_available_output)
+TEST_F(MinimalWindowManagerTest, DISABLED_windows_on_removed_output_are_placed_on_next_available_output)
 {
     tools().move_cursor_to(geom::PointF(900, 100));
 
@@ -1434,5 +1434,5 @@ TEST_F(MinimalWindowManagerTest, windows_on_removed_output_are_placed_on_next_av
     });
     update_outputs(new_output_configs);
     geom::Rectangle const window_rect(window.top_left(), window.size());
-    EXPECT_FALSE(window_rect.overlaps(new_output_configs[0].extents()));
+    EXPECT_TRUE(window_rect.overlaps(new_output_configs[0].extents()));
 }


### PR DESCRIPTION
We have been testing that a behaviour fails when that behaviour happens intermittently (and is probably what we want).

We don't currently understand why the behaviour isn't consistent, but changing the tests to test for the correct behaviour and disabling them seems a good intermediate condition 