### PR TITLE
Providing the Executor in the ScreenShooterFactory::create method instead of the constructor

### DIFF
--- a/src/include/server/mir/compositor/screen_shooter_factory.h
+++ b/src/include/server/mir/compositor/screen_shooter_factory.h
@@ -22,6 +22,8 @@
 
 namespace mir
 {
+class Executor;
+
 namespace compositor
 {
 class ScreenShooterFactory
@@ -30,7 +32,10 @@ public:
     ScreenShooterFactory() = default;
     virtual ~ScreenShooterFactory() = default;
 
-    virtual auto create() -> std::unique_ptr<ScreenShooter> = 0;
+    /// Creates a new screen shooter
+    /// \param executor responsible for queuing the screenshot request
+    /// \return a new screen shooter
+    virtual auto create(Executor& executor) -> std::unique_ptr<ScreenShooter> = 0;
 };
 }
 }

--- a/src/server/compositor/basic_screen_shooter_factory.cpp
+++ b/src/server/compositor/basic_screen_shooter_factory.cpp
@@ -25,21 +25,19 @@ namespace mt = mir::time;
 mc::BasicScreenShooterFactory::BasicScreenShooterFactory(
     std::shared_ptr<Scene> const& scene,
     std::shared_ptr<mt::Clock> const& clock,
-    Executor& executor,
     std::vector<std::shared_ptr<mg::GLRenderingProvider>> const& providers,
     std::shared_ptr<mr::RendererFactory> const& render_factory,
     std::shared_ptr<mg::GraphicBufferAllocator> const& buffer_allocator,
     std::shared_ptr<mg::GLConfig> const& config)
     : scene(scene),
       clock(clock),
-      executor(executor),
       providers(providers),
       renderer_factory(render_factory),
       buffer_allocator(buffer_allocator),
       config(config)
 {}
 
-auto mc::BasicScreenShooterFactory::create() -> std::unique_ptr<ScreenShooter>
+auto mc::BasicScreenShooterFactory::create(Executor& executor) -> std::unique_ptr<ScreenShooter>
 {
     return std::make_unique<BasicScreenShooter>(
         scene, clock, executor, providers, renderer_factory, buffer_allocator, config);

--- a/src/server/compositor/basic_screen_shooter_factory.h
+++ b/src/server/compositor/basic_screen_shooter_factory.h
@@ -44,17 +44,15 @@ public:
     BasicScreenShooterFactory(
         std::shared_ptr<Scene> const& scene,
         std::shared_ptr<time::Clock> const& clock,
-        Executor& executor,
         std::vector<std::shared_ptr<graphics::GLRenderingProvider>> const& providers,
         std::shared_ptr<renderer::RendererFactory> const& render_factory,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
         std::shared_ptr<graphics::GLConfig> const& config);
-    auto create() -> std::unique_ptr<ScreenShooter> override;
+    auto create(Executor& executor) -> std::unique_ptr<ScreenShooter> override;
 
 private:
     std::shared_ptr<Scene> const scene;
     std::shared_ptr<time::Clock> const clock;
-    Executor& executor;
     std::vector<std::shared_ptr<graphics::GLRenderingProvider>> providers;
     std::shared_ptr<renderer::RendererFactory> const renderer_factory;
     std::shared_ptr<graphics::GraphicBufferAllocator> buffer_allocator;

--- a/src/server/compositor/default_configuration.cpp
+++ b/src/server/compositor/default_configuration.cpp
@@ -154,13 +154,12 @@ auto mir::DefaultServerConfiguration::the_screen_shooter_factory() -> std::share
             if (providers.empty())
             {
                 log_error("Failed to create screen shooter factory: No platform provides GL rendering support");
-                return std::make_shared<compositor::NullScreenShooterFactory>(thread_pool_executor);
+                return std::make_shared<compositor::NullScreenShooterFactory>();
             }
 
             return std::make_shared<compositor::BasicScreenShooterFactory>(
                 the_scene(),
                 the_clock(),
-                thread_pool_executor,
                 providers,
                 the_renderer_factory(),
                 the_buffer_allocator(),

--- a/src/server/compositor/null_screen_shooter_factory.cpp
+++ b/src/server/compositor/null_screen_shooter_factory.cpp
@@ -19,12 +19,7 @@
 
 namespace mc = mir::compositor;
 
-mc::NullScreenShooterFactory::NullScreenShooterFactory(Executor& executor)
-    : executor(executor)
-{
-}
-
-auto mc::NullScreenShooterFactory::create() -> std::unique_ptr<ScreenShooter>
+auto mc::NullScreenShooterFactory::create(Executor& executor) -> std::unique_ptr<ScreenShooter>
 {
     return std::make_unique<NullScreenShooter>(executor);
 }

--- a/src/server/compositor/null_screen_shooter_factory.h
+++ b/src/server/compositor/null_screen_shooter_factory.h
@@ -28,11 +28,7 @@ namespace compositor
 class NullScreenShooterFactory : public ScreenShooterFactory
 {
 public:
-    explicit NullScreenShooterFactory(Executor& executor);
-    auto create() -> std::unique_ptr<ScreenShooter> override;
-
-private:
-    Executor& executor;
+    auto create(Executor& executor) -> std::unique_ptr<ScreenShooter> override;
 };
 }
 }

--- a/src/server/frontend_wayland/wlr_screencopy_v1.cpp
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.cpp
@@ -363,7 +363,7 @@ mf::WlrScreencopyManagerV1::WlrScreencopyManagerV1(
     wl_resource* resource,
     std::shared_ptr<WlrScreencopyV1Ctx> const& ctx)
     : wayland::WlrScreencopyManagerV1{resource, Version<3>()},
-      screen_shooter(ctx->screen_shooter_factory->create()),
+      screen_shooter(ctx->screen_shooter_factory->create(thread_pool_executor)),
       ctx{ctx},
       damage_tracker{*ctx->wayland_executor, *ctx->surface_stack}
 {

--- a/tests/unit-tests/compositor/test_basic_screen_shooter_factory.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter_factory.cpp
@@ -55,7 +55,6 @@ public:
         factory = std::make_unique<mc::BasicScreenShooterFactory>(
             scene,
             clock,
-            executor,
             gl_providers,
             renderer_factory,
             buffer_allocator,
@@ -74,5 +73,5 @@ public:
 
 TEST_F(BasicScreenShooterFactoryTest, creates_basic_screen_shooter)
 {
-    EXPECT_THAT(factory->create(), NotNull());
+    EXPECT_THAT(factory->create(executor), NotNull());
 }


### PR DESCRIPTION
# Why?
Different `ScreenShooter` creators will want to provide a different executor to screen shoot with different timing. For example, the magnifier will want to screen shoot using the `immediate_executor` so that the process is blocking, while wlr screen copy wants to use the `thread_pool_executor`