### PR TITLE
Remove unused `mir::gl::Renderer::output_filter`

### DIFF
--- a/src/renderers/gl/renderer.h
+++ b/src/renderers/gl/renderer.h
@@ -106,7 +106,6 @@ private:
 
     class ProgramFactory;
     std::unique_ptr<ProgramFactory> const program_factory;
-    MirOutputFilter output_filter;
     geometry::Rectangle viewport;
     glm::mat4 screen_to_gl_coords;
     glm::mat4 display_transform;


### PR DESCRIPTION
Clang doesn't like it being unused :/