### PR TITLE
Clean up server example

### DIFF
--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -14,7 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "miral/bounce_keys.h"
 #include "server_example_input_event_filter.h"
 #include "server_example_input_filter.h"
 #include "server_example_test_client.h"
@@ -32,26 +31,22 @@
 #include <miral/x11_support.h>
 #include <miral/cursor_scale.h>
 #include <miral/output_filter.h>
+#include <miral/bounce_keys.h>
 
 #include "mir/abnormal_exit.h"
 #include "mir/main_loop.h"
 #include "mir/options/option.h"
 #include "mir/report_exception.h"
 #include "mir/server.h"
-#include "mir/log.h"
 
 #include <boost/exception/diagnostic_information.hpp>
 
 #include <chrono>
 #include <cstdlib>
-#include <iostream>
-#include <list>
-#include <mutex>
 
 namespace mir { class AbnormalExit; }
 
 namespace me = mir::examples;
-namespace live_config = miral::live_config;
 
 ///\example server_example.cpp
 /// A simple server illustrating several customisations


### PR DESCRIPTION
Removes unused includes and namespace aliases, and moves the bounce keys include to the correct place with the correct style.