### PR TITLE
live_config::Store: `std::span<std::string_view>` => `std::span<std::string>`

### DIFF
--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -171,7 +171,7 @@ public:
     void add_string_attribute(live_config::Key const& key, std::string_view description, std::string_view preset,
         HandleString handler) override;
     void add_strings_attribute(live_config::Key const& key, std::string_view description,
-        std::span<std::string_view const> preset, HandleStrings handler) override;
+        std::span<std::string const> preset, HandleStrings handler) override;
 
     void on_done(HandleDone handler) override;
 
@@ -291,7 +291,7 @@ void DemoConfigFile::add_string_attribute(live_config::Key const& key, std::stri
 }
 
 void DemoConfigFile::add_strings_attribute(live_config::Key const& key, std::string_view description,
-    std::span<std::string_view const> preset, HandleStrings handler)
+    std::span<std::string const> preset, HandleStrings handler)
 {
     // Not implemented: not needed for discussion
     (void)handler; (void)description; (void)key; (void)preset;

--- a/include/miral/miral/live_config.h
+++ b/include/miral/miral/live_config.h
@@ -74,7 +74,7 @@ public:
     using HandleFloat = std::function<void(Key const& key, std::optional<float> value)>;
     using HandleFloats = std::function<void(Key const& key, std::optional<std::span<float const>> value)>;
     using HandleString = std::function<void(Key const& key, std::optional<std::string_view> value)>;
-    using HandleStrings = std::function<void(Key const& key, std::optional<std::span<std::string_view const>> value)>;
+    using HandleStrings = std::function<void(Key const& key, std::optional<std::span<std::string const>> value)>;
     using HandleDone = std::function<void()>;
 
     virtual void add_int_attribute(Key const& key, std::string_view description, HandleInt handler) = 0;
@@ -93,7 +93,7 @@ public:
     virtual void add_float_attribute(Key const& key, std::string_view description, float preset, HandleFloat handler) = 0;
     virtual void add_floats_attribute(Key const& key, std::string_view description, std::span<float const> preset, HandleFloats handler) = 0;
     virtual void add_string_attribute(Key const& key, std::string_view description, std::string_view preset, HandleString handler) = 0;
-    virtual void add_strings_attribute(Key const& key, std::string_view description, std::span<std::string_view const> preset, HandleStrings handler) = 0;
+    virtual void add_strings_attribute(Key const& key, std::string_view description, std::span<std::string const> preset, HandleStrings handler) = 0;
 
     /// Called following a set of related updates (e.g. a file reload) to allow
     /// multiple attributes to be updated transactionally


### PR DESCRIPTION
`std::span<std::string_view>` is an indirection too many.`std::span<T>` is view on a container of `T` which would require the implementer of `Store` to construct that container as well as maintaining the actual content.

A more reasonable requirement is to hold array values in `std::string`