### PR TITLE
Accounting for surface orientation in BasicSurface::input_area_contains

### DIFF
--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -360,16 +360,31 @@ bool ms::BasicSurface::input_area_contains(geom::Point const& point) const
 
     if (state->custom_input_rectangles.empty())
     {
-        // no custom input, restrict to bounding rectangle
+        // The surface has no custom input, so it is restricted to its bounding rectangle.
+        // Note that the "content_size" returned here is already oriented properly, so the
+        // width and height do NOT need to be swapped, ujnlike the custom input rectangles
+        // case.
         auto const input_rect = geom::Rectangle{content_top_left(*state), content_size(*state)};
         return input_rect.contains(point);
     }
     else
     {
-        auto local_point = as_point(point - content_top_left(*state));
+        auto const local_point = as_point(point - content_top_left(*state));
         for (auto const& rectangle : state->custom_input_rectangles)
         {
-            if (rectangle.contains(local_point))
+            // When a surface is rendered with an orientation, it is unrotated so that it appears
+            // upright. The input region that the surface provides is also rotated according to the
+            // same rules. Hence, we need to swap the width and height of the input region if the
+            // surface is rotated 90 or 270 degrees.
+            if (state->orientation == mir_orientation_right || state->orientation == mir_orientation_left)
+            {
+                auto rotated_rect = rectangle;
+                rotated_rect.size.width = geom::Width(rectangle.size.height.as_value());
+                rotated_rect.size.height = geom::Height(rectangle.size.width.as_value());
+                if (rotated_rect.contains(local_point))
+                    return true;
+            }
+            else if (rectangle.contains(local_point))
                 return true;
         }
     }

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -575,6 +575,28 @@ TEST_F(BasicSurfaceTest, set_input_region)
     }
 }
 
+class BasicSurfaceOrientationTest : public BasicSurfaceTest, public testing::WithParamInterface<MirOrientation>
+{};
+
+TEST_P(BasicSurfaceOrientationTest, set_input_region_on_rotated_surface)
+{
+    std::vector<geom::Rectangle> const rectangles = {
+        {{geom::X{0}, geom::Y{0}}, {geom::Width{2}, geom::Height{5}}},
+    };
+
+    surface.set_orientation(GetParam());
+    surface.register_interest(observer, executor);
+    surface.set_input_region(rectangles);
+
+    auto const test_pt = rect.top_left + geom::Displacement{4, 1};
+    EXPECT_THAT(surface.input_area_contains(test_pt), testing::Eq(true));
+}
+
+INSTANTIATE_TEST_SUITE_P(BasicSurfaceOrientationTest, BasicSurfaceOrientationTest, ::testing::Values(
+    mir_orientation_right,
+    mir_orientation_left
+));
+
 TEST_F(BasicSurfaceTest, updates_default_input_region_when_surface_is_resized_to_larger_size)
 {
     geom::Rectangle const new_rect{rect.top_left,{20,20}};


### PR DESCRIPTION
## What's new?
- Updated `BasicSurface::input_area_contains` to account for the orientation of the surface when intersecting its custom input rectangles so that oriented surfaces work
- Wrote a test

## How to test?
- Run `weston-transformed`
- When the surface is oriented either 90 or 270 degrees, note that your cursor treats the input area such that the width is always 500 and the height is always 250
- Your cursor will disappear when intersecting the surface (by design of weston-transformed!)

Note that this does NOT contain the visual side of things (that is #4031)