### PR TITLE
(#3933) fixing improper texture allocation across cards

### DIFF
--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -17,11 +17,11 @@
 #ifndef MIR_GRAPHICS_GBM_SHM_BUFFER_H_
 #define MIR_GRAPHICS_GBM_SHM_BUFFER_H_
 
+#include "mir/synchronised.h"
 #include "mir/graphics/buffer_basic.h"
 #include "mir/geometry/dimensions.h"
 #include "mir/geometry/size.h"
 #include "mir_toolkit/common.h"
-#include "mir_toolkit/mir_native_buffer.h"
 #include "mir/renderer/sw/pixel_source.h"
 #include "mir/graphics/texture.h"
 
@@ -63,36 +63,11 @@ protected:
     ShmBuffer(
         geometry::Size const& size,
         MirPixelFormat const& format);
-
-    class ShmBufferTexture : public gl::Texture
-    {
-    public:
-        explicit ShmBufferTexture(std::shared_ptr<EGLContextExecutor> const& egl_delegate);
-        ~ShmBufferTexture() override;
-        void bind() override;
-        auto tex_id() const -> GLuint override;
-        gl::Program const& shader(gl::ProgramFactory& factory) const override;
-        Layout layout() const override;
-        void add_syncpoint() override;
-        void try_upload_to_texture(
-            BufferID id,
-            void const* pixels,
-            geometry::Size const& size,
-            geometry::Stride const& stride,
-            MirPixelFormat pixel_format);
-        void mark_dirty();
-
-    private:
-        std::shared_ptr<EGLContextExecutor> egl_delegate;
-        GLuint tex_id_;
-        std::mutex uploaded_mutex;
-        bool uploaded = false;
-    };
+    class ShmBufferTexture;
 
     virtual void on_texture_accessed(std::shared_ptr<ShmBufferTexture> const&) = 0;
 
-    std::mutex tex_mutex;
-    std::map<RenderingProvider*, std::shared_ptr<ShmBufferTexture>> provider_to_texture_map;
+    Synchronised<std::map<RenderingProvider*, std::shared_ptr<ShmBufferTexture>>> provider_to_texture_map;
 private:
     geometry::Size const size_;
     MirPixelFormat const pixel_format_;

--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -27,7 +27,8 @@
 
 #include <GLES2/gl2.h>
 
-#include <future>
+#include <mutex>
+#include <map>
 
 namespace mir
 {
@@ -35,14 +36,15 @@ class ShmFile;
 
 namespace graphics
 {
+class RenderingProvider;
+
 namespace common
 {
 class EGLContextExecutor;
 
 class ShmBuffer :
     public BufferBasic,
-    public NativeBufferBase,
-    public graphics::gl::Texture
+    public NativeBufferBase
 {
 public:
     ~ShmBuffer() noexcept override;
@@ -53,24 +55,47 @@ public:
     MirPixelFormat pixel_format() const override;
     NativeBufferBase* native_buffer_base() override;
 
-    void bind() override;
-    gl::Program const& shader(gl::ProgramFactory& cache) const override;
-    Layout layout() const override;
-    void add_syncpoint() override;
-    auto tex_id() const -> GLuint override;
+    auto texture_for_provider(
+        std::shared_ptr<EGLContextExecutor> const& egl_delegate,
+        RenderingProvider* provider) -> std::shared_ptr<gl::Texture>;
+
 protected:
     ShmBuffer(
         geometry::Size const& size,
-        MirPixelFormat const& format,
-        std::shared_ptr<EGLContextExecutor> egl_delegate);
+        MirPixelFormat const& format);
 
-    /// \note This must be called with a current GL context
-    void upload_to_texture(void const* pixels, geometry::Stride const& stride);
+    class ShmBufferTexture : public gl::Texture
+    {
+    public:
+        explicit ShmBufferTexture(std::shared_ptr<EGLContextExecutor> const& egl_delegate);
+        ~ShmBufferTexture() override;
+        void bind() override;
+        auto tex_id() const -> GLuint override;
+        gl::Program const& shader(gl::ProgramFactory& factory) const override;
+        Layout layout() const override;
+        void add_syncpoint() override;
+        void try_upload_to_texture(
+            BufferID id,
+            void const* pixels,
+            geometry::Size const& size,
+            geometry::Stride const& stride,
+            MirPixelFormat pixel_format);
+        void mark_dirty();
+
+    private:
+        std::shared_ptr<EGLContextExecutor> egl_delegate;
+        GLuint tex_id_;
+        std::mutex uploaded_mutex;
+        bool uploaded = false;
+    };
+
+    virtual void on_texture_accessed(std::shared_ptr<ShmBufferTexture> const&) = 0;
+
+    std::mutex tex_mutex;
+    std::map<RenderingProvider*, std::shared_ptr<ShmBufferTexture>> provider_to_texture_map;
 private:
     geometry::Size const size_;
     MirPixelFormat const pixel_format_;
-    std::shared_ptr<EGLContextExecutor> const egl_delegate;
-    std::shared_future<GLuint> const tex;
 };
 
 class MemoryBackedShmBuffer :
@@ -80,15 +105,11 @@ class MemoryBackedShmBuffer :
 public:
     MemoryBackedShmBuffer(
         geometry::Size const& size,
-        MirPixelFormat const& pixel_format,
-        std::shared_ptr<EGLContextExecutor> egl_delegate);
+        MirPixelFormat const& pixel_format);
 
     auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
     auto map_readable() -> std::unique_ptr<renderer::software::Mapping<unsigned char const>> override;
-
     auto map_rw() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
-
-    void bind() override;
 
     auto format() const -> MirPixelFormat override { return ShmBuffer::pixel_format(); }
     auto stride() const -> geometry::Stride override { return stride_; }
@@ -97,6 +118,10 @@ public:
 
     MemoryBackedShmBuffer(MemoryBackedShmBuffer const&) = delete;
     MemoryBackedShmBuffer& operator=(MemoryBackedShmBuffer const&) = delete;
+
+protected:
+    void on_texture_accessed(std::shared_ptr<ShmBufferTexture> const&) override;
+
 private:
     template<typename T>
     class Mapping;
@@ -106,8 +131,6 @@ private:
 
     geometry::Stride const stride_;
     std::unique_ptr<unsigned char[]> const pixels;
-    std::mutex uploaded_mutex;
-    bool uploaded{false};
 };
 
 class MappableBackedShmBuffer :
@@ -116,14 +139,11 @@ class MappableBackedShmBuffer :
 {
 public:
     MappableBackedShmBuffer(
-        std::shared_ptr<renderer::software::RWMappableBuffer> data,
-        std::shared_ptr<EGLContextExecutor> egl_delegate);
+        std::shared_ptr<RWMappableBuffer> data);
 
     auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
     auto map_readable() -> std::unique_ptr<renderer::software::Mapping<unsigned char const>> override;
     auto map_rw() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
-
-    void bind() override;
 
     auto format() const -> MirPixelFormat override;
     auto stride() const -> geometry::Stride override;
@@ -131,10 +151,12 @@ public:
 
     MappableBackedShmBuffer(MappableBackedShmBuffer const&) = delete;
     MappableBackedShmBuffer& operator=(MappableBackedShmBuffer const&) = delete;
+
+protected:
+    void on_texture_accessed(std::shared_ptr<ShmBufferTexture> const&) override;
+
 private:
-    std::shared_ptr<renderer::software::RWMappableBuffer> const data;
-    std::mutex uploaded_mutex;
-    bool uploaded{false};
+    std::shared_ptr<RWMappableBuffer> const data;
 };
 
 class NotifyingMappableBackedShmBuffer : public MappableBackedShmBuffer
@@ -142,17 +164,17 @@ class NotifyingMappableBackedShmBuffer : public MappableBackedShmBuffer
 public:
     NotifyingMappableBackedShmBuffer(
         std::shared_ptr<renderer::software::RWMappableBuffer> data,
-        std::shared_ptr<common::EGLContextExecutor> egl_delegate,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release);
 
     ~NotifyingMappableBackedShmBuffer() override;
 
-    void bind() override;
-
     auto map_readable() -> std::unique_ptr<renderer::software::Mapping<unsigned char const>> override;
     auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
     auto map_rw() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
+
+protected:
+    void on_texture_accessed(std::shared_ptr<ShmBufferTexture> const&) override;
 
 private:
     void notify_consumed();

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<mg::Buffer> mge::BufferAllocator::alloc_software_buffer(geom::Si
                 "Trying to create SHM buffer with unsupported pixel format"));
     }
 
-    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format, egl_delegate);
+    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format);
 }
 
 std::vector<MirPixelFormat> mge::BufferAllocator::supported_pixel_formats()
@@ -550,7 +550,6 @@ auto mge::BufferAllocator::buffer_from_shm(
 {
     return std::make_shared<mgc::NotifyingMappableBackedShmBuffer>(
         std::move(data),
-        egl_delegate,
         std::move(on_consumed),
         std::move(on_release));
 }

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<mg::Buffer> mgg::BufferAllocator::alloc_software_buffer(
                 "Trying to create SHM buffer with unsupported pixel format"));
     }
 
-    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format, egl_delegate);
+    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format);
 }
 
 std::vector<MirPixelFormat> mgg::BufferAllocator::supported_pixel_formats()
@@ -204,7 +204,6 @@ auto mgg::BufferAllocator::buffer_from_shm(
 {
     return std::make_shared<mgc::NotifyingMappableBackedShmBuffer>(
         std::move(data),
-        egl_delegate,
         std::move(on_consumed),
         std::move(on_release));
 }
@@ -220,6 +219,10 @@ auto mgg::GLRenderingProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std
     if (auto dmabuf_texture = dmabuf_provider->as_texture(native_buffer))
     {
         return dmabuf_texture;
+    }
+    else if (auto shm = std::dynamic_pointer_cast<mgc::ShmBuffer>(native_buffer))
+    {
+        return shm->texture_for_provider(egl_delegate, this);
     }
     else if (auto tex = std::dynamic_pointer_cast<gl::Texture>(native_buffer))
     {

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -181,7 +181,7 @@ std::shared_ptr<mg::Buffer> mge::BufferAllocator::alloc_software_buffer(
                 "Trying to create SHM buffer with unsupported pixel format"));
     }
 
-    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format, egl_delegate);
+    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format);
 }
 
 std::vector<MirPixelFormat> mge::BufferAllocator::supported_pixel_formats()
@@ -299,7 +299,6 @@ auto mge::BufferAllocator::buffer_from_shm(
 {
     return std::make_shared<mgc::NotifyingMappableBackedShmBuffer>(
         std::move(data),
-        egl_delegate,
         std::move(on_consumed),
         std::move(on_release));
 }
@@ -319,6 +318,11 @@ auto mge::GLRenderingProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std
             return tex;
         }
     }
+    if (auto shm = std::dynamic_pointer_cast<mgc::ShmBuffer>(native_buffer))
+    {
+        return shm->texture_for_provider(egl_delegate, this);
+    }
+
     // TODO: Should this be abstracted, like dmabuf_provider above?
     return std::dynamic_pointer_cast<gl::Texture>(native_buffer);
 }
@@ -443,9 +447,11 @@ auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)
 mge::GLRenderingProvider::GLRenderingProvider(
     EGLDisplay dpy,
     EGLContext ctx,
-    std::shared_ptr<mg::DMABufEGLProvider> dmabuf_provider)
+    std::shared_ptr<mg::DMABufEGLProvider> dmabuf_provider,
+    std::shared_ptr<mgc::EGLContextExecutor> egl_delegate)
     : dpy{dpy},
       ctx{ctx},
-      dmabuf_provider{std::move(dmabuf_provider)}
+      dmabuf_provider{std::move(dmabuf_provider)},
+      egl_delegate(egl_delegate)
 {
 }

--- a/src/platforms/renderer-generic-egl/buffer_allocator.h
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.h
@@ -88,7 +88,8 @@ public:
     GLRenderingProvider(
          EGLDisplay dpy,
          EGLContext ctx,
-         std::shared_ptr<DMABufEGLProvider> dmabuf_provider);
+         std::shared_ptr<DMABufEGLProvider> dmabuf_provider,
+         std::shared_ptr<common::EGLContextExecutor> egl_delegate);
 
     auto make_framebuffer_provider(DisplaySink& sink)
         -> std::unique_ptr<FramebufferProvider> override;
@@ -107,6 +108,7 @@ private:
     EGLDisplay const dpy;
     EGLContext const ctx;
     std::shared_ptr<DMABufEGLProvider> const dmabuf_provider;
+    std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
 };
 }
 }

--- a/src/platforms/renderer-generic-egl/rendering_platform.cpp
+++ b/src/platforms/renderer-generic-egl/rendering_platform.cpp
@@ -208,7 +208,8 @@ mge::RenderingPlatform::RenderingPlatform(std::tuple<EGLDisplay, bool> display)
           maybe_make_dmabuf_provider(
               dpy,
               std::make_shared<mg::EGLExtensions>(),
-              std::make_shared<mgc::EGLContextExecutor>(ctx->make_share_context()))}
+              std::make_shared<mgc::EGLContextExecutor>(ctx->make_share_context()))},
+      egl_delegate{std::make_shared<mg::common::EGLContextExecutor>(ctx->make_share_context())}
 {
 }
 
@@ -225,7 +226,11 @@ auto mge::RenderingPlatform::maybe_create_provider(RenderingProvider::Tag const&
 {
     if (dynamic_cast<GLRenderingProvider::Tag const*>(&tag))
     {
-        return std::make_shared<mge::GLRenderingProvider>(dpy, static_cast<EGLContext>(*ctx), dmabuf_provider);
+        return std::make_shared<mge::GLRenderingProvider>(
+            dpy,
+            static_cast<EGLContext>(*ctx),
+            dmabuf_provider,
+            egl_delegate);
     }
     return nullptr;
 }

--- a/src/platforms/renderer-generic-egl/rendering_platform.h
+++ b/src/platforms/renderer-generic-egl/rendering_platform.h
@@ -72,6 +72,7 @@ private:
     EGLDisplayHandle dpy;
     std::unique_ptr<renderer::gl::Context> const ctx;
     std::shared_ptr<DMABufEGLProvider> const dmabuf_provider;
+    std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
 };
 
 }

--- a/tests/mir_test_doubles/stub_buffer_allocator.cpp
+++ b/tests/mir_test_doubles/stub_buffer_allocator.cpp
@@ -93,7 +93,6 @@ auto mtd::StubBufferAllocator::buffer_from_shm(
 {
     auto buffer = std::make_shared<mg::common::NotifyingMappableBackedShmBuffer>(
         std::move(data),
-        std::make_shared<mg::common::EGLContextExecutor>(std::make_unique<mtd::NullGLContext>()),
         std::move(on_consumed),
         std::move(on_release));
 

--- a/tests/unit-tests/graphics/test_shm_buffer.cpp
+++ b/tests/unit-tests/graphics/test_shm_buffer.cpp
@@ -204,7 +204,7 @@ TEST_P(UploadTest, reuploads_after_mapping)
             desc.gl_format, desc.gl_type,
             buf.pixel_buffer())).Times(1);
 
-    auto const texture = buf.texture_for_provider(egl_delegate, rendering_provider.get());
+    auto texture = buf.texture_for_provider(egl_delegate, rendering_provider.get());
     texture->bind();
 
     // Mapping is in its own scope so that destruction happens
@@ -223,6 +223,7 @@ TEST_P(UploadTest, reuploads_after_mapping)
             buf.pixel_buffer()))
         .Times(1)
         .After(gl_use);
+    texture = buf.texture_for_provider(egl_delegate, rendering_provider.get());
     texture->bind();
 }
 


### PR DESCRIPTION
fixes #3933 

## What's new?
- `GLRenderingProvider::as_texture` now checks if we have a `ShmBuffer` and returns a texture for that specific provider instead of a single texture for all providers
- Implemented `ShmBuffer::texture_for_provider` which will return a `gl::Texture` either from a map cache or elsewhere
- Added `ShmBuffer::create_texture` which has a default implementation, but will be overridden for each of the subclasses. These subclasses mostly need to override the `bind()` method
- `ShmBuffer` no longer implements `gl::Texture`
- `ShmBuffer` no longer takes an `EGLContextExecutor` unless it is creating a texture
- Updated the associated unit tests