### PR TITLE
Add the software renderable cursor overlays to their own list

### DIFF
--- a/src/include/server/mir/input/scene.h
+++ b/src/include/server/mir/input/scene.h
@@ -48,10 +48,16 @@ public:
     virtual void remove_observer(std::weak_ptr<scene::Observer> const& observer) = 0;
 
     // An interface which the input stack can use to add certain non-interactive input visualizations
-    // in to the scene (i.e. cursors, touchspots). Overlay renderables will be rendered above all surfaces.
+    // in to the scene (i.e. touchspots). Overlay renderables will be rendered above all surfaces.
     // Within the set of overlay renderables, rendering order is undefined.
     virtual void add_input_visualization(std::shared_ptr<graphics::Renderable> const& overlay) = 0;
     virtual void remove_input_visualization(std::weak_ptr<graphics::Renderable> const& overlay) = 0;
+
+    /// An interface for adding a cursor renderable to the scene. The cursor is guaranteed to appear
+    /// above any other input visualization. Callers may add multiple cursors, primarily to avoid
+    /// any visual blips. Within the set of cursors, rendering or is undefined.
+    virtual void add_cursor(std::shared_ptr<graphics::Renderable> const& cursor) = 0;
+    virtual void remove_cursor(std::weak_ptr<graphics::Renderable> const& cursor) = 0;
     
     // As input visualizations added through the overlay system will not use the standard SurfaceObserver
     // mechanism, we require this method to trigger recomposition.

--- a/src/server/graphics/software_cursor.cpp
+++ b/src/server/graphics/software_cursor.cpp
@@ -167,11 +167,11 @@ void mg::SoftwareCursor::show(std::shared_ptr<CursorImage> const& cursor_image)
         [scene = scene, to_remove = to_remove, to_add = renderable]()
         {
             // Add the new renderable first, then remove the old one to avoid visual glitches
-            scene->add_input_visualization(to_add);
+            scene->add_cursor(to_add);
 
             if (to_remove)
             {
-                scene->remove_input_visualization(to_remove);
+                scene->remove_cursor(to_remove);
             }
         });
 }

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -174,6 +174,10 @@ mc::SceneElementSequence ms::SurfaceStack::scene_elements_for(mc::CompositorID i
     {
         elements.emplace_back(std::make_shared<OverlaySceneElement>(renderable));
     }
+    for (auto const& cursor : cursors)
+    {
+        elements.emplace_back(std::make_shared<OverlaySceneElement>(cursor));
+    }
     return elements;
 }
 
@@ -217,6 +221,33 @@ void ms::SurfaceStack::remove_input_visualization(
             BOOST_THROW_EXCEPTION(std::runtime_error("Attempt to remove an overlay which was never added or which has been previously removed"));
         }
         overlays.erase(p);
+    }
+
+    emit_scene_changed();
+}
+
+void ms::SurfaceStack::add_cursor(
+    std::shared_ptr<mg::Renderable> const& cursor)
+{
+    {
+        RecursiveWriteLock lg(guard);
+        cursors.push_back(cursor);
+    }
+    emit_scene_changed();
+}
+
+void ms::SurfaceStack::remove_cursor(
+    std::weak_ptr<mg::Renderable> const& weak_cursor)
+{
+    auto cursor = weak_cursor.lock();
+    {
+        RecursiveWriteLock lg(guard);
+        auto const p = std::find(cursors.begin(), cursors.end(), cursor);
+        if (p == cursors.end())
+        {
+            BOOST_THROW_EXCEPTION(std::runtime_error("Attempt to remove a cursor which was never added or which has been previously removed"));
+        }
+        cursors.erase(p);
     }
 
     emit_scene_changed();

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -120,6 +120,9 @@ public:
     void add_input_visualization(std::shared_ptr<graphics::Renderable> const& overlay) override;
     void remove_input_visualization(std::weak_ptr<graphics::Renderable> const& overlay) override;
 
+    void add_cursor(std::shared_ptr<graphics::Renderable> const& cursor) override;
+    void remove_cursor(std::weak_ptr<graphics::Renderable> const& cursor) override;
+
     void emit_scene_changed() override;
     void lock() override;
     void unlock() override;
@@ -158,6 +161,7 @@ private:
     std::set<compositor::CompositorID> registered_compositors;
 
     std::vector<std::shared_ptr<graphics::Renderable>> overlays;
+    std::vector<std::shared_ptr<graphics::Renderable>> cursors;
 
     Observers observers;
     /// If not expired the screen is locked (and only surfaces that appear on the lock screen should be shown)

--- a/tests/include/mir/test/doubles/stub_input_scene.h
+++ b/tests/include/mir/test/doubles/stub_input_scene.h
@@ -45,6 +45,13 @@ class StubInputScene : public input::Scene
     void remove_input_visualization(std::weak_ptr<graphics::Renderable> const& /* overlay */) override
     {
     }
+
+    void add_cursor(std::shared_ptr<graphics::Renderable> const& /* cursor */) override
+    {
+    }
+    void remove_cursor(std::weak_ptr<graphics::Renderable> const& /* cursor */) override
+    {
+    }
     
     void emit_scene_changed() override
     {

--- a/tests/unit-tests/graphics/test_software_cursor.cpp
+++ b/tests/unit-tests/graphics/test_software_cursor.cpp
@@ -40,10 +40,10 @@ namespace
 
 struct MockInputScene : mtd::StubInputScene
 {
-    MOCK_METHOD1(add_input_visualization,
+    MOCK_METHOD1(add_cursor,
                  void(std::shared_ptr<mg::Renderable> const&));
 
-    MOCK_METHOD1(remove_input_visualization,
+    MOCK_METHOD1(remove_cursor,
                  void(std::weak_ptr<mg::Renderable> const&));
 
     MOCK_METHOD0(emit_scene_changed, void());
@@ -172,7 +172,7 @@ TEST_F(SoftwareCursor, is_added_to_scene_when_shown)
 {
     using namespace testing;
 
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_));
+    EXPECT_CALL(mock_input_scene, add_cursor(_));
 
     cursor.show(stub_cursor_image);
 }
@@ -182,12 +182,12 @@ TEST_F(SoftwareCursor, tolerates_being_hidden_while_being_shown)
     using namespace testing;
 
     InSequence s;
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_))
+    EXPECT_CALL(mock_input_scene, add_cursor(_))
         .WillOnce(Invoke([&](auto)
             {
                 cursor.hide();
             }));
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_)).Times(AnyNumber());
+    EXPECT_CALL(mock_input_scene, remove_cursor(_)).Times(AnyNumber());
 
     cursor.show(stub_cursor_image);
     executor.execute();
@@ -200,14 +200,14 @@ TEST_F(SoftwareCursor, tolerates_being_hidden_while_being_reshown)
     using namespace testing;
 
     InSequence s;
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_));
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_));
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_))
+    EXPECT_CALL(mock_input_scene, add_cursor(_));
+    EXPECT_CALL(mock_input_scene, remove_cursor(_));
+    EXPECT_CALL(mock_input_scene, add_cursor(_))
         .WillOnce(Invoke([&](auto)
             {
                 cursor.hide();
             }));
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_)).Times(AnyNumber());
+    EXPECT_CALL(mock_input_scene, remove_cursor(_)).Times(AnyNumber());
 
     cursor.show(stub_cursor_image);
     executor.execute();
@@ -224,8 +224,8 @@ TEST_F(SoftwareCursor, is_removed_from_scene_when_hidden)
     using namespace testing;
 
     InSequence s;
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_));
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_));
+    EXPECT_CALL(mock_input_scene, add_cursor(_));
+    EXPECT_CALL(mock_input_scene, remove_cursor(_));
 
     cursor.show(stub_cursor_image);
     executor.execute();
@@ -240,7 +240,7 @@ TEST_F(SoftwareCursor, renderable_has_cursor_size)
     using namespace testing;
 
     EXPECT_CALL(mock_input_scene,
-                add_input_visualization(
+                add_cursor(
                     RenderableWithSize(stub_cursor_image->size())));
 
     cursor.show(stub_cursor_image);
@@ -253,7 +253,7 @@ TEST_F(SoftwareCursor, places_renderable_at_origin_offset_by_hotspot)
     auto const pos = geom::Point{0,0} - stub_cursor_image->hotspot();
 
     EXPECT_CALL(mock_input_scene,
-                add_input_visualization(RenderableWithPosition(pos)));
+                add_cursor(RenderableWithPosition(pos)));
 
     cursor.show(stub_cursor_image);
 }
@@ -264,7 +264,7 @@ TEST_F(SoftwareCursor, moves_scene_renderable_offset_by_hotspot_when_moved)
 
     std::shared_ptr<mg::Renderable> cursor_renderable;
 
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_))
+    EXPECT_CALL(mock_input_scene, add_cursor(_))
         .WillOnce(SaveArg<0>(&cursor_renderable));
 
     cursor.show(stub_cursor_image);
@@ -301,7 +301,7 @@ TEST_F(SoftwareCursor, creates_renderable_with_filled_buffer)
 
     std::shared_ptr<mg::Renderable> cursor_renderable;
 
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_)).
+    EXPECT_CALL(mock_input_scene, add_cursor(_)).
         WillOnce(SaveArg<0>(&cursor_renderable));
 
     cursor.show(stub_cursor_image);
@@ -316,7 +316,7 @@ TEST_F(SoftwareCursor, does_not_hide_or_move_when_already_hidden)
 {
     using namespace testing;
 
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_)).Times(0);
+    EXPECT_CALL(mock_input_scene, remove_cursor(_)).Times(0);
     EXPECT_CALL(mock_input_scene, emit_scene_changed()).Times(0);
 
     // Already hidden, nothing should happen
@@ -332,7 +332,7 @@ TEST_F(SoftwareCursor, creates_new_renderable_for_new_cursor_image)
 
     std::shared_ptr<mg::Renderable> first_cursor_renderable;
 
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_)).
+    EXPECT_CALL(mock_input_scene, add_cursor(_)).
         WillOnce(SaveArg<0>(&first_cursor_renderable));
 
     cursor.show(stub_cursor_image);
@@ -341,8 +341,8 @@ TEST_F(SoftwareCursor, creates_new_renderable_for_new_cursor_image)
     Mock::VerifyAndClearExpectations(&mock_input_scene);
 
     EXPECT_CALL(mock_input_scene,
-                remove_input_visualization(WeakPtrEq(first_cursor_renderable)));
-    EXPECT_CALL(mock_input_scene, add_input_visualization(Ne(first_cursor_renderable)));
+                remove_cursor(WeakPtrEq(first_cursor_renderable)));
+    EXPECT_CALL(mock_input_scene, add_cursor(Ne(first_cursor_renderable)));
 
     cursor.show(another_stub_cursor_image);
     executor.execute();
@@ -366,7 +366,7 @@ TEST_F(SoftwareCursor, places_new_cursor_renderable_at_correct_position)
     auto const renderable_position =
         cursor_position - another_stub_cursor_image->hotspot();
     EXPECT_CALL(mock_input_scene,
-                add_input_visualization(RenderableWithPosition(renderable_position)));
+                add_cursor(RenderableWithPosition(renderable_position)));
 
     cursor.show(another_stub_cursor_image);
 }
@@ -391,11 +391,11 @@ TEST_F(SoftwareCursor, doesnt_try_to_remove_after_hiding)
     using namespace testing;
 
     Sequence seq;
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_))
+    EXPECT_CALL(mock_input_scene, add_cursor(_))
         .InSequence(seq);
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_))
+    EXPECT_CALL(mock_input_scene, remove_cursor(_))
         .InSequence(seq);
-    EXPECT_CALL(mock_input_scene, add_input_visualization(_))
+    EXPECT_CALL(mock_input_scene, add_cursor(_))
         .InSequence(seq);
     cursor.show(stub_cursor_image);
     executor.execute();


### PR DESCRIPTION
## Why?
As part of the magnification work, I'm going to need to make it so that the `BasicScreenShooter` can selectively not render the cursor (also per the [wlr screencopy protocol](https://wayland.app/protocols/wlr-screencopy-unstable-v1#zwlr_screencopy_manager_v1:request:capture_output)). To do this, we need to develop a better understanding of what is a cursor and what isn't a cursor. I will then open up a follow up PR where we tell the scene "hey, I want everything except the cursors". We will also want a way to temporarily add a software cursor to the render in the event that we have a hardware cursor. Fun stuff :smile: 

ALSO - cursors should not be obfuscated by other overlays (e.g. touchspots), so it makes sense to put it on its own layer. The user pretty much always wants to see the cursor.

## What's new?
- Add `mi::Scene::add_cursor` and `mi::Scene::remove_cursor`
- Added them to the scene at the appropriate time
- Updated the tests