### PR TITLE
Add AppendKeyboardEventFilter helper

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -5,6 +5,8 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::AddInitCallback::~AddInitCallback()@MIRAL_5.0" 5.0.0
  (c++)"miral::AppendEventFilter::AppendEventFilter(std::function<bool (MirEvent const*)> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::AppendEventFilter::operator()(mir::Server&)@MIRAL_5.0" 5.0.0
+ (c++)"miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter(std::function<bool (MirKeyboardEvent const*)> const&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::AppendKeyboardEventFilter::operator()(mir::Server&)@MIRAL_5.4" 5.4.0
  (c++)"miral::ApplicationCredentials::ApplicationCredentials(mir::frontend::SessionCredentials const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::ApplicationCredentials::gid() const@MIRAL_5.0" 5.0.0
  (c++)"miral::ApplicationCredentials::pid() const@MIRAL_5.0" 5.0.0

--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -5,8 +5,6 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::AddInitCallback::~AddInitCallback()@MIRAL_5.0" 5.0.0
  (c++)"miral::AppendEventFilter::AppendEventFilter(std::function<bool (MirEvent const*)> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::AppendEventFilter::operator()(mir::Server&)@MIRAL_5.0" 5.0.0
- (c++)"miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter(std::function<bool (MirKeyboardEvent const*)> const&)@MIRAL_5.0" 5.4.0
- (c++)"miral::AppendKeyboardEventFilter::operator()(mir::Server&)@MIRAL_5.0" 5.4.0
  (c++)"miral::ApplicationCredentials::ApplicationCredentials(mir::frontend::SessionCredentials const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::ApplicationCredentials::gid() const@MIRAL_5.0" 5.0.0
  (c++)"miral::ApplicationCredentials::pid() const@MIRAL_5.0" 5.0.0
@@ -565,6 +563,8 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::SimulatedSecondaryClick::on_secondary_click(std::function<void ()>&&)@MIRAL_5.3" 5.3.0
  (c++)"miral::SimulatedSecondaryClick::operator()(mir::Server&)@MIRAL_5.3" 5.3.0
  MIRAL_5.4@MIRAL_5.4 5.4.0
+ (c++)"miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter(std::function<bool (MirKeyboardEvent const*)> const&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::AppendKeyboardEventFilter::operator()(mir::Server&)@MIRAL_5.4" 5.4.0
  (c++)"miral::CursorScale::CursorScale(miral::live_config::Store&)@MIRAL_5.4" 5.4.0
  (c++)"miral::InputConfiguration::InputConfiguration(miral::live_config::Store&)@MIRAL_5.4" 5.4.0
  (c++)"miral::OutputFilter::OutputFilter(miral::live_config::Store&)@MIRAL_5.4" 5.4.0

--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -5,8 +5,8 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::AddInitCallback::~AddInitCallback()@MIRAL_5.0" 5.0.0
  (c++)"miral::AppendEventFilter::AppendEventFilter(std::function<bool (MirEvent const*)> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::AppendEventFilter::operator()(mir::Server&)@MIRAL_5.0" 5.0.0
- (c++)"miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter(std::function<bool (MirKeyboardEvent const*)> const&)@MIRAL_5.4" 5.4.0
- (c++)"miral::AppendKeyboardEventFilter::operator()(mir::Server&)@MIRAL_5.4" 5.4.0
+ (c++)"miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter(std::function<bool (MirKeyboardEvent const*)> const&)@MIRAL_5.0" 5.4.0
+ (c++)"miral::AppendKeyboardEventFilter::operator()(mir::Server&)@MIRAL_5.0" 5.4.0
  (c++)"miral::ApplicationCredentials::ApplicationCredentials(mir::frontend::SessionCredentials const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::ApplicationCredentials::gid() const@MIRAL_5.0" 5.0.0
  (c++)"miral::ApplicationCredentials::pid() const@MIRAL_5.0" 5.0.0

--- a/doc/sphinx/how-to/how-to-handle-keyboard-input.md
+++ b/doc/sphinx/how-to/how-to-handle-keyboard-input.md
@@ -20,14 +20,14 @@ Compositor](../tutorial/write-your-first-wayland-compositor.md) is a prerequisit
 this how-to.
 
 ### Header changes
-Here we just include `append_event_filter.h` for the declaration of
-`AppendEventFilter` and `toolkit_event` to get definitions for event types and
+Here we just include `append_keyboard_event_filter.h` for the declaration of
+`AppendKeyboardEventFilter` and `toolkit_event` to get definitions for event types and
 functions. We import everything from `miral::toolkit` to make the code a bit
 easier to read.
 ```diff
 @@ -1,10 +1,15 @@
  #include <miral/runner.h>
-+#include <miral/append_event_filter.h>
++#include <miral/append_keyboard_event_filter.h>
  #include <miral/minimal_window_manager.h>
  #include <miral/set_window_management_policy.h>
 +#include <miral/toolkit_event.h>
@@ -47,28 +47,18 @@ This big block of code can be broken down into three parts:
 +    std::string terminal_cmd{"kgx"};
 +    miral::ExternalClientLauncher external_client_launcher;
 +
-+    auto const builtin_keybinds = [&](MirEvent const* event)
++    auto const builtin_keybinds = [&](MirKeyboardEvent const* event)
 +        {
-+            // Skip non-input events
-+            if (mir_event_get_type(event) != mir_event_type_input)
-+                return false;
-+
-+            // Skip non-key input events
-+            MirInputEvent const* input_event = mir_event_get_input_event(event);
-+            if (mir_input_event_get_type(input_event) != mir_input_event_type_key)
-+                return false;
-+
 +            // Skip anything but down presses
-+            MirKeyboardEvent const* kev = mir_input_event_get_keyboard_event(input_event);
-+            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
++            if (mir_keyboard_event_action(event) != mir_keyboard_action_down)
 +                return false;
 +
 +            // CTRL + ALT must be pressed
-+            MirInputEventModifiers mods = mir_keyboard_event_modifiers(kev);
++            MirInputEventModifiers mods = mir_keyboard_event_modifiers(event);
 +            if (!(mods & mir_input_event_modifier_alt) || !(mods & mir_input_event_modifier_ctrl))
 +                return false;
 +
-+            switch (mir_keyboard_event_keysym(kev))
++            switch (mir_keyboard_event_keysym(event))
 +            {
 +            // Exit program
 +            case XKB_KEY_BackSpace:
@@ -98,7 +88,7 @@ subsection.
          {
              set_window_management_policy<MinimalWindowManager>(),
 +            external_client_launcher,
-+            miral::AppendEventFilter{builtin_keybinds}
++            miral::AppendKeyboardEventFilter{builtin_keybinds}
          });
  }
 ```

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -24,7 +24,7 @@
 #include <miral/external_client.h>
 #include <miral/runner.h>
 #include <miral/window_management_options.h>
-#include <miral/append_event_filter.h>
+#include <miral/append_keyboard_event_filter.h>
 #include <miral/internal_client.h>
 #include <miral/command_line_option.h>
 #include <miral/cursor_theme.h>
@@ -88,16 +88,8 @@ int main(int argc, char const* argv[])
 
     std::string terminal_cmd{"miral-terminal"};
 
-    auto const quit_on_ctrl_alt_bksp = [&](MirEvent const* event)
+    auto const quit_on_ctrl_alt_bksp = [&](MirKeyboardEvent const* kev)
         {
-            if (mir_event_get_type(event) != mir_event_type_input)
-                return false;
-
-            MirInputEvent const* input_event = mir_event_get_input_event(event);
-            if (mir_input_event_get_type(input_event) != mir_input_event_type_key)
-                return false;
-
-            MirKeyboardEvent const* kev = mir_input_event_get_keyboard_event(input_event);
             if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
                 return false;
 
@@ -149,15 +141,7 @@ int main(int argc, char const* argv[])
     auto const initial_mousekeys_state = false;
     miral::MouseKeysConfig mousekeys_config{initial_mousekeys_state};
 
-    auto toggle_mousekeys_filter = [mousekeys_on = initial_mousekeys_state, &mousekeys_config](MirEvent const* event) mutable {
-        if(mir_event_get_type(event) != mir_event_type_input)
-            return false;
-
-        auto const* input_event = mir_event_get_input_event(event);
-        if(mir_input_event_get_type(input_event) != mir_input_event_type_key)
-            return false;
-
-        auto const* key_event = mir_input_event_get_keyboard_event(input_event);
+    auto toggle_mousekeys_filter = [mousekeys_on = initial_mousekeys_state, &mousekeys_config](MirKeyboardEvent const* key_event) mutable {
         auto const modifiers = mir_keyboard_event_modifiers(key_event);
 
         if ((modifiers & mir_input_event_modifier_ctrl) && (modifiers & mir_input_event_modifier_shift) &&
@@ -176,15 +160,7 @@ int main(int argc, char const* argv[])
     };
 
     miral::OutputFilter output_filter;
-    auto toggle_output_filter_filter = [invert_on = false, &output_filter](MirEvent const* event) mutable {
-        if(mir_event_get_type(event) != mir_event_type_input)
-            return false;
-
-        auto const* input_event = mir_event_get_input_event(event);
-        if(mir_input_event_get_type(input_event) != mir_input_event_type_key)
-            return false;
-
-        auto const* key_event = mir_input_event_get_keyboard_event(input_event);
+    auto toggle_output_filter_filter = [invert_on = false, &output_filter](MirKeyboardEvent const* key_event) mutable {
         auto const modifiers = mir_keyboard_event_modifiers(key_event);
 
         if (mir_keyboard_event_action(key_event) != mir_keyboard_action_down)
@@ -224,7 +200,7 @@ int main(int argc, char const* argv[])
             external_client_launcher,
             launcher,
             config_keymap,
-            AppendEventFilter{quit_on_ctrl_alt_bksp},
+            AppendKeyboardEventFilter{quit_on_ctrl_alt_bksp},
             StartupInternalClient{spinner},
             ConfigurationOption{run_startup_apps, "startup-apps", "Colon separated list of startup apps", ""},
             pre_init(ConfigurationOption{[&](std::string const& typeface) { ::wallpaper::font_file(typeface); },
@@ -232,9 +208,9 @@ int main(int argc, char const* argv[])
             ConfigurationOption{[&](std::string const& cmd) { terminal_cmd = cmd; },
                                 "shell-terminal-emulator", "terminal emulator to use", terminal_cmd},
             mousekeys_config,
-            AppendEventFilter{toggle_mousekeys_filter},
+            AppendKeyboardEventFilter{toggle_mousekeys_filter},
             output_filter,
-            AppendEventFilter{toggle_output_filter_filter},
+            AppendKeyboardEventFilter{toggle_output_filter_filter},
             ssc_config,
             hover_click_config
         });

--- a/examples/miral-system-compositor/system_compositor_main.cpp
+++ b/examples/miral-system-compositor/system_compositor_main.cpp
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <miral/append_event_filter.h>
+#include <miral/append_keyboard_event_filter.h>
 #include <miral/command_line_option.h>
 #include <miral/display_configuration_option.h>
 #include <miral/runner.h>
@@ -38,19 +38,11 @@ int main(int argc, char const* argv[])
         "disable-quit",
         "Disable Ctrl-Alt-Shift-BkSp to quit"};
 
-    AppendEventFilter quit_on_ctrl_alt_bksp{[&](MirEvent const* event)
+    AppendKeyboardEventFilter quit_on_ctrl_alt_bksp{[&](MirKeyboardEvent const* kev)
         {
             if (!allow_quit)
                 return false;
 
-            if (mir_event_get_type(event) != mir_event_type_input)
-                return false;
-
-            MirInputEvent const* input_event = mir_event_get_input_event(event);
-            if (mir_input_event_get_type(input_event) != mir_input_event_type_key)
-                return false;
-
-            MirKeyboardEvent const* kev = mir_input_event_get_keyboard_event(input_event);
             if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
                 return false;
 

--- a/include/miral/miral/append_keyboard_event_filter.h
+++ b/include/miral/miral/append_keyboard_event_filter.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_APPEND_KEYBOARD_EVENT_FILTER_H
+#define MIRAL_APPEND_KEYBOARD_EVENT_FILTER_H
+
+#include <functional>
+#include <memory>
+
+struct MirKeyboardEvent;
+
+namespace mir { class Server; }
+
+namespace miral
+{
+class AppendKeyboardEventFilter
+{
+public:
+    /// Append a keyboard event filter (after any existing filters, including the window manager).
+    /// The supplied filter should return true if and only if it handles the keyboard event as filters
+    /// later in the list will not be called.
+    explicit AppendKeyboardEventFilter(std::function<bool(MirKeyboardEvent const* event)> const& filter);
+
+    void operator()(mir::Server& server);
+
+private:
+    class Filter;
+    std::shared_ptr<Filter> const filter;
+};
+}
+
+#endif //MIRAL_APPEND_KEYBOARD_EVENT_FILTER_H

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(miral-external OBJECT
     display_configuration_option.cpp    ${miral_include}/miral/display_configuration_option.h
     output.cpp                          ${miral_include}/miral/output.h
     append_event_filter.cpp             ${miral_include}/miral/append_event_filter.h
+    append_keyboard_event_filter.cpp    ${miral_include}/miral/append_keyboard_event_filter.h
     wayland_extensions.cpp              ${miral_include}/miral/wayland_extensions.h
     window.cpp                          ${miral_include}/miral/window.h
     window_info.cpp                     ${miral_include}/miral/window_info.h

--- a/src/miral/append_keyboard_event_filter.cpp
+++ b/src/miral/append_keyboard_event_filter.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "miral/append_keyboard_event_filter.h"
+
+#include <mir/input/event_filter.h>
+#include <mir/input/composite_event_filter.h>
+#include <mir/server.h>
+
+class miral::AppendKeyboardEventFilter::Filter : public mir::input::EventFilter
+{
+public:
+    Filter(std::function<bool(MirKeyboardEvent const* event)> const& filter) :
+        filter{filter} {}
+
+    bool handle(MirEvent const& event) override
+    {
+        // Skip non-input events
+        if (mir_event_get_type(&event) != mir_event_type_input)
+            return false;
+
+        // Skip non-key input events
+        MirInputEvent const* input_event = mir_event_get_input_event(&event);
+        if (mir_input_event_get_type(input_event) != mir_input_event_type_key)
+            return false;
+
+        MirKeyboardEvent const* kev = mir_input_event_get_keyboard_event(input_event);
+        return filter(kev);
+    }
+
+private:
+    std::function<bool(MirKeyboardEvent const* event)> const filter;
+};
+
+miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter(std::function<bool(MirKeyboardEvent const* event)> const& filter) :
+    filter{std::make_shared<Filter>(filter)}
+{
+}
+
+void miral::AppendKeyboardEventFilter::operator()(mir::Server& server)
+{
+    server.add_init_callback([this, &server] { server.the_composite_event_filter()->append(filter); });
+}

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -6,8 +6,6 @@ global:
     miral::AddInitCallback::operator*;
     miral::AppendEventFilter::AppendEventFilter*;
     miral::AppendEventFilter::operator*;
-    miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter*;
-    miral::AppendKeyboardEventFilter::operator*;
     miral::ApplicationAuthorizer::?ApplicationAuthorizer*;
     miral::ApplicationAuthorizer::ApplicationAuthorizer*;
     miral::ApplicationAuthorizer::operator*;
@@ -594,6 +592,8 @@ global:
 MIRAL_5.4 {
 global:
   extern "C++" {
+    miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter*;
+    miral::AppendKeyboardEventFilter::operator*;
     "miral::CursorScale::CursorScale(miral::live_config::Store&)";
     "miral::InputConfiguration::InputConfiguration(miral::live_config::Store&)";
     "miral::OutputFilter::OutputFilter(miral::live_config::Store&)";

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -6,6 +6,8 @@ global:
     miral::AddInitCallback::operator*;
     miral::AppendEventFilter::AppendEventFilter*;
     miral::AppendEventFilter::operator*;
+    miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter*;
+    miral::AppendKeyboardEventFilter::operator*;
     miral::ApplicationAuthorizer::?ApplicationAuthorizer*;
     miral::ApplicationAuthorizer::ApplicationAuthorizer*;
     miral::ApplicationAuthorizer::operator*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -407,7 +407,6 @@ global:
     non-virtual?thunk?to?miral::WindowManagementPolicy::advise_state_change*;
     typeinfo?for?miral::AddInitCallback;
     typeinfo?for?miral::AppendEventFilter;
-    typeinfo?for?miral::AppendKeyboardEventFilter;
     typeinfo?for?miral::ApplicationAuthorizer;
     typeinfo?for?miral::ApplicationCredentials;
     typeinfo?for?miral::ApplicationInfo;
@@ -625,6 +624,7 @@ global:
     non-virtual?thunk?to?miral::live_config::IniFile::add_strings_attribute*;
     non-virtual?thunk?to?miral::live_config::IniFile::on_done*;
     non-virtual?thunk?to?miral::live_config::Store::?Store*;
+    typeinfo?for?miral::AppendKeyboardEventFilter;
     typeinfo?for?miral::live_config::IniFile;
     typeinfo?for?miral::live_config::Key;
     typeinfo?for?miral::live_config::Store;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -409,6 +409,7 @@ global:
     non-virtual?thunk?to?miral::WindowManagementPolicy::advise_state_change*;
     typeinfo?for?miral::AddInitCallback;
     typeinfo?for?miral::AppendEventFilter;
+    typeinfo?for?miral::AppendKeyboardEventFilter;
     typeinfo?for?miral::ApplicationAuthorizer;
     typeinfo?for?miral::ApplicationCredentials;
     typeinfo?for?miral::ApplicationInfo;


### PR DESCRIPTION
A lot of code adds event filters for keyboard events only; add a helper class to remove this boilerplate code.