### PR TITLE
Expose the cursor's renerable via Cursor::renderable and access it in the compositor itself instead of the scene

### DIFF
--- a/include/platform/mir/graphics/cursor.h
+++ b/include/platform/mir/graphics/cursor.h
@@ -20,6 +20,7 @@
 
 #include "mir/geometry/size.h"
 #include "mir/geometry/point.h"
+#include "mir/graphics/renderable.h"
 
 #include <memory>
 
@@ -28,6 +29,7 @@ namespace mir
 namespace graphics
 {
 class CursorImage;
+class Renderable;
 class Cursor
 {
 public:
@@ -37,6 +39,8 @@ public:
     virtual void move_to(geometry::Point position) = 0;
 
     virtual void scale(float new_scale) = 0;
+
+    virtual auto renderable() -> std::shared_ptr<Renderable> = 0;
 protected:
     Cursor() = default;
     virtual ~Cursor() = default;

--- a/include/test/mir/test/doubles/stub_cursor.h
+++ b/include/test/mir/test/doubles/stub_cursor.h
@@ -33,6 +33,7 @@ struct StubCursor : public graphics::Cursor
     void hide() override {}
     void move_to(geometry::Point) override {}
     void scale(float) override {}
+    auto renderable() -> std::shared_ptr<graphics::Renderable> override { return nullptr; }
 };
 
 }

--- a/src/miroil/mir_server_hooks.cpp
+++ b/src/miroil/mir_server_hooks.cpp
@@ -78,6 +78,8 @@ struct HiddenCursorWrapper : mg::Cursor
 
     void scale(float new_scale) override { wrapped->scale(new_scale); }
 
+    auto renderable() -> std::shared_ptr<mir::graphics::Renderable> override { return wrapped->renderable(); }
+
 private:
     std::shared_ptr<mg::Cursor> const wrapped;
 };

--- a/src/platforms/atomic-kms/server/kms/cursor.cpp
+++ b/src/platforms/atomic-kms/server/kms/cursor.cpp
@@ -452,3 +452,8 @@ void mir::graphics::atomic::Cursor::scale(float new_scale)
 
     show(current_cursor_image);
 }
+
+auto mir::graphics::atomic::Cursor::renderable() -> std::shared_ptr<Renderable>
+{
+    return nullptr;
+}

--- a/src/platforms/atomic-kms/server/kms/cursor.h
+++ b/src/platforms/atomic-kms/server/kms/cursor.h
@@ -78,6 +78,8 @@ public:
 
     void scale(float) override;
 
+    auto renderable() -> std::shared_ptr<Renderable> override;
+
 private:
     enum ForceCursorState { UpdateState, ForceState };
     struct GBMBOWrapper;

--- a/src/platforms/gbm-kms/server/kms/cursor.cpp
+++ b/src/platforms/gbm-kms/server/kms/cursor.cpp
@@ -452,3 +452,9 @@ void mir::graphics::gbm::Cursor::scale(float new_scale)
 
     show(current_cursor_image);
 }
+
+auto mir::graphics::gbm::Cursor::renderable() -> std::shared_ptr<Renderable>
+{
+    return nullptr;
+}
+

--- a/src/platforms/gbm-kms/server/kms/cursor.h
+++ b/src/platforms/gbm-kms/server/kms/cursor.h
@@ -79,6 +79,8 @@ public:
 
     void scale(float) override;
 
+    auto renderable() -> std::shared_ptr<Renderable> override;
+
 private:
     enum ForceCursorState { UpdateState, ForceState };
     struct GBMBOWrapper;

--- a/src/platforms/wayland/cursor.cpp
+++ b/src/platforms/wayland/cursor.cpp
@@ -138,3 +138,9 @@ void mir::platform::wayland::Cursor::scale(float new_scale)
 
     show(current_cursor_image);
 }
+
+auto mir::platform::wayland::Cursor::renderable() -> std::shared_ptr<graphics::Renderable>
+{
+    return nullptr;
+}
+

--- a/src/platforms/wayland/cursor.h
+++ b/src/platforms/wayland/cursor.h
@@ -50,6 +50,8 @@ public:
 
     void scale(float) override;
 
+    auto renderable() -> std::shared_ptr<graphics::Renderable> override;
+
 private:
     wl_shm* const shm;
     std::function<void()> const flush_wl;

--- a/src/server/compositor/default_configuration.cpp
+++ b/src/server/compositor/default_configuration.cpp
@@ -82,6 +82,7 @@ mir::DefaultServerConfiguration::the_compositor()
                 the_scene(),
                 the_shell(),
                 the_compositor_report(),
+                the_cursor(),
                 composite_delay,
                 true);
         });

--- a/src/server/compositor/multi_threaded_compositor.h
+++ b/src/server/compositor/multi_threaded_compositor.h
@@ -30,6 +30,7 @@ namespace mir
 namespace graphics
 {
 class Display;
+class Cursor;
 }
 namespace scene
 {
@@ -62,6 +63,7 @@ public:
         std::shared_ptr<Scene> const& scene,
         std::shared_ptr<DisplayListener> const& display_listener,
         std::shared_ptr<CompositorReport> const& compositor_report,
+        std::shared_ptr<graphics::Cursor> const& cursor,
         std::chrono::milliseconds fixed_composite_delay,  // -1 = automatic
         bool compose_on_start);
     ~MultiThreadedCompositor();
@@ -78,6 +80,7 @@ private:
     std::shared_ptr<Scene> const scene;
     std::shared_ptr<DisplayListener> const display_listener;
     std::shared_ptr<CompositorReport> const report;
+    std::shared_ptr<graphics::Cursor> const cursor;
 
     std::vector<std::unique_ptr<CompositingFunctor>> thread_functors;
 

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -415,7 +415,6 @@ mir::DefaultServerConfiguration::the_cursor()
                 mir::log_info("Using software cursor");
                 primary_cursor = std::make_shared<mg::SoftwareCursor>(
                     the_buffer_allocator(),
-                    the_main_loop(),
                     the_input_scene());
             }
 

--- a/src/server/graphics/multiplexing_hw_cursor.cpp
+++ b/src/server/graphics/multiplexing_hw_cursor.cpp
@@ -73,3 +73,8 @@ void mir::graphics::MultiplexingCursor::scale(float new_scale)
         cursor->scale(new_scale);
 }
 
+auto mg::MultiplexingCursor::renderable() -> std::shared_ptr<Renderable>
+{
+    return nullptr;
+}
+

--- a/src/server/graphics/multiplexing_hw_cursor.h
+++ b/src/server/graphics/multiplexing_hw_cursor.h
@@ -34,6 +34,8 @@ public:
 
     void scale(float) override;
 
+    auto renderable() -> std::shared_ptr<Renderable> override;
+
 private:
     std::vector<std::shared_ptr<Cursor>> const platform_cursors;
 };

--- a/src/server/graphics/null_cursor.h
+++ b/src/server/graphics/null_cursor.h
@@ -31,6 +31,7 @@ public:
     void hide() override {}
     void move_to(geometry::Point) override {}
     void scale(float) override {}
+    auto renderable() -> std::shared_ptr<Renderable> override { return nullptr; }
 };
 
 }

--- a/src/server/graphics/software_cursor.h
+++ b/src/server/graphics/software_cursor.h
@@ -43,7 +43,6 @@ class SoftwareCursor : public Cursor
 public:
     SoftwareCursor(
         std::shared_ptr<GraphicBufferAllocator> const& allocator,
-        std::shared_ptr<Executor> const& scene_executor,
         std::shared_ptr<input::Scene> const& scene);
     ~SoftwareCursor();
 
@@ -51,6 +50,7 @@ public:
     void hide() override;
     void move_to(geometry::Point position) override;
     void scale(float) override;
+    auto renderable() -> std::shared_ptr<Renderable> override;
 
 private:
     std::shared_ptr<detail::CursorRenderable> create_scaled_renderable_for(
@@ -60,12 +60,8 @@ private:
     std::shared_ptr<input::Scene> const scene;
     MirPixelFormat const format;
 
-    /// If input visualisations are removed from the scene before they are added, the scene throws and Mir crashes
-    /// We don't want to call into the scene under lock, so we make these calls on with an executor
-    std::shared_ptr<Executor> const scene_executor;
-
     std::mutex guard;
-    std::shared_ptr<detail::CursorRenderable> renderable;
+    std::shared_ptr<detail::CursorRenderable> renderable_;
     bool visible;
     geometry::Displacement hotspot;
 

--- a/tests/integration-tests/test_surface_stack_with_compositor.cpp
+++ b/tests/integration-tests/test_surface_stack_with_compositor.cpp
@@ -40,6 +40,7 @@
 #include "mir/test/doubles/stub_buffer_allocator.h"
 #include "mir/test/doubles/stub_main_loop.h"
 #include "mir/test/doubles/stub_output_filter.h"
+#include "mir/test/doubles/stub_cursor.h"
 
 #include <condition_variable>
 #include <mutex>
@@ -200,6 +201,7 @@ struct SurfaceStackCompositor : public Test
     CountingDisplaySyncGroup stub_secondary_db;
     StubDisplay stub_display{stub_primary_db, stub_secondary_db};
     StubDisplayListener stub_display_listener;
+    std::shared_ptr<mtd::StubCursor> stub_cursor{std::make_shared<mtd::StubCursor>()};
 
     mc::DefaultDisplayBufferCompositorFactory dbc_factory{
         std::vector<std::shared_ptr<mg::GLRenderingProvider>>{std::make_shared<mtd::StubGlRenderingProvider>()},
@@ -224,7 +226,7 @@ TEST_F(SurfaceStackCompositor, composes_on_start_if_told_to_in_constructor_when_
         mt::fake_shared(dbc_factory),
         mt::fake_shared(stack),
         mt::fake_shared(stub_display_listener),
-        null_comp_report, default_delay, true);
+        null_comp_report, stub_cursor, default_delay, true);
     mt_compositor.start();
 
     EXPECT_TRUE(stub_primary_db.has_posted_at_least(1, timeout));
@@ -238,7 +240,7 @@ TEST_F(SurfaceStackCompositor, does_not_compose_on_start_if_told_to_in_construct
         mt::fake_shared(dbc_factory),
         mt::fake_shared(stack),
         mt::fake_shared(stub_display_listener),
-        null_comp_report, default_delay, true);
+        null_comp_report, stub_cursor, default_delay, true);
     mt_compositor.start();
 
     EXPECT_TRUE(stub_primary_db.has_posted_at_least(0, timeout));
@@ -252,7 +254,7 @@ TEST_F(SurfaceStackCompositor, does_not_composes_on_start_if_told_not_to_in_cons
         mt::fake_shared(dbc_factory),
         mt::fake_shared(stack),
         mt::fake_shared(stub_display_listener),
-        null_comp_report, default_delay, false);
+        null_comp_report, stub_cursor, default_delay, false);
     mt_compositor.start();
 
     EXPECT_TRUE(stub_primary_db.has_posted_at_least(0, timeout));
@@ -266,7 +268,7 @@ TEST_F(SurfaceStackCompositor, swapping_a_surface_that_has_been_added_triggers_a
         mt::fake_shared(dbc_factory),
         mt::fake_shared(stack),
         mt::fake_shared(stub_display_listener),
-        null_comp_report, default_delay, false);
+        null_comp_report, stub_cursor, default_delay, false);
     mt_compositor.start();
 
     stack.add_surface(stub_surface, mi::InputReceptionMode::normal);
@@ -283,7 +285,7 @@ TEST_F(SurfaceStackCompositor, an_empty_scene_retriggers)
         mt::fake_shared(dbc_factory),
         mt::fake_shared(stack),
         mt::fake_shared(stub_display_listener),
-        null_comp_report, default_delay, false);
+        null_comp_report, stub_cursor, default_delay, false);
     mt_compositor.start();
 
     stack.add_surface(stub_surface, mi::InputReceptionMode::normal);
@@ -308,7 +310,7 @@ TEST_F(SurfaceStackCompositor, moving_a_surface_triggers_composition)
         mt::fake_shared(dbc_factory),
         mt::fake_shared(stack),
         mt::fake_shared(stub_display_listener),
-        null_comp_report, default_delay, false);
+        null_comp_report, stub_cursor, default_delay, false);
 
     mt_compositor.start();
     stub_surface->move_to(geom::Point{1,1});
@@ -330,7 +332,7 @@ TEST_F(SurfaceStackCompositor, removing_a_surface_triggers_composition)
         mt::fake_shared(dbc_factory),
         mt::fake_shared(stack),
         mt::fake_shared(stub_display_listener),
-        null_comp_report, default_delay, false);
+        null_comp_report, stub_cursor, default_delay, false);
 
     mt_compositor.start();
     stack.remove_surface(stub_surface);
@@ -349,7 +351,7 @@ TEST_F(SurfaceStackCompositor, buffer_updates_trigger_composition)
         mt::fake_shared(dbc_factory),
         mt::fake_shared(stack),
         mt::fake_shared(stub_display_listener),
-        null_comp_report, default_delay, false);
+        null_comp_report, stub_cursor, default_delay, false);
 
     mt_compositor.start();
     streams.front().stream->submit_buffer(stub_buffer, stub_buffer->size(), {{0, 0}, geom::SizeD{stub_buffer->size()}});

--- a/tests/unit-tests/input/test_cursor_controller.cpp
+++ b/tests/unit-tests/input/test_cursor_controller.cpp
@@ -100,6 +100,7 @@ struct MockCursor : public mg::Cursor
 
     MOCK_METHOD1(move_to, void(geom::Point));
     MOCK_METHOD1(scale, void(float));
+    MOCK_METHOD0(renderable, std::shared_ptr<mg::Renderable>());
 };
 
 // TODO: This should only inherit from mi::Surface but to use the Scene observer we need an


### PR DESCRIPTION
## What's new?
- Exposed `Cursor::renderable()` that will return the renderable associated with the cursor, if there is any
- No longer adding the `Cursor::renderable()` to the `Scene`. Instead, adding directly in the compositor
- Updated the associated `SoftwareCursor` implementation and tests for this new interface
- Existing hardware implementations return `nullptr` for now (but I will address this in later work, as I state below!)

## Why?
The `Cursor` is not logically a part of the `Scene` as it is not a surface or anything. Hence, it is up to the compositor to decide whether or not it will display it.

## What's next?
This work isn't done, but this is the minimal reviewable chunk that I want to get in before tackling the rest of it. Coming next:

1. Add `Cursor::needs_compositing` so that the compositor can rely on that boolean flag to decide whether or not to add that `Cursor`'s renderable
2. Implement `Cursor::renderable()` for each hardware cursor (including the Multiplexing cursor!)
3. Render the cursor in the `BasicScreenShooter` based off whether or not an `include_cursor` flag is set
