### PR TITLE
live configuration facilities

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -551,3 +551,11 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::SimulatedSecondaryClick::on_hold_start(std::function<void ()>&&)@MIRAL_5.3" 5.3.0
  (c++)"miral::SimulatedSecondaryClick::on_secondary_click(std::function<void ()>&&)@MIRAL_5.3" 5.3.0
  (c++)"miral::SimulatedSecondaryClick::operator()(mir::Server&)@MIRAL_5.3" 5.3.0
+ MIRAL_5.4@MIRAL_5.4 5.4.0
+ (c++)"miral::CursorScale::CursorScale(miral::live_config::Store&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::InputConfiguration::InputConfiguration(miral::live_config::Store&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::OutputFilter::OutputFilter(miral::live_config::Store&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::live_config::Key::Key(std::initializer_list<std::basic_string_view<char, std::char_traits<char> > const>)@MIRAL_5.4" 5.4.0
+ (c++)"miral::live_config::Key::operator<=>(miral::live_config::Key const&) const@MIRAL_5.4" 5.4.0
+ (c++)"miral::live_config::Key::to_string[abi:cxx11]() const@MIRAL_5.4" 5.4.0
+ (c++)"miral::live_config::Key::with_key(std::function<void (std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)> const&) const@MIRAL_5.4" 5.4.0

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -120,40 +120,7 @@ catch (...)
 {
 }
 
-// Struct for illustrative purposes, this would be rolled into miral::OutputFilter
-struct OutputFilter : miral::OutputFilter
-{
-    explicit OutputFilter(live_config::Store& config_store)
-    {
-        config_store.add_string_attribute({"output_filter"}, "Output filter to use [{none,grayscale,invert}]",
-                                            [this](live_config::Key const& key, std::optional<std::string_view> val)
-                                            {
-                                                MirOutputFilter new_filter = mir_output_filter_none;
-                                                if (val)
-                                                {
-                                                    auto filter_name = *val;
-                                                    if (filter_name == "grayscale")
-                                                    {
-                                                        new_filter = mir_output_filter_grayscale;
-                                                    }
-                                                    else if (filter_name == "invert")
-                                                    {
-                                                        new_filter = mir_output_filter_invert;
-                                                    }
-                                                    else
-                                                    {
-                                                        mir::log_warning(
-                                                            "Config key '%s' has invalid value: %s",
-                                                            key.to_string().c_str(),
-                                                            val->data());
-                                                    }
-                                                }
-                                                filter(new_filter);
-                                            });
-    }
-};
-
-// Struct for illustrative purposes, this would be rolled into miral::InputConfiguration
+// for illustrative purposes
 class DemoConfigFile : public live_config::Store
 {
 public:
@@ -355,7 +322,7 @@ void DemoConfigFile::add_int_attribute(live_config::Key const& key, std::string_
                 mir::log_warning(
                     "Config key '%s' has invalid integer value: %s",
                     key.to_string().c_str(),
-                    val->data());
+                    std::format("{}",*val).c_str());
                 handler(key, std::nullopt);
             }
         }
@@ -383,9 +350,9 @@ void DemoConfigFile::add_bool_attribute(live_config::Key const& key, std::string
             else
             {
                 mir::log_warning(
-                    "Config key '%s' has invalid boolean value: %s",
+                    "Config key '%s' has invalid integer value: %s",
                     key.to_string().c_str(),
-                    val->data());
+                    std::format("{}",*val).c_str());
                 handler(key, std::nullopt);
             }
         }
@@ -413,9 +380,9 @@ void DemoConfigFile::add_float_attribute(live_config::Key const& key, std::strin
             else
             {
                 mir::log_warning(
-                    "Config key '%s' has invalid floating point value: %s",
+                    "Config key '%s' has invalid integer value: %s",
                     key.to_string().c_str(),
-                    val->data());
+                    std::format("{}",*val).c_str());
                 handler(key, std::nullopt);
             }
         }
@@ -442,7 +409,7 @@ try
     runner.set_exception_handler(exception_handler);
 
     miral::CursorScale cursor_scale{demo_configuration};
-    OutputFilter output_filter{demo_configuration};
+    miral::OutputFilter output_filter{demo_configuration};
     miral::InputConfiguration input_configuration{demo_configuration};
     demo_configuration.handle_initial_config();
 

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -49,7 +49,7 @@
 namespace mir { class AbnormalExit; }
 
 namespace me = mir::examples;
-namespace mlc = miral::live_config;
+namespace live_config = miral::live_config;
 
 ///\example server_example.cpp
 /// A simple server illustrating several customisations
@@ -123,10 +123,10 @@ catch (...)
 // Struct for illustrative purposes, this would be rolled into miral::OutputFilter
 struct OutputFilter : miral::OutputFilter
 {
-    explicit OutputFilter(mlc::Store& config_store)
+    explicit OutputFilter(live_config::Store& config_store)
     {
         config_store.add_string_attribute({"output_filter"}, "Output filter to use [{none,grayscale,invert}]",
-                                            [this](mlc::Key const& key, std::optional<std::string_view> val)
+                                            [this](live_config::Key const& key, std::optional<std::string_view> val)
                                             {
                                                 MirOutputFilter new_filter = mir_output_filter_none;
                                                 if (val)
@@ -153,38 +153,8 @@ struct OutputFilter : miral::OutputFilter
     }
 };
 
-struct CursorScale : miral::CursorScale
-{
-    explicit CursorScale(mlc::Store& config_store) : miral::CursorScale{}
-    {
-        config_store.add_float_attribute({"cursor", "scale"}, "Cursor scale",
-                                           [this](mlc::Key const& key, std::optional<float> val)
-                                           {
-                                               if (val)
-                                               {
-                                                   if (*val >= 0.0)
-                                                   {
-                                                       scale(*val);
-                                                   }
-                                                   else
-                                                   {
-                                                       mir::log_warning(
-                                                           "Config value %s does not support negative values. Ignoring the supplied value (%f)...",
-                                                           key.to_string().c_str(), *val);
-                                                   }
-                                               }
-                                           });
-
-        // {arg} Just a demo that should turn into a test
-        std::string_view constexpr preset[]{"foo", "bar", "baz"};
-
-        config_store.add_strings_attribute({"foo", "bar"}, "Foobar", std::span{preset},
-                                             [](mlc::Key, std::optional<std::span<std::string_view const>>){});
-    }
-};
-
 // Struct for illustrative purposes, this would be rolled into miral::InputConfiguration
-class DemoConfigFile : public mlc::Store
+class DemoConfigFile : public live_config::Store
 {
 public:
     DemoConfigFile(miral::MirRunner& runner, std::filesystem::path file) :
@@ -210,37 +180,37 @@ public:
         init_part2();
     }
 
-    void add_int_attribute(mlc::Key const& key, std::string_view description, HandleInt handler) override;
-    void add_ints_attribute(mlc::Key const& key, std::string_view description, HandleInts handler) override;
-    void add_bool_attribute(mlc::Key const& key, std::string_view description, HandleBool handler) override;
-    void add_bools_attribute(mlc::Key const& key, std::string_view description, HandleBools handler) override;
-    void add_float_attribute(mlc::Key const& key, std::string_view description, HandleFloat handler) override;
-    void add_floats_attribute(mlc::Key const& key, std::string_view description, HandleFloats handler) override;
-    void add_string_attribute(mlc::Key const& key, std::string_view description, HandleString handler) override;
-    void add_strings_attribute(mlc::Key const& key, std::string_view description, HandleStrings handler) override;
+    void add_int_attribute(live_config::Key const& key, std::string_view description, HandleInt handler) override;
+    void add_ints_attribute(live_config::Key const& key, std::string_view description, HandleInts handler) override;
+    void add_bool_attribute(live_config::Key const& key, std::string_view description, HandleBool handler) override;
+    void add_bools_attribute(live_config::Key const& key, std::string_view description, HandleBools handler) override;
+    void add_float_attribute(live_config::Key const& key, std::string_view description, HandleFloat handler) override;
+    void add_floats_attribute(live_config::Key const& key, std::string_view description, HandleFloats handler) override;
+    void add_string_attribute(live_config::Key const& key, std::string_view description, HandleString handler) override;
+    void add_strings_attribute(live_config::Key const& key, std::string_view description, HandleStrings handler) override;
 
-    void add_int_attribute(mlc::Key const& key, std::string_view description, int preset,
+    void add_int_attribute(live_config::Key const& key, std::string_view description, int preset,
         HandleInt handler) override;
-    void add_ints_attribute(mlc::Key const& key, std::string_view description, std::span<int const> preset,
+    void add_ints_attribute(live_config::Key const& key, std::string_view description, std::span<int const> preset,
                             HandleInts handler) override;
-    void add_bool_attribute(mlc::Key const& key, std::string_view description, bool preset,
+    void add_bool_attribute(live_config::Key const& key, std::string_view description, bool preset,
         HandleBool handler) override;
-    void add_bools_attribute(mlc::Key const& key, std::string_view description, std::span<bool const> preset,
+    void add_bools_attribute(live_config::Key const& key, std::string_view description, std::span<bool const> preset,
                              HandleBools handler) override;
-    void add_float_attribute(mlc::Key const& key, std::string_view description, float preset,
+    void add_float_attribute(live_config::Key const& key, std::string_view description, float preset,
         HandleFloat handler) override;
-    void add_floats_attribute(mlc::Key const& key, std::string_view description, std::span<float const> preset,
+    void add_floats_attribute(live_config::Key const& key, std::string_view description, std::span<float const> preset,
                               HandleFloats handler) override;
-    void add_string_attribute(mlc::Key const& key, std::string_view description, std::string_view preset,
+    void add_string_attribute(live_config::Key const& key, std::string_view description, std::string_view preset,
         HandleString handler) override;
-    void add_strings_attribute(mlc::Key const& key, std::string_view description,
+    void add_strings_attribute(live_config::Key const& key, std::string_view description,
         std::span<std::string_view const> preset, HandleStrings handler) override;
 
     void on_done(HandleDone handler) override;
 
 private:
 
-    std::map<mlc::Key, HandleString> attribute_handlers;
+    std::map<live_config::Key, HandleString> attribute_handlers;
     std::list<HandleDone> done_handlers;
 
     std::mutex config_mutex;
@@ -266,7 +236,7 @@ private:
             if (line.contains("="))
             {
                 auto const eq = line.find_first_of("=");
-                auto const key = mlc::Key{line.substr(0, eq)};
+                auto const key = live_config::Key{line.substr(0, eq)};
                 auto const value = line.substr(eq+1);
 
                 if (auto const handler = attribute_handlers.find(key); handler != attribute_handlers.end())
@@ -280,80 +250,80 @@ private:
     }
 };
 
-void DemoConfigFile::add_ints_attribute(mlc::Key const& key, std::string_view, HandleInts handler)
+void DemoConfigFile::add_ints_attribute(live_config::Key const& key, std::string_view, HandleInts handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)key;
 }
 
-void DemoConfigFile::add_bools_attribute(mlc::Key const& key, std::string_view, HandleBools handler)
+void DemoConfigFile::add_bools_attribute(live_config::Key const& key, std::string_view, HandleBools handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)key;
 }
 
-void DemoConfigFile::add_floats_attribute(mlc::Key const& key, std::string_view, HandleFloats handler)
+void DemoConfigFile::add_floats_attribute(live_config::Key const& key, std::string_view, HandleFloats handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)key;
 }
 
-void DemoConfigFile::add_strings_attribute(mlc::Key const& key, std::string_view, HandleStrings handler)
+void DemoConfigFile::add_strings_attribute(live_config::Key const& key, std::string_view, HandleStrings handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)key;
 }
 
-void DemoConfigFile::add_int_attribute(mlc::Key const& key, std::string_view description, int preset,
+void DemoConfigFile::add_int_attribute(live_config::Key const& key, std::string_view description, int preset,
     HandleInt handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)description; (void)key; (void)preset;
 }
 
-void DemoConfigFile::add_ints_attribute(mlc::Key const& key, std::string_view description,
+void DemoConfigFile::add_ints_attribute(live_config::Key const& key, std::string_view description,
                                         std::span<int const> preset, HandleInts handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)description; (void)key; (void)preset;
 }
 
-void DemoConfigFile::add_bool_attribute(mlc::Key const& key, std::string_view description, bool preset,
+void DemoConfigFile::add_bool_attribute(live_config::Key const& key, std::string_view description, bool preset,
     HandleBool handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)description; (void)key; (void)preset;
 }
 
-void DemoConfigFile::add_bools_attribute(mlc::Key const& key, std::string_view description,
+void DemoConfigFile::add_bools_attribute(live_config::Key const& key, std::string_view description,
                                          std::span<bool const> preset, HandleBools handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)description; (void)key; (void)preset;
 }
 
-void DemoConfigFile::add_float_attribute(mlc::Key const& key, std::string_view description, float preset,
+void DemoConfigFile::add_float_attribute(live_config::Key const& key, std::string_view description, float preset,
     HandleFloat handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)description; (void)key; (void)preset;
 }
 
-void DemoConfigFile::add_floats_attribute(mlc::Key const& key, std::string_view description,
+void DemoConfigFile::add_floats_attribute(live_config::Key const& key, std::string_view description,
                                           std::span<float const> preset, HandleFloats handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)description; (void)key; (void)preset;
 }
 
-void DemoConfigFile::add_string_attribute(mlc::Key const& key, std::string_view description,
+void DemoConfigFile::add_string_attribute(live_config::Key const& key, std::string_view description,
     std::string_view preset, HandleString handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)description; (void)key; (void)preset;
 }
 
-void DemoConfigFile::add_strings_attribute(mlc::Key const& key, std::string_view description,
+void DemoConfigFile::add_strings_attribute(live_config::Key const& key, std::string_view description,
     std::span<std::string_view const> preset, HandleStrings handler)
 {
     // Not implemented: not needed for discussion
@@ -366,9 +336,9 @@ void DemoConfigFile::on_done(HandleDone handler)
     done_handlers.emplace_back(std::move(handler));
 }
 
-void DemoConfigFile::add_int_attribute(mlc::Key const& key, std::string_view description, HandleInt handler)
+void DemoConfigFile::add_int_attribute(live_config::Key const& key, std::string_view description, HandleInt handler)
 {
-    add_string_attribute(key, description, [handler](mlc::Key const& key, std::optional<std::string_view> val)
+    add_string_attribute(key, description, [handler](live_config::Key const& key, std::optional<std::string_view> val)
     {
         if (val)
         {
@@ -396,9 +366,9 @@ void DemoConfigFile::add_int_attribute(mlc::Key const& key, std::string_view des
     });
 }
 
-void DemoConfigFile::add_bool_attribute(mlc::Key const& key, std::string_view description, HandleBool handler)
+void DemoConfigFile::add_bool_attribute(live_config::Key const& key, std::string_view description, HandleBool handler)
 {
-    add_string_attribute(key, description, [handler](mlc::Key const& key, std::optional<std::string_view> val)
+    add_string_attribute(key, description, [handler](live_config::Key const& key, std::optional<std::string_view> val)
     {
         if (val)
         {
@@ -426,9 +396,9 @@ void DemoConfigFile::add_bool_attribute(mlc::Key const& key, std::string_view de
     });
 }
 
-void DemoConfigFile::add_float_attribute(mlc::Key const& key, std::string_view description, HandleFloat handler)
+void DemoConfigFile::add_float_attribute(live_config::Key const& key, std::string_view description, HandleFloat handler)
 {
-    add_string_attribute(key, description, [handler](mlc::Key const& key, std::optional<std::string_view> val)
+    add_string_attribute(key, description, [handler](live_config::Key const& key, std::optional<std::string_view> val)
     {
         if (val)
         {
@@ -456,7 +426,7 @@ void DemoConfigFile::add_float_attribute(mlc::Key const& key, std::string_view d
     });
 }
 
-void DemoConfigFile::add_string_attribute(mlc::Key const& key, std::string_view, HandleString handler)
+void DemoConfigFile::add_string_attribute(live_config::Key const& key, std::string_view, HandleString handler)
 {
     std::lock_guard lock{config_mutex};
     attribute_handlers[key] = handler;
@@ -471,7 +441,7 @@ try
     DemoConfigFile demo_configuration{runner, "mir_demo_server.live-config"};
     runner.set_exception_handler(exception_handler);
 
-    CursorScale cursor_scale{demo_configuration};
+    miral::CursorScale cursor_scale{demo_configuration};
     OutputFilter output_filter{demo_configuration};
     miral::InputConfiguration input_configuration{demo_configuration};
     demo_configuration.handle_initial_config();

--- a/include/miral/miral/cursor_scale.h
+++ b/include/miral/miral/cursor_scale.h
@@ -23,12 +23,18 @@ namespace mir { class Server; }
 
 namespace miral
 {
+namespace live_config { class Store; }
+
 /// Allows for the configuration of the cursor's scale at runtime.
 /// \remark Since MirAL 5.3
 class CursorScale
 {
 public:
     explicit CursorScale();
+
+    /// Construct registering with a configuration store
+    /// \remark Since Miral 5.4
+    explicit CursorScale(live_config::Store& config_store);
     explicit CursorScale(float default_scale);
     ~CursorScale();
 

--- a/include/miral/miral/input_configuration.h
+++ b/include/miral/miral/input_configuration.h
@@ -27,6 +27,8 @@ namespace mir { class Server; }
 
 namespace miral
 {
+namespace live_config { class Store; }
+
 /** Input configuration.
  * Allow servers to make input configuration changes at runtime
  * \remark Since MirAL 5.1
@@ -35,6 +37,11 @@ class InputConfiguration
 {
 public:
     InputConfiguration();
+
+    /// Construct registering with a configuration store
+    /// \remark Since Miral 5.4
+    explicit InputConfiguration(live_config::Store& config_store);
+
     ~InputConfiguration();
     void operator()(mir::Server& server);
 

--- a/include/miral/miral/live_config.h
+++ b/include/miral/miral/live_config.h
@@ -17,26 +17,33 @@
 #ifndef MIRAL_LIVE_CONFIG_H
 #define MIRAL_LIVE_CONFIG_H
 
+#include <functional>
 #include <initializer_list>
-#include <string>
 #include <memory>
-#include <vector>
 #include <optional>
+#include <span>
+#include <string>
+#include <vector>
 
 namespace miral::live_config
 {
-/// Registration key for a configuration property. The key is essentially a tuple of
-/// identifiers.
-/// To simplify mapping these identifiers to multiple configuration backends, each identifier
-/// is non-empty, starts with [a..z], and contains only [a..z,0..9,_]
+/// Registration key for a configuration attribute. The key is essentially a tuple of
+/// identifiers
+///
+/// \remark Since MirAL 5.4
 class Key
 {
 public:
+    /// To simplify mapping these identifiers to multiple configuration backends, each identifier
+    /// within the key is non-empty, starts with [a..z], and contains only [a..z,0..9,_]
     Key(std::initializer_list<std::string_view const> key);
 
-    auto as_path() const -> std::vector<std::string>;
+    /// Expose the key elements
+    void with_key(std::function<void(std::vector<std::string> const& key)> const& f) const;
 
+    /// The key represented as a "_" joined string
     auto to_string() const -> std::string;
+
     auto operator<=>(Key const& that) const -> std::strong_ordering;
 
 private:
@@ -44,6 +51,53 @@ private:
    std::shared_ptr<State> self;
 };
 
+/// Interface for adding attributes to a live configuration store.
+///
+/// The handlers should be called when the configuration is updated. There is
+/// no requirement to check the previous value has changed.
+///
+/// The key is passed to the handler as it can be useful (e.g. for diagnostics)
+///
+/// This could be supported by various backends (an ini file, a YAML node, etc)
+///
+/// \remark Since MirAL 5.4
+class Store
+{
+public:
+    using HandleInt = std::function<void(Key const& key, std::optional<int> value)>;
+    using HandleInts = std::function<void(Key const& key, std::optional<std::span<int const>> value)>;
+    using HandleBool = std::function<void(Key const& key, std::optional<bool> value)>;
+    using HandleBools = std::function<void(Key const& key, std::optional<std::span<bool const>> value)>;
+    using HandleFloat = std::function<void(Key const& key, std::optional<float> value)>;
+    using HandleFloats = std::function<void(Key const& key, std::optional<std::span<float const>> value)>;
+    using HandleString = std::function<void(Key const& key, std::optional<std::string_view> value)>;
+    using HandleStrings = std::function<void(Key const& key, std::optional<std::span<std::string_view const>> value)>;
+    using HandleDone = std::function<void()>;
+
+    virtual void add_int_attribute(Key const& key, std::string_view description, HandleInt handler) = 0;
+    virtual void add_ints_attribute(Key const& key, std::string_view description, HandleInts handler) = 0;
+    virtual void add_bool_attribute(Key const& key, std::string_view description, HandleBool handler) = 0;
+    virtual void add_bools_attribute(Key const& key, std::string_view description, HandleBools handler) = 0;
+    virtual void add_float_attribute(Key const& key, std::string_view description, HandleFloat handler) = 0;
+    virtual void add_floats_attribute(Key const& key, std::string_view description, HandleFloats handler) = 0;
+    virtual void add_string_attribute(Key const& key, std::string_view description, HandleString handler) = 0;
+    virtual void add_strings_attribute(Key const& key, std::string_view description, HandleStrings handler) = 0;
+
+    virtual void add_int_attribute(Key const& key, std::string_view description, int preset, HandleInt handler) = 0;
+    virtual void add_ints_attribute(Key const& key, std::string_view description, std::span<int const> preset, HandleInts handler) = 0;
+    virtual void add_bool_attribute(Key const& key, std::string_view description, bool preset, HandleBool handler) = 0;
+    virtual void add_bools_attribute(Key const& key, std::string_view description, std::span<bool const> preset, HandleBools handler) = 0;
+    virtual void add_float_attribute(Key const& key, std::string_view description, float preset, HandleFloat handler) = 0;
+    virtual void add_floats_attribute(Key const& key, std::string_view description, std::span<float const> preset, HandleFloats handler) = 0;
+    virtual void add_string_attribute(Key const& key, std::string_view description, std::string_view preset, HandleString handler) = 0;
+    virtual void add_strings_attribute(Key const& key, std::string_view description, std::span<std::string_view const> preset, HandleStrings handler) = 0;
+
+    /// Called following a set of related updates (e.g. a file reload) to allow
+    /// multiple attributes to be updated transactionally
+    virtual void on_done(HandleDone handler) = 0;
+
+    virtual ~Store() = default;
+};
 }
 
 #endif //MIRAL_LIVE_CONFIG_H

--- a/include/miral/miral/live_config.h
+++ b/include/miral/miral/live_config.h
@@ -56,6 +56,9 @@ private:
 /// The handlers should be called when the configuration is updated. There is
 /// no requirement to check the previous value has changed.
 ///
+/// The `value` provided to the Handlers is `optional` to support values being
+/// explicitly unset. Store implementations default absent keys to `preset`.
+///
 /// The key is passed to the handler as it can be useful (e.g. for diagnostics)
 ///
 /// This could be supported by various backends (an ini file, a YAML node, etc)

--- a/include/miral/miral/live_config.h
+++ b/include/miral/miral/live_config.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_LIVE_CONFIG_H
+#define MIRAL_LIVE_CONFIG_H
+
+#include <initializer_list>
+#include <string>
+#include <memory>
+#include <vector>
+#include <optional>
+
+namespace miral::live_config
+{
+class Key
+{
+public:
+    Key(std::initializer_list<std::string_view const> key);
+
+    auto as_path() const -> std::vector<std::string>;
+
+    auto to_string() const -> std::string;
+    auto operator<=>(Key const& that) const -> std::strong_ordering;
+
+private:
+   struct State;
+   std::shared_ptr<State> self;
+};
+
+}
+
+#endif //MIRAL_LIVE_CONFIG_H

--- a/include/miral/miral/live_config.h
+++ b/include/miral/miral/live_config.h
@@ -25,6 +25,10 @@
 
 namespace miral::live_config
 {
+/// Registration key for a configuration property. The key is essentially a tuple of
+/// identifiers.
+/// To simplify mapping these identifiers to multiple configuration backends, each identifier
+/// is non-empty, starts with [a..z], and contains only [a..z,0..9,_]
 class Key
 {
 public:

--- a/include/miral/miral/output_filter.h
+++ b/include/miral/miral/output_filter.h
@@ -25,12 +25,18 @@ namespace mir { class Server; }
 
 namespace miral
 {
+namespace live_config { class Store; }
+
 /// Allows for the configuration of the output filter at runtime.
 /// \remark Since MirAL 5.3
 class OutputFilter
 {
 public:
     explicit OutputFilter();
+
+    /// Construct registering with a configuration store
+    /// \remark Since Miral 5.4
+    explicit OutputFilter(live_config::Store& config_store);
     explicit OutputFilter(MirOutputFilter default_filter);
     ~OutputFilter();
 

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -92,6 +92,7 @@ add_library(miral-external OBJECT
     mousekeys_config.cpp                ${miral_include}/miral/mousekeys_config.h
     output_filter.cpp                   ${miral_include}/miral/output_filter.h
     simulated_secondary_click.cpp       ${miral_include}/miral/simulated_secondary_click.h
+    live_config.cpp                     ${miral_include}/miral/live_config.h
 )
 
 add_library(miral SHARED

--- a/src/miral/cursor_scale.cpp
+++ b/src/miral/cursor_scale.cpp
@@ -108,6 +108,6 @@ void miral::CursorScale::operator()(mir::Server& server) const
             self->accessibility_manager = server.the_accessibility_manager();
             auto const scale = options->get<double>(cursor_scale_opt);
 
-            self->scale(scale);
+            self->scale(static_cast<float>(scale));
         });
 }

--- a/src/miral/cursor_scale.cpp
+++ b/src/miral/cursor_scale.cpp
@@ -15,8 +15,10 @@
  */
 
 #include "miral/cursor_scale.h"
+#include "miral/live_config.h"
 
 #include "mir/options/option.h"
+#include "mir/log.h"
 #include "mir/server.h"
 #include "mir/shell/accessibility_manager.h"
 
@@ -49,6 +51,29 @@ struct miral::CursorScale::Self
 miral::CursorScale::CursorScale()
     : self{std::make_shared<Self>(1.0)}
 {
+}
+
+miral::CursorScale::CursorScale(live_config::Store& config_store) : miral::CursorScale{}
+{
+    config_store.add_float_attribute(
+        {"cursor", "scale"},
+        "Cursor scale",
+       [this](live_config::Key const& key, std::optional<float> val)
+        {
+            if (val)
+            {
+                if (*val >= 0.0)
+                {
+                    scale(*val);
+                }
+                else
+                {
+                    mir::log_warning(
+                        "Config value %s does not support negative values. Ignoring the supplied value (%f)...",
+                        key.to_string().c_str(), *val);
+                }
+            }
+        });
 }
 
 miral::CursorScale::CursorScale(float default_scale)

--- a/src/miral/cursor_scale.cpp
+++ b/src/miral/cursor_scale.cpp
@@ -28,6 +28,7 @@
 struct miral::CursorScale::Self
 {
     Self(float default_scale) :
+        default_scale{default_scale},
         scale_(default_scale)
     {
     }
@@ -42,6 +43,7 @@ struct miral::CursorScale::Self
         accessibility_manager.lock()->cursor_scale(scale_);
     }
 
+    float const default_scale;
     std::atomic<float> scale_;
 
     // accessibility_manager is only updated during the single-threaded initialization phase of startup
@@ -72,6 +74,10 @@ miral::CursorScale::CursorScale(live_config::Store& config_store) : miral::Curso
                         "Config value %s does not support negative values. Ignoring the supplied value (%f)...",
                         key.to_string().c_str(), *val);
                 }
+            }
+            else
+            {
+                scale(self->default_scale);
             }
         });
 }

--- a/src/miral/input_configuration.cpp
+++ b/src/miral/input_configuration.cpp
@@ -25,6 +25,7 @@
 #include "mir/shell/accessibility_manager.h"
 
 #include <algorithm>
+#include <format>
 #include <memory>
 
 class miral::InputConfiguration::Mouse::Self : public MouseInputConfiguration
@@ -96,18 +97,16 @@ public:
 
     struct Config
     {
-        Config(miral::InputConfiguration::Mouse mouse,
-        miral::InputConfiguration::Touchpad touchpad,
-        miral::InputConfiguration::Keyboard keyboard) :
-        mouse{mouse},
-        touchpad{touchpad},
-        keyboard{keyboard}
+        Config(Mouse mouse, Touchpad touchpad, Keyboard keyboard) :
+            mouse{mouse},
+            touchpad{touchpad},
+            keyboard{keyboard}
         {}
 
         std::mutex config_mutex;
-        miral::InputConfiguration::Mouse mouse;
-        miral::InputConfiguration::Touchpad touchpad;
-        miral::InputConfiguration::Keyboard keyboard;
+        Mouse mouse;
+        Touchpad touchpad;
+        Keyboard keyboard;
     } config{mouse(), touchpad(), keyboard()};
 
     void start_callback()
@@ -200,9 +199,9 @@ miral::InputConfiguration::InputConfiguration(live_config::Store& config_store) 
                             self->config.mouse.handedness(mir_pointer_handedness_left);
                         else
                             mir::log_warning(
-                                "Config key '%s' has invalid value: %s",
+                                "Config key '%s' has invalid integer value: %s",
                                 key.to_string().c_str(),
-                                val->data());
+                                std::format("{}",*val).c_str());
                     }
                 });
 
@@ -225,9 +224,9 @@ miral::InputConfiguration::InputConfiguration(live_config::Store& config_store) 
                         self->config.touchpad.scroll_mode(mir_touchpad_scroll_mode_button_down_scroll);
                     else
                         mir::log_warning(
-                            "Config key '%s' has invalid value: %s",
+                            "Config key '%s' has invalid integer value: %s",
                             key.to_string().c_str(),
-                            val->data());
+                            std::format("{}",*val).c_str());
                 }
             });
 

--- a/src/miral/input_configuration.cpp
+++ b/src/miral/input_configuration.cpp
@@ -111,12 +111,9 @@ public:
 
     void start_callback()
     {
-        // Merge the input options collected from the command line,
+        // Merge the any input options collected from the command line,
         // environment, and default `.config` file with the options we
-        // read from the `.input` file.
-        //
-        // In this case, the `.input` file takes precedence. You can
-        // reverse the arguments to de-prioritize it.
+        // read from the live configuration file.
         std::lock_guard lock{config.config_mutex};
         config.mouse.merge(mouse());
         config.keyboard.merge(keyboard());

--- a/src/miral/input_configuration.cpp
+++ b/src/miral/input_configuration.cpp
@@ -15,15 +15,17 @@
  */
 
 #include "miral/input_configuration.h"
+#include "miral/live_config.h"
 
 #include "input_device_config.h"
+
+#include <mir/input/input_device_hub.h>
+#include <mir/log.h>
+#include <mir/server.h>
 #include "mir/shell/accessibility_manager.h"
 
-#include <memory>
-#include <mir/server.h>
-#include <mir/input/input_device_hub.h>
-
 #include <algorithm>
+#include <memory>
 
 class miral::InputConfiguration::Mouse::Self : public MouseInputConfiguration
 {
@@ -91,6 +93,36 @@ public:
         }
         keyboard(k);
     }
+
+    struct Config
+    {
+        Config(miral::InputConfiguration::Mouse mouse,
+        miral::InputConfiguration::Touchpad touchpad,
+        miral::InputConfiguration::Keyboard keyboard) :
+        mouse{mouse},
+        touchpad{touchpad},
+        keyboard{keyboard}
+        {}
+
+        std::mutex config_mutex;
+        miral::InputConfiguration::Mouse mouse;
+        miral::InputConfiguration::Touchpad touchpad;
+        miral::InputConfiguration::Keyboard keyboard;
+    } config{mouse(), touchpad(), keyboard()};
+
+    void start_callback()
+    {
+        // Merge the input options collected from the command line,
+        // environment, and default `.config` file with the options we
+        // read from the `.input` file.
+        //
+        // In this case, the `.input` file takes precedence. You can
+        // reverse the arguments to de-prioritize it.
+        std::lock_guard lock{config.config_mutex};
+        config.mouse.merge(mouse());
+        config.keyboard.merge(keyboard());
+        config.touchpad.merge(touchpad());
+    }
 };
 
 auto miral::InputConfiguration::Self::mouse() -> Mouse
@@ -151,6 +183,105 @@ miral::InputConfiguration::InputConfiguration() :
 {
 }
 
+miral::InputConfiguration::InputConfiguration(live_config::Store& config_store) : InputConfiguration{}
+{
+        config_store.add_string_attribute(
+            {"pointer", "handedness"},
+            "Pointer handedness [{right, left}]",
+                [this](live_config::Key const& key, std::optional<std::string_view> val)
+                {
+                    if (val)
+                    {
+                        std::lock_guard lock{self->config.config_mutex};
+                        auto const& value = *val;
+                        if (value == "right")
+                            self->config.mouse.handedness(mir_pointer_handedness_right);
+                        else if (value == "left")
+                            self->config.mouse.handedness(mir_pointer_handedness_left);
+                        else
+                            mir::log_warning(
+                                "Config key '%s' has invalid value: %s",
+                                key.to_string().c_str(),
+                                val->data());
+                    }
+                });
+
+        config_store.add_string_attribute(
+            {"touchpad", "scroll_mode"},
+            "Touchpad scroll mode [{none, two_finger_scroll, edge_scroll, button_down_scroll}]",
+            [this](live_config::Key const& key, std::optional<std::string_view> val)
+            {
+                if (val)
+                {
+                    std::lock_guard lock{self->config.config_mutex};
+                    auto const& value = *val;
+                    if (value == "none")
+                        self->config.touchpad.scroll_mode(mir_touchpad_scroll_mode_none);
+                    else if (value == "two_finger_scroll")
+                        self->config.touchpad.scroll_mode(mir_touchpad_scroll_mode_two_finger_scroll);
+                    else if (value == "edge_scroll")
+                        self->config.touchpad.scroll_mode(mir_touchpad_scroll_mode_edge_scroll);
+                    else if (value == "button_down_scroll")
+                        self->config.touchpad.scroll_mode(mir_touchpad_scroll_mode_button_down_scroll);
+                    else
+                        mir::log_warning(
+                            "Config key '%s' has invalid value: %s",
+                            key.to_string().c_str(),
+                            val->data());
+                }
+            });
+
+        config_store.add_int_attribute(
+            {"keyboard", "repeat_rate"},
+            "Keyboard repeat rate",
+            [this](live_config::Key const& key, std::optional<int> val)
+            {
+                if (val)
+                {
+                    if (val >= 0)
+                    {
+                        std::lock_guard lock{self->config.config_mutex};
+                        self->config.keyboard.set_repeat_rate(*val);
+                    }
+                    else
+                    {
+                        mir::log_warning(
+                            "Config value %s does not support negative values. Ignoring the supplied value (%d)...",
+                            key.to_string().c_str(), *val);
+                    }
+                }
+            });
+
+        config_store.add_int_attribute(
+            {"keyboard", "repeat_delay"},
+            "Keyboard repeat delay",
+            [this](live_config::Key const& key, std::optional<int> val)
+            {
+                if (val)
+                {
+                    if (val >= 0)
+                    {
+                        std::lock_guard lock{self->config.config_mutex};
+                        self->config.keyboard.set_repeat_delay(*val);
+                    }
+                    else
+                    {
+                        mir::log_warning(
+                            "Config value %s does not support negative values. Ignoring the supplied value (%d)...",
+                            key.to_string().c_str(), *val);
+                    }
+                }
+            });
+
+        config_store.on_done([this]
+            {
+                std::lock_guard lock{self->config.config_mutex};
+                mouse(self->config.mouse);
+                touchpad(self->config.touchpad);
+                keyboard(self->config.keyboard);
+            });
+}
+
 void miral::InputConfiguration::mouse(Mouse const& m)
 {
     self->apply(m);
@@ -165,6 +296,7 @@ void miral::InputConfiguration::operator()(mir::Server& server)
         self->input_device_hub = server.the_input_device_hub();
         self->input_device_config = InputDeviceConfig::the_input_configuration(server.get_options());
         self->accessibility_manager = server.the_accessibility_manager();
+        self->start_callback();
     });
 }
 

--- a/src/miral/live_config.cpp
+++ b/src/miral/live_config.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright © Canonical Ltd.
+ * Copyright © Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -16,6 +16,9 @@
 
 #include "miral/live_config.h"
 
+#include <format>
+#include <stdexcept>
+
 struct miral::live_config::Key::State
 {
     std::vector<std::string> const path;
@@ -24,6 +27,21 @@ struct miral::live_config::Key::State
     State(std::initializer_list<std::string_view const> key) :
         path{key.begin(), key.end()}
     {
+        if (key.begin() == key.end())
+            throw std::invalid_argument{std::format("Invalid (empty) live config key")};
+
+        for (auto const &element : key)
+        {
+            if (element.empty())
+                throw std::invalid_argument{std::format("Invalid config key element: {}", element)};
+
+            if (!islower(element[0]))
+                throw std::invalid_argument{std::format("Invalid config key element: {}", element)};
+
+            for (auto const &c : element)
+                if (!islower(c) && !isdigit(c) && c != '_')
+                    throw std::invalid_argument{std::format("Invalid config key element: {}", element)};
+        }
     }
 
     auto operator<=>(State const& that) const { return key <=> that.key; }

--- a/src/miral/live_config.cpp
+++ b/src/miral/live_config.cpp
@@ -67,9 +67,9 @@ miral::live_config::Key::Key(std::initializer_list<std::string_view const> key) 
 {
 }
 
-auto miral::live_config::Key::as_path() const -> std::vector<std::string>
+void miral::live_config::Key::with_key(std::function<void(std::vector<std::string> const& key)> const& f) const
 {
-    return self->path;
+    f(self->path);
 }
 
 auto miral::live_config::Key::to_string() const -> std::string

--- a/src/miral/live_config.cpp
+++ b/src/miral/live_config.cpp
@@ -1,0 +1,66 @@
+/*
+* Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "miral/live_config.h"
+
+struct miral::live_config::Key::State
+{
+    std::vector<std::string> const path;
+    std::string const key{to_string()};
+
+    State(std::initializer_list<std::string_view const> key) :
+        path{key.begin(), key.end()}
+    {
+    }
+
+    auto operator<=>(State const& that) const { return key <=> that.key; }
+
+    auto to_string() const -> std::string
+    {
+        std::string result;
+        for (auto const& element : path)
+        {
+            if (!result.empty())
+                result += '_';
+
+            result += element;
+        }
+
+        return result;
+    }
+};
+
+
+miral::live_config::Key::Key(std::initializer_list<std::string_view const> key) :
+    self{std::make_unique<State>(key)}
+{
+}
+
+auto miral::live_config::Key::as_path() const -> std::vector<std::string>
+{
+    return self->path;
+}
+
+auto miral::live_config::Key::to_string() const -> std::string
+{
+    return self->key;
+}
+
+auto miral::live_config::Key::operator<=>(Key const& that) const -> std::strong_ordering
+{
+    return *self <=> *that.self;
+}
+

--- a/src/miral/output_filter.cpp
+++ b/src/miral/output_filter.cpp
@@ -29,7 +29,8 @@
 struct miral::OutputFilter::Self
 {
     Self(MirOutputFilter default_filter) :
-        filter_(default_filter)
+        default_filter{default_filter},
+        filter_{default_filter}
     {
     }
 
@@ -43,6 +44,7 @@ struct miral::OutputFilter::Self
         output_filter.lock()->filter(filter_);
     }
 
+    MirOutputFilter const default_filter;
     std::atomic<MirOutputFilter> filter_;
 
     // output_filter is only updated during the single-threaded initialization phase of startup
@@ -61,7 +63,7 @@ miral::OutputFilter::OutputFilter(live_config::Store& config_store) : OutputFilt
         "Output filter to use [{none,grayscale,invert}]",
         [this](live_config::Key const& key, std::optional<std::string_view> val)
         {
-            MirOutputFilter new_filter = mir_output_filter_none;
+            MirOutputFilter new_filter = self->default_filter;
             if (val)
             {
                 auto filter_name = *val;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -471,7 +471,7 @@ global:
     miral::IdleListener::on_wake*;
     miral::IdleListener::operator*;
     miral::InputConfiguration::?InputConfiguration*;
-    miral::InputConfiguration::InputConfiguration*;
+    "miral::InputConfiguration::InputConfiguration()";
     miral::InputConfiguration::Mouse::?Mouse*;
     miral::InputConfiguration::Mouse::Mouse*;
     miral::InputConfiguration::Mouse::acceleration*;
@@ -525,7 +525,8 @@ MIRAL_5.3 {
 global:
   extern "C++" {
     miral::CursorScale::?CursorScale*;
-    miral::CursorScale::CursorScale*;
+    "miral::CursorScale::CursorScale()";
+    "miral::CursorScale::CursorScale(float)";
     miral::CursorScale::operator*;
     miral::CursorScale::scale*;
     miral::DisplayConfiguration::Node::?Node*;
@@ -552,7 +553,8 @@ global:
     miral::MouseKeysConfig::set_keymap*;
     miral::MouseKeysConfig::set_max_speed*;
     miral::OutputFilter::?OutputFilter*;
-    miral::OutputFilter::OutputFilter*;
+    "miral::OutputFilter::OutputFilter()";
+    "miral::OutputFilter::OutputFilter(MirOutputFilter)";
     miral::OutputFilter::operator*;
     miral::OutputFilter::filter*;
     miral::WindowInfo::tiled_edges*;
@@ -578,9 +580,17 @@ global:
 MIRAL_5.4 {
 global:
   extern "C++" {
-    "miral::live_config::Key::Key(std::initializer_list<std::basic_string_view<char, std::char_traits<char> > const>)";
-    "miral::live_config::Key::with_key(std::function<void (std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)> const&) const";
-    "miral::live_config::Key::to_string[abi:cxx11]() const";
-    "miral::live_config::Key::operator<=>(miral::live_config::Key const&) const";
+    "miral::CursorScale::CursorScale(miral::live_config::Store&)";
+    "miral::InputConfiguration::InputConfiguration(miral::live_config::Store&)";
+    "miral::OutputFilter::OutputFilter(miral::live_config::Store&)";
+    miral::live_config::Key::Key*;
+    miral::live_config::Key::with_key*;
+    miral::live_config::Key::to_string*;
+    miral::live_config::Key::operator*;
+    miral::live_config::Store::?Store*;
+    non-virtual?thunk?to?miral::live_config::Store::?Store*;
+    typeinfo?for?miral::live_config::Key;
+    typeinfo?for?miral::live_config::Store;
+    vtable?for?miral::live_config::Store;
   };
 } MIRAL_5.3;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -579,7 +579,7 @@ MIRAL_5.4 {
 global:
   extern "C++" {
     "miral::live_config::Key::Key(std::initializer_list<std::basic_string_view<char, std::char_traits<char> > const>)";
-    "miral::live_config::Key::as_path[abi:cxx11]() const";
+    "miral::live_config::Key::with_key(std::function<void (std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)> const&) const";
     "miral::live_config::Key::to_string[abi:cxx11]() const";
     "miral::live_config::Key::operator<=>(miral::live_config::Key const&) const";
   };

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -574,3 +574,13 @@ global:
     typeinfo?for?miral::SimulatedSecondaryClick;
   };
 } MIRAL_5.2;
+
+MIRAL_5.4 {
+global:
+  extern "C++" {
+    "miral::live_config::Key::Key(std::initializer_list<std::basic_string_view<char, std::char_traits<char> > const>)";
+    "miral::live_config::Key::as_path[abi:cxx11]() const";
+    "miral::live_config::Key::to_string[abi:cxx11]() const";
+    "miral::live_config::Key::operator<=>(miral::live_config::Key const&) const";
+  };
+} MIRAL_5.3;

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(miral-test-internal
 mir_add_wrapped_executable(miral-test NOINSTALL
     external_client.cpp
     config_file.cpp
+    live_config.cpp
     runner.cpp
     wayland_extensions.cpp
     zone.cpp

--- a/tests/miral/live_config.cpp
+++ b/tests/miral/live_config.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <miral/live_config.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace testing;
+
+TEST(LiveConfig, key_cannot_be_empty)
+{
+    EXPECT_THAT([] { miral::live_config::Key{}; },
+        ThrowsMessage<std::invalid_argument>("Invalid (empty) live config key"));
+}
+
+TEST(LiveConfig, key_cannot_contain_empty_element)
+{
+    EXPECT_THAT([] { miral::live_config::Key{""}; },
+        ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"", "bar", "baz"}; }),
+        ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "", "baz"}; }),
+        ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", ""}; }),
+        ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
+}
+
+TEST(LiveConfig, key_cannot_contain_an_element_starting_with_a_digit)
+{
+    EXPECT_THAT([] { miral::live_config::Key{"1"}; },
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: 1"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"0oo", "bar", "baz"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: 0oo"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "2ar", "baz"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: 2ar"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "9az"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: 9az"));
+}
+
+TEST(LiveConfig, key_cannot_contain_an_element_starting_with_underscore)
+{
+    EXPECT_THAT([] { miral::live_config::Key{"_"}; },
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: _"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"_oo", "bar", "baz"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: _oo"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "_ar", "baz"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: _ar"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "_az"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: _az"));
+}
+
+TEST(LiveConfig, key_cannot_contain_an_element_containing_uppercase)
+{
+    EXPECT_THAT([] { miral::live_config::Key{"Foo"}; },
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: Foo"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bAr", "baz"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: bAr"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "baZ"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: baZ"));
+}
+
+TEST(LiveConfig, key_cannot_contain_an_element_containing_whitespaces_or_punctuation)
+{
+    EXPECT_THAT([] { miral::live_config::Key{"foo bar baz"}; },
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: foo bar baz"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar\n", "baz"}; }),
+        ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "baz%"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: baz%"));
+
+    EXPECT_THAT([] { miral::live_config::Key{"foo.bar.baz"}; },
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: foo.bar.baz"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "baz!"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: baz!"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar/", "baz"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: bar/"));
+
+    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "baz*"}; }),
+        ThrowsMessage<std::invalid_argument>("Invalid config key element: baz*"));
+}
+
+TEST(LiveConfig, key_can_contain_elements_with_digit_and_underscores)
+{
+    miral::live_config::Key{"foo_bar_baz"};
+
+    miral::live_config::Key{"foo1", "bar2", "baz3"};
+
+    miral::live_config::Key{"foo_122", "bar_", "baz"};
+
+    miral::live_config::Key{"foo", "bar", "baz9"};
+}

--- a/tests/miral/live_config.cpp
+++ b/tests/miral/live_config.cpp
@@ -20,101 +20,126 @@
 #include <gmock/gmock.h>
 
 using namespace testing;
+namespace mlc = miral::live_config;
 
 TEST(LiveConfig, key_cannot_be_empty)
 {
-    EXPECT_THAT([] { miral::live_config::Key{}; },
+    EXPECT_THAT([] { mlc::Key{}; },
         ThrowsMessage<std::invalid_argument>("Invalid (empty) live config key"));
 }
 
 TEST(LiveConfig, key_cannot_contain_empty_element)
 {
-    EXPECT_THAT([] { miral::live_config::Key{""}; },
+    EXPECT_THAT([] { mlc::Key{""}; },
         ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"", "bar", "baz"}; }),
+    EXPECT_THAT(([] { mlc::Key{"", "bar", "baz"}; }),
         ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "", "baz"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "", "baz"}; }),
         ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", ""}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bar", ""}; }),
         ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
 }
 
 TEST(LiveConfig, key_cannot_contain_an_element_starting_with_a_digit)
 {
-    EXPECT_THAT([] { miral::live_config::Key{"1"}; },
+    EXPECT_THAT([] { mlc::Key{"1"}; },
         ThrowsMessage<std::invalid_argument>("Invalid config key element: 1"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"0oo", "bar", "baz"}; }),
+    EXPECT_THAT(([] { mlc::Key{"0oo", "bar", "baz"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: 0oo"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "2ar", "baz"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "2ar", "baz"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: 2ar"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "9az"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bar", "9az"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: 9az"));
 }
 
 TEST(LiveConfig, key_cannot_contain_an_element_starting_with_underscore)
 {
-    EXPECT_THAT([] { miral::live_config::Key{"_"}; },
+    EXPECT_THAT([] { mlc::Key{"_"}; },
         ThrowsMessage<std::invalid_argument>("Invalid config key element: _"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"_oo", "bar", "baz"}; }),
+    EXPECT_THAT(([] { mlc::Key{"_oo", "bar", "baz"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: _oo"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "_ar", "baz"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "_ar", "baz"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: _ar"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "_az"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bar", "_az"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: _az"));
 }
 
 TEST(LiveConfig, key_cannot_contain_an_element_containing_uppercase)
 {
-    EXPECT_THAT([] { miral::live_config::Key{"Foo"}; },
+    EXPECT_THAT([] { mlc::Key{"Foo"}; },
         ThrowsMessage<std::invalid_argument>("Invalid config key element: Foo"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bAr", "baz"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bAr", "baz"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: bAr"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "baZ"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bar", "baZ"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: baZ"));
 }
 
 TEST(LiveConfig, key_cannot_contain_an_element_containing_whitespaces_or_punctuation)
 {
-    EXPECT_THAT([] { miral::live_config::Key{"foo bar baz"}; },
+    EXPECT_THAT([] { mlc::Key{"foo bar baz"}; },
         ThrowsMessage<std::invalid_argument>("Invalid config key element: foo bar baz"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar\n", "baz"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bar\n", "baz"}; }),
         ThrowsMessage<std::invalid_argument>(HasSubstr("Invalid config key element:")));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "baz%"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bar", "baz%"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: baz%"));
 
-    EXPECT_THAT([] { miral::live_config::Key{"foo.bar.baz"}; },
+    EXPECT_THAT([] { mlc::Key{"foo.bar.baz"}; },
         ThrowsMessage<std::invalid_argument>("Invalid config key element: foo.bar.baz"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "baz!"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bar", "baz!"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: baz!"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar/", "baz"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bar/", "baz"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: bar/"));
 
-    EXPECT_THAT(([] { miral::live_config::Key{"foo", "bar", "baz*"}; }),
+    EXPECT_THAT(([] { mlc::Key{"foo", "bar", "baz*"}; }),
         ThrowsMessage<std::invalid_argument>("Invalid config key element: baz*"));
 }
 
 TEST(LiveConfig, key_can_contain_elements_with_digit_and_underscores)
 {
-    miral::live_config::Key{"foo_bar_baz"};
+    mlc::Key{"foo_bar_baz"};
 
-    miral::live_config::Key{"foo1", "bar2", "baz3"};
+    mlc::Key{"foo1", "bar2", "baz3"};
 
-    miral::live_config::Key{"foo_122", "bar_", "baz"};
+    mlc::Key{"foo_122", "bar_", "baz"};
 
-    miral::live_config::Key{"foo", "bar", "baz9"};
+    mlc::Key{"foo", "bar", "baz9"};
+}
+
+TEST(LiveConfig, key_has_expected_representations)
+{
+    mlc::Key const foo_bar_baz{"foo_bar_baz"};
+    EXPECT_THAT(foo_bar_baz.to_string(), Eq("foo_bar_baz"));
+    foo_bar_baz.with_key([&](std::vector<std::string> const& key)
+    {
+        EXPECT_THAT(key, ElementsAre("foo_bar_baz"));
+    });
+
+    mlc::Key const foo1_bar2_baz3{"foo1", "bar2", "baz3"};
+    EXPECT_THAT(foo1_bar2_baz3.to_string(), Eq("foo1_bar2_baz3"));
+    foo1_bar2_baz3.with_key([&](std::vector<std::string> const& key)
+    {
+        EXPECT_THAT(key, ElementsAre("foo1", "bar2", "baz3"));
+    });
+
+    mlc::Key const foo_122_bar__baz{"foo_122", "bar_", "baz"};
+    EXPECT_THAT(foo_122_bar__baz.to_string(), Eq("foo_122_bar__baz"));
+    foo_122_bar__baz.with_key([&](std::vector<std::string> const& key)
+    {
+        EXPECT_THAT(key, ElementsAre("foo_122", "bar_", "baz"));
+    });
 }

--- a/tools/symbols_map_generator/main.py
+++ b/tools/symbols_map_generator/main.py
@@ -31,6 +31,9 @@ HIDDEN_SYMBOLS = {
     "miral::WaylandExtensions::Context::Context*;",
     "vtable?for?miral::WaylandExtensions::Context;",
     "mir::DefaultServerConfiguration::pointer_input_dispatcher*;",
+    "miral::CursorScale::CursorScale*;",
+    "miral::InputConfiguration::InputConfiguration*;",
+    "miral::OutputFilter::OutputFilter*;",
 }
 
 class HeaderDirectory(TypedDict):


### PR DESCRIPTION
This is the first part of providing a pluggable live configuration mechanism

This PR provides 

1. the `miral::live_config::Store` API to be implemented over a configuration mechanism; and,
2. Constructors for  `OutputFilter`, `CursorScale` and `InputConfiguration` that register for configuration changes

There's also a POC .ini file style implementation in `mir_demo_server`.

Further PRs will provide implementations of `miral::live_config::Store` based on ".ini file" (replacing the POC with something complete and product ready), YAML and gsettings.

Shells will be able to choose between these implementations and rolling their own