### PR TITLE
Implement the 'overlay_cursor' flag for WlrScreencopy

### DIFF
--- a/src/include/server/mir/compositor/screen_shooter.h
+++ b/src/include/server/mir/compositor/screen_shooter.h
@@ -47,6 +47,7 @@ public:
     virtual void capture(
         std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
         mir::geometry::Rectangle const& area,
+        bool overlay_cursor,
         std::function<void(std::optional<time::Timestamp>)>&& callback) = 0;
 
 private:

--- a/src/server/compositor/basic_screen_shooter.h
+++ b/src/server/compositor/basic_screen_shooter.h
@@ -35,6 +35,7 @@ class RendererFactory;
 }
 namespace graphics
 {
+class Cursor;
 class OutputFilter;
 }
 namespace compositor
@@ -52,11 +53,13 @@ public:
         std::shared_ptr<renderer::RendererFactory> render_factory,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
         std::shared_ptr<mir::graphics::GLConfig> const& config,
-        std::shared_ptr<graphics::OutputFilter> const& output_filter);
+        std::shared_ptr<graphics::OutputFilter> const& output_filter,
+        std::shared_ptr<graphics::Cursor> const& cursor);
 
     void capture(
         std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
         geometry::Rectangle const& area,
+        bool overlay_cursor,
         std::function<void(std::optional<time::Timestamp>)>&& callback) override;
 
 private:
@@ -70,11 +73,13 @@ private:
             std::shared_ptr<graphics::GLRenderingProvider> provider,
             std::shared_ptr<renderer::RendererFactory> render_factory,
             std::shared_ptr<mir::graphics::GLConfig> const& config,
-            std::shared_ptr<graphics::OutputFilter> const& output_filter);
+            std::shared_ptr<graphics::OutputFilter> const& output_filter,
+std::shared_ptr<graphics::Cursor> const& cursor);
 
         auto render(
             std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
-            geometry::Rectangle const& area) -> time::Timestamp;
+            geometry::Rectangle const& area,
+            bool overlay_cursor) -> time::Timestamp;
 
         auto renderer_for_buffer(std::shared_ptr<renderer::software::WriteMappableBuffer> buffer)
             -> renderer::Renderer&;
@@ -96,6 +101,7 @@ private:
         std::shared_ptr<OneShotBufferDisplayProvider> const output;
         std::shared_ptr<mir::graphics::GLConfig> config;
         std::shared_ptr<graphics::OutputFilter> const output_filter;
+        std::shared_ptr<graphics::Cursor> cursor;
     };
     std::shared_ptr<Self> const self;
     Executor& executor;

--- a/src/server/compositor/basic_screen_shooter_factory.cpp
+++ b/src/server/compositor/basic_screen_shooter_factory.cpp
@@ -29,18 +29,20 @@ mc::BasicScreenShooterFactory::BasicScreenShooterFactory(
     std::shared_ptr<mr::RendererFactory> const& render_factory,
     std::shared_ptr<mg::GraphicBufferAllocator> const& buffer_allocator,
     std::shared_ptr<mg::GLConfig> const& config,
-    std::shared_ptr<mg::OutputFilter> const& output_filter)
+    std::shared_ptr<mg::OutputFilter> const& output_filter,
+    std::shared_ptr<graphics::Cursor> const& cursor)
     : scene(scene),
       clock(clock),
       providers(providers),
       renderer_factory(render_factory),
       buffer_allocator(buffer_allocator),
       config(config),
-      output_filter(output_filter)
+      output_filter(output_filter),
+      cursor(cursor)
 {}
 
 auto mc::BasicScreenShooterFactory::create(Executor& executor) -> std::unique_ptr<ScreenShooter>
 {
     return std::make_unique<BasicScreenShooter>(
-        scene, clock, executor, providers, renderer_factory, buffer_allocator, config, output_filter);
+        scene, clock, executor, providers, renderer_factory, buffer_allocator, config, output_filter, cursor);
 }

--- a/src/server/compositor/basic_screen_shooter_factory.h
+++ b/src/server/compositor/basic_screen_shooter_factory.h
@@ -31,6 +31,7 @@ class RendererFactory;
 
 namespace graphics
 {
+class Cursor;
 class OutputFilter;
 }
 
@@ -53,7 +54,8 @@ public:
         std::shared_ptr<renderer::RendererFactory> const& render_factory,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
         std::shared_ptr<graphics::GLConfig> const& config,
-        std::shared_ptr<graphics::OutputFilter> const& output_filter);
+        std::shared_ptr<graphics::OutputFilter> const& output_filter,
+        std::shared_ptr<graphics::Cursor> const& cursor);
     auto create(Executor& executor) -> std::unique_ptr<ScreenShooter> override;
 
 private:
@@ -64,6 +66,7 @@ private:
     std::shared_ptr<graphics::GraphicBufferAllocator> buffer_allocator;
     std::shared_ptr<graphics::GLConfig> config;
     std::shared_ptr<graphics::OutputFilter> const output_filter;
+    std::shared_ptr<graphics::Cursor> cursor;
 };
 }
 }

--- a/src/server/compositor/default_configuration.cpp
+++ b/src/server/compositor/default_configuration.cpp
@@ -126,7 +126,8 @@ auto mir::DefaultServerConfiguration::the_screen_shooter() -> std::shared_ptr<co
                     the_renderer_factory(),
                     the_buffer_allocator(),
                     the_gl_config(),
-                    the_output_filter());
+                    the_output_filter(),
+                    the_cursor());
             }
             catch (...)
             {
@@ -167,6 +168,7 @@ auto mir::DefaultServerConfiguration::the_screen_shooter_factory() -> std::share
                 the_renderer_factory(),
                 the_buffer_allocator(),
                 the_gl_config(),
-                the_output_filter());
+                the_output_filter(),
+                the_cursor());
         });
 }

--- a/src/server/compositor/null_screen_shooter.cpp
+++ b/src/server/compositor/null_screen_shooter.cpp
@@ -30,6 +30,7 @@ mc::NullScreenShooter::NullScreenShooter(Executor& executor)
 void mc::NullScreenShooter::capture(
     std::shared_ptr<mrs::WriteMappableBuffer> const&,
     geom::Rectangle const&,
+    bool,
     std::function<void(std::optional<time::Timestamp>)>&& callback)
 {
     log_warning("Failed to capture screen because NullScreenShooter is in use");

--- a/src/server/compositor/null_screen_shooter.h
+++ b/src/server/compositor/null_screen_shooter.h
@@ -34,6 +34,7 @@ public:
     void capture(
         std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
         geometry::Rectangle const& area,
+        bool overlay_cursor,
         std::function<void(std::optional<time::Timestamp>)>&& callback) override;
 
 private:

--- a/src/server/frontend_wayland/wlr_screencopy_v1.h
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.h
@@ -59,6 +59,7 @@ public:
         wl_resource* output;
         geometry::Rectangle output_space_area;
         geometry::Size buffer_size;
+        bool overlay_cursor;
 
         auto operator==(FrameParams const& other) const -> bool
         {

--- a/tests/unit-tests/compositor/test_basic_screen_shooter_factory.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter_factory.cpp
@@ -30,6 +30,7 @@
 #include "mir/test/doubles/stub_output_filter.h"
 #include "mir/test/doubles/stub_gl_config.h"
 #include "mir/test/doubles/stub_buffer_allocator.h"
+#include "mir/test/doubles/stub_cursor.h"
 
 #include <gtest/gtest.h>
 
@@ -57,7 +58,8 @@ public:
             renderer_factory,
             buffer_allocator,
             std::make_shared<mtd::StubGLConfig>(),
-            std::make_shared<mtd::StubOutputFilter>());
+            std::make_shared<mtd::StubOutputFilter>(),
+            std::make_shared<mtd::StubCursor>());
     }
 
     std::shared_ptr<mtd::MockScene> scene{std::make_shared<NiceMock<mtd::MockScene>>()};

--- a/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
+++ b/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
@@ -40,12 +40,12 @@ struct MockFrame : mf::WlrScreencopyV1DamageTracker::Frame, mw::LifetimeTracker
 {
 public:
     MockFrame(geom::Rectangle output_space_area)
-        : params{nullptr, output_space_area, output_space_area.size}
+        : params{nullptr, output_space_area, output_space_area.size, false}
     {
     }
 
     MockFrame(geom::Rectangle output_space_area, geom::Size buffer_size)
-        : params{nullptr, output_space_area, buffer_size}
+        : params{nullptr, output_space_area, buffer_size, false}
     {
     }
 


### PR DESCRIPTION
## What's new?
- Add `overlay_cursor` parameter to `ScreenShooter::capture` and implement it in the `BasicScreenShooter`
- Pass the flag through wlr screencopy v1
- Wrote a test for the new functionality

## How to test
1. Run your compositor with wlr screencopy support
2. Run `grimshot --cursor save output`
3. See your cursor on screen

**WARNING**: This does not yet work with the atomic-kms platform, but that will come once #4011 has landed. Neither PR depends on the other.

## Example
This is running on gbm-kms with two outputs:

![2025-06-13T10:48:23,224506997-04:00](https://github.com/user-attachments/assets/9c2dd9ee-c6ff-401c-8cca-b9190f1c3e2a)
