### PR TITLE
Try allocating surfaces with flags first

### DIFF
--- a/src/platforms/atomic-kms/server/kms/quirks.h
+++ b/src/platforms/atomic-kms/server/kms/quirks.h
@@ -38,18 +38,6 @@ namespace graphics::atomic
 class GbmQuirks
 {
 public:
-    class CreateSurfaceFlagsQuirk
-    {
-    public:
-        CreateSurfaceFlagsQuirk() = default;
-        virtual ~CreateSurfaceFlagsQuirk() = default;
-
-        CreateSurfaceFlagsQuirk(CreateSurfaceFlagsQuirk const&) = delete;
-        CreateSurfaceFlagsQuirk& operator=(CreateSurfaceFlagsQuirk const&) = delete;
-
-        virtual auto gbm_create_surface_flags() const -> uint32_t = 0;
-    };
-
     class SurfaceHasFreeBuffersQuirk
     {
     public:
@@ -62,15 +50,12 @@ public:
         virtual auto gbm_surface_has_free_buffers(gbm_surface* gbm_surface) const -> int = 0;
     };
 
-    GbmQuirks(
-        std::unique_ptr<CreateSurfaceFlagsQuirk> create_surface_flags,
-        std::unique_ptr<SurfaceHasFreeBuffersQuirk> surface_has_free_buffers);
+    GbmQuirks(std::unique_ptr<SurfaceHasFreeBuffersQuirk> surface_has_free_buffers);
 
     auto gbm_create_surface_flags() const -> uint32_t;
     auto gbm_surface_has_free_buffers(gbm_surface* gbm_surface) const -> int;
 
 private:
-    std::unique_ptr<CreateSurfaceFlagsQuirk> const create_surface_flags;
     std::unique_ptr<SurfaceHasFreeBuffersQuirk> const surface_has_free_buffers;
 };
 


### PR DESCRIPTION
# What's new
Nvidia fixed  `gbm_surface_create`  with their 575 drivers. But that now causes `eglCreatePlatformWindowSurface` to error out with our workaround of passing no flags (see #4047 for the nitty gritty)

We still have to support 570 and 550. After a brief discussion, we agreed that we can try allocating normally which should work for the majority of cases, and if that fails, we can allocate with no flags to specifically support pre 575 nvidia drivers.

In addition, this nullifies the need for `CreateSurfaceFlagsQuirk`, so that has now been removed along with its quirk option.

# How to test
If you have an Nvidia card, run mir with `--platform-display-libs=mir:atomic-kms`. On 570 and earlier, you should get a warning "Failed to create surface with flags. Attempting to create one without flags", but things should still work. On 575, this warning should not be printed.