### PR TITLE
server/GLibMainLoop: Turn off workaround for now-fixed GLib bug

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -83,6 +83,17 @@ set_property(
     SOURCE glib_main_loop.cpp glib_main_loop_sources.cpp default_server_configuration.cpp
     PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
 
+if(GLIB_VERSION VERSION_GREATER_EQUAL 2.85)
+    # This version fixes the (at least) 11 year old bug we encountered in LP #1401488
+    # Unfortunately, the fix interacts badly with our workaround to the bug
+    # Fortunately, we added the workaround we added a #define to turn it off, and
+    # use the correct code!
+    set_property(
+        SOURCE glib_main_loop_sources.cpp
+        APPEND
+        PROPERTY COMPILE_DEFINITIONS GLIB_HAS_FIXED_LP_1401488)
+endif()
+
 set(MIR_SERVER_REFERENCES
   mirserverobjects
   mirinput


### PR DESCRIPTION
GLib 2.85 fixes a looooong-standing bug we were hitting. Unfortunately, the fix interacts badly with the workaround we use. Fortunately, we put the workaround behind a `#ifndef GLIB_IS_FIXED`, so we can now just add that `#define` on sufficiently-new GLibs.

C.f. https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2187

Fixes: #4003