### PR TITLE
Drop dead function declaration

### DIFF
--- a/src/include/server/mir/server.h
+++ b/src/include/server/mir/server.h
@@ -472,11 +472,6 @@ public:
     /// \param connect_handler callback to be invoked when the client connects
     auto open_client_wayland(ConnectHandler const& connect_handler) -> int;
 
-    /// Get a file descriptor that can be used to connect a prompt provider
-    /// It can be passed to another process, or used directly with mir_connect()
-    /// using the format "fd://%d".
-    auto open_prompt_socket() -> Fd;
-
     /// Get a file descriptor that can be used to connect a Wayland client
     /// It can be passed to another process, or used with wl_display_connect_to_fd()
     auto open_wayland_client_socket() -> Fd;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -163,7 +163,6 @@ global:
     mir::Server::get_activation_token*;
     mir::Server::get_options*;
     mir::Server::open_client_wayland*;
-    mir::Server::open_prompt_socket*;
     mir::Server::open_wayland_client_socket*;
     mir::Server::override_the_accessibility_manager*;
     mir::Server::override_the_application_not_responding_detector*;


### PR DESCRIPTION
The definition has gone, drop the declaration too 