### PR TITLE
Remove invalid and unused symbol

### DIFF
--- a/debian/libmircore2.symbols
+++ b/debian/libmircore2.symbols
@@ -33,8 +33,6 @@ libmircore.so.2 libmircore2 #MINVER#
  (c++)"vtable for mir::AnonymousShmFile@MIR_CORE_2.9" 2.8.0
  MIR_CORE_2.21@MIR_CORE_2.21 2.21.0
  (c++)"mir::input::MouseKeysKeymap::MouseKeysKeymap(std::initializer_list<std::pair<unsigned int, mir::input::MouseKeysKeymap::Action> >)@MIR_CORE_2.21" 2.21.0
- (c++)"mir::input::MouseKeysKeymap::MouseKeysKeymap()@MIR_CORE_2.21"
- (c++)"mir::input::MouseKeysKeymap::MouseKeysKeymap(std::initializer_list<std::pair<unsigned int, mir::input::MouseKeysKeymap::Action> >)@MIR_CORE_2.21" 2.21.0
  (c++)"mir::input::MouseKeysKeymap::MouseKeysKeymap()@MIR_CORE_2.21" 2.21.0
  (c++)"mir::input::MouseKeysKeymap::set_action(unsigned int, std::optional<mir::input::MouseKeysKeymap::Action>)@MIR_CORE_2.21" 2.21.0
  (c++)"mir::input::MouseKeysKeymap::get_action(unsigned int) const@MIR_CORE_2.21" 2.21.0


### PR DESCRIPTION
Build warning:
dpkg-gensymbols: warning: failed to parse line in debian/libmircore2.symbols:  (c++)"mir::input::MouseKeysKeymap::MouseKeysKeymap()@MIR_CORE_2.21"