### PR TITLE
Don't call out to other objects under lock

### DIFF
--- a/src/miral/bounce_keys.cpp
+++ b/src/miral/bounce_keys.cpp
@@ -79,10 +79,10 @@ struct miral::BounceKeys::Self
 
             auto const keysym = mir_keyboard_event_keysym(key_event);
 
+            last_key_clearer->cancel();
             auto state = runtime_state.lock();
             auto config_ = config->lock();
 
-            last_key_clearer->cancel();
             last_key_clearer->reschedule_in(config_->delay);
 
             if(!state->last_key || *state->last_key != keysym)


### PR DESCRIPTION
The `BounceKeys::last_key_clearer` callback locks the `runtime_state` and can be called by `last_key_clearer->cancel()`. So the latter should not be called while `runtime_state` is locked.

Fixes: #4065