### PR TITLE
Add `GbmQuirks` to go around nVidia bugs

### DIFF
--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -30,7 +30,7 @@ mga::GBMDisplayAllocator::GBMDisplayAllocator(
     mir::Fd drm_fd,
     std::shared_ptr<struct gbm_device> gbm,
     geom::Size size,
-    std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks) :
+    std::shared_ptr<RuntimeQuirks> runtime_quirks) :
     fd{std::move(drm_fd)},
     gbm{std::move(gbm)},
     size{size},
@@ -126,13 +126,10 @@ auto create_gbm_surface(
     geom::Size size,
     mg::DRMFormat format,
     std::span<uint64_t> modifiers,
-    std::optional<std::shared_ptr<mga::RuntimeQuirks>> runtime_quirks) -> std::shared_ptr<gbm_surface>
+    std::shared_ptr<mga::RuntimeQuirks> runtime_quirks) -> std::shared_ptr<gbm_surface>
 {
     auto const flags =
-        *runtime_quirks
-             .transform([](auto& rtq)
-                        { return rtq->gbm_create_surface_flags_broken() ? std::optional{0} : std::nullopt; })
-             .value_or(GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT);
+        runtime_quirks->gbm_create_surface_flags_broken() ? 0 : GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT;
 
     auto const surface =
         [&]()
@@ -182,7 +179,7 @@ public:
         geom::Size size,
         mg::DRMFormat const format,
         std::span<uint64_t> modifiers,
-        std::optional<std::shared_ptr<mga::RuntimeQuirks>> runtime_quirks) :
+        std::shared_ptr<mga::RuntimeQuirks> runtime_quirks) :
         drm_fd{std::move(drm_fd)},
         runtime_quirks{runtime_quirks},
         surface{create_gbm_surface(gbm, size, format, modifiers, runtime_quirks)}
@@ -199,10 +196,7 @@ public:
 
     auto claim_framebuffer() -> std::unique_ptr<mg::Framebuffer> override
     {
-        auto const skip_surface_free_buffers_check =
-            runtime_quirks.transform([](auto& rtq) { return rtq->gbm_surface_has_free_buffers_broken(); })
-                .value_or(false);
-
+        auto const skip_surface_free_buffers_check = runtime_quirks->gbm_surface_has_free_buffers_broken();
         if (!skip_surface_free_buffers_check && !gbm_surface_has_free_buffers(surface.get()))
         {
             BOOST_THROW_EXCEPTION((
@@ -230,7 +224,7 @@ public:
     }
 private:
     mir::Fd const drm_fd;
-    std::optional<std::shared_ptr<mga::RuntimeQuirks>> const runtime_quirks;
+    std::shared_ptr<mga::RuntimeQuirks> const runtime_quirks;
     std::shared_ptr<gbm_surface> const surface;
 };
 }

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -128,9 +128,7 @@ auto create_gbm_surface(
     std::span<uint64_t> modifiers,
     std::shared_ptr<mga::GbmWorkarounds> runtime_quirks) -> std::shared_ptr<gbm_surface>
 {
-    auto const flags =
-        runtime_quirks->gbm_create_surface_flags_broken() ? 0 : GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT;
-
+    auto const flags = runtime_quirks->adjust_gbm_create_surface_flags(GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT);
     auto const surface =
         [&]()
         {

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -30,7 +30,7 @@ mga::GBMDisplayAllocator::GBMDisplayAllocator(
     mir::Fd drm_fd,
     std::shared_ptr<struct gbm_device> gbm,
     geom::Size size,
-    std::shared_ptr<RuntimeQuirks> runtime_quirks) :
+    std::shared_ptr<GbmWorkarounds> runtime_quirks) :
     fd{std::move(drm_fd)},
     gbm{std::move(gbm)},
     size{size},
@@ -126,7 +126,7 @@ auto create_gbm_surface(
     geom::Size size,
     mg::DRMFormat format,
     std::span<uint64_t> modifiers,
-    std::shared_ptr<mga::RuntimeQuirks> runtime_quirks) -> std::shared_ptr<gbm_surface>
+    std::shared_ptr<mga::GbmWorkarounds> runtime_quirks) -> std::shared_ptr<gbm_surface>
 {
     auto const flags =
         runtime_quirks->gbm_create_surface_flags_broken() ? 0 : GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT;
@@ -179,7 +179,7 @@ public:
         geom::Size size,
         mg::DRMFormat const format,
         std::span<uint64_t> modifiers,
-        std::shared_ptr<mga::RuntimeQuirks> runtime_quirks) :
+        std::shared_ptr<mga::GbmWorkarounds> runtime_quirks) :
         drm_fd{std::move(drm_fd)},
         runtime_quirks{runtime_quirks},
         surface{create_gbm_surface(gbm, size, format, modifiers, runtime_quirks)}
@@ -224,7 +224,7 @@ public:
     }
 private:
     mir::Fd const drm_fd;
-    std::shared_ptr<mga::RuntimeQuirks> const runtime_quirks;
+    std::shared_ptr<mga::GbmWorkarounds> const runtime_quirks;
     std::shared_ptr<gbm_surface> const surface;
 };
 }

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -128,7 +128,6 @@ auto create_gbm_surface(
     std::span<uint64_t> modifiers,
     std::optional<std::shared_ptr<mga::RuntimeQuirks>> runtime_quirks) -> std::shared_ptr<gbm_surface>
 {
-    assert(*runtime_quirks != nullptr);
     auto const flags =
         *runtime_quirks
              .transform([](auto& rtq)

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -30,7 +30,7 @@ mga::GBMDisplayAllocator::GBMDisplayAllocator(
     mir::Fd drm_fd,
     std::shared_ptr<struct gbm_device> gbm,
     geom::Size size,
-    std::shared_ptr<GbmWorkarounds> runtime_quirks) :
+    std::shared_ptr<GbmQuirks> runtime_quirks) :
     fd{std::move(drm_fd)},
     gbm{std::move(gbm)},
     size{size},
@@ -126,7 +126,7 @@ auto create_gbm_surface(
     geom::Size size,
     mg::DRMFormat format,
     std::span<uint64_t> modifiers,
-    std::shared_ptr<mga::GbmWorkarounds> runtime_quirks) -> std::shared_ptr<gbm_surface>
+    std::shared_ptr<mga::GbmQuirks> runtime_quirks) -> std::shared_ptr<gbm_surface>
 {
     auto const flags = runtime_quirks->adjust_gbm_create_surface_flags(GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT);
     auto const surface =
@@ -177,7 +177,7 @@ public:
         geom::Size size,
         mg::DRMFormat const format,
         std::span<uint64_t> modifiers,
-        std::shared_ptr<mga::GbmWorkarounds> runtime_quirks) :
+        std::shared_ptr<mga::GbmQuirks> runtime_quirks) :
         drm_fd{std::move(drm_fd)},
         runtime_quirks{runtime_quirks},
         surface{create_gbm_surface(gbm, size, format, modifiers, runtime_quirks)}
@@ -222,7 +222,7 @@ public:
     }
 private:
     mir::Fd const drm_fd;
-    std::shared_ptr<mga::GbmWorkarounds> const runtime_quirks;
+    std::shared_ptr<mga::GbmQuirks> const runtime_quirks;
     std::shared_ptr<gbm_surface> const surface;
 };
 }

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -128,7 +128,7 @@ auto create_gbm_surface(
     std::span<uint64_t> modifiers,
     std::shared_ptr<mga::GbmQuirks> runtime_quirks) -> std::shared_ptr<gbm_surface>
 {
-    auto const flags = runtime_quirks->adjust_gbm_create_surface_flags(GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT);
+    auto const flags = runtime_quirks->gbm_create_surface_flags();
     auto const surface =
         [&]()
         {
@@ -194,8 +194,7 @@ public:
 
     auto claim_framebuffer() -> std::unique_ptr<mg::Framebuffer> override
     {
-        auto const skip_surface_free_buffers_check = runtime_quirks->gbm_surface_has_free_buffers_broken();
-        if (!skip_surface_free_buffers_check && !gbm_surface_has_free_buffers(surface.get()))
+        if (!runtime_quirks->gbm_surface_has_free_buffers(surface.get()))
         {
             BOOST_THROW_EXCEPTION((
                 std::system_error{

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.h
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.h
@@ -19,10 +19,15 @@
 
 namespace mir::graphics::atomic
 {
+class RuntimeQuirks;
 class GBMDisplayAllocator : public graphics::GBMDisplayAllocator
 {
 public:
-    GBMDisplayAllocator(mir::Fd drm_fd, std::shared_ptr<struct gbm_device> gbm, geometry::Size size);
+    GBMDisplayAllocator(
+        mir::Fd drm_fd,
+        std::shared_ptr<struct gbm_device> gbm,
+        geometry::Size size,
+        std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks);
 
     auto supported_formats() const -> std::vector<DRMFormat> override;
 
@@ -33,5 +38,6 @@ private:
     mir::Fd const fd;
     std::shared_ptr<struct gbm_device> const gbm;
     geometry::Size const size;
+    std::optional<std::shared_ptr<RuntimeQuirks>> const runtime_quirks;
 };
 }

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.h
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.h
@@ -27,7 +27,7 @@ public:
         mir::Fd drm_fd,
         std::shared_ptr<struct gbm_device> gbm,
         geometry::Size size,
-        std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks);
+        std::shared_ptr<RuntimeQuirks> runtime_quirks);
 
     auto supported_formats() const -> std::vector<DRMFormat> override;
 
@@ -38,6 +38,6 @@ private:
     mir::Fd const fd;
     std::shared_ptr<struct gbm_device> const gbm;
     geometry::Size const size;
-    std::optional<std::shared_ptr<RuntimeQuirks>> const runtime_quirks;
+    std::shared_ptr<RuntimeQuirks> const runtime_quirks;
 };
 }

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.h
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.h
@@ -19,7 +19,7 @@
 
 namespace mir::graphics::atomic
 {
-class RuntimeQuirks;
+class GbmWorkarounds;
 class GBMDisplayAllocator : public graphics::GBMDisplayAllocator
 {
 public:
@@ -27,7 +27,7 @@ public:
         mir::Fd drm_fd,
         std::shared_ptr<struct gbm_device> gbm,
         geometry::Size size,
-        std::shared_ptr<RuntimeQuirks> runtime_quirks);
+        std::shared_ptr<GbmWorkarounds> runtime_quirks);
 
     auto supported_formats() const -> std::vector<DRMFormat> override;
 
@@ -38,6 +38,6 @@ private:
     mir::Fd const fd;
     std::shared_ptr<struct gbm_device> const gbm;
     geometry::Size const size;
-    std::shared_ptr<RuntimeQuirks> const runtime_quirks;
+    std::shared_ptr<GbmWorkarounds> const runtime_quirks;
 };
 }

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.h
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.h
@@ -19,7 +19,7 @@
 
 namespace mir::graphics::atomic
 {
-class GbmWorkarounds;
+class GbmQuirks;
 class GBMDisplayAllocator : public graphics::GBMDisplayAllocator
 {
 public:
@@ -27,7 +27,7 @@ public:
         mir::Fd drm_fd,
         std::shared_ptr<struct gbm_device> gbm,
         geometry::Size size,
-        std::shared_ptr<GbmWorkarounds> runtime_quirks);
+        std::shared_ptr<GbmQuirks> runtime_quirks);
 
     auto supported_formats() const -> std::vector<DRMFormat> override;
 
@@ -38,6 +38,6 @@ private:
     mir::Fd const fd;
     std::shared_ptr<struct gbm_device> const gbm;
     geometry::Size const size;
-    std::shared_ptr<GbmWorkarounds> const runtime_quirks;
+    std::shared_ptr<GbmQuirks> const runtime_quirks;
 };
 }

--- a/src/platforms/atomic-kms/server/kms/display.cpp
+++ b/src/platforms/atomic-kms/server/kms/display.cpp
@@ -137,7 +137,7 @@ mga::Display::Display(
     mga::BypassOption bypass_option,
     std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
     std::shared_ptr<DisplayReport> const& listener,
-    std::shared_ptr<RuntimeQuirks> runtime_quirks)
+    std::shared_ptr<GbmWorkarounds> runtime_quirks)
     : drm_fd{std::move(drm_fd)},
       gbm{std::move(gbm)},
       listener(listener),

--- a/src/platforms/atomic-kms/server/kms/display.cpp
+++ b/src/platforms/atomic-kms/server/kms/display.cpp
@@ -137,7 +137,7 @@ mga::Display::Display(
     mga::BypassOption bypass_option,
     std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
     std::shared_ptr<DisplayReport> const& listener,
-    std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks)
+    std::shared_ptr<RuntimeQuirks> runtime_quirks)
     : drm_fd{std::move(drm_fd)},
       gbm{std::move(gbm)},
       listener(listener),

--- a/src/platforms/atomic-kms/server/kms/display.cpp
+++ b/src/platforms/atomic-kms/server/kms/display.cpp
@@ -137,7 +137,7 @@ mga::Display::Display(
     mga::BypassOption bypass_option,
     std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
     std::shared_ptr<DisplayReport> const& listener,
-    std::shared_ptr<GbmWorkarounds> runtime_quirks)
+    std::shared_ptr<GbmQuirks> runtime_quirks)
     : drm_fd{std::move(drm_fd)},
       gbm{std::move(gbm)},
       listener(listener),

--- a/src/platforms/atomic-kms/server/kms/display.cpp
+++ b/src/platforms/atomic-kms/server/kms/display.cpp
@@ -136,7 +136,8 @@ mga::Display::Display(
     std::shared_ptr<struct gbm_device> gbm,
     mga::BypassOption bypass_option,
     std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
-    std::shared_ptr<DisplayReport> const& listener)
+    std::shared_ptr<DisplayReport> const& listener,
+    std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks)
     : drm_fd{std::move(drm_fd)},
       gbm{std::move(gbm)},
       listener(listener),
@@ -146,7 +147,8 @@ mga::Display::Display(
             this->drm_fd)},
       current_display_configuration{output_container},
       dirty_configuration{false},
-      bypass_option(bypass_option)
+      bypass_option(bypass_option),
+      runtime_quirks{runtime_quirks}
 {
     monitor.filter_by_subsystem_and_type("drm", "drm_minor");
     monitor.enable();
@@ -393,7 +395,8 @@ void mga::Display::configure_locked(
                     listener,
                     std::move(kms_output),
                     out.extents(),
-                    transform);
+                    transform, 
+                    runtime_quirks);
 
                 display_buffers_new.push_back(std::move(db));
             }

--- a/src/platforms/atomic-kms/server/kms/display.h
+++ b/src/platforms/atomic-kms/server/kms/display.h
@@ -62,7 +62,7 @@ public:
         BypassOption bypass_option,
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
         std::shared_ptr<DisplayReport> const& listener,
-        std::optional<std::shared_ptr<RuntimeQuirks>> quirks);
+        std::shared_ptr<RuntimeQuirks> quirks);
     ~Display();
 
     geometry::Rectangle view_area() const;
@@ -101,7 +101,7 @@ private:
 
     BypassOption bypass_option;
     std::weak_ptr<Cursor> cursor;
-    std::optional<std::shared_ptr<RuntimeQuirks>> const runtime_quirks;
+    std::shared_ptr<RuntimeQuirks> const runtime_quirks;
 };
 
 class GBMDisplayProvider : public graphics::GBMDisplayProvider

--- a/src/platforms/atomic-kms/server/kms/display.h
+++ b/src/platforms/atomic-kms/server/kms/display.h
@@ -51,7 +51,7 @@ class GBMHelper;
 class DisplaySink;
 class KMSOutput;
 class Cursor;
-class GbmWorkarounds;
+class GbmQuirks;
 
 class Display : public graphics::Display
 {
@@ -62,7 +62,7 @@ public:
         BypassOption bypass_option,
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
         std::shared_ptr<DisplayReport> const& listener,
-        std::shared_ptr<GbmWorkarounds> quirks);
+        std::shared_ptr<GbmQuirks> quirks);
     ~Display();
 
     geometry::Rectangle view_area() const;
@@ -101,7 +101,7 @@ private:
 
     BypassOption bypass_option;
     std::weak_ptr<Cursor> cursor;
-    std::shared_ptr<GbmWorkarounds> const runtime_quirks;
+    std::shared_ptr<GbmQuirks> const runtime_quirks;
 };
 
 class GBMDisplayProvider : public graphics::GBMDisplayProvider

--- a/src/platforms/atomic-kms/server/kms/display.h
+++ b/src/platforms/atomic-kms/server/kms/display.h
@@ -51,7 +51,7 @@ class GBMHelper;
 class DisplaySink;
 class KMSOutput;
 class Cursor;
-class RuntimeQuirks;
+class GbmWorkarounds;
 
 class Display : public graphics::Display
 {
@@ -62,7 +62,7 @@ public:
         BypassOption bypass_option,
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
         std::shared_ptr<DisplayReport> const& listener,
-        std::shared_ptr<RuntimeQuirks> quirks);
+        std::shared_ptr<GbmWorkarounds> quirks);
     ~Display();
 
     geometry::Rectangle view_area() const;
@@ -101,7 +101,7 @@ private:
 
     BypassOption bypass_option;
     std::weak_ptr<Cursor> cursor;
-    std::shared_ptr<RuntimeQuirks> const runtime_quirks;
+    std::shared_ptr<GbmWorkarounds> const runtime_quirks;
 };
 
 class GBMDisplayProvider : public graphics::GBMDisplayProvider

--- a/src/platforms/atomic-kms/server/kms/display.h
+++ b/src/platforms/atomic-kms/server/kms/display.h
@@ -51,6 +51,7 @@ class GBMHelper;
 class DisplaySink;
 class KMSOutput;
 class Cursor;
+class RuntimeQuirks;
 
 class Display : public graphics::Display
 {
@@ -60,7 +61,8 @@ public:
         std::shared_ptr<struct gbm_device> gbm,
         BypassOption bypass_option,
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
-        std::shared_ptr<DisplayReport> const& listener);
+        std::shared_ptr<DisplayReport> const& listener,
+        std::optional<std::shared_ptr<RuntimeQuirks>> quirks);
     ~Display();
 
     geometry::Rectangle view_area() const;
@@ -99,6 +101,7 @@ private:
 
     BypassOption bypass_option;
     std::weak_ptr<Cursor> cursor;
+    std::optional<std::shared_ptr<RuntimeQuirks>> const runtime_quirks;
 };
 
 class GBMDisplayProvider : public graphics::GBMDisplayProvider

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -55,7 +55,7 @@ mga::DisplaySink::DisplaySink(
     std::shared_ptr<KMSOutput> output,
     geom::Rectangle const& area,
     glm::mat2 const& transformation,
-    std::shared_ptr<RuntimeQuirks> runtime_quirks)
+    std::shared_ptr<GbmWorkarounds> runtime_quirks)
     : gbm{std::move(gbm)},
       listener(listener),
       output{std::move(output)},

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -55,7 +55,7 @@ mga::DisplaySink::DisplaySink(
     std::shared_ptr<KMSOutput> output,
     geom::Rectangle const& area,
     glm::mat2 const& transformation,
-    std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks)
+    std::shared_ptr<RuntimeQuirks> runtime_quirks)
     : gbm{std::move(gbm)},
       listener(listener),
       output{std::move(output)},

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -55,7 +55,7 @@ mga::DisplaySink::DisplaySink(
     std::shared_ptr<KMSOutput> output,
     geom::Rectangle const& area,
     glm::mat2 const& transformation,
-    std::shared_ptr<GbmWorkarounds> runtime_quirks)
+    std::shared_ptr<GbmQuirks> runtime_quirks)
     : gbm{std::move(gbm)},
       listener(listener),
       output{std::move(output)},

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -54,13 +54,15 @@ mga::DisplaySink::DisplaySink(
     std::shared_ptr<DisplayReport> const& listener,
     std::shared_ptr<KMSOutput> output,
     geom::Rectangle const& area,
-    glm::mat2 const& transformation)
+    glm::mat2 const& transformation,
+    std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks)
     : gbm{std::move(gbm)},
       listener(listener),
       output{std::move(output)},
       area(area),
       transform{transformation},
-      needs_set_crtc{false}
+      needs_set_crtc{false},
+      runtime_quirks{runtime_quirks}
 {
     listener->report_successful_setup_of_native_resources();
 
@@ -254,7 +256,7 @@ auto mga::DisplaySink::maybe_create_allocator(DisplayAllocator::Tag const& type_
     {
         if (!gbm_allocator)
         {
-            gbm_allocator = std::make_unique<GBMDisplayAllocator>(drm_fd(), gbm, output->size());
+            gbm_allocator = std::make_unique<GBMDisplayAllocator>(drm_fd(), gbm, output->size(), runtime_quirks);
         }
         return gbm_allocator.get();
     }

--- a/src/platforms/atomic-kms/server/kms/display_sink.h
+++ b/src/platforms/atomic-kms/server/kms/display_sink.h
@@ -48,7 +48,7 @@ namespace atomic
 
 class Platform;
 class KMSOutput;
-class RuntimeQuirks;
+class GbmWorkarounds;
 
 class DisplaySink : public graphics::DisplaySink,
                     public graphics::DisplaySyncGroup
@@ -62,7 +62,7 @@ public:
         std::shared_ptr<KMSOutput> output,
         geometry::Rectangle const& area,
         glm::mat2 const& transformation,
-        std::shared_ptr<RuntimeQuirks> runtime_quirks);
+        std::shared_ptr<GbmWorkarounds> runtime_quirks);
     ~DisplaySink();
 
     geometry::Rectangle view_area() const override;
@@ -110,7 +110,7 @@ private:
     glm::mat2 transform;
     std::atomic<bool> needs_set_crtc;
     std::chrono::milliseconds recommend_sleep{0};
-    std::shared_ptr<RuntimeQuirks> const runtime_quirks;
+    std::shared_ptr<GbmWorkarounds> const runtime_quirks;
 };
 
 }

--- a/src/platforms/atomic-kms/server/kms/display_sink.h
+++ b/src/platforms/atomic-kms/server/kms/display_sink.h
@@ -48,7 +48,7 @@ namespace atomic
 
 class Platform;
 class KMSOutput;
-class GbmWorkarounds;
+class GbmQuirks;
 
 class DisplaySink : public graphics::DisplaySink,
                     public graphics::DisplaySyncGroup
@@ -62,7 +62,7 @@ public:
         std::shared_ptr<KMSOutput> output,
         geometry::Rectangle const& area,
         glm::mat2 const& transformation,
-        std::shared_ptr<GbmWorkarounds> runtime_quirks);
+        std::shared_ptr<GbmQuirks> runtime_quirks);
     ~DisplaySink();
 
     geometry::Rectangle view_area() const override;
@@ -110,7 +110,7 @@ private:
     glm::mat2 transform;
     std::atomic<bool> needs_set_crtc;
     std::chrono::milliseconds recommend_sleep{0};
-    std::shared_ptr<GbmWorkarounds> const runtime_quirks;
+    std::shared_ptr<GbmQuirks> const runtime_quirks;
 };
 
 }

--- a/src/platforms/atomic-kms/server/kms/display_sink.h
+++ b/src/platforms/atomic-kms/server/kms/display_sink.h
@@ -48,6 +48,7 @@ namespace atomic
 
 class Platform;
 class KMSOutput;
+class RuntimeQuirks;
 
 class DisplaySink : public graphics::DisplaySink,
                     public graphics::DisplaySyncGroup
@@ -60,7 +61,8 @@ public:
         std::shared_ptr<DisplayReport> const& listener,
         std::shared_ptr<KMSOutput> output,
         geometry::Rectangle const& area,
-        glm::mat2 const& transformation);
+        glm::mat2 const& transformation,
+        std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks);
     ~DisplaySink();
 
     geometry::Rectangle view_area() const override;
@@ -108,6 +110,7 @@ private:
     glm::mat2 transform;
     std::atomic<bool> needs_set_crtc;
     std::chrono::milliseconds recommend_sleep{0};
+    std::optional<std::shared_ptr<RuntimeQuirks>> const runtime_quirks;
 };
 
 }

--- a/src/platforms/atomic-kms/server/kms/display_sink.h
+++ b/src/platforms/atomic-kms/server/kms/display_sink.h
@@ -62,7 +62,7 @@ public:
         std::shared_ptr<KMSOutput> output,
         geometry::Rectangle const& area,
         glm::mat2 const& transformation,
-        std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks);
+        std::shared_ptr<RuntimeQuirks> runtime_quirks);
     ~DisplaySink();
 
     geometry::Rectangle view_area() const override;
@@ -110,7 +110,7 @@ private:
     glm::mat2 transform;
     std::atomic<bool> needs_set_crtc;
     std::chrono::milliseconds recommend_sleep{0};
-    std::optional<std::shared_ptr<RuntimeQuirks>> const runtime_quirks;
+    std::shared_ptr<RuntimeQuirks> const runtime_quirks;
 };
 
 }

--- a/src/platforms/atomic-kms/server/kms/platform.cpp
+++ b/src/platforms/atomic-kms/server/kms/platform.cpp
@@ -87,7 +87,7 @@ mga::Platform::Platform(
     ConsoleServices& vt,
     EmergencyCleanupRegistry& registry,
     BypassOption bypass_option,
-    std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks)
+    std::shared_ptr<RuntimeQuirks> runtime_quirks)
     : Platform(master_fd_for_device(device, vt), listener, registry, bypass_option, runtime_quirks)
 {
 }
@@ -97,7 +97,7 @@ mga::Platform::Platform(
     std::shared_ptr<DisplayReport> const& listener,
     EmergencyCleanupRegistry&,
     BypassOption bypass_option,
-    std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks)
+    std::shared_ptr<RuntimeQuirks> runtime_quirks)
     : udev{std::make_shared<mir::udev::Context>()},
       listener{listener},
       device_handle{std::move(std::get<0>(drm))},

--- a/src/platforms/atomic-kms/server/kms/platform.cpp
+++ b/src/platforms/atomic-kms/server/kms/platform.cpp
@@ -87,7 +87,7 @@ mga::Platform::Platform(
     ConsoleServices& vt,
     EmergencyCleanupRegistry& registry,
     BypassOption bypass_option,
-    std::shared_ptr<GbmWorkarounds> runtime_quirks)
+    std::shared_ptr<GbmQuirks> runtime_quirks)
     : Platform(master_fd_for_device(device, vt), listener, registry, bypass_option, runtime_quirks)
 {
 }
@@ -97,7 +97,7 @@ mga::Platform::Platform(
     std::shared_ptr<DisplayReport> const& listener,
     EmergencyCleanupRegistry&,
     BypassOption bypass_option,
-    std::shared_ptr<GbmWorkarounds> runtime_quirks)
+    std::shared_ptr<GbmQuirks> runtime_quirks)
     : udev{std::make_shared<mir::udev::Context>()},
       listener{listener},
       device_handle{std::move(std::get<0>(drm))},

--- a/src/platforms/atomic-kms/server/kms/platform.cpp
+++ b/src/platforms/atomic-kms/server/kms/platform.cpp
@@ -87,7 +87,7 @@ mga::Platform::Platform(
     ConsoleServices& vt,
     EmergencyCleanupRegistry& registry,
     BypassOption bypass_option,
-    std::shared_ptr<RuntimeQuirks> runtime_quirks)
+    std::shared_ptr<GbmWorkarounds> runtime_quirks)
     : Platform(master_fd_for_device(device, vt), listener, registry, bypass_option, runtime_quirks)
 {
 }
@@ -97,7 +97,7 @@ mga::Platform::Platform(
     std::shared_ptr<DisplayReport> const& listener,
     EmergencyCleanupRegistry&,
     BypassOption bypass_option,
-    std::shared_ptr<RuntimeQuirks> runtime_quirks)
+    std::shared_ptr<GbmWorkarounds> runtime_quirks)
     : udev{std::make_shared<mir::udev::Context>()},
       listener{listener},
       device_handle{std::move(std::get<0>(drm))},

--- a/src/platforms/atomic-kms/server/kms/platform.cpp
+++ b/src/platforms/atomic-kms/server/kms/platform.cpp
@@ -86,8 +86,9 @@ mga::Platform::Platform(
     std::shared_ptr<DisplayReport> const& listener,
     ConsoleServices& vt,
     EmergencyCleanupRegistry& registry,
-    BypassOption bypass_option)
-    : Platform(master_fd_for_device(device, vt), listener, registry, bypass_option)
+    BypassOption bypass_option,
+    std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks)
+    : Platform(master_fd_for_device(device, vt), listener, registry, bypass_option, runtime_quirks)
 {
 }
 
@@ -95,13 +96,15 @@ mga::Platform::Platform(
     std::tuple<std::unique_ptr<Device>, mir::Fd> drm,
     std::shared_ptr<DisplayReport> const& listener,
     EmergencyCleanupRegistry&,
-    BypassOption bypass_option)
+    BypassOption bypass_option,
+    std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks)
     : udev{std::make_shared<mir::udev::Context>()},
       listener{listener},
       device_handle{std::move(std::get<0>(drm))},
       drm_fd{std::move(std::get<1>(drm))},
       gbm_display_provider{maybe_make_gbm_provider(drm_fd)},
-      bypass_option_{bypass_option}
+      bypass_option_{bypass_option},
+      runtime_quirks{runtime_quirks}
 {
     if (drm_fd == mir::Fd::invalid)
     {
@@ -132,7 +135,8 @@ mir::UniqueModulePtr<mg::Display> mga::Platform::create_display(
         gbm_device_from_provider(gbm_display_provider),
         bypass_option_,
         initial_conf_policy,
-        listener);
+        listener,
+        runtime_quirks);
 }
 
 auto mga::Platform::maybe_create_provider(DisplayProvider::Tag const& type_tag)

--- a/src/platforms/atomic-kms/server/kms/platform.h
+++ b/src/platforms/atomic-kms/server/kms/platform.h
@@ -33,7 +33,7 @@ namespace graphics
 namespace atomic
 {
 
-class RuntimeQuirks;
+class GbmWorkarounds;
 
 class Platform : public graphics::DisplayPlatform
 {
@@ -44,7 +44,7 @@ public:
         ConsoleServices& vt,
         EmergencyCleanupRegistry& emergency_cleanup_registry,
         BypassOption bypass_option,
-        std::shared_ptr<RuntimeQuirks> runtime_quirks);
+        std::shared_ptr<GbmWorkarounds> runtime_quirks);
 
     ~Platform() override;
 
@@ -69,7 +69,7 @@ private:
         std::shared_ptr<DisplayReport> const& reporter,
         EmergencyCleanupRegistry& emergency_cleanup_registry,
         BypassOption bypass_option,
-        std::shared_ptr<RuntimeQuirks> runtime_quirks);
+        std::shared_ptr<GbmWorkarounds> runtime_quirks);
 
     std::unique_ptr<Device> const device_handle;
     mir::Fd const drm_fd;
@@ -77,7 +77,7 @@ private:
     std::shared_ptr<GBMDisplayProvider> gbm_display_provider;
 
     BypassOption const bypass_option_;
-    std::shared_ptr<RuntimeQuirks> const runtime_quirks;
+    std::shared_ptr<GbmWorkarounds> const runtime_quirks;
 };
 }
 }

--- a/src/platforms/atomic-kms/server/kms/platform.h
+++ b/src/platforms/atomic-kms/server/kms/platform.h
@@ -33,7 +33,7 @@ namespace graphics
 namespace atomic
 {
 
-class Quirks;
+class RuntimeQuirks;
 
 class Platform : public graphics::DisplayPlatform
 {
@@ -43,7 +43,8 @@ public:
         std::shared_ptr<DisplayReport> const& reporter,
         ConsoleServices& vt,
         EmergencyCleanupRegistry& emergency_cleanup_registry,
-        BypassOption bypass_option);
+        BypassOption bypass_option,
+        std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks);
 
     ~Platform() override;
 
@@ -67,14 +68,16 @@ private:
         std::tuple<std::unique_ptr<Device>, mir::Fd> drm,
         std::shared_ptr<DisplayReport> const& reporter,
         EmergencyCleanupRegistry& emergency_cleanup_registry,
-        BypassOption bypass_option);
-    
+        BypassOption bypass_option,
+        std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks);
+
     std::unique_ptr<Device> const device_handle;
     mir::Fd const drm_fd;
 
     std::shared_ptr<GBMDisplayProvider> gbm_display_provider;
 
     BypassOption const bypass_option_;
+    std::optional<std::shared_ptr<RuntimeQuirks>> const runtime_quirks;
 };
 }
 }

--- a/src/platforms/atomic-kms/server/kms/platform.h
+++ b/src/platforms/atomic-kms/server/kms/platform.h
@@ -44,7 +44,7 @@ public:
         ConsoleServices& vt,
         EmergencyCleanupRegistry& emergency_cleanup_registry,
         BypassOption bypass_option,
-        std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks);
+        std::shared_ptr<RuntimeQuirks> runtime_quirks);
 
     ~Platform() override;
 
@@ -69,7 +69,7 @@ private:
         std::shared_ptr<DisplayReport> const& reporter,
         EmergencyCleanupRegistry& emergency_cleanup_registry,
         BypassOption bypass_option,
-        std::optional<std::shared_ptr<RuntimeQuirks>> runtime_quirks);
+        std::shared_ptr<RuntimeQuirks> runtime_quirks);
 
     std::unique_ptr<Device> const device_handle;
     mir::Fd const drm_fd;
@@ -77,7 +77,7 @@ private:
     std::shared_ptr<GBMDisplayProvider> gbm_display_provider;
 
     BypassOption const bypass_option_;
-    std::optional<std::shared_ptr<RuntimeQuirks>> const runtime_quirks;
+    std::shared_ptr<RuntimeQuirks> const runtime_quirks;
 };
 }
 }

--- a/src/platforms/atomic-kms/server/kms/platform.h
+++ b/src/platforms/atomic-kms/server/kms/platform.h
@@ -33,7 +33,7 @@ namespace graphics
 namespace atomic
 {
 
-class GbmWorkarounds;
+class GbmQuirks;
 
 class Platform : public graphics::DisplayPlatform
 {
@@ -44,7 +44,7 @@ public:
         ConsoleServices& vt,
         EmergencyCleanupRegistry& emergency_cleanup_registry,
         BypassOption bypass_option,
-        std::shared_ptr<GbmWorkarounds> runtime_quirks);
+        std::shared_ptr<GbmQuirks> runtime_quirks);
 
     ~Platform() override;
 
@@ -69,7 +69,7 @@ private:
         std::shared_ptr<DisplayReport> const& reporter,
         EmergencyCleanupRegistry& emergency_cleanup_registry,
         BypassOption bypass_option,
-        std::shared_ptr<GbmWorkarounds> runtime_quirks);
+        std::shared_ptr<GbmQuirks> runtime_quirks);
 
     std::unique_ptr<Device> const device_handle;
     mir::Fd const drm_fd;
@@ -77,7 +77,7 @@ private:
     std::shared_ptr<GBMDisplayProvider> gbm_display_provider;
 
     BypassOption const bypass_option_;
-    std::shared_ptr<GbmWorkarounds> const runtime_quirks;
+    std::shared_ptr<GbmQuirks> const runtime_quirks;
 };
 }
 }

--- a/src/platforms/atomic-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/atomic-kms/server/kms/platform_symbols.cpp
@@ -73,7 +73,12 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
         bypass_option = mga::BypassOption::prohibited;
 
     return mir::make_module_ptr<mga::Platform>(
-        *device.device, report, *console, *emergency_cleanup_registry, bypass_option);
+        *device.device,
+        report,
+        *console,
+        *emergency_cleanup_registry,
+        bypass_option,
+        mir::graphics::atomic::Quirks{*options}.runtime_quirks_for(*device.device));
 }
 
 void add_graphics_platform_options(boost::program_options::options_description& config)

--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -163,7 +163,7 @@ private:
      * https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084046
      * https://github.com/canonical/mir/issues/3710
      */
-    std::unordered_set<std::string> drivers_to_skip = { "nvidia", "ast", "simple-framebuffer"};
+    std::unordered_set<std::string> drivers_to_skip = { "ast", "simple-framebuffer"};
     std::unordered_set<std::string> devnodes_to_skip;
     // We know this is currently useful for virtio_gpu, vc4-drm and v3d
     std::unordered_set<std::string> skip_modesetting_support = { "virtio_gpu", "vc4-drm", "v3d" };

--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -134,7 +134,7 @@ public:
         return !should_skip_modesetting_support;
     }
 
-    auto runtime_quirks_for(udev::Device const& device) -> std::optional<std::shared_ptr<RuntimeQuirks>>
+    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<RuntimeQuirks>
     {
         auto const driver = get_device_driver(device.parent().get());
         if(std::strcmp(driver, "nvidia") == 0)
@@ -154,7 +154,19 @@ public:
             return std::make_shared<NvidiaRuntimeQuirks>();
         }
 
-        return std::nullopt;
+        class DefaultRuntimeQuirks : public RuntimeQuirks
+        {
+            auto gbm_create_surface_flags_broken() -> bool override
+            {
+                return false;
+            }
+            auto gbm_surface_has_free_buffers_broken() -> bool override
+            {
+                return false;
+            }
+        };
+
+        return std::make_shared<DefaultRuntimeQuirks>();
     }
 
 private:
@@ -222,7 +234,7 @@ auto mir::graphics::atomic::Quirks::require_modesetting_support(mir::udev::Devic
     }
 }
 auto mir::graphics::atomic::Quirks::runtime_quirks_for(udev::Device const& device)
-    -> std::optional<std::shared_ptr<RuntimeQuirks>>
+    -> std::shared_ptr<RuntimeQuirks>
 {
     return impl->runtime_quirks_for(device);
 }

--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -104,16 +104,7 @@ public:
     {
         auto const devnode = value_or(device.devnode(), "");
         auto const parent_device = device.parent();
-        auto const driver =
-            [&]()
-            {
-                if (parent_device)
-                {
-                    return value_or(parent_device->driver(), "");
-                }
-                mir::log_warning("udev device has no parent! Unable to determine driver for quirks.");
-                return "<UNKNOWN>";
-            }();
+        auto const driver = get_device_driver(parent_device.get());
         mir::log_debug("Quirks: checking device with devnode: %s, driver %s", device.devnode(), driver);
         bool const should_skip_driver = drivers_to_skip.count(driver);
         bool const should_skip_devnode = devnodes_to_skip.count(devnode);
@@ -132,16 +123,7 @@ public:
     {
         auto const devnode = value_or(device.devnode(), "");
         auto const parent_device = device.parent();
-        auto const driver =
-            [&]()
-            {
-                if (parent_device)
-                {
-                    return value_or(parent_device->driver(), "");
-                }
-                mir::log_warning("udev device has no parent! Unable to determine driver for quirks.");
-                return "<UNKNOWN>";
-            }();
+        auto const driver = get_device_driver(parent_device.get());
         mir::log_debug("Quirks: checking device with devnode: %s, driver %s", device.devnode(), driver);
 
         bool const should_skip_modesetting_support = skip_modesetting_support.count(driver);
@@ -153,6 +135,16 @@ public:
     }
 
 private:
+    auto get_device_driver(mir::udev::Device const* parent_device) const -> const char*
+    {
+        if (parent_device)
+        {
+            return value_or(parent_device->driver(), "");
+        }
+        mir::log_warning("udev device has no parent! Unable to determine driver for quirks.");
+        return "<UNKNOWN>";
+    }
+
     /* AST is a simple 2D output device, built into some motherboards.
      * They do not have any 3D engine associated, so were quirked off to avoid https://github.com/canonical/mir/issues/2678
      *

--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -20,6 +20,7 @@
 #include "mir/options/option.h"
 #include "mir/udev/wrapper.h"
 
+
 #include <vector>
 #include <unordered_set>
 
@@ -141,13 +142,13 @@ public:
         {
             class NvidiaGbmQuirks : public GbmQuirks
             {
-                auto adjust_gbm_create_surface_flags(uint32_t) -> uint32_t override
+                auto gbm_create_surface_flags() const -> uint32_t override
                 {
                     return 0;
                 }
-                auto gbm_surface_has_free_buffers_broken() -> bool override
+                auto gbm_surface_has_free_buffers(gbm_surface*) const -> int override
                 {
-                    return true;
+                    return 1;
                 }
             };
 
@@ -156,13 +157,13 @@ public:
 
         class DefaultGbmQuirks : public GbmQuirks
         {
-            auto adjust_gbm_create_surface_flags(uint32_t flags) -> uint32_t override
+            auto gbm_create_surface_flags() const -> uint32_t override
             {
-                return flags;
+                return GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT;
             }
-            auto gbm_surface_has_free_buffers_broken() -> bool override
+            auto gbm_surface_has_free_buffers(gbm_surface* gbm_surface) const -> int override
             {
-                return false;
+                return ::gbm_surface_has_free_buffers(gbm_surface);
             }
         };
 

--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -134,12 +134,12 @@ public:
         return !should_skip_modesetting_support;
     }
 
-    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<GbmWorkarounds>
+    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<GbmQuirks>
     {
         auto const driver = get_device_driver(device.parent().get());
         if(std::strcmp(driver, "nvidia") == 0)
         {
-            class NvidiaGbmWorkarounds : public GbmWorkarounds
+            class NvidiaGbmQuirks : public GbmQuirks
             {
                 auto adjust_gbm_create_surface_flags(uint32_t) -> uint32_t override
                 {
@@ -151,10 +151,10 @@ public:
                 }
             };
 
-            return std::make_shared<NvidiaGbmWorkarounds>();
+            return std::make_shared<NvidiaGbmQuirks>();
         }
 
-        class DefaultGbmWorkarounds : public GbmWorkarounds
+        class DefaultGbmQuirks : public GbmQuirks
         {
             auto adjust_gbm_create_surface_flags(uint32_t flags) -> uint32_t override
             {
@@ -166,7 +166,7 @@ public:
             }
         };
 
-        return std::make_shared<DefaultGbmWorkarounds>();
+        return std::make_shared<DefaultGbmQuirks>();
     }
 
 private:
@@ -234,7 +234,7 @@ auto mir::graphics::atomic::Quirks::require_modesetting_support(mir::udev::Devic
     }
 }
 auto mir::graphics::atomic::Quirks::runtime_quirks_for(udev::Device const& device)
-    -> std::shared_ptr<GbmWorkarounds>
+    -> std::shared_ptr<GbmQuirks>
 {
     return impl->runtime_quirks_for(device);
 }

--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -134,12 +134,12 @@ public:
         return !should_skip_modesetting_support;
     }
 
-    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<RuntimeQuirks>
+    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<GbmWorkarounds>
     {
         auto const driver = get_device_driver(device.parent().get());
         if(std::strcmp(driver, "nvidia") == 0)
         {
-            class NvidiaRuntimeQuirks : public RuntimeQuirks
+            class NvidiaGbmWorkarounds : public GbmWorkarounds
             {
                 auto gbm_create_surface_flags_broken() -> bool override
                 {
@@ -154,7 +154,7 @@ public:
             return std::make_shared<NvidiaRuntimeQuirks>();
         }
 
-        class DefaultRuntimeQuirks : public RuntimeQuirks
+        class DefaultGbmWorkarounds : public GbmWorkarounds
         {
             auto gbm_create_surface_flags_broken() -> bool override
             {
@@ -234,7 +234,7 @@ auto mir::graphics::atomic::Quirks::require_modesetting_support(mir::udev::Devic
     }
 }
 auto mir::graphics::atomic::Quirks::runtime_quirks_for(udev::Device const& device)
-    -> std::shared_ptr<RuntimeQuirks>
+    -> std::shared_ptr<GbmWorkarounds>
 {
     return impl->runtime_quirks_for(device);
 }

--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -141,9 +141,9 @@ public:
         {
             class NvidiaGbmWorkarounds : public GbmWorkarounds
             {
-                auto gbm_create_surface_flags_broken() -> bool override
+                auto adjust_gbm_create_surface_flags(uint32_t) -> uint32_t override
                 {
-                    return true;
+                    return 0;
                 }
                 auto gbm_surface_has_free_buffers_broken() -> bool override
                 {
@@ -151,14 +151,14 @@ public:
                 }
             };
 
-            return std::make_shared<NvidiaRuntimeQuirks>();
+            return std::make_shared<NvidiaGbmWorkarounds>();
         }
 
         class DefaultGbmWorkarounds : public GbmWorkarounds
         {
-            auto gbm_create_surface_flags_broken() -> bool override
+            auto adjust_gbm_create_surface_flags(uint32_t flags) -> uint32_t override
             {
-                return false;
+                return flags;
             }
             auto gbm_surface_has_free_buffers_broken() -> bool override
             {
@@ -166,7 +166,7 @@ public:
             }
         };
 
-        return std::make_shared<DefaultRuntimeQuirks>();
+        return std::make_shared<DefaultGbmWorkarounds>();
     }
 
 private:

--- a/src/platforms/atomic-kms/server/kms/quirks.h
+++ b/src/platforms/atomic-kms/server/kms/quirks.h
@@ -33,10 +33,10 @@ class Device;
 
 namespace graphics::atomic
 {
-class RuntimeQuirks
+class GbmWorkarounds
 {
 public:
-    virtual ~RuntimeQuirks() = default;
+    virtual ~GbmWorkarounds() = default;
     virtual auto gbm_create_surface_flags_broken() -> bool = 0;
     virtual auto gbm_surface_has_free_buffers_broken() -> bool = 0;
 };
@@ -65,7 +65,7 @@ public:
     static void add_quirks_option(boost::program_options::options_description& config);
 
     [[nodiscard]]
-    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<RuntimeQuirks>;
+    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<GbmWorkarounds>;
 
 private:
     class Impl;

--- a/src/platforms/atomic-kms/server/kms/quirks.h
+++ b/src/platforms/atomic-kms/server/kms/quirks.h
@@ -37,7 +37,7 @@ class GbmWorkarounds
 {
 public:
     virtual ~GbmWorkarounds() = default;
-    virtual auto gbm_create_surface_flags_broken() -> bool = 0;
+    virtual auto adjust_gbm_create_surface_flags(uint32_t) -> uint32_t = 0;
     virtual auto gbm_surface_has_free_buffers_broken() -> bool = 0;
 };
 

--- a/src/platforms/atomic-kms/server/kms/quirks.h
+++ b/src/platforms/atomic-kms/server/kms/quirks.h
@@ -65,7 +65,7 @@ public:
     static void add_quirks_option(boost::program_options::options_description& config);
 
     [[nodiscard]]
-    auto runtime_quirks_for(udev::Device const& device) -> std::optional<std::shared_ptr<RuntimeQuirks>>;
+    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<RuntimeQuirks>;
 
 private:
     class Impl;

--- a/src/platforms/atomic-kms/server/kms/quirks.h
+++ b/src/platforms/atomic-kms/server/kms/quirks.h
@@ -20,6 +20,8 @@
 #include <memory>
 #include <boost/program_options.hpp>
 
+#include <gbm.h>
+
 namespace mir
 {
 namespace options
@@ -37,8 +39,8 @@ class GbmQuirks
 {
 public:
     virtual ~GbmQuirks() = default;
-    virtual auto adjust_gbm_create_surface_flags(uint32_t) -> uint32_t = 0;
-    virtual auto gbm_surface_has_free_buffers_broken() -> bool = 0;
+    virtual auto gbm_create_surface_flags() const -> uint32_t = 0;
+    virtual auto gbm_surface_has_free_buffers(gbm_surface* gbm_surface) const -> int = 0;
 };
 
 /**

--- a/src/platforms/atomic-kms/server/kms/quirks.h
+++ b/src/platforms/atomic-kms/server/kms/quirks.h
@@ -33,6 +33,14 @@ class Device;
 
 namespace graphics::atomic
 {
+class RuntimeQuirks
+{
+public:
+    virtual ~RuntimeQuirks() = default;
+    virtual auto gbm_create_surface_flags_broken() -> bool = 0;
+    virtual auto gbm_surface_has_free_buffers_broken() -> bool = 0;
+};
+
 /**
  * Interface for querying device-specific quirks
  */
@@ -55,6 +63,9 @@ public:
     auto require_modesetting_support(udev::Device const& device) const -> bool;
 
     static void add_quirks_option(boost::program_options::options_description& config);
+
+    [[nodiscard]]
+    auto runtime_quirks_for(udev::Device const& device) -> std::optional<std::shared_ptr<RuntimeQuirks>>;
 
 private:
     class Impl;

--- a/src/platforms/atomic-kms/server/kms/quirks.h
+++ b/src/platforms/atomic-kms/server/kms/quirks.h
@@ -33,10 +33,10 @@ class Device;
 
 namespace graphics::atomic
 {
-class GbmWorkarounds
+class GbmQuirks
 {
 public:
-    virtual ~GbmWorkarounds() = default;
+    virtual ~GbmQuirks() = default;
     virtual auto adjust_gbm_create_surface_flags(uint32_t) -> uint32_t = 0;
     virtual auto gbm_surface_has_free_buffers_broken() -> bool = 0;
 };
@@ -65,7 +65,7 @@ public:
     static void add_quirks_option(boost::program_options::options_description& config);
 
     [[nodiscard]]
-    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<GbmWorkarounds>;
+    auto runtime_quirks_for(udev::Device const& device) -> std::shared_ptr<GbmQuirks>;
 
 private:
     class Impl;

--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -163,7 +163,7 @@ private:
      * https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084046
      * https://github.com/canonical/mir/issues/3710
      */
-    std::unordered_set<std::string> drivers_to_skip = { "nvidia", "ast", "simple-framebuffer"};
+    std::unordered_set<std::string> drivers_to_skip = {"ast", "simple-framebuffer"};
     std::unordered_set<std::string> devnodes_to_skip;
     // We know this is currently useful for virtio_gpu, vc4-drm and v3d
     std::unordered_set<std::string> skip_modesetting_support = { "virtio_gpu", "vc4-drm", "v3d" };

--- a/tests/unit-tests/graphics/test_platform_prober.cpp
+++ b/tests/unit-tests/graphics/test_platform_prober.cpp
@@ -1078,7 +1078,7 @@ TEST_F(FullProbeStack, manually_selecting_only_virtual_platform_with_required_op
     EXPECT_THAT(devices.front(), Pair(_, ModuleNameMatches(StrEq("mir:virtual"))));
 }
 
-TEST_F(FullProbeStack, gbm_kms_is_not_selected_for_nvidia_driver_by_default)
+TEST_F(FullProbeStack, gbm_kms_is_selected_for_nvidia_driver_by_default)
 {
     using namespace testing;
 
@@ -1099,7 +1099,8 @@ TEST_F(FullProbeStack, gbm_kms_is_not_selected_for_nvidia_driver_by_default)
 
     EXPECT_THAT(devices, UnorderedElementsAre(
         Pair(IsPlatformForDevice(nouveau_device.get()), ModuleNameMatches(StrEq("mir:gbm-kms"))),
-        Pair(IsPlatformForDevice(amd_device.get()), ModuleNameMatches(StrEq("mir:gbm-kms")))
+        Pair(IsPlatformForDevice(amd_device.get()), ModuleNameMatches(StrEq("mir:gbm-kms"))),
+        Pair(IsPlatformForDevice(nvidia_device.get()), ModuleNameMatches(StrEq("mir:gbm-kms")))
         ));
 }
 


### PR DESCRIPTION
# What's new
What the title says. Still not thoroughly tested (how??)

# How to test:
If you have an nVidia GPU, run mir with 
```
--platform-display-libs=mir:atomic-kms --platform-rendering-libs=mir:gbm-kms
```

Additionally, if you have an extra GPU or an integrated GPU, make sure to add 
```
--driver-quirks=skip:driver:<your other gpu's driver> 
```

At the moment, it launches fine, terminal launches fine, and glmark2-wayland launches and runs fine (have not tried running it to completion)