### PR TITLE
Implement slow keys

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -579,6 +579,18 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::CursorScale::CursorScale(miral::live_config::Store&)@MIRAL_5.4" 5.4.0
  (c++)"miral::InputConfiguration::InputConfiguration(miral::live_config::Store&)@MIRAL_5.4" 5.4.0
  (c++)"miral::OutputFilter::OutputFilter(miral::live_config::Store&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::SlowKeys(miral::live_config::Store&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::SlowKeys(std::shared_ptr<miral::SlowKeys::Self>)@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::disable()@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::disabled()@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::enable()@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::enabled()@MIRAL_5.4" 5.4.0
+ (c++|arch-bits=64)"miral::SlowKeys::hold_delay(std::chrono::duration<long, std::ratio<1l, 1000l> >)@MIRAL_5.4" 5.4.0
+ (c++|arch-bits=32)"miral::SlowKeys::hold_delay(std::chrono::duration<long long, std::ratio<1ll, 1000ll> >)@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::on_key_accepted(std::function<void (unsigned int)>&&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::on_key_down(std::function<void (unsigned int)>&&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::on_key_rejected(std::function<void (unsigned int)>&&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::SlowKeys::operator()(mir::Server&)@MIRAL_5.4" 5.4.0
  (c++)"miral::WaylandTools::WaylandTools()@MIRAL_5.4" 5.4.0
  (c++)"miral::WaylandTools::WaylandTools(miral::WaylandTools const&)@MIRAL_5.4" 5.4.0
  (c++)"miral::WaylandTools::for_each_binding(mir::wayland::Client*, miral::Output const&, std::function<void (wl_resource*)> const&) const@MIRAL_5.4" 5.4.0

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -32,6 +32,7 @@
 #include <miral/cursor_scale.h>
 #include <miral/output_filter.h>
 #include <miral/bounce_keys.h>
+#include <miral/slow_keys.h>
 
 #include "mir/abnormal_exit.h"
 #include "mir/main_loop.h"
@@ -129,6 +130,7 @@ try
     miral::OutputFilter output_filter{config_store};
     miral::InputConfiguration input_configuration{config_store};
     miral::BounceKeys bounce_keys{config_store};
+    miral::SlowKeys slow_keys{config_store};
 
     miral::ConfigFile config_file{
         runner,
@@ -161,6 +163,7 @@ try
         input_configuration,
         cursor_scale,
         bounce_keys,
+        slow_keys
     });
 
     // Propagate any test failure

--- a/include/miral/miral/slow_keys.h
+++ b/include/miral/miral/slow_keys.h
@@ -28,20 +28,51 @@ class Server;
 namespace miral
 {
 namespace live_config { class Store; }
+/// Enables configuring slow keys at runtime.
+///
+/// Slow keys is an accessibility feature that enables the rejection of
+/// keypresses that don't last long enough. It can be useful in cases where the
+/// user has issues that cause them to press buttons accidentally.
+///
+/// You can optionally assign handlers for when the key is pressed down, is
+/// rejected, or when the press is accepted.
+///
+/// \remark  Since MirAL 5.4
 class SlowKeys
 {
 public:
+    /// Creates a `SlowKeys` instance that's enabled by default.
     static auto enabled() -> SlowKeys;
+
+    /// Creates a `SlowKeys` instance that's disabled by default.
     static auto disabled() -> SlowKeys;
+
+    /// Construct a `SlowKeys` instance with access to a live config store.
     explicit SlowKeys(miral::live_config::Store& config_store);
 
     void operator()(mir::Server& server);
 
+    // Enables slow keys.
+    // When already enabled, further calls have no effect.
     SlowKeys& enable();
+    
+    // Disables slow keys.
+    // When already disabled, further calls have no effect.
     SlowKeys& disable();
+
+    /// Configures the duration a key has to be pressed down for to register as a key press.
     SlowKeys& hold_delay(std::chrono::milliseconds hold_delay);
+
+    /// Configures the callback that's invoked when the key is pressed down.
+    /// Useful for providing feedback to users.
     SlowKeys& on_key_down(std::function<void(unsigned int)>&& on_key_down);
+    
+    /// Configures the callback that's invoked when a press is rejected.
+    /// Useful for providing feedback to users.
     SlowKeys& on_key_rejected(std::function<void(unsigned int)>&& on_key_rejected);
+    
+    /// Configures the callback that's invoked when a press is accepted.
+    /// Useful for providing feedback to users.
     SlowKeys& on_key_accepted(std::function<void(unsigned int)>&& on_key_accepted);
 
 private:

--- a/include/miral/miral/slow_keys.h
+++ b/include/miral/miral/slow_keys.h
@@ -30,7 +30,8 @@ namespace miral
 class SlowKeys
 {
 public:
-    explicit SlowKeys(bool enabled_by_default);
+    static auto enabled() -> SlowKeys;
+    static auto disabled() -> SlowKeys;
 
     void operator()(mir::Server& server);
 
@@ -43,6 +44,7 @@ public:
 
 private:
     struct Self;
+    explicit SlowKeys(std::shared_ptr<Self>);
     std::shared_ptr<Self> self;
 };
 }

--- a/include/miral/miral/slow_keys.h
+++ b/include/miral/miral/slow_keys.h
@@ -27,11 +27,13 @@ class Server;
 
 namespace miral
 {
+namespace live_config { class Store; }
 class SlowKeys
 {
 public:
     static auto enabled() -> SlowKeys;
     static auto disabled() -> SlowKeys;
+    explicit SlowKeys(miral::live_config::Store& config_store);
 
     void operator()(mir::Server& server);
 

--- a/include/miral/miral/slow_keys.h
+++ b/include/miral/miral/slow_keys.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_SLOW_KEYS_H
+#define MIRAL_SLOW_KEYS_H
+
+#include <chrono>
+#include <functional>
+
+namespace mir
+{
+class Server;
+}
+
+namespace miral
+{
+class SlowKeys
+{
+public:
+    explicit SlowKeys(bool enabled_by_default);
+
+    void operator()(mir::Server& server);
+
+    SlowKeys& enable();
+    SlowKeys& disable();
+    SlowKeys& hold_delay(std::chrono::milliseconds hold_delay);
+    SlowKeys& on_key_down(std::function<void(unsigned int)>&& on_key_down);
+    SlowKeys& on_key_rejected(std::function<void(unsigned int)>&& on_key_rejected);
+    SlowKeys& on_key_accepted(std::function<void(unsigned int)>&& on_key_accepted);
+
+private:
+    struct Self;
+    std::shared_ptr<Self> self;
+};
+}
+
+#endif // MIRAL_SLOW_KEYS_H

--- a/include/miral/miral/slow_keys.h
+++ b/include/miral/miral/slow_keys.h
@@ -28,6 +28,7 @@ class Server;
 namespace miral
 {
 namespace live_config { class Store; }
+
 /// Enables configuring slow keys at runtime.
 ///
 /// Slow keys is an accessibility feature that enables the rejection of

--- a/src/include/server/mir/shell/accessibility_manager.h
+++ b/src/include/server/mir/shell/accessibility_manager.h
@@ -31,6 +31,7 @@ namespace shell
 class KeyboardHelper;
 class SimulatedSecondaryClickTransformer;
 class HoverClickTransformer;
+class SlowKeysTransformer;
 class AccessibilityManager
 {
 public:
@@ -55,6 +56,9 @@ public:
 
     virtual void hover_click_enabled(bool enabled) = 0;
     virtual auto hover_click() -> HoverClickTransformer& = 0;
+
+    virtual void slow_keys_enabled(bool enabled) = 0;
+    virtual auto slow_keys() -> SlowKeysTransformer& = 0;
 };
 }
 }

--- a/src/include/server/mir/shell/slow_keys_transformer.h
+++ b/src/include/server/mir/shell/slow_keys_transformer.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/input/input_event_transformer.h"
+
+
+namespace mir
+{
+class MainLoop;
+namespace shell
+{
+class SlowKeysTransformer : public mir::input::InputEventTransformer::Transformer
+{
+public:
+    virtual void on_key_down(std::function<void(unsigned int)>&&) = 0;
+    virtual void on_key_rejected(std::function<void(unsigned int)>&&) = 0;
+    virtual void on_key_accepted(std::function<void(unsigned int)>&&) = 0;
+
+    virtual void delay(std::chrono::milliseconds) = 0;
+};
+}
+}
+

--- a/src/include/server/mir/shell/slow_keys_transformer.h
+++ b/src/include/server/mir/shell/slow_keys_transformer.h
@@ -14,6 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef MIR_SHELL_SLOW_KEYS_TRANSFORMER
+#define MIR_SHELL_SLOW_KEYS_TRANSFORMER
+
 #include "mir/input/input_event_transformer.h"
 
 
@@ -34,3 +37,4 @@ public:
 }
 }
 
+#endif // MIR_SHELL_SLOW_KEYS_TRANSFORMER

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(miral-external OBJECT
     live_config_ini_file.cpp            ${miral_include}/miral/live_config_ini_file.h
     hover_click.cpp                     ${miral_include}/miral/hover_click.h
     bounce_keys.cpp                     ${miral_include}/miral/bounce_keys.h
+    slow_keys.cpp                       ${miral_include}/miral/slow_keys.h
 )
 
 add_library(miral SHARED

--- a/src/miral/slow_keys.cpp
+++ b/src/miral/slow_keys.cpp
@@ -38,7 +38,9 @@ struct miral::SlowKeys::Self
 
         bool enabled;
         std::chrono::milliseconds hold_delay{200};
-        std::function<void(unsigned int)> on_key_down, on_key_rejected, on_key_accepted;
+        std::function<void(unsigned int)> on_key_down{[](auto){}};
+        std::function<void(unsigned int)> on_key_rejected{[](auto){}};
+        std::function<void(unsigned int)> on_key_accepted{[](auto){}};
     };
 
     mir::Synchronised<State> state;

--- a/src/miral/slow_keys.cpp
+++ b/src/miral/slow_keys.cpp
@@ -64,57 +64,60 @@ miral::SlowKeys::SlowKeys(std::shared_ptr<Self> s) :
 
 miral::SlowKeys& miral::SlowKeys::enable()
 {
-    self->state.lock()->enabled = true;
     if (auto const accessibility_manager = self->accessibility_manager.lock())
         accessibility_manager->slow_keys_enabled(true);
+    else
+        self->state.lock()->enabled = true;
 
     return *this;
 }
 
 miral::SlowKeys& miral::SlowKeys::disable()
 {
-    self->state.lock()->enabled = false;
     if (auto const accessibility_manager = self->accessibility_manager.lock())
         accessibility_manager->slow_keys_enabled(false);
+    else
+        self->state.lock()->enabled = false;
 
     return *this;
 }
 
 miral::SlowKeys& miral::SlowKeys::hold_delay(std::chrono::milliseconds hold_delay)
 {
-    self->state.lock()->hold_delay = hold_delay;
     if (auto const accessibility_manager = self->accessibility_manager.lock())
         accessibility_manager->slow_keys().delay(hold_delay);
+    else
+        self->state.lock()->hold_delay = hold_delay;
 
     return *this;
 }
 
 miral::SlowKeys& miral::SlowKeys::on_key_down(std::function<void(unsigned int)>&& on_key_down)
 {
-    auto const state = self->state.lock();
-    state->on_key_down = std::move(on_key_down);
     if (auto const accessibility_manager = self->accessibility_manager.lock())
-        accessibility_manager->slow_keys().on_key_down(std::move(state->on_key_down));
+        accessibility_manager->slow_keys().on_key_down(std::move(on_key_down));
+    else
+        self->state.lock()->on_key_down = std::move(on_key_down);
 
     return *this;
 }
 
 miral::SlowKeys& miral::SlowKeys::on_key_rejected(std::function<void(unsigned int)>&& on_key_rejected)
 {
-    auto const state = self->state.lock();
-    state->on_key_rejected = std::move(on_key_rejected);
     if (auto const accessibility_manager = self->accessibility_manager.lock())
-        accessibility_manager->slow_keys().on_key_rejected(std::move(state->on_key_rejected));
+        accessibility_manager->slow_keys().on_key_rejected(std::move(on_key_rejected));
+    else
+        self->state.lock()->on_key_rejected = std::move(on_key_rejected);
 
     return *this;
 }
 
 miral::SlowKeys& miral::SlowKeys::on_key_accepted(std::function<void(unsigned int)>&& on_key_accepted)
 {
-    auto const state = self->state.lock();
-    state->on_key_accepted = std::move(on_key_accepted);
     if (auto const accessibility_manager = self->accessibility_manager.lock())
-        accessibility_manager->slow_keys().on_key_accepted(std::move(state->on_key_accepted));
+        accessibility_manager->slow_keys().on_key_accepted(std::move(on_key_accepted));
+    else
+        self->state.lock()->on_key_accepted = std::move(on_key_accepted);
 
     return *this;
 }

--- a/src/miral/slow_keys.cpp
+++ b/src/miral/slow_keys.cpp
@@ -45,8 +45,18 @@ struct miral::SlowKeys::Self
     std::weak_ptr<mir::shell::AccessibilityManager> accessibility_manager;
 };
 
-miral::SlowKeys::SlowKeys(bool enabled_by_default) :
-    self{std::make_shared<Self>(enabled_by_default)}
+auto miral::SlowKeys::enabled() -> SlowKeys
+{
+    return SlowKeys{std::make_shared<Self>(true)};
+}
+
+auto miral::SlowKeys::disabled() -> SlowKeys
+{
+    return SlowKeys{std::make_shared<Self>(false)};
+}
+
+miral::SlowKeys::SlowKeys(std::shared_ptr<Self> s) :
+    self{std::move(s)}
 {
 }
 

--- a/src/miral/slow_keys.cpp
+++ b/src/miral/slow_keys.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "miral/slow_keys.h"
+#include "mir/options/option.h"
+#include "mir/server.h"
+#include "mir/shell/accessibility_manager.h"
+#include "mir/shell/slow_keys_transformer.h"
+
+#include "mir/synchronised.h"
+
+struct miral::SlowKeys::Self
+{
+    explicit Self(bool enabled) :
+        state{State{enabled}}
+    {
+    }
+
+    struct State
+    {
+        explicit State(bool enabled) :
+            enabled{enabled}
+        {
+        }
+
+        bool enabled;
+        std::chrono::milliseconds hold_delay{200};
+        std::function<void(unsigned int)> on_key_down, on_key_rejected, on_key_accepted;
+    };
+
+    mir::Synchronised<State> state;
+    std::weak_ptr<mir::shell::AccessibilityManager> accessibility_manager;
+};
+
+miral::SlowKeys::SlowKeys(bool enabled_by_default) :
+    self{std::make_shared<Self>(enabled_by_default)}
+{
+}
+
+miral::SlowKeys& miral::SlowKeys::enable()
+{
+    self->state.lock()->enabled = true;
+    if (auto const accessibility_manager = self->accessibility_manager.lock())
+        accessibility_manager->slow_keys_enabled(true);
+
+    return *this;
+}
+
+miral::SlowKeys& miral::SlowKeys::disable()
+{
+    self->state.lock()->enabled = false;
+    if (auto const accessibility_manager = self->accessibility_manager.lock())
+        accessibility_manager->slow_keys_enabled(false);
+
+    return *this;
+}
+
+miral::SlowKeys& miral::SlowKeys::hold_delay(std::chrono::milliseconds hold_delay)
+{
+    self->state.lock()->hold_delay = hold_delay;
+    if (auto const accessibility_manager = self->accessibility_manager.lock())
+        accessibility_manager->slow_keys().delay(hold_delay);
+
+    return *this;
+}
+
+miral::SlowKeys& miral::SlowKeys::on_key_down(std::function<void(unsigned int)>&& on_key_down)
+{
+    auto const state = self->state.lock();
+    state->on_key_down = std::move(on_key_down);
+    if (auto const accessibility_manager = self->accessibility_manager.lock())
+        accessibility_manager->slow_keys().on_key_down(std::move(state->on_key_down));
+
+    return *this;
+}
+
+miral::SlowKeys& miral::SlowKeys::on_key_rejected(std::function<void(unsigned int)>&& on_key_rejected)
+{
+    auto const state = self->state.lock();
+    state->on_key_rejected = std::move(on_key_rejected);
+    if (auto const accessibility_manager = self->accessibility_manager.lock())
+        accessibility_manager->slow_keys().on_key_rejected(std::move(state->on_key_rejected));
+
+    return *this;
+}
+
+miral::SlowKeys& miral::SlowKeys::on_key_accepted(std::function<void(unsigned int)>&& on_key_accepted)
+{
+    auto const state = self->state.lock();
+    state->on_key_accepted = std::move(on_key_accepted);
+    if (auto const accessibility_manager = self->accessibility_manager.lock())
+        accessibility_manager->slow_keys().on_key_accepted(std::move(state->on_key_accepted));
+
+    return *this;
+}
+
+void miral::SlowKeys::operator()(mir::Server& server)
+{
+    constexpr auto* enable_slow_keys_opt = "enable-slow-keys";
+    constexpr auto* slow_keys_hold_delay = "slow-keys-hold-delay";
+
+    {
+        auto const state = self->state.lock();
+        server.add_configuration_option(
+            enable_slow_keys_opt,
+            "Enable slow keys (presses not registering unless keys are held for a certain period)",
+            state->enabled);
+        server.add_configuration_option(
+            slow_keys_hold_delay,
+            "delay required before a press registers",
+            static_cast<int>(state->hold_delay.count()));
+    }
+
+    server.add_init_callback(
+        [&server, this]
+        {
+            self->accessibility_manager = server.the_accessibility_manager();
+
+            if (server.get_options()->get<bool>(enable_slow_keys_opt))
+                enable();
+
+            hold_delay(std::chrono::milliseconds(server.get_options()->get<int>(slow_keys_hold_delay)));
+
+            if (auto& on_key_down_ = self->state.lock()->on_key_down)
+                on_key_down(std::move(on_key_down_));
+            if (auto& on_key_rejected_ = self->state.lock()->on_key_rejected)
+                on_key_rejected(std::move(on_key_rejected_));
+            if (auto& on_key_accepted_ = self->state.lock()->on_key_accepted)
+                on_key_accepted(std::move(on_key_accepted_));
+        });
+}

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -579,23 +579,12 @@ global:
     miral::SimulatedSecondaryClick::on_hold_start*;
     miral::SimulatedSecondaryClick::on_secondary_click*;
     miral::SimulatedSecondaryClick::operator*;
-    miral::SlowKeys::SlowKeys*;
-    miral::SlowKeys::disable*;
-    miral::SlowKeys::enable*;
-    miral::SlowKeys::hold_delay*;
-    miral::SlowKeys::on_disabled*;
-    miral::SlowKeys::on_enabled*;
-    miral::SlowKeys::on_key_accepted*;
-    miral::SlowKeys::on_key_down*;
-    miral::SlowKeys::on_key_rejected*;
-    miral::SlowKeys::operator*;
     typeinfo?for?miral::CursorScale;
     typeinfo?for?miral::DisplayConfiguration::Node;
     typeinfo?for?miral::HoverClick;
     typeinfo?for?miral::MouseKeysConfig;
     typeinfo?for?miral::OutputFilter;
     typeinfo?for?miral::SimulatedSecondaryClick;
-    typeinfo?for?miral::SlowKeys;
   };
 } MIRAL_5.2;
 
@@ -615,6 +604,16 @@ global:
     "miral::CursorScale::CursorScale(miral::live_config::Store&)";
     "miral::InputConfiguration::InputConfiguration(miral::live_config::Store&)";
     "miral::OutputFilter::OutputFilter(miral::live_config::Store&)";
+    miral::SlowKeys::SlowKeys*;
+    miral::SlowKeys::disable*;
+    miral::SlowKeys::disabled*;
+    miral::SlowKeys::enable*;
+    miral::SlowKeys::enabled*;
+    miral::SlowKeys::hold_delay*;
+    miral::SlowKeys::on_key_accepted*;
+    miral::SlowKeys::on_key_down*;
+    miral::SlowKeys::on_key_rejected*;
+    miral::SlowKeys::operator*;
     miral::WaylandTools::?WaylandTools*;
     miral::WaylandTools::WaylandTools*;
     miral::WaylandTools::for_each_binding*;
@@ -649,6 +648,7 @@ global:
     non-virtual?thunk?to?miral::live_config::Store::?Store*;
     typeinfo?for?miral::AppendKeyboardEventFilter;
     typeinfo?for?miral::BounceKeys;
+    typeinfo?for?miral::SlowKeys;
     typeinfo?for?miral::WaylandTools;
     typeinfo?for?miral::live_config::IniFile;
     typeinfo?for?miral::live_config::Key;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -579,12 +579,23 @@ global:
     miral::SimulatedSecondaryClick::on_hold_start*;
     miral::SimulatedSecondaryClick::on_secondary_click*;
     miral::SimulatedSecondaryClick::operator*;
+    miral::SlowKeys::SlowKeys*;
+    miral::SlowKeys::disable*;
+    miral::SlowKeys::enable*;
+    miral::SlowKeys::hold_delay*;
+    miral::SlowKeys::on_disabled*;
+    miral::SlowKeys::on_enabled*;
+    miral::SlowKeys::on_key_accepted*;
+    miral::SlowKeys::on_key_down*;
+    miral::SlowKeys::on_key_rejected*;
+    miral::SlowKeys::operator*;
     typeinfo?for?miral::CursorScale;
     typeinfo?for?miral::DisplayConfiguration::Node;
     typeinfo?for?miral::HoverClick;
     typeinfo?for?miral::MouseKeysConfig;
     typeinfo?for?miral::OutputFilter;
     typeinfo?for?miral::SimulatedSecondaryClick;
+    typeinfo?for?miral::SlowKeys;
   };
 } MIRAL_5.2;
 

--- a/src/server/shell/CMakeLists.txt
+++ b/src/server/shell/CMakeLists.txt
@@ -21,6 +21,7 @@ set(
   mouse_keys_transformer.cpp mouse_keys_transformer.h
   basic_simulated_secondary_click_transformer.cpp basic_simulated_secondary_click_transformer.h
   basic_hover_click_transformer.cpp basic_hover_click_transformer.h
+  basic_slow_keys_transformer.cpp basic_slow_keys_transformer.h
 )
 
 add_library(

--- a/src/server/shell/basic_accessibility_manager.cpp
+++ b/src/server/shell/basic_accessibility_manager.cpp
@@ -18,6 +18,7 @@
 #include "basic_hover_click_transformer.h"
 #include "mouse_keys_transformer.h"
 #include "basic_simulated_secondary_click_transformer.h"
+#include "basic_slow_keys_transformer.h"
 
 #include "mir/graphics/cursor.h"
 #include "mir/shell/keyboard_helper.h"
@@ -97,13 +98,15 @@ mir::shell::BasicAccessibilityManager::BasicAccessibilityManager(
     std::shared_ptr<mir::graphics::Cursor> const& cursor,
     std::shared_ptr<shell::MouseKeysTransformer> const& mousekeys_transformer,
     std::shared_ptr<SimulatedSecondaryClickTransformer> const& simulated_secondary_click_transformer,
-    std::shared_ptr<HoverClickTransformer> const& hover_click_transformer) :
+    std::shared_ptr<HoverClickTransformer> const& hover_click_transformer,
+    std::shared_ptr<SlowKeysTransformer> const& slow_keys_transformer) :
     enable_key_repeat{enable_key_repeat},
     cursor{cursor},
     event_transformer{event_transformer},
     mouse_keys_transformer{mousekeys_transformer},
     simulated_secondary_click_transformer{simulated_secondary_click_transformer},
-    hover_click_transformer{hover_click_transformer}
+    hover_click_transformer{hover_click_transformer},
+    slow_keys_transformer{slow_keys_transformer}
 {
 }
 

--- a/src/server/shell/basic_accessibility_manager.cpp
+++ b/src/server/shell/basic_accessibility_manager.cpp
@@ -155,3 +155,13 @@ auto mir::shell::BasicAccessibilityManager::hover_click() -> HoverClickTransform
     return *hover_click_transformer;
 }
 
+void mir::shell::BasicAccessibilityManager::slow_keys_enabled(bool enabled)
+{
+    auto const state = mutable_state.lock();
+    toggle_transformer(enabled, state->slow_keys_on, slow_keys_transformer, event_transformer);
+}
+
+auto mir::shell::BasicAccessibilityManager::slow_keys() -> SlowKeysTransformer&
+{
+    return *slow_keys_transformer;
+}

--- a/src/server/shell/basic_accessibility_manager.h
+++ b/src/server/shell/basic_accessibility_manager.h
@@ -47,6 +47,7 @@ namespace shell
 {
 class MouseKeysTransformer;
 class BasicHoverClickTransformer;
+class SlowKeysTransformer;
 class BasicAccessibilityManager : public AccessibilityManager
 {
 public:
@@ -56,7 +57,9 @@ public:
         std::shared_ptr<mir::graphics::Cursor> const& cursor,
         std::shared_ptr<MouseKeysTransformer> const& mousekeys_transformer,
         std::shared_ptr<SimulatedSecondaryClickTransformer> const& simulated_secondary_click_transformer,
-        std::shared_ptr<shell::HoverClickTransformer> const& hover_click_transformer);
+        std::shared_ptr<shell::HoverClickTransformer> const& hover_click_transformer,
+        std::shared_ptr<SlowKeysTransformer> const& slow_keys_transformer);
+
     ~BasicAccessibilityManager();
 
     void register_keyboard_helper(std::shared_ptr<shell::KeyboardHelper> const&) override;
@@ -92,10 +95,12 @@ private:
 
     bool const enable_key_repeat;
     std::shared_ptr<graphics::Cursor> const cursor;
+
     std::shared_ptr<input::InputEventTransformer> const event_transformer;
     std::shared_ptr<MouseKeysTransformer> const mouse_keys_transformer;
     std::shared_ptr<SimulatedSecondaryClickTransformer> const simulated_secondary_click_transformer;
     std::shared_ptr<HoverClickTransformer> const hover_click_transformer;
+    std::shared_ptr<SlowKeysTransformer> const slow_keys_transformer;
 };
 }
 }

--- a/src/server/shell/basic_accessibility_manager.h
+++ b/src/server/shell/basic_accessibility_manager.h
@@ -80,6 +80,9 @@ public:
 
     void hover_click_enabled(bool enabled) override;
     auto hover_click() -> HoverClickTransformer& override;
+
+    void slow_keys_enabled(bool enabled) override;
+    auto slow_keys() -> SlowKeysTransformer& override;
 private:
     struct MutableState {
         // 25 rate and 600 delay are the default in Weston and Sway
@@ -88,7 +91,7 @@ private:
 
         std::vector<std::shared_ptr<shell::KeyboardHelper>> keyboard_helpers;
 
-        bool mousekeys_on{false}, ssc_on{false}, hover_click_on{false};
+        bool mousekeys_on{false}, ssc_on{false}, hover_click_on{false}, slow_keys_on{false};
     };
 
     Synchronised<MutableState> mutable_state;

--- a/src/server/shell/basic_slow_keys_transformer.cpp
+++ b/src/server/shell/basic_slow_keys_transformer.cpp
@@ -80,9 +80,7 @@ bool msh::BasicSlowKeysTransformer::transform_input_event(
             }
         }
 
-    case mir_keyboard_action_repeat:
-    case mir_keyboard_action_modifiers:
-    case mir_keyboard_actions:
+    default:
         break;
     }
 

--- a/src/server/shell/basic_slow_keys_transformer.cpp
+++ b/src/server/shell/basic_slow_keys_transformer.cpp
@@ -19,14 +19,17 @@
 #include "mir/events/keyboard_event.h"
 #include "mir/main_loop.h"
 
-mir::shell::BasicSlowKeysTransformer::BasicSlowKeysTransformer(std::shared_ptr<MainLoop> const& main_loop) :
+namespace msh = mir::shell;
+namespace mi = mir::input;
+
+msh::BasicSlowKeysTransformer::BasicSlowKeysTransformer(std::shared_ptr<MainLoop> const& main_loop) :
     main_loop{main_loop}
 {
 }
 
-bool mir::shell::BasicSlowKeysTransformer::transform_input_event(
-    mir::input::InputEventTransformer::EventDispatcher const& dispatcher,
-    mir::input::EventBuilder*,
+bool msh::BasicSlowKeysTransformer::transform_input_event(
+    mi::InputEventTransformer::EventDispatcher const& dispatcher,
+    mi::EventBuilder*,
     MirEvent const& event)
 {
     if (event.type() != mir_event_type_input)
@@ -86,22 +89,22 @@ bool mir::shell::BasicSlowKeysTransformer::transform_input_event(
     return false;
 }
 
-void mir::shell::BasicSlowKeysTransformer::on_key_down(std::function<void(unsigned int)>&& okd)
+void msh::BasicSlowKeysTransformer::on_key_down(std::function<void(unsigned int)>&& okd)
 {
     config.lock()->on_key_down = std::move(okd);
 }
 
-void mir::shell::BasicSlowKeysTransformer::on_key_rejected(std::function<void(unsigned int)>&& okr)
+void msh::BasicSlowKeysTransformer::on_key_rejected(std::function<void(unsigned int)>&& okr)
 {
     config.lock()->on_key_rejected = std::move(okr);
 }
 
-void mir::shell::BasicSlowKeysTransformer::on_key_accepted(std::function<void(unsigned int)>&& oka)
+void msh::BasicSlowKeysTransformer::on_key_accepted(std::function<void(unsigned int)>&& oka)
 {
     config.lock()->on_key_accepted = std::move(oka);
 }
 
-void mir::shell::BasicSlowKeysTransformer::delay(std::chrono::milliseconds delay)
+void msh::BasicSlowKeysTransformer::delay(std::chrono::milliseconds delay)
 {
     config.lock()->delay = delay;
 }

--- a/src/server/shell/basic_slow_keys_transformer.cpp
+++ b/src/server/shell/basic_slow_keys_transformer.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "basic_slow_keys_transformer.h"
+#include "mir/events/input_event.h"
+#include "mir/events/keyboard_event.h"
+#include "mir/main_loop.h"
+
+mir::shell::BasicSlowKeysTransformer::BasicSlowKeysTransformer(std::shared_ptr<MainLoop> const& main_loop) :
+    main_loop{main_loop}
+{
+}
+
+bool mir::shell::BasicSlowKeysTransformer::transform_input_event(
+    mir::input::InputEventTransformer::EventDispatcher const& dispatcher,
+    mir::input::EventBuilder*,
+    MirEvent const& event)
+{
+    if (event.type() != mir_event_type_input)
+        return false;
+
+    auto* const input_event = event.to_input();
+    if (input_event->input_type() != mir_input_event_type_key)
+        return false;
+
+    auto* const key_event = input_event->to_keyboard();
+    auto const keysym = key_event->keysym();
+    auto const state = mutable_state.lock();
+    switch (key_event->action())
+    {
+    case mir_keyboard_action_down:
+        {
+            auto alarm = main_loop->create_alarm(
+                [this, dispatcher, event_clone = std::shared_ptr<MirEvent>(event.clone()), keysym]
+                {
+                    auto const state = mutable_state.lock();
+                    auto iter = state->keys_in_flight.find(keysym);
+                    if (iter == state->keys_in_flight.end())
+                        return;
+
+                    auto& [_, data] = *iter;
+                    data.second = true;
+
+                    dispatcher(event_clone);
+                    state->on_key_accepted(keysym);
+                });
+            alarm->reschedule_in(state->delay);
+            state->keys_in_flight.insert_or_assign(keysym, std::pair{std::move(alarm), false});
+            state->on_key_down(keysym);
+
+            return true;
+        }
+    case mir_keyboard_action_up:
+        {
+            auto iter = state->keys_in_flight.find(keysym);
+
+            if (iter == state->keys_in_flight.end())
+                return false;
+
+            auto& [_, data] = *iter;
+            auto& [alarm, dispatched] = data;
+
+            if (dispatched)
+                return false;
+
+            alarm->cancel();
+            state->on_key_rejected(keysym);
+
+            return true;
+        }
+
+    case mir_keyboard_action_repeat:
+    case mir_keyboard_action_modifiers:
+    case mir_keyboard_actions:
+        break;
+    }
+
+    return false;
+}
+
+void mir::shell::BasicSlowKeysTransformer::on_key_down(std::function<void(unsigned int)>&& okd)
+{
+    mutable_state.lock()->on_key_down = std::move(okd);
+}
+
+void mir::shell::BasicSlowKeysTransformer::on_key_rejected(std::function<void(unsigned int)>&& okr)
+{
+    mutable_state.lock()->on_key_rejected = std::move(okr);
+}
+
+void mir::shell::BasicSlowKeysTransformer::on_key_accepted(std::function<void(unsigned int)>&& oka)
+{
+    mutable_state.lock()->on_key_accepted = std::move(oka);
+}
+
+void mir::shell::BasicSlowKeysTransformer::delay(std::chrono::milliseconds delay)
+{
+    mutable_state.lock()->delay = delay;
+}

--- a/src/server/shell/basic_slow_keys_transformer.h
+++ b/src/server/shell/basic_slow_keys_transformer.h
@@ -41,18 +41,18 @@ public:
 private:
     std::shared_ptr<MainLoop> const main_loop;
 
-    struct MutableState
-    {
-        // Runtime state
-        std::unordered_map<unsigned int, std::pair<std::unique_ptr<mir::time::Alarm>, bool>> keys_in_flight;
+    using KeysInFlight = std::unordered_map<unsigned int, std::pair<std::unique_ptr<mir::time::Alarm>, bool>>;
 
-        // Configuration state.
+    struct ConfigState
+    {
         std::chrono::milliseconds delay{1000};
-        std::function<void(unsigned int)> on_key_down{[](auto) {}}, on_key_rejected{[](auto) {}},
-            on_key_accepted{[](auto) {}};
+        std::function<void(unsigned int)> on_key_down{[](auto) {}};
+        std::function<void(unsigned int)> on_key_rejected{[](auto) {}};
+        std::function<void(unsigned int)> on_key_accepted{[](auto) {}};
     };
 
-    mir::Synchronised<MutableState> mutable_state;
+    mir::Synchronised<KeysInFlight> keys_in_flight;
+    mir::Synchronised<ConfigState> config;
 };
 }
 }

--- a/src/server/shell/basic_slow_keys_transformer.h
+++ b/src/server/shell/basic_slow_keys_transformer.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/shell/slow_keys_transformer.h"
+
+#include "mir/input/input_event_transformer.h"
+#include "mir/synchronised.h"
+#include "mir/time/alarm.h"
+
+namespace mir
+{
+class MainLoop;
+namespace shell
+{
+class BasicSlowKeysTransformer : public SlowKeysTransformer
+{
+public:
+    BasicSlowKeysTransformer(std::shared_ptr<MainLoop> const& main_loop);
+
+    virtual bool transform_input_event(
+        input::InputEventTransformer::EventDispatcher const&, input::EventBuilder*, MirEvent const&) override;
+
+    void on_key_down(std::function<void(unsigned int)>&& okd) override;
+    void on_key_rejected(std::function<void(unsigned int)>&& okr) override;
+    void on_key_accepted(std::function<void(unsigned int)>&& oka) override;
+    void delay(std::chrono::milliseconds) override;
+
+private:
+    std::shared_ptr<MainLoop> const main_loop;
+
+    struct MutableState
+    {
+        // Runtime state
+        std::unordered_map<unsigned int, std::pair<std::unique_ptr<mir::time::Alarm>, bool>> keys_in_flight;
+
+        // Configuration state.
+        std::chrono::milliseconds delay{1000};
+        std::function<void(unsigned int)> on_key_down{[](auto) {}}, on_key_rejected{[](auto) {}},
+            on_key_accepted{[](auto) {}};
+    };
+
+    mir::Synchronised<MutableState> mutable_state;
+};
+}
+}

--- a/src/server/shell/basic_slow_keys_transformer.h
+++ b/src/server/shell/basic_slow_keys_transformer.h
@@ -14,6 +14,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+#ifndef MIR_SHELL_BASIC_SLOW_KEYS_TRANSFORMER_H
+#define MIR_SHELL_BASIC_SLOW_KEYS_TRANSFORMER_H
+
 #include "mir/shell/slow_keys_transformer.h"
 
 #include "mir/input/input_event_transformer.h"
@@ -56,3 +60,5 @@ private:
 };
 }
 }
+
+#endif // MIR_SHELL_BASIC_SLOW_KEYS_TRANSFORMER_H

--- a/src/server/shell/basic_slow_keys_transformer.h
+++ b/src/server/shell/basic_slow_keys_transformer.h
@@ -41,7 +41,7 @@ public:
 private:
     std::shared_ptr<MainLoop> const main_loop;
 
-    using KeysInFlight = std::unordered_map<unsigned int, std::pair<std::unique_ptr<mir::time::Alarm>, bool>>;
+    using KeysInFlight = std::unordered_map<unsigned int, std::unique_ptr<mir::time::Alarm>>;
 
     struct ConfigState
     {

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -25,6 +25,7 @@
 #include "mouse_keys_transformer.h"
 #include "basic_simulated_secondary_click_transformer.h"
 #include "basic_hover_click_transformer.h"
+#include "basic_slow_keys_transformer.h"
 
 #include "mir/abnormal_exit.h"
 #include "mir/input/composite_event_filter.h"
@@ -198,6 +199,7 @@ auto mir::DefaultServerConfiguration::the_accessibility_manager() -> std::shared
                 the_cursor(),
                 std::make_shared<shell::BasicMouseKeysTransformer>(the_main_loop(), the_clock()),
                 std::make_shared<shell::BasicSimulatedSecondaryClickTransformer>(the_main_loop()),
-                std::make_shared<shell::BasicHoverClickTransformer>(the_main_loop(), the_cursor_observer_multiplexer()));
+                std::make_shared<shell::BasicHoverClickTransformer>(the_main_loop(), the_cursor_observer_multiplexer()),
+                std::make_shared<shell::BasicSlowKeysTransformer>(the_main_loop()));
         });
 }

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1405,6 +1405,7 @@ global:
     typeinfo?for?mir::shell::ShellReport;
     typeinfo?for?mir::shell::ShellWrapper;
     typeinfo?for?mir::shell::SimulatedSecondaryClickTransformer;
+    typeinfo?for?mir::shell::SlowKeysTransformer;
     typeinfo?for?mir::shell::StreamSpecification;
     typeinfo?for?mir::shell::SurfaceAspectRatio;
     typeinfo?for?mir::shell::SurfaceSpecification;
@@ -1604,6 +1605,7 @@ global:
     vtable?for?mir::shell::ShellReport;
     vtable?for?mir::shell::ShellWrapper;
     vtable?for?mir::shell::SimulatedSecondaryClickTransformer;
+    vtable?for?mir::shell::SlowKeysTransformer;
     vtable?for?mir::shell::SurfaceStack;
     vtable?for?mir::shell::SurfaceStackWrapper;
     vtable?for?mir::shell::SystemCompositorWindowManager;

--- a/tests/miral/test_mousekeys_config.cpp
+++ b/tests/miral/test_mousekeys_config.cpp
@@ -44,6 +44,8 @@ public:
     MOCK_METHOD(mir::shell::SimulatedSecondaryClickTransformer&, simulated_secondary_click, (), (override));
     MOCK_METHOD(void, hover_click_enabled, (bool), (override));
     MOCK_METHOD(mir::shell::HoverClickTransformer&, hover_click, (), (override));
+    MOCK_METHOD(void, slow_keys_enabled, (bool enabled), (override));
+    MOCK_METHOD(mir::shell::SlowKeysTransformer&, slow_keys, (), (override));
 };
 
 struct TestMouseKeysConfig : miral::TestServer

--- a/tests/unit-tests/shell/CMakeLists.txt
+++ b/tests/unit-tests/shell/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND UNIT_TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_basic_accessibility_manager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_simulated_secondary_click_transformer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_hover_click_transformer.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_slow_keys_transformer.cpp
 )
 
 set(

--- a/tests/unit-tests/shell/test_basic_accessibility_manager.cpp
+++ b/tests/unit-tests/shell/test_basic_accessibility_manager.cpp
@@ -337,7 +337,8 @@ enum class TransformerToTest
 {
     MouseKeys,
     SSC,
-    HoverClick
+    HoverClick,
+    SlowKeys
 };
 
 struct TestArbitraryEnablesAndDisables :
@@ -354,6 +355,8 @@ struct TestArbitraryEnablesAndDisables :
             return mock_simulated_secondary_click_transformer;
         case TransformerToTest::HoverClick:
             return mock_hover_click_transformer;
+        case TransformerToTest::SlowKeys:
+            return mock_slow_keys_transformer;
         }
         std::unreachable();
     }
@@ -370,6 +373,9 @@ struct TestArbitraryEnablesAndDisables :
             break;
         case TransformerToTest::HoverClick:
             basic_accessibility_manager.hover_click_enabled(on);
+            break;
+        case TransformerToTest::SlowKeys:
+            basic_accessibility_manager.slow_keys_enabled(on);
             break;
         }
     }

--- a/tests/unit-tests/shell/test_basic_accessibility_manager.cpp
+++ b/tests/unit-tests/shell/test_basic_accessibility_manager.cpp
@@ -22,6 +22,7 @@
 
 #include "mir/input/input_event_transformer.h"
 #include "mir/input/mousekeys_keymap.h"
+#include "mir/shell/slow_keys_transformer.h"
 #include "mir/test/fake_shared.h"
 
 #include "mir/test/doubles/mock_input_seat.h"
@@ -92,17 +93,33 @@ struct MockInputEventTransformer: public mir::input::InputEventTransformer
 struct MockHoverClickTransformer : public mir::shell::HoverClickTransformer
 {
     MockHoverClickTransformer() = default;
+
+    MOCK_METHOD(
+        bool,
+        transform_input_event,
+        (mir::input::InputEventTransformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
+        (override));
+
     MOCK_METHOD(void, hover_duration,(std::chrono::milliseconds delay), (override));
     MOCK_METHOD(void, cancel_displacement_threshold,(int displacement), (override));
     MOCK_METHOD(void, reclick_displacement_threshold,(int displacement), (override));
     MOCK_METHOD(void, on_hover_start,(std::function<void()>&& on_hover_start), (override));
     MOCK_METHOD(void, on_hover_cancel,(std::function<void()>&& on_hover_cancelled), (override));
     MOCK_METHOD(void, on_click_dispatched,(std::function<void()>&& on_click_dispatched), (override));
+};
+
+struct MockSlowKeysTransformer : public mir::shell::SlowKeysTransformer
+{
     MOCK_METHOD(
         bool,
         transform_input_event,
         (mir::input::InputEventTransformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
         (override));
+
+    MOCK_METHOD(void, on_key_down, (std::function<void(unsigned int)>&&), (override));
+    MOCK_METHOD(void, on_key_rejected, (std::function<void(unsigned int)>&&), (override));
+    MOCK_METHOD(void, on_key_accepted, (std::function<void(unsigned int)>&&), (override));
+    MOCK_METHOD(void, delay, (std::chrono::milliseconds), (override));
 };
 
 struct TestBasicAccessibilityManager : Test
@@ -114,7 +131,8 @@ struct TestBasicAccessibilityManager : Test
             std::make_shared<mir::test::doubles::StubCursor>(),
             mock_mousekeys_transformer,
             mock_simulated_secondary_click_transformer,
-            mock_hover_click_transformer}
+            mock_hover_click_transformer,
+            mock_slow_keys_transformer}
     {
         basic_accessibility_manager.register_keyboard_helper(mock_key_helper);
     }
@@ -129,7 +147,8 @@ struct TestBasicAccessibilityManager : Test
         std::make_shared<NiceMock<MockSimulatedSecondaryClickTransformer>>()};
     std::shared_ptr<NiceMock<MockHoverClickTransformer>> mock_hover_click_transformer{
         std::make_shared<NiceMock<MockHoverClickTransformer>>()};
-
+    std::shared_ptr<NiceMock<MockSlowKeysTransformer>> mock_slow_keys_transformer{
+        std::make_shared<NiceMock<MockSlowKeysTransformer>>()};
     NiceMock<MockInputEventTransformer> input_event_transformer{mt::fake_shared(mock_seat), mt::fake_shared(clock)};
 
     mir::shell::BasicAccessibilityManager basic_accessibility_manager;

--- a/tests/unit-tests/shell/test_slow_keys_transformer.cpp
+++ b/tests/unit-tests/shell/test_slow_keys_transformer.cpp
@@ -50,6 +50,16 @@ struct TestSlowKeysTransformer : Test
         transformer->delay(test_slow_keys_delay);
     }
 
+    auto key_down(unsigned int keysym, unsigned int scancode) -> mir::EventUPtr
+    {
+        return event_builder.key_event(std::nullopt, mir_keyboard_action_down, keysym, scancode);
+    }
+
+    auto key_up(unsigned int keysym, unsigned int scancode) -> mir::EventUPtr
+    {
+        return event_builder.key_event(std::nullopt, mir_keyboard_action_up, keysym, scancode);
+    }
+
     mtd::AdvanceableClock clock;
     std::shared_ptr<mtd::QueuedAlarmStubMainLoop> const main_loop;
     std::shared_ptr<mir::shell::SlowKeysTransformer> const transformer;
@@ -74,14 +84,12 @@ TEST_P(TestDifferentPressDelays, only_presses_held_for_slow_keys_delay_are_accep
     auto const attempts = 5;
     for(auto i = 0; i < attempts; i++)
     {
-        transformer->transform_input_event(
-            dispatch, &event_builder, *event_builder.key_event(std::nullopt, mir_keyboard_action_down, XKB_KEY_d, 32));
+        transformer->transform_input_event(dispatch, &event_builder, *key_down(XKB_KEY_d, 32));
 
         clock.advance_by(press_delay);
         main_loop->call_queued();
 
-        transformer->transform_input_event(
-            dispatch, &event_builder, *event_builder.key_event(std::nullopt, mir_keyboard_action_up, XKB_KEY_d, 32));
+        transformer->transform_input_event(dispatch, &event_builder, *key_up(XKB_KEY_d, 32));
     }
 
     EXPECT_THAT(down, Eq(attempts));

--- a/tests/unit-tests/shell/test_slow_keys_transformer.cpp
+++ b/tests/unit-tests/shell/test_slow_keys_transformer.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir_toolkit/event.h"
+#include "mir/shell/accessibility_manager.h"
+#include "src/server/input/default_event_builder.h"
+#include "src/server/shell/basic_slow_keys_transformer.h"
+
+#include "mir/test/doubles/advanceable_clock.h"
+#include "mir/test/doubles/queued_alarm_stub_main_loop.h"
+#include "mir/test/fake_shared.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace mi = mir::input;
+namespace mt = mir::test;
+namespace mtd = mt::doubles;
+using namespace ::testing;
+using namespace std::chrono_literals;
+
+namespace
+{
+static auto constexpr test_slow_keys_delay = 100ms;
+}
+
+struct TestSlowKeysTransformer : Test
+{
+    TestSlowKeysTransformer() :
+        main_loop{std::make_shared<mtd::QueuedAlarmStubMainLoop>(mt::fake_shared(clock))},
+        transformer{
+            std::make_shared<mir::shell::BasicSlowKeysTransformer>(main_loop),
+        },
+        event_builder{0, mt::fake_shared(clock)},
+        dispatch{[&](std::shared_ptr<MirEvent> const&) {}}
+    {
+        transformer->delay(test_slow_keys_delay);
+    }
+
+    mtd::AdvanceableClock clock;
+    std::shared_ptr<mtd::QueuedAlarmStubMainLoop> const main_loop;
+    std::shared_ptr<mir::shell::SlowKeysTransformer> const transformer;
+    mi::DefaultEventBuilder event_builder;
+
+    std::function<void(std::shared_ptr<MirEvent> const& event)> dispatch;
+};
+
+struct TestDifferentPressDelays: public TestSlowKeysTransformer, public WithParamInterface<std::chrono::milliseconds>
+{
+};
+
+TEST_P(TestDifferentPressDelays, only_presses_held_for_slow_keys_delay_are_accepted)
+{
+    auto const press_delay = GetParam();
+
+    auto accepted = 0, rejected = 0, down = 0;
+    transformer->on_key_accepted([&accepted](auto) { accepted += 1; });
+    transformer->on_key_rejected([&rejected](auto) { rejected += 1; });
+    transformer->on_key_down([&down](auto) { down += 1; });
+
+    auto const attempts = 5;
+    for(auto i = 0; i < attempts; i++)
+    {
+        transformer->transform_input_event(
+            dispatch, &event_builder, *event_builder.key_event(std::nullopt, mir_keyboard_action_down, XKB_KEY_d, 32));
+
+        clock.advance_by(press_delay);
+        main_loop->call_queued();
+
+        transformer->transform_input_event(
+            dispatch, &event_builder, *event_builder.key_event(std::nullopt, mir_keyboard_action_up, XKB_KEY_d, 32));
+    }
+
+    EXPECT_THAT(down, Eq(attempts));
+    EXPECT_THAT(press_delay < test_slow_keys_delay ? rejected : accepted, Eq(attempts));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TestSlowKeysTransformer, TestDifferentPressDelays, Values(test_slow_keys_delay - 1ms, test_slow_keys_delay + 1ms));

--- a/tests/unit-tests/shell/test_slow_keys_transformer.cpp
+++ b/tests/unit-tests/shell/test_slow_keys_transformer.cpp
@@ -68,11 +68,11 @@ struct TestSlowKeysTransformer : Test
     std::function<void(std::shared_ptr<MirEvent> const& event)> dispatch;
 };
 
-struct TestDifferentPressDelays: public TestSlowKeysTransformer, public WithParamInterface<std::chrono::milliseconds>
+struct TestSlowKeysTransformerPressDelays: public TestSlowKeysTransformer, public WithParamInterface<std::chrono::milliseconds>
 {
 };
 
-TEST_P(TestDifferentPressDelays, only_presses_held_for_slow_keys_delay_are_accepted)
+TEST_P(TestSlowKeysTransformerPressDelays, only_presses_held_for_slow_keys_delay_are_accepted)
 {
     auto const press_delay = GetParam();
 
@@ -97,14 +97,14 @@ TEST_P(TestDifferentPressDelays, only_presses_held_for_slow_keys_delay_are_accep
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    TestSlowKeysTransformer, TestDifferentPressDelays, Values(test_slow_keys_delay - 1ms, test_slow_keys_delay + 1ms));
+    TestSlowKeysTransformer, TestSlowKeysTransformerPressDelays, Values(test_slow_keys_delay - 1ms, test_slow_keys_delay + 1ms));
 
 
-struct TestKeyInterference: public TestSlowKeysTransformer, public WithParamInterface<std::chrono::milliseconds>
+struct TestSlowKeysTransformerWithKeyInterference: public TestSlowKeysTransformer, public WithParamInterface<std::chrono::milliseconds>
 {
 };
 
-TEST_P(TestKeyInterference, different_buttons_dont_interfere_with_each_other)
+TEST_P(TestSlowKeysTransformerWithKeyInterference, different_buttons_dont_interfere_with_each_other)
 {
     auto const press_delay = GetParam();
 
@@ -141,4 +141,4 @@ TEST_P(TestKeyInterference, different_buttons_dont_interfere_with_each_other)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    TestSlowKeysTransformer, TestKeyInterference, Values(test_slow_keys_delay - 1ms, test_slow_keys_delay + 1ms));
+    TestSlowKeysTransformer, TestSlowKeysTransformerWithKeyInterference, Values(test_slow_keys_delay - 1ms, test_slow_keys_delay + 1ms));


### PR DESCRIPTION
# What's new
Adds slow keys, an accessibility feature which allows users to define how long they have to press a button before it registers as a real press. If the user continues to hold the button down, key repeat activates. If the user taps the button continuously, the no key presses are registered.

# How to test
At the moment, slow keys is enabled by default for prototyping purposes. To test, you can open any application with text input such as `xterm` or `kgx`. Try tapping a key, holding it until it registers a press, and also holding it further until repeat activates.