### PR TITLE
debian: add questing's broken binutils version

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -33,7 +33,7 @@ COMMON_CONFIGURE_OPTIONS = \
 # Disable LTO on broken binutils
 # https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/2070302
 ifeq ($(filter arm64,$(DEB_HOST_ARCH)),arm64)
-	ifneq ($(shell ld --version | grep -E '2.4(4|3.1)$$'),)
+	ifneq ($(shell ld --version | grep -E '(2.43.1|2.44|2.44.50.20250604)$$'),)
 		DEB_BUILD_MAINT_OPTIONS += optimize=-lto
 	endif
 endif


### PR DESCRIPTION
Ref.: https://launchpad.net/ubuntu/+source/binutils