### PR TITLE
Enable generation of compile_commands.json for use by clangd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# Enable generation of compile_commands.json, for use by the clangd LSP
+set(CMAKE_EXPORT_COMPILE_COMMANDS on)
+
 option(use_debflags "Use build flags from dpkg-buildflags." OFF)
 if(use_debflags)
   include (cmake/Debian.cmake)


### PR DESCRIPTION
This improves the experience for people using editors with LSP support, and file is small relative to a full Mir build tree so there is not much harm in generating it in cases where it won't be used.