### PR TITLE
Fix param name that mismatches cpp source

### DIFF
--- a/src/platforms/atomic-kms/server/gbm_display_allocator.h
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.h
@@ -22,7 +22,7 @@ namespace mir::graphics::atomic
 class GBMDisplayAllocator : public graphics::GBMDisplayAllocator
 {
 public:
-    GBMDisplayAllocator(mir::Fd drm_fd, std::shared_ptr<struct gbm_device> atomic, geometry::Size size);
+    GBMDisplayAllocator(mir::Fd drm_fd, std::shared_ptr<struct gbm_device> gbm, geometry::Size size);
 
     auto supported_formats() const -> std::vector<DRMFormat> override;
 


### PR DESCRIPTION
Seems to be a global replace when atomic-kms was copied from gbm-kms.