### PR TITLE
Use MirMirrorMode on renderables in the renderer

### DIFF
--- a/include/core/mir_toolkit/common.h
+++ b/include/core/mir_toolkit/common.h
@@ -184,7 +184,8 @@ typedef enum MirPixelFormat
                                 (f) == mir_pixel_format_rgba_4444 ? 2 : \
                                                                     4)
 
-/** Direction relative to the "natural" orientation of the display */
+/// Describes transformations applied to both outputs and client surfaces.
+/// Rotations are counter-clockwise.
 typedef enum MirOrientation
 {
     mir_orientation_normal = 0,
@@ -193,7 +194,7 @@ typedef enum MirOrientation
     mir_orientation_right = 270
 } MirOrientation;
 
-/** Mirroring axis relative to the "natural" orientation of the display */
+/// Describes a mirror transformation that is applied to client surfaces.
 typedef enum MirMirrorMode
 {
     mir_mirror_mode_none,

--- a/include/platform/mir/graphics/renderable.h
+++ b/include/platform/mir/graphics/renderable.h
@@ -85,6 +85,11 @@ public:
      */
     virtual MirOrientation orientation() const = 0;
 
+    /**
+     * The mirror mode of the buffer.
+     */
+    virtual MirMirrorMode mirror_mode() const = 0;
+
     virtual bool shaped() const = 0;  // meaning the pixel format has alpha
 
     virtual auto surface_if_any() const

--- a/src/include/server/mir/scene/basic_surface.h
+++ b/src/include/server/mir/scene/basic_surface.h
@@ -195,6 +195,7 @@ private:
         geometry::Rectangle surface_rect;
         glm::mat4 transformation_matrix;
         MirOrientation orientation = mir_orientation_normal;
+        MirMirrorMode mirror_mode = mir_mirror_mode_none;
         float surface_alpha;
         bool hidden;
         input::InputReceptionMode input_mode;

--- a/src/platforms/atomic-kms/server/kms/cursor.cpp
+++ b/src/platforms/atomic-kms/server/kms/cursor.cpp
@@ -527,6 +527,11 @@ auto mir::graphics::atomic::Cursor::renderable() -> std::shared_ptr<Renderable>
             return mir_orientation_normal;
         }
 
+        MirMirrorMode mirror_mode() const override
+        {
+            return mir_mirror_mode_none;
+        }
+
     private:
         std::shared_ptr<Buffer> buffer_;
         geom::Point position;

--- a/src/platforms/gbm-kms/server/kms/cursor.cpp
+++ b/src/platforms/gbm-kms/server/kms/cursor.cpp
@@ -527,6 +527,11 @@ auto mir::graphics::gbm::Cursor::renderable() -> std::shared_ptr<Renderable>
             return mir_orientation_normal;
         }
 
+        MirMirrorMode mirror_mode() const override
+        {
+            return mir_mirror_mode_none;
+        }
+
     private:
         std::shared_ptr<Buffer> buffer_;
         geom::Point position;

--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -715,8 +715,11 @@ void mrg::Renderer::draw(mg::Renderable const& renderable) const
     // orientation. However, the surface is already rotated by the output's
     // orientation when we render it. To solve this, we need to unrotate the
     // surface using the inverse of its transform so that it appears upright.
-    glm::mat4 transform = renderable.transformation() * glm::mat4(
-        mg::inverse_transformation(renderable.orientation()));
+    auto const mirror_mode = renderable.mirror_mode();
+    auto const orientation = renderable.orientation();
+    glm::mat4 transform = renderable.transformation()
+        * glm::mat4(mg::transformation(mirror_mode))          // Unflip the buffer
+        * glm::mat4(mg::inverse_transformation(orientation)); // Unrotate the buffer
     if (texture->layout() == mg::gl::Texture::Layout::TopRowFirst)
     {
         // GL textures have (0,0) at bottom-left rather than top-left

--- a/src/server/graphics/software_cursor.cpp
+++ b/src/server/graphics/software_cursor.cpp
@@ -107,6 +107,11 @@ public:
         return mir_orientation_normal;
     }
 
+    MirMirrorMode mirror_mode() const override
+    {
+        return mir_mirror_mode_none;
+    }
+
     bool shaped() const override
     {
         return true;

--- a/src/server/input/touchspot_controller.cpp
+++ b/src/server/input/touchspot_controller.cpp
@@ -46,8 +46,6 @@ public:
     {
     }
 
-// mg::Renderable
-
     mg::Renderable::ID id() const override
     {
         return this;
@@ -86,6 +84,11 @@ public:
     MirOrientation orientation() const override
     {
         return mir_orientation_normal;
+    }
+
+    MirMirrorMode mirror_mode() const override
+    {
+        return mir_mirror_mode_none;
     }
 
     bool shaped() const override

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -681,6 +681,7 @@ public:
         std::optional<geom::Rectangle> const& clip_area,
         glm::mat4 const& transform,
         MirOrientation orientation,
+        MirMirrorMode mirror_mode,
         float alpha,
         mg::Renderable::ID id,
         ms::Surface const* surface)
@@ -690,6 +691,7 @@ public:
       clip_area_{clip_area},
       transformation_{transform},
       orientation_{orientation},
+      mirror_mode_{mirror_mode},
       id_{id},
       surface{surface}
     {
@@ -722,6 +724,9 @@ public:
     MirOrientation orientation() const override
     { return orientation_; }
 
+    MirMirrorMode mirror_mode() const override
+    { return mirror_mode_; }
+
     bool shaped() const override
     {
         return entry->pixel_format().info().transform([](auto info) { return info.has_alpha();}).value_or(true);
@@ -741,6 +746,7 @@ private:
     std::optional<geom::Rectangle> const clip_area_;
     glm::mat4 const transformation_;
     MirOrientation orientation_;
+    MirMirrorMode mirror_mode_;
     mg::Renderable::ID const id_;
     ms::Surface const* surface;
 };
@@ -805,6 +811,7 @@ mg::RenderableList ms::BasicSurface::generate_renderables(mc::CompositorID id) c
                 state->clip_area,
                 state->transformation_matrix,
                 state->orientation,
+                state->mirror_mode,
                 state->surface_alpha,
                 info.stream.get(),
                 this));

--- a/src/server/shell/basic_idle_handler.cpp
+++ b/src/server/shell/basic_idle_handler.cpp
@@ -91,6 +91,11 @@ public:
         return mir_orientation_normal;
     }
 
+    auto mirror_mode() const -> MirMirrorMode override
+    {
+        return mir_mirror_mode_none;
+    }
+
     auto shaped() const -> bool override
     {
         return false;

--- a/tests/include/mir/test/doubles/fake_renderable.h
+++ b/tests/include/mir/test/doubles/fake_renderable.h
@@ -78,6 +78,11 @@ public:
         return mir_orientation_normal;
     }
 
+    MirMirrorMode mirror_mode() const override
+    {
+        return mir_mirror_mode_none;
+    }
+
     bool shaped() const override
     {
         return !rectangular;

--- a/tests/include/mir/test/doubles/mock_renderable.h
+++ b/tests/include/mir/test/doubles/mock_renderable.h
@@ -53,6 +53,7 @@ struct MockRenderable : public graphics::Renderable
     MOCK_CONST_METHOD0(alpha, float());
     MOCK_CONST_METHOD0(transformation, glm::mat4());
     MOCK_CONST_METHOD0(orientation, MirOrientation());
+    MOCK_CONST_METHOD0(mirror_mode, MirMirrorMode());
     MOCK_CONST_METHOD0(visible, bool());
     MOCK_CONST_METHOD0(shaped, bool());
     MOCK_CONST_METHOD0(surface_if_any, std::optional<mir::scene::Surface const*>());

--- a/tests/include/mir/test/doubles/stub_renderable.h
+++ b/tests/include/mir/test/doubles/stub_renderable.h
@@ -92,6 +92,10 @@ public:
     {
         return mir_orientation_normal;
     }
+    MirMirrorMode mirror_mode() const override
+    {
+        return mir_mirror_mode_none;
+    }
     bool shaped() const override
     {
         return false;

--- a/tests/platform_test_harness/graphics_platform_test_harness.cpp
+++ b/tests/platform_test_harness/graphics_platform_test_harness.cpp
@@ -429,6 +429,11 @@ void basic_software_buffer_drawing(
             return mir_orientation_normal;
         }
 
+        MirMirrorMode mirror_mode() const override
+        {
+            return mir_mirror_mode_none;
+        }
+
         bool shaped() const override
         {
             return mg::contains_alpha(buffer_->pixel_format());

--- a/tests/unit-tests/graphics/test_software_cursor.cpp
+++ b/tests/unit-tests/graphics/test_software_cursor.cpp
@@ -435,6 +435,12 @@ TEST_F(SoftwareCursor, renderable_has_normal_orientation)
     EXPECT_THAT(cursor.renderable()->orientation(), testing::Eq(mir_orientation_normal));
 }
 
+TEST_F(SoftwareCursor, renderable_has_nonone_mirror_mode)
+{
+    cursor.show(stub_cursor_image);
+    EXPECT_THAT(cursor.renderable()->mirror_mode(), testing::Eq(mir_mirror_mode_none));
+}
+
 TEST_F(SoftwareCursor, does_not_need_compositing_when_not_shown)
 {
     using namespace testing;

--- a/tests/unit-tests/platforms/atomic-kms/kms/test_cursor.cpp
+++ b/tests/unit-tests/platforms/atomic-kms/kms/test_cursor.cpp
@@ -410,3 +410,14 @@ TEST_F(AtomicKmsCursorTest, does_not_need_compositing)
 {
     EXPECT_THAT(cursor.needs_compositing(), Eq(false));
 }
+
+
+TEST_F(AtomicKmsCursorTest, renderable_has_mirror_mode_none)
+{
+    using namespace testing;
+
+    auto image = std::make_shared<StubCursorImage>();
+    cursor.show(image);
+
+    EXPECT_THAT(cursor.renderable()->mirror_mode(), Eq(mir_mirror_mode_none));
+}

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -1477,6 +1477,25 @@ TEST_F(BasicSurfaceTest, renderables_of_new_buffers_are_normal)
     EXPECT_THAT(renderables[0]->orientation(), mir_orientation_normal);
 }
 
+TEST_F(BasicSurfaceTest, renderables_of_new_buffers_have_none_mirror_mode)
+{
+    using namespace testing;
+    auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
+    geom::Displacement const d0{0,0};
+
+    ON_CALL(*buffer_stream->submission, pixel_format)
+        .WillByDefault(Return(mg::DRMFormat{DRM_FORMAT_ARGB8888}));
+
+    std::list<ms::StreamInfo> streams = {
+        { buffer_stream, d0}
+    };
+    surface.set_streams(streams);
+
+    auto renderables = surface.generate_renderables(this);
+    ASSERT_THAT(renderables.size(), Eq(1));
+    EXPECT_THAT(renderables[0]->mirror_mode(), mir_mirror_mode_none);
+}
+
 namespace
 {
 struct VisibilityObserver : ms::NullSurfaceObserver

--- a/tests/unit-tests/shell/test_basic_idle_handler.cpp
+++ b/tests/unit-tests/shell/test_basic_idle_handler.cpp
@@ -336,6 +336,17 @@ TEST_F(BasicIdleHandler, renderable_added_to_has_normal_orientation)
     EXPECT_THAT(renderable->orientation(), Eq(mir_orientation_normal));
 }
 
+TEST_F(BasicIdleHandler, renderable_added_to_has_none_mirror_mode)
+{
+    handler.set_display_off_timeout(30s);
+    auto const observer = observer_for(20s);
+    std::shared_ptr<mg::Renderable> renderable;
+    EXPECT_CALL(*input_scene, add_input_visualization(testing::_))
+        .WillOnce(SaveArg<0>(&renderable));
+    observer->idle();
+    EXPECT_THAT(renderable->mirror_mode(), Eq(mir_mirror_mode_none));
+}
+
 TEST_F(BasicIdleHandler, renderable_removed_from_scene_on_active)
 {
     handler.set_display_off_timeout(30s);


### PR DESCRIPTION
## What's new?
- To properly support [all of the allowed transforms](https://wayland.app/protocols/wayland#wl_output:enum:transform), we need to support `mirror_mode()` on renderables in addition to orientation
- We apply this mirror mode to the renderable at render time to un-flip the content
- Wrote tests for everything