### PR TITLE
platforms/eglstream-kms: Update for ShmBuffer interface changes

### DIFF
--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -22,6 +22,7 @@
 #include "mir/anonymous_shm_file.h"
 #include "mir/graphics/display_sink.h"
 #include "mir/graphics/drm_formats.h"
+#include "mir/graphics/egl_context_executor.h"
 #include "mir/graphics/egl_resources.h"
 #include "mir/graphics/gl_config.h"
 #include "mir/graphics/platform.h"
@@ -721,8 +722,11 @@ auto pick_stream_surface_config(EGLDisplay dpy, mg::GLConfig const& gl_config) -
 }
 }
 
-mge::GLRenderingProvider::GLRenderingProvider(EGLDisplay dpy, std::unique_ptr<mir::renderer::gl::Context> ctx)
+mge::GLRenderingProvider::GLRenderingProvider(
+    EGLDisplay dpy,
+    std::unique_ptr<mir::renderer::gl::Context> ctx)
     : dpy{dpy},
+      egl_delegate{std::make_shared<mgc::EGLContextExecutor>(ctx->make_share_context())},
       ctx{std::move(ctx)}
 {
 }
@@ -733,6 +737,10 @@ auto mir::graphics::eglstream::GLRenderingProvider::as_texture(std::shared_ptr<B
     -> std::shared_ptr<gl::Texture>
 {
     std::shared_ptr<NativeBufferBase> native_buffer{buffer, buffer->native_buffer_base()};
+    if (auto shm = std::dynamic_pointer_cast<mgc::ShmBuffer>(native_buffer))
+    {
+        return shm->texture_for_provider(egl_delegate, this);
+    }
     return std::dynamic_pointer_cast<gl::Texture>(std::move(native_buffer));
 }
 

--- a/src/platforms/eglstream-kms/server/buffer_allocator.h
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.h
@@ -111,6 +111,7 @@ public:
         GLConfig const& gl_config) -> std::unique_ptr<gl::OutputSurface> override;
 private:
     EGLDisplay dpy;
+    std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
     std::unique_ptr<renderer::gl::Context> const ctx;
 };
 


### PR DESCRIPTION
This is a follow up for #3968, fixing an immediate crash on eglstream-kms.