### PR TITLE
Fixing issue where alarm could be scheduled with a null click_dispatcher

### DIFF
--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -47,7 +47,7 @@ public:
         // shouldn't be handled by later transformers, whether the transformer is
         // accumulating events for later dispatching or has immediately dispatched
         // an event is an implementation detail of the transformer
-        virtual bool transform_input_event(EventDispatcher const&, EventBuilder*,  MirEvent const&) = 0;
+        virtual bool transform_input_event(EventDispatcher const&, EventBuilder*, MirEvent const&) = 0;
     };
 
     InputEventTransformer(std::shared_ptr<Seat> const& seat, std::shared_ptr<time::Clock> const& clock);

--- a/src/server/input/input_event_transformer.cpp
+++ b/src/server/input/input_event_transformer.cpp
@@ -148,7 +148,7 @@ bool mi::InputEventTransformer::transform(MirEvent const& event)
     return handled;
 }
 
-void mi::InputEventTransformer::append(std::weak_ptr<mi::InputEventTransformer::Transformer> const& transformer)
+void mi::InputEventTransformer::append(std::weak_ptr<Transformer> const& transformer)
 {
     std::lock_guard lock{mutex};
 
@@ -166,7 +166,7 @@ void mi::InputEventTransformer::append(std::weak_ptr<mi::InputEventTransformer::
     input_transformers.push_back(transformer);
 }
 
-void mi::InputEventTransformer::remove(std::shared_ptr<mi::InputEventTransformer::Transformer> const& transformer)
+void mi::InputEventTransformer::remove(std::shared_ptr<Transformer> const& transformer)
 {
     std::lock_guard lock{mutex};
     auto [remove_start, remove_end] = std::ranges::remove(

--- a/src/server/shell/basic_hover_click_transformer.h
+++ b/src/server/shell/basic_hover_click_transformer.h
@@ -62,9 +62,10 @@ private:
     static constexpr auto grace_period_percentage = 0.1f;
     static constexpr auto hover_delay_percentage = 1.0f - grace_period_percentage;
 
+    class CursorObserver;
     struct MutableState 
     {
-        std::unique_ptr<time::Alarm> click_dispatcher;
+        std::optional<std::unique_ptr<time::Alarm>> click_dispatcher;
 
         // We repeatedly record the most recent cursor position. Once the grace
         // period is up, we "pin" this position into `hover_click_origin`, which is


### PR DESCRIPTION
Whoops! `state->click_dispatcher` is initialized lazily. We should make it more obvious that this is the case :)