### PR TITLE
Fix Alpine CI failure

### DIFF
--- a/tests/integration-tests/input/test_single_seat_setup.cpp
+++ b/tests/integration-tests/input/test_single_seat_setup.cpp
@@ -134,7 +134,7 @@ struct SingleSeatInputDeviceHubSetup : ::testing::Test
     {
         for (int i = 0; i != count; ++i)
         {
-            mt::fd_becomes_readable(multiplexer.watch_fd(), 5s);
+            EXPECT_TRUE(mt::fd_becomes_readable(multiplexer.watch_fd(), 5s));
             multiplexer.dispatch(mir::dispatch::FdEvent::readable);
         }
     }

--- a/tests/unit-tests/input/test_default_input_device_hub.cpp
+++ b/tests/unit-tests/input/test_default_input_device_hub.cpp
@@ -100,7 +100,7 @@ struct InputDeviceHubTest : ::testing::Test
 
     void expect_and_execute_multiplexer()
     {
-        mt::fd_becomes_readable(multiplexer.watch_fd(), 2s);
+        EXPECT_TRUE(mt::fd_becomes_readable(multiplexer.watch_fd(), 2s));
         multiplexer.dispatch(mir::dispatch::FdEvent::readable);
     }
 };

--- a/tests/unit-tests/input/test_input_event_transformer.cpp
+++ b/tests/unit-tests/input/test_input_event_transformer.cpp
@@ -63,7 +63,7 @@ struct TestInputEventTransformer : testing::Test
     // Borrowed from `test_single_seat_setup.cpp`
     void expect_and_execute_multiplexer()
     {
-        mt::fd_becomes_readable(multiplexer.watch_fd(), std::chrono::milliseconds(100));
+        EXPECT_TRUE(mt::fd_becomes_readable(multiplexer.watch_fd(), std::chrono::milliseconds(100)));
         multiplexer.dispatch(mir::dispatch::FdEvent::readable);
     }
 


### PR DESCRIPTION
error: ignoring returned value of type 'testing::AssertionResult', declared with attribute 'nodiscard' [-Werror=unused-result]