### PR TITLE
Account for the OutputFilter in the BasicScreenShooter

### DIFF
--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -27,6 +27,7 @@
 #include "mir/renderer/renderer_factory.h"
 #include "mir/renderer/sw/pixel_source.h"
 #include "mir/graphics/display_sink.h"
+#include "mir/graphics/output_filter.h"
 
 namespace mc = mir::compositor;
 namespace mr = mir::renderer;
@@ -156,14 +157,16 @@ mc::BasicScreenShooter::Self::Self(
     std::shared_ptr<time::Clock> const& clock,
     std::shared_ptr<mg::GLRenderingProvider> render_provider,
     std::shared_ptr<mr::RendererFactory> renderer_factory,
-    std::shared_ptr<mir::graphics::GLConfig> const& config)
+    std::shared_ptr<mir::graphics::GLConfig> const& config,
+    std::shared_ptr<graphics::OutputFilter> const& output_filter)
     : scene{scene},
       clock{clock},
       render_provider{std::move(render_provider)},
       renderer_factory{std::move(renderer_factory)},
       last_rendered_size{0, 0},
       output{std::make_shared<OneShotBufferDisplayProvider>()},
-      config{config}
+      config{config},
+      output_filter{output_filter}
 {
 }
 
@@ -185,6 +188,7 @@ auto mc::BasicScreenShooter::Self::render(
 
     auto& renderer = renderer_for_buffer(buffer);
     renderer.set_viewport(area);
+    renderer.set_output_filter(output_filter->filter());
     /* We don't need the result of this `render` call, as we know it's
      * going into the buffer we just set
      */
@@ -257,8 +261,9 @@ mc::BasicScreenShooter::BasicScreenShooter(
     std::span<std::shared_ptr<mg::GLRenderingProvider>> const& providers,
     std::shared_ptr<mr::RendererFactory> render_factory,
     std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
-    std::shared_ptr<mir::graphics::GLConfig> const& config)
-    : self{std::make_shared<Self>(scene, clock, select_provider(providers, buffer_allocator), std::move(render_factory), config)},
+    std::shared_ptr<mir::graphics::GLConfig> const& config,
+    std::shared_ptr<graphics::OutputFilter> const& output_filter)
+    : self{std::make_shared<Self>(scene, clock, select_provider(providers, buffer_allocator), std::move(render_factory), config, output_filter)},
       executor{executor}
 {
 }

--- a/src/server/compositor/basic_screen_shooter.h
+++ b/src/server/compositor/basic_screen_shooter.h
@@ -33,6 +33,10 @@ namespace renderer
 class Renderer;
 class RendererFactory;
 }
+namespace graphics
+{
+class OutputFilter;
+}
 namespace compositor
 {
 class Scene;
@@ -47,7 +51,8 @@ public:
         std::span<std::shared_ptr<graphics::GLRenderingProvider>> const& providers,
         std::shared_ptr<renderer::RendererFactory> render_factory,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
-        std::shared_ptr<mir::graphics::GLConfig> const& config);
+        std::shared_ptr<mir::graphics::GLConfig> const& config,
+        std::shared_ptr<graphics::OutputFilter> const& output_filter);
 
     void capture(
         std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
@@ -64,7 +69,8 @@ private:
             std::shared_ptr<time::Clock> const& clock,
             std::shared_ptr<graphics::GLRenderingProvider> provider,
             std::shared_ptr<renderer::RendererFactory> render_factory,
-            std::shared_ptr<mir::graphics::GLConfig> const& config);
+            std::shared_ptr<mir::graphics::GLConfig> const& config,
+            std::shared_ptr<graphics::OutputFilter> const& output_filter);
 
         auto render(
             std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
@@ -89,6 +95,7 @@ private:
         std::unique_ptr<graphics::DisplaySink> offscreen_sink;
         std::shared_ptr<OneShotBufferDisplayProvider> const output;
         std::shared_ptr<mir::graphics::GLConfig> config;
+        std::shared_ptr<graphics::OutputFilter> const output_filter;
     };
     std::shared_ptr<Self> const self;
     Executor& executor;

--- a/src/server/compositor/basic_screen_shooter_factory.cpp
+++ b/src/server/compositor/basic_screen_shooter_factory.cpp
@@ -28,17 +28,19 @@ mc::BasicScreenShooterFactory::BasicScreenShooterFactory(
     std::vector<std::shared_ptr<mg::GLRenderingProvider>> const& providers,
     std::shared_ptr<mr::RendererFactory> const& render_factory,
     std::shared_ptr<mg::GraphicBufferAllocator> const& buffer_allocator,
-    std::shared_ptr<mg::GLConfig> const& config)
+    std::shared_ptr<mg::GLConfig> const& config,
+    std::shared_ptr<mg::OutputFilter> const& output_filter)
     : scene(scene),
       clock(clock),
       providers(providers),
       renderer_factory(render_factory),
       buffer_allocator(buffer_allocator),
-      config(config)
+      config(config),
+      output_filter(output_filter)
 {}
 
 auto mc::BasicScreenShooterFactory::create(Executor& executor) -> std::unique_ptr<ScreenShooter>
 {
     return std::make_unique<BasicScreenShooter>(
-        scene, clock, executor, providers, renderer_factory, buffer_allocator, config);
+        scene, clock, executor, providers, renderer_factory, buffer_allocator, config, output_filter);
 }

--- a/src/server/compositor/basic_screen_shooter_factory.h
+++ b/src/server/compositor/basic_screen_shooter_factory.h
@@ -29,6 +29,11 @@ class Renderer;
 class RendererFactory;
 }
 
+namespace graphics
+{
+class OutputFilter;
+}
+
 namespace time
 {
 class Clock;
@@ -47,7 +52,8 @@ public:
         std::vector<std::shared_ptr<graphics::GLRenderingProvider>> const& providers,
         std::shared_ptr<renderer::RendererFactory> const& render_factory,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
-        std::shared_ptr<graphics::GLConfig> const& config);
+        std::shared_ptr<graphics::GLConfig> const& config,
+        std::shared_ptr<graphics::OutputFilter> const& output_filter);
     auto create(Executor& executor) -> std::unique_ptr<ScreenShooter> override;
 
 private:
@@ -57,6 +63,7 @@ private:
     std::shared_ptr<renderer::RendererFactory> const renderer_factory;
     std::shared_ptr<graphics::GraphicBufferAllocator> buffer_allocator;
     std::shared_ptr<graphics::GLConfig> config;
+    std::shared_ptr<graphics::OutputFilter> const output_filter;
 };
 }
 }

--- a/src/server/compositor/default_configuration.cpp
+++ b/src/server/compositor/default_configuration.cpp
@@ -124,7 +124,8 @@ auto mir::DefaultServerConfiguration::the_screen_shooter() -> std::shared_ptr<co
                     providers,
                     the_renderer_factory(),
                     the_buffer_allocator(),
-                    the_gl_config());
+                    the_gl_config(),
+                    the_output_filter());
             }
             catch (...)
             {
@@ -164,6 +165,7 @@ auto mir::DefaultServerConfiguration::the_screen_shooter_factory() -> std::share
                 providers,
                 the_renderer_factory(),
                 the_buffer_allocator(),
-                the_gl_config());
+                the_gl_config(),
+                the_output_filter());
         });
 }

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -32,6 +32,7 @@
 #include "mir/test/doubles/stub_renderable.h"
 #include "mir/test/doubles/stub_gl_config.h"
 #include "mir/test/doubles/stub_buffer_allocator.h"
+#include "mir/test/doubles/stub_output_filter.h"
 
 #include <gtest/gtest.h>
 
@@ -100,7 +101,8 @@ struct BasicScreenShooter : Test
             gl_providers,
             renderer_factory,
             buffer_allocator,
-            std::make_shared<mtd::StubGLConfig>());
+            std::make_shared<mtd::StubGLConfig>(),
+            std::make_shared<mtd::StubOutputFilter>());
     }
 
     std::unique_ptr<mtd::MockRenderer> next_renderer{std::make_unique<testing::NiceMock<mtd::MockRenderer>>()};
@@ -244,7 +246,8 @@ TEST_F(BasicScreenShooter, ensures_renderer_is_current_on_only_one_thread)
         gl_providers,
         renderer_factory,
         buffer_allocator,
-        std::make_shared<mtd::StubGLConfig>());
+        std::make_shared<mtd::StubGLConfig>(),
+        std::make_shared<mtd::StubOutputFilter>());
 
     ON_CALL(*next_renderer, render(_))
         .WillByDefault(

--- a/tests/unit-tests/compositor/test_basic_screen_shooter_factory.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter_factory.cpp
@@ -18,7 +18,6 @@
 #include "mir/graphics/platform.h"
 #include "mir/graphics/display_sink.h"
 #include "mir/renderer/gl/gl_surface.h"
-#include "mir/test/doubles/stub_gl_rendering_provider.h"
 #include "src/server/compositor/basic_screen_shooter_factory.h"
 
 #include "mir/test/doubles/mock_scene.h"
@@ -28,8 +27,7 @@
 #include "mir/test/doubles/advanceable_clock.h"
 #include "mir/test/doubles/explicit_executor.h"
 #include "mir/test/doubles/stub_buffer.h"
-#include "mir/test/doubles/stub_scene_element.h"
-#include "mir/test/doubles/stub_renderable.h"
+#include "mir/test/doubles/stub_output_filter.h"
 #include "mir/test/doubles/stub_gl_config.h"
 #include "mir/test/doubles/stub_buffer_allocator.h"
 
@@ -58,7 +56,8 @@ public:
             gl_providers,
             renderer_factory,
             buffer_allocator,
-            std::make_shared<mtd::StubGLConfig>());
+            std::make_shared<mtd::StubGLConfig>(),
+            std::make_shared<mtd::StubOutputFilter>());
     }
 
     std::shared_ptr<mtd::MockScene> scene{std::make_shared<NiceMock<mtd::MockScene>>()};


### PR DESCRIPTION
## What's new?
- When doing magnification work, I noticed that the color of the scene was always inverted after pulling latest from `main`
- Looks like we needed to set the filter in the `BasicScreenShooter`

## To test
- Run miral-shell
- Run `grimshot save output`. Note that the image is correctly not inverted
- Invert the color using Ctrl + I
- Run `grimshot save output` again. Note that the image is correctly inverted