### PR TITLE
Implement Cursor::renderable for the atomic-kms platform

### DIFF
--- a/src/platforms/atomic-kms/server/kms/cursor.cpp
+++ b/src/platforms/atomic-kms/server/kms/cursor.cpp
@@ -19,6 +19,7 @@
 #include "kms_output.h"
 #include "kms_output_container.h"
 #include "kms_display_configuration.h"
+#include "shm_buffer.h"
 #include "mir/geometry/rectangle.h"
 #include "mir/graphics/cursor_image.h"
 #include "mir/graphics/pixman_image_scaling.h"
@@ -31,6 +32,7 @@
 #include <vector>
 
 namespace mg = mir::graphics;
+namespace mgc = mir::graphics::common;
 namespace mga = mg::atomic;
 namespace geom = mir::geometry;
 
@@ -171,9 +173,9 @@ void mga::Cursor::write_buffer_data_locked(
 
 void mga::Cursor::pad_and_write_image_data_locked(
     std::lock_guard<std::mutex> const& lg,
-    GBMBOWrapper& buffer)
+    GBMBOWrapper& gbm_buffer)
 {
-    auto const orientation = buffer.orientation();
+    auto const orientation = gbm_buffer.orientation();
     bool const sideways = orientation == mir_orientation_left || orientation == mir_orientation_right;
 
     auto const min_width  = sideways ? min_buffer_width : min_buffer_height;
@@ -183,15 +185,16 @@ void mga::Cursor::pad_and_write_image_data_locked(
     auto const image_height = std::min(min_height, size.height.as_uint32_t());
     auto const image_stride = size.width.as_uint32_t() * 4;
 
-    auto const buffer_stride = std::max(min_width*4, gbm_bo_get_stride(buffer));  // in bytes
-    auto const buffer_height = std::max(min_height, gbm_bo_get_height(buffer));
+    auto const buffer_stride = std::max(min_width*4, gbm_bo_get_stride(gbm_buffer));  // in bytes
+    auto const buffer_height = std::max(min_height, gbm_bo_get_height(gbm_buffer));
     size_t const padded_size = buffer_stride * buffer_height;
 
     auto padded = std::unique_ptr<uint8_t[]>(new uint8_t[padded_size]);
     size_t rhs_padding = buffer_stride - 4*image_width;
 
     auto const filler = 0; // 0x3f; is useful to make buffer visible for debugging
-    uint8_t const* src = argb8888.data();
+    auto const mapping = buffer->map_readable();
+    uint8_t const* src = mapping->data();
     uint8_t* dest = &padded[0];
 
     switch (orientation)
@@ -251,7 +254,7 @@ void mga::Cursor::pad_and_write_image_data_locked(
         break;
     }
 
-    write_buffer_data_locked(lg, buffer, &padded[0], padded_size);
+    write_buffer_data_locked(lg, gbm_buffer, &padded[0], padded_size);
 }
 
 void mga::Cursor::show(std::shared_ptr<CursorImage> const& cursor_image)
@@ -264,8 +267,10 @@ void mga::Cursor::show(std::shared_ptr<CursorImage> const& cursor_image)
     auto const scaled_cursor_buf = mg::scale_cursor_image(*current_cursor_image, current_scale);
     auto const buf_size_bytes = scaled_cursor_buf.size.width.as_value() * scaled_cursor_buf.size.height.as_value() * 4;
 
-    argb8888.resize(buf_size_bytes);
-    memcpy(argb8888.data(), scaled_cursor_buf.data.get(), buf_size_bytes);
+    buffer = std::make_shared<mgc::MemoryBackedShmBuffer>(
+        size,
+        mir_pixel_format_argb_8888);
+    memcpy(buffer->map_writeable()->data(), scaled_cursor_buf.data.get(), buf_size_bytes);
 
     hotspot = current_cursor_image->hotspot() * current_scale;
     {
@@ -455,7 +460,85 @@ void mir::graphics::atomic::Cursor::scale(float new_scale)
 
 auto mir::graphics::atomic::Cursor::renderable() -> std::shared_ptr<Renderable>
 {
-    return nullptr;
+    class CursorRenderable : public Renderable
+    {
+    public:
+        CursorRenderable(
+            std::shared_ptr<Buffer> const& buffer,
+            geom::Point const& position)
+            : buffer_(buffer),
+              position(position)
+        {
+        }
+
+        ID id() const override
+        {
+            return this;
+        }
+
+        std::shared_ptr<Buffer> buffer() const override
+        {
+            return buffer_;
+        }
+
+        geom::Rectangle screen_position() const override
+        {
+            return geom::Rectangle{
+                position,
+                buffer_->size()
+            };
+        }
+
+        geom::RectangleD src_bounds() const override
+        {
+            return geom::RectangleD{
+                    {0, 0},
+                    buffer_->size()
+                };
+        }
+
+        std::optional<geometry::Rectangle> clip_area() const override
+        {
+            return std::nullopt;
+        }
+
+        float alpha() const override
+        {
+            return 1;
+        }
+
+        glm::mat4 transformation() const override
+        {
+            return glm::mat4(1.f);
+        }
+
+        bool shaped() const override
+        {
+            return true;
+        }
+
+        auto surface_if_any() const -> std::optional<mir::scene::Surface const*> override
+        {
+            return std::nullopt;
+        }
+
+        MirOrientation orientation() const override
+        {
+            return mir_orientation_normal;
+        }
+
+    private:
+        std::shared_ptr<Buffer> buffer_;
+        geom::Point position;
+    };
+
+    std::lock_guard lg(guard);
+    if (!visible)
+        return nullptr;
+
+    return std::make_shared<CursorRenderable>(
+        buffer,
+        current_position);
 }
 
 auto mir::graphics::atomic::Cursor::needs_compositing() const -> bool

--- a/src/platforms/atomic-kms/server/kms/cursor.h
+++ b/src/platforms/atomic-kms/server/kms/cursor.h
@@ -38,6 +38,11 @@ namespace graphics
 class CursorImage;
 class DisplayConfigurationOutput;
 
+namespace common
+{
+class MemoryBackedShmBuffer;
+}
+
 namespace atomic
 {
 class KMSOutputContainer;
@@ -95,7 +100,7 @@ private:
         size_t count);
     void pad_and_write_image_data_locked(
         std::lock_guard<std::mutex> const&,
-        GBMBOWrapper& buffer);
+        GBMBOWrapper& gbm_buffer);
     void clear(std::lock_guard<std::mutex> const&);
 
     GBMBOWrapper& buffer_for_output(KMSOutput const& output);
@@ -106,7 +111,7 @@ private:
     geometry::Point current_position;
     geometry::Displacement hotspot;
     geometry::Size size;
-    std::vector<uint8_t> argb8888;
+    std::shared_ptr<common::MemoryBackedShmBuffer> buffer;
 
     bool visible;
     bool last_set_failed;

--- a/tests/unit-tests/platforms/CMakeLists.txt
+++ b/tests/unit-tests/platforms/CMakeLists.txt
@@ -2,6 +2,10 @@ if (MIR_BUILD_PLATFORM_GBM_KMS)
   add_subdirectory(gbm-kms/)
 endif()
 
+if (MIR_BUILD_PLATFORM_ATOMIC_KMS)
+  add_subdirectory(atomic-kms/)
+endif()
+
 if (MIR_BUILD_PLATFORM_EGLSTREAM_KMS)
   add_subdirectory(eglstream-kms)
 endif()

--- a/tests/unit-tests/platforms/atomic-kms/CMakeLists.txt
+++ b/tests/unit-tests/platforms/atomic-kms/CMakeLists.txt
@@ -1,0 +1,9 @@
+include_directories(
+  ${PROJECT_SOURCE_DIR}/src/platforms/atomic-kms/server
+)
+
+if (MIR_BUILD_PLATFORM_GBM_KMS)
+  add_subdirectory(kms/)
+endif()
+
+set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/platforms/atomic-kms/kms/CMakeLists.txt
+++ b/tests/unit-tests/platforms/atomic-kms/kms/CMakeLists.txt
@@ -1,0 +1,32 @@
+mir_add_wrapped_executable(mir_unit_tests_atomic-kms NOINSTALL
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_cursor.cpp
+  ${MIR_SERVER_OBJECTS}
+  $<TARGET_OBJECTS:mirplatformgraphicsatomickmsobjects>
+  $<TARGET_OBJECTS:mirsharedatomickmscommon-static>
+  $<TARGET_OBJECTS:mir-umock-test-framework>
+)
+
+add_dependencies(mir_unit_tests_atomic-kms GMock)
+
+set_target_properties(
+  mir_unit_tests_atomic-kms
+  PROPERTIES
+    ENABLE_EXPORTS TRUE
+)
+
+target_link_libraries(
+  mir_unit_tests_atomic-kms
+
+  mir-test-static
+  mir-test-framework-static
+  mir-test-doubles-static
+  mir-test-doubles-platform-static
+  mirsharedgbmservercommon-static
+
+  PkgConfig::DRM
+  PkgConfig::GBM
+)
+
+if (MIR_RUN_UNIT_TESTS)
+  mir_discover_tests_with_fd_leak_detection(mir_unit_tests_atomic-kms LD_PRELOAD=libumockdev-preload.so.0 G_SLICE=always-malloc G_DEBUG=gc-friendly)
+endif (MIR_RUN_UNIT_TESTS)

--- a/tests/unit-tests/platforms/atomic-kms/kms/mock_kms_output.h
+++ b/tests/unit-tests/platforms/atomic-kms/kms/mock_kms_output.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MOCK_KMS_OUTPUT_H_
+#define MOCK_KMS_OUTPUT_H_
+
+#include "src/platforms/atomic-kms/server/kms/kms_output.h"
+#include <gmock/gmock.h>
+
+namespace mir
+{
+
+namespace test
+{
+
+class MockKMSOutput : public graphics::atomic::KMSOutput
+{
+public:
+    MOCK_METHOD(uint32_t, id, (), (const, override));
+    MOCK_METHOD(void, reset, (), (override));
+    MOCK_METHOD(void, configure, (geometry::Displacement, size_t), (override));
+    MOCK_METHOD(geometry::Size, size, (), (const, override));
+    MOCK_METHOD(int, max_refresh_rate, (), (const, override));
+    MOCK_METHOD(bool, set_crtc, (graphics::FBHandle const&), (override));
+    MOCK_METHOD(bool, has_crtc_mismatch, (), (override));
+    MOCK_METHOD(void, clear_crtc, (), (override));
+    MOCK_METHOD(bool, page_flip, (graphics::FBHandle const&), (override));
+    MOCK_METHOD(void, set_cursor_image, (gbm_bo*), (override));
+    MOCK_METHOD(void, move_cursor, (geometry::Point), (override));
+    MOCK_METHOD(bool, clear_cursor, (), (override));
+    MOCK_METHOD(bool, has_cursor_image, (), (const, override));
+    MOCK_METHOD(void, set_power_mode, (MirPowerMode), (override));
+    MOCK_METHOD(void, set_gamma, (graphics::GammaCurves const&), (override));
+    MOCK_METHOD(void, refresh_hardware_state, (), (override));
+    MOCK_METHOD(void, update_from_hardware_state, (graphics::DisplayConfigurationOutput&), (const, override));
+    MOCK_METHOD(int, drm_fd, (), (const, override));
+};
+
+} // namespace test
+} // namespace mir
+
+#endif // MOCK_KMS_OUTPUT_H_

--- a/tests/unit-tests/platforms/atomic-kms/kms/test_cursor.cpp
+++ b/tests/unit-tests/platforms/atomic-kms/kms/test_cursor.cpp
@@ -1,0 +1,412 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "src/platforms/atomic-kms/server/kms/cursor.h"
+#include "src/platforms/atomic-kms/server/kms/kms_output.h"
+#include "src/platforms/atomic-kms/server/kms/kms_output_container.h"
+#include "src/platforms/atomic-kms/server/kms/kms_display_configuration.h"
+#include "mir/graphics/cursor_image.h"
+#include "mir/test/doubles/stub_display_configuration.h"
+#include "mir/test/doubles/mock_gbm.h"
+#include "mir/test/doubles/mock_drm.h"
+#include "mir/test/fake_shared.h"
+#include "mock_kms_output.h"
+#include "kms/atomic_kms_output.h"
+
+#include <memory>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace mg = mir::graphics;
+namespace mga = mir::graphics::atomic;
+namespace geom = mir::geometry;
+namespace mt = mir::test;
+namespace mtd = mt::doubles;
+using mt::MockKMSOutput;
+using namespace ::testing;
+
+namespace
+{
+
+class StubKMSOutputContainer : public mga::KMSOutputContainer
+{
+public:
+    void add_output(geom::Size size)
+    {
+        auto const output = std::make_shared<testing::NiceMock<MockKMSOutput>>();
+        outputs.push_back(output);
+
+        auto& out = *output;
+        ON_CALL(out, size())
+            .WillByDefault(Return(size));
+        ON_CALL(out, has_cursor_image())
+            .WillByDefault(Return(true));
+        ON_CALL(out, clear_cursor())
+            .WillByDefault(Return(true));
+    }
+
+    void for_each_output(std::function<void(std::shared_ptr<mga::KMSOutput> const&)> functor) const override
+    {
+        for (auto const& output : outputs)
+            functor(output);
+    }
+
+    void update_from_hardware_state() override
+    {
+    }
+
+    std::vector<std::shared_ptr<testing::NiceMock<MockKMSOutput>>> outputs;
+};
+
+class StubKMSDisplayConfiguration : public mga::KMSDisplayConfiguration
+{
+public:
+    explicit StubKMSDisplayConfiguration(StubKMSOutputContainer& container)
+        : mga::KMSDisplayConfiguration(),
+          container{container},
+          stub_config{
+            {{
+                mg::DisplayConfigurationOutputId{0},
+                mg::DisplayConfigurationCardId{},
+                mg::DisplayConfigurationLogicalGroupId{},
+                mg::DisplayConfigurationOutputType::vga,
+                {},
+                {
+                    {geom::Size{10, 20}, 59.9},
+                    {geom::Size{200, 100}, 59.9},
+                },
+                1,
+                geom::Size{324, 642},
+                true,
+                true,
+                geom::Point{0, 0},
+                1,
+                mir_pixel_format_invalid,
+                mir_power_mode_on,
+                mir_orientation_normal,
+                1.0f,
+                mir_form_factor_monitor,
+                mir_subpixel_arrangement_unknown,
+                {},
+                mir_output_gamma_unsupported,
+                {},
+                {}
+            },
+            {
+                mg::DisplayConfigurationOutputId{1},
+                mg::DisplayConfigurationCardId{},
+                mg::DisplayConfigurationLogicalGroupId{},
+                mg::DisplayConfigurationOutputType::vga,
+                {},
+                {
+                    {geom::Size{200, 200}, 59.9},
+                    {geom::Size{100, 200}, 59.9},
+                },
+                0,
+                geom::Size{566, 111},
+                true,
+                true,
+                geom::Point{100, 50},
+                0,
+                mir_pixel_format_invalid,
+                mir_power_mode_on,
+                mir_orientation_normal,
+                1.0f,
+                mir_form_factor_monitor,
+                mir_subpixel_arrangement_unknown,
+                {},
+                mir_output_gamma_unsupported,
+                {},
+                {}
+            },
+            {
+                mg::DisplayConfigurationOutputId{2},
+                mg::DisplayConfigurationCardId{},
+                mg::DisplayConfigurationLogicalGroupId{},
+                mg::DisplayConfigurationOutputType::vga,
+                {},
+                {
+                    {geom::Size{800, 200}, 59.9},
+                    {geom::Size{100, 200}, 59.9},
+                },
+                0,
+                geom::Size{800, 200},
+                true,
+                true,
+                geom::Point{666, 0},
+                0,
+                mir_pixel_format_invalid,
+                mir_power_mode_on,
+                mir_orientation_right,
+                1.0f,
+                mir_form_factor_monitor,
+                mir_subpixel_arrangement_unknown,
+                {},
+                mir_output_gamma_unsupported,
+                {},
+                {}
+            }}}
+    {
+        stub_config.for_each_output([&container](auto const& conf)
+            {
+                container.add_output(conf.modes[conf.current_mode_index].size);
+            });
+        container.for_each_output(
+            [this](auto const& output)
+            {
+                outputs.push_back(output);
+            });
+    }
+
+    void for_each_output(std::function<void(mg::DisplayConfigurationOutput const&)> f) const override
+    {
+        stub_config.for_each_output(f);
+    }
+
+    void for_each_output(std::function<void(mg::UserDisplayConfigurationOutput&)> f) override
+    {
+        stub_config.for_each_output(f);
+    }
+
+    std::unique_ptr<DisplayConfiguration> clone() const override
+    {
+        return stub_config.clone();
+    }
+
+    bool valid() const override
+    {
+        return stub_config.valid();
+    }
+
+    std::shared_ptr<mga::KMSOutput> get_output_for(mg::DisplayConfigurationOutputId id) const override
+    {
+        return outputs[id.as_value()];
+    }
+
+    size_t get_kms_mode_index(mg::DisplayConfigurationOutputId, size_t conf_mode_index) const override
+    {
+        return conf_mode_index;
+    }
+
+    void update() override
+    {
+    }
+
+    StubKMSOutputContainer& container;
+    mtd::StubDisplayConfig stub_config;
+    std::vector<std::shared_ptr<mga::KMSOutput>> outputs;
+};
+
+class StubCurrentConfiguration : public mga::CurrentConfiguration
+{
+public:
+    explicit StubCurrentConfiguration(StubKMSOutputContainer& container)
+        : conf(container)
+    {
+    }
+
+    void with_current_configuration_do(
+        std::function<void(mga::KMSDisplayConfiguration const&)> const& exec)
+    {
+        exec(conf);
+    }
+
+    StubKMSDisplayConfiguration conf;
+};
+
+class StubCursorImage : public mg::CursorImage
+{
+public:
+    void const* as_argb_8888() const
+    {
+        return image_data;
+    }
+    geom::Size size() const
+    {
+        return geom::Size{geom::Width{64}, geom::Height{64}};
+    }
+    geom::Displacement hotspot() const
+    {
+        return geom::Displacement{0, 0};
+    }
+
+    static void const* image_data;
+};
+
+char const stub_data[128*128*4] = { 0 };
+void const* StubCursorImage::image_data = stub_data;
+
+class AtomicKmsCursorTest : public Test
+{
+public:
+    AtomicKmsCursorTest()
+        : cursor{output_container,
+          mt::fake_shared(current_configuration)}
+    {
+        ON_CALL(mock_drm, drmGetCap(_, DRM_CAP_CURSOR_WIDTH, _))
+            .WillByDefault(Invoke([](int , uint64_t , uint64_t *value)
+              {
+                  *value = 64;
+                  return 0;
+              }));
+        ON_CALL(mock_drm, drmGetCap(_, DRM_CAP_CURSOR_HEIGHT, _))
+            .WillByDefault(Invoke([](int , uint64_t , uint64_t *value)
+              {
+                  *value = 64;
+                  return 0;
+              }));
+    }
+
+    struct MockGBM : NiceMock<mtd::MockGBM>
+    {
+        MockGBM()
+        {
+            using namespace ::testing;
+            const uint32_t default_cursor_size = 64;
+            ON_CALL(*this, gbm_bo_get_width(_))
+                .WillByDefault(Return(default_cursor_size));
+            ON_CALL(*this, gbm_bo_get_height(_))
+                .WillByDefault(Return(default_cursor_size));
+
+        }
+    } mock_gbm;
+    NiceMock<mtd::MockDRM> mock_drm;
+    StubKMSOutputContainer output_container;
+    StubCurrentConfiguration current_configuration{output_container};
+    mga::Cursor cursor;
+
+};
+}
+
+TEST_F(AtomicKmsCursorTest, if_shown_cursor_renderable_is_not_null)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable(), NotNull());
+}
+
+TEST_F(AtomicKmsCursorTest, cursor_renderable_buffer_is_not_null)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->buffer(), NotNull());
+}
+
+TEST_F(AtomicKmsCursorTest, cursor_renderable_id_is_not_null)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->id(), NotNull());
+}
+
+TEST_F(AtomicKmsCursorTest, cursor_renderable_screen_position_is_expected)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.move_to(geom::Point{50, 50});
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->screen_position(), Eq(
+        geom::Rectangle({50, 50}, {image->size()})));
+}
+
+TEST_F(AtomicKmsCursorTest, cursor_renderable_src_bounds_is_expected)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.move_to(geom::Point{50, 50});
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->src_bounds(), Eq(
+        geom::RectangleD({0, 0}, image->size())));
+}
+
+TEST_F(AtomicKmsCursorTest, cursor_renderable_clip_area_is_unset)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->clip_area(), Eq(std::nullopt));
+}
+
+TEST_F(AtomicKmsCursorTest, cursor_renderable_alpha_is_one)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->alpha(), Eq(1));
+}
+
+TEST_F(AtomicKmsCursorTest, cursor_renderable_transformation_is_identity)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->transformation(), Eq(glm::mat4(1.f)));
+}
+
+TEST_F(AtomicKmsCursorTest, cursor_renderable_shaped_is_true)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->shaped(), Eq(true));
+}
+
+TEST_F(AtomicKmsCursorTest, cursor_renderable_surface_is_nullopt)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->surface_if_any(), Eq(std::nullopt));
+}
+
+TEST_F(AtomicKmsCursorTest, if_hidden_cursor_renderable_is_null)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+    cursor.hide();
+
+    EXPECT_THAT(cursor.renderable(), IsNull());
+}
+
+TEST_F(AtomicKmsCursorTest, does_not_need_compositing)
+{
+    EXPECT_THAT(cursor.needs_compositing(), Eq(false));
+}


### PR DESCRIPTION
## What's new?
- Gave the `atomic-kms` cursor the same implementation as the `gbm-kms` cursor
- Added our first `atomic-kms` tests for the new methods