### PR TITLE
Revert "tics: add `python3-clang` dep (#3997)"

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -71,7 +71,6 @@ jobs:
           mesa-utils \
           ninja-build \
           pylint \
-          python3-clang \
           xwayland
 
         sudo --preserve-env apt-get build-dep --yes ./


### PR DESCRIPTION
This reverts commit 6c089a081609b9f25865672df1913e31484a7530, reversing changes made to b66c2e6b067d3a1e449ae8b6ddb1e24e5ce91699.