### PR TITLE
RFC/live-config-prototype

### DIFF
--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -134,9 +134,9 @@ public:
     using HandleString = std::function<void(std::string_view key, std::optional<std::string_view> value)>;
     using HandleDone = std::function<void()>;
 
-    virtual void add_attribute(std::string_view key, HandleInt handler) = 0;
-    virtual void add_attribute(std::string_view key, HandleFloat handler) = 0;
-    virtual void add_attribute(std::string_view key, HandleString handler) = 0;
+    virtual void add_int_attribute(std::string_view key, HandleInt handler) = 0;
+    virtual void add_float_attribute(std::string_view key, HandleFloat handler) = 0;
+    virtual void add_string_attribute(std::string_view key, HandleString handler) = 0;
 
     /// Called following a set of related updates (e.g. a file reload) to allow
     /// multiple attributes to be updated transactionally
@@ -167,9 +167,9 @@ public:
         cursor_scale(server);
     }
 
-    void add_attribute(std::string_view key, HandleInt handler) override;
-    void add_attribute(std::string_view key, HandleFloat handler) override;
-    void add_attribute(std::string_view key, HandleString handler) override;
+    void add_int_attribute(std::string_view key, HandleInt handler) override;
+    void add_float_attribute(std::string_view key, HandleFloat handler) override;
+    void add_string_attribute(std::string_view key, HandleString handler) override;
     void on_done(HandleDone handler) override;
 
 private:
@@ -241,9 +241,9 @@ void DemoConfigFile::on_done(HandleDone handler)
     done_handlers.emplace_back(std::move(handler));
 }
 
-void DemoConfigFile::add_attribute(std::string_view key, HandleInt handler)
+void DemoConfigFile::add_int_attribute(std::string_view key, HandleInt handler)
 {
-    add_attribute(key, [handler](std::string_view key, std::optional<std::string_view> val)
+    add_string_attribute(key, [handler](std::string_view key, std::optional<std::string_view> val)
     {
         if (val)
         {
@@ -271,9 +271,9 @@ void DemoConfigFile::add_attribute(std::string_view key, HandleInt handler)
     });
 }
 
-void DemoConfigFile::add_attribute(std::string_view key, HandleFloat handler)
+void DemoConfigFile::add_float_attribute(std::string_view key, HandleFloat handler)
 {
-    add_attribute(key, [handler](std::string_view key, std::optional<std::string_view> val)
+    add_string_attribute(key, [handler](std::string_view key, std::optional<std::string_view> val)
     {
         if (val)
         {
@@ -301,7 +301,7 @@ void DemoConfigFile::add_attribute(std::string_view key, HandleFloat handler)
     });
 }
 
-void DemoConfigFile::add_attribute(std::string_view key, HandleString handler)
+void DemoConfigFile::add_string_attribute(std::string_view key, HandleString handler)
 {
     std::lock_guard lock{config_mutex};
     attribute_handlers[std::string{key}] = handler;
@@ -312,7 +312,7 @@ struct OutputFilter : miral::OutputFilter
 {
     explicit OutputFilter(AttributeHandler& config_handler)
     {
-        config_handler.add_attribute("output_filter",
+        config_handler.add_string_attribute("output_filter",
             [this](std::string_view key, std::optional<std::string_view> val)
             {
                 MirOutputFilter new_filter = mir_output_filter_none;
@@ -349,7 +349,7 @@ struct InputConfiguration : miral::InputConfiguration
 
     explicit InputConfiguration(AttributeHandler& config_handler) : miral::InputConfiguration{}
     {
-        config_handler.add_attribute("pointer_handedness",
+        config_handler.add_string_attribute("pointer_handedness",
             [this](std::string_view key, std::optional<std::string_view> val)
             {
                 if (val)
@@ -367,7 +367,7 @@ struct InputConfiguration : miral::InputConfiguration
                 }
             });
 
-        config_handler.add_attribute("touchpad_scroll_mode",
+        config_handler.add_string_attribute("touchpad_scroll_mode",
             [this](std::string_view key, std::optional<std::string_view> val)
             {
                 if (val)
@@ -389,7 +389,7 @@ struct InputConfiguration : miral::InputConfiguration
                 }
             });
 
-        config_handler.add_attribute("repeat_rate", AttributeHandler::HandleInt{
+        config_handler.add_int_attribute("repeat_rate",
             [this](std::string_view key, std::optional<int> val)
             {
                 if (val)
@@ -405,9 +405,9 @@ struct InputConfiguration : miral::InputConfiguration
                             key.data(), *val);
                     }
                 }
-            }});
+            });
 
-        config_handler.add_attribute("repeat_delay", AttributeHandler::HandleInt{
+        config_handler.add_int_attribute("repeat_delay",
             [this](std::string_view key, std::optional<int> val)
             {
                 if (val)
@@ -423,7 +423,7 @@ struct InputConfiguration : miral::InputConfiguration
                             key.data(), *val);
                     }
                 }
-            }});
+            });
 
         config_handler.on_done([this]
         {

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -122,7 +122,12 @@ class ConfigurationKey
 {
 public:
     ConfigurationKey(std::initializer_list<std::string_view> key) :
-        self(std::make_unique<State>(key))
+        self{std::make_unique<State>(key)}
+    {
+    }
+
+    ConfigurationKey(std::initializer_list<std::string_view> key, std::string_view description) :
+        self{std::make_unique<State>(key, description)}
     {
     }
 
@@ -136,15 +141,26 @@ public:
         return self->key;
     }
 
+    auto description() const -> std::optional<std::string>
+    {
+        return self->description;
+    }
+
 private:
     struct State
     {
         std::vector<std::string> const path;
-        std::string const key;
+        std::string const key{to_string()};
+        std::optional<std::string> const description;
 
         State(std::initializer_list<std::string_view> key) :
+            path{key.begin(), key.end()}
+        {
+        }
+
+        State(std::initializer_list<std::string_view> key, std::string_view description) :
             path{key.begin(), key.end()},
-            key{to_string()}
+            description{description}
         {
         }
 

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -343,9 +343,23 @@ struct OutputFilter : miral::OutputFilter
 // Struct for illustrative purposes, this would be rolled into miral::InputConfiguration
 struct InputConfiguration : miral::InputConfiguration
 {
-    miral::InputConfiguration::Mouse mouse_ = mouse();
-    miral::InputConfiguration::Touchpad touchpad_ = touchpad();
-    miral::InputConfiguration::Keyboard keyboard_ = keyboard();
+    struct State
+    {
+        State(miral::InputConfiguration::Mouse mouse,
+        miral::InputConfiguration::Touchpad touchpad,
+        miral::InputConfiguration::Keyboard keyboard) :
+        mouse{mouse},
+        touchpad{touchpad},
+        keyboard{keyboard}
+        {}
+
+        std::mutex mutex;
+        miral::InputConfiguration::Mouse mouse;
+        miral::InputConfiguration::Touchpad touchpad;
+        miral::InputConfiguration::Keyboard keyboard;
+    };
+
+    std::shared_ptr<State> const state = std::make_shared<State>(mouse(), touchpad(), keyboard());
 
     explicit InputConfiguration(AttributeHandler& config_handler) : miral::InputConfiguration{}
     {
@@ -354,11 +368,12 @@ struct InputConfiguration : miral::InputConfiguration
             {
                 if (val)
                 {
+                    std::lock_guard lock{state->mutex};
                     auto const& value = *val;
                     if (value == "right")
-                        mouse_.handedness(mir_pointer_handedness_right);
+                        state->mouse.handedness(mir_pointer_handedness_right);
                     else if (value == "left")
-                        mouse_.handedness(mir_pointer_handedness_left);
+                        state->mouse.handedness(mir_pointer_handedness_left);
                     else
                         mir::log_warning(
                             "Config key '%s' has invalid value: %s",
@@ -372,15 +387,16 @@ struct InputConfiguration : miral::InputConfiguration
             {
                 if (val)
                 {
+                    std::lock_guard lock{state->mutex};
                     auto const& value = *val;
                     if (value == "none")
-                        touchpad_.scroll_mode(mir_touchpad_scroll_mode_none);
+                        state->touchpad.scroll_mode(mir_touchpad_scroll_mode_none);
                     else if (value == "two_finger_scroll")
-                        touchpad_.scroll_mode(mir_touchpad_scroll_mode_two_finger_scroll);
+                        state->touchpad.scroll_mode(mir_touchpad_scroll_mode_two_finger_scroll);
                     else if (value == "edge_scroll")
-                        touchpad_.scroll_mode(mir_touchpad_scroll_mode_edge_scroll);
+                        state->touchpad.scroll_mode(mir_touchpad_scroll_mode_edge_scroll);
                     else if (value == "button_down_scroll")
-                        touchpad_.scroll_mode(mir_touchpad_scroll_mode_button_down_scroll);
+                        state->touchpad.scroll_mode(mir_touchpad_scroll_mode_button_down_scroll);
                     else
                         mir::log_warning(
                             "Config key '%s' has invalid value: %s",
@@ -396,7 +412,8 @@ struct InputConfiguration : miral::InputConfiguration
                 {
                     if (val >= 0)
                     {
-                        keyboard_.set_repeat_rate(*val);
+                        std::lock_guard lock{state->mutex};
+                        state->keyboard.set_repeat_rate(*val);
                     }
                     else
                     {
@@ -414,7 +431,8 @@ struct InputConfiguration : miral::InputConfiguration
                 {
                     if (val >= 0)
                     {
-                        keyboard_.set_repeat_delay(*val);
+                        std::lock_guard lock{state->mutex};
+                        state->keyboard.set_repeat_delay(*val);
                     }
                     else
                     {
@@ -427,10 +445,25 @@ struct InputConfiguration : miral::InputConfiguration
 
         config_handler.on_done([this]
         {
-            mouse(mouse_);
-            touchpad(touchpad_);
-            keyboard(keyboard_);
+            std::lock_guard lock{state->mutex};
+            mouse(state->mouse);
+            touchpad(state->touchpad);
+            keyboard(state->keyboard);
         });
+    }
+
+    void start_callback()
+    {
+        // Merge the input options collected from the command line,
+        // environment, and default `.config` file with the options we
+        // read from the `.input` file.
+        //
+        // In this case, the `.input` file takes precedence. You can
+        // reverse the arguments to de-prioritize it.
+        std::lock_guard lock{state->mutex};
+        state->mouse.merge(mouse());
+        state->keyboard.merge(keyboard());
+        state->touchpad.merge(touchpad());
     }
 };
 }
@@ -445,6 +478,7 @@ try
 
     OutputFilter output_filter{demo_configuration};
     InputConfiguration input_configuration{demo_configuration};
+    runner.add_start_callback([&input_configuration] { input_configuration.start_callback(); });
 
     std::function<void()> shutdown_hook{[]{}};
     runner.add_stop_callback([&] { shutdown_hook(); });


### PR DESCRIPTION
*This is not ready to merge*

I am looking for feedback before fixing this approach as an API.

* Is this doing what folks expect?
* Do the names make sense?

Proposal:  we need something like the `AttributeHandler` interface introduced to miral. This will allow miral types that support "live configuration" to register the attributes they support without knowing the configuration engine that supports these attributes.

I've illustrated this with extensions:

* `OutputFilter : miral::OutputFilter`;
* `InputConfiguration : miral::InputConfiguration`;  and,
* `CursorScale : miral::CursorScale`

These show the logic that would need to be added to these classes (via an additional constructor?) 

As a POC I've reworked the `mir_demo_server` `DemoConfigFile` on this basis, and extended the types it was already supporting to provide the existing functionality.

I've not tried to illustrate use with a YAML, or a gsettings backend, but these should be tractable. For these the `AttributeHandler` supplied would know any additional context needed (such as the node on which these attributes exist)