### PR TITLE
Move `InputEventTransformer::Transformer` into its own header

### DIFF
--- a/include/common/mir/input/transformer.h
+++ b/include/common/mir/input/transformer.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_INPUT_TRANSFORMER_H_
+#define MIR_INPUT_TRANSFORMER_H_
+
+#include <functional>
+#include <memory>
+
+class MirEvent;
+
+namespace mir
+{
+namespace input
+{
+class EventBuilder;
+/// Transformers are used early on in the input processing pipeline to process
+/// events for various accessibilty methods. They can consume or pass events,
+/// similar to filters. They additionally can emit events at a later time using
+/// the passed `EventBuilder` and `EventDispatcher`.
+///
+/// Do note that despite the event dispatcher being a reference and the event
+/// builder being a pointer, they're guaranteed to outlive the transformer.
+///
+/// Transformers need to be registered to an `InputEventTransformer` to receive
+/// events. At the moment, the central instance of `InputEventTransformer` is
+/// not accessible from miral. This class is only exposed for testing.
+class Transformer
+{
+public:
+    using EventDispatcher = std::function<void(std::shared_ptr<MirEvent>)>;
+
+    virtual ~Transformer() = default;
+
+    // Returning true means that the event has been successfully processed and
+    // shouldn't be handled by later transformers, whether the transformer is
+    // accumulating events for later dispatching or has immediately dispatched
+    // an event is an implementation detail of the transformer
+    virtual bool transform_input_event(EventDispatcher const&, EventBuilder*, MirEvent const&) = 0;
+};
+}
+}
+
+#endif // MIR_INPUT_INPUT_EVENT_TRANSFORMER_H_ 

--- a/src/include/server/mir/input/input_event_transformer.h
+++ b/src/include/server/mir/input/input_event_transformer.h
@@ -17,6 +17,8 @@
 #ifndef MIR_INPUT_INPUT_EVENT_TRANSFORMER_H_
 #define MIR_INPUT_INPUT_EVENT_TRANSFORMER_H_
 
+#include "mir/input/transformer.h"
+
 #include "mir/input/seat.h"
 #include "mir_toolkit/events/event.h"
 
@@ -37,18 +39,6 @@ class EventBuilder;
 class InputEventTransformer : public Seat
 {
 public:
-    using EventDispatcher = std::function<void(std::shared_ptr<MirEvent>)>;
-    class Transformer
-    {
-    public:
-        virtual ~Transformer() = default;
-
-        // Returning true means that the event has been successfully processed and
-        // shouldn't be handled by later transformers, whether the transformer is
-        // accumulating events for later dispatching or has immediately dispatched
-        // an event is an implementation detail of the transformer
-        virtual bool transform_input_event(EventDispatcher const&, EventBuilder*, MirEvent const&) = 0;
-    };
 
     InputEventTransformer(std::shared_ptr<Seat> const& seat, std::shared_ptr<time::Clock> const& clock);
     ~InputEventTransformer();

--- a/src/include/server/mir/shell/hover_click_transformer.h
+++ b/src/include/server/mir/shell/hover_click_transformer.h
@@ -17,13 +17,15 @@
 #ifndef MIR_SHELL_HOVER_CLICK_TRANSFORMER_H_
 #define MIR_SHELL_HOVER_CLICK_TRANSFORMER_H_
 
-#include "mir/input/input_event_transformer.h"
+#include <mir/input/transformer.h>
+
+#include <chrono>
 
 namespace mir
 {
 namespace shell
 {
-class HoverClickTransformer : public input::InputEventTransformer::Transformer
+class HoverClickTransformer : public input::Transformer
 {
 public:
     virtual void hover_duration(std::chrono::milliseconds delay) = 0;

--- a/src/include/server/mir/shell/simulated_secondary_click_transformer.h
+++ b/src/include/server/mir/shell/simulated_secondary_click_transformer.h
@@ -17,13 +17,15 @@
 #ifndef MIR_SHELL_SIMULATED_SECONDARY_CLICK_TRANSFORMER_H
 #define MIR_SHELL_SIMULATED_SECONDARY_CLICK_TRANSFORMER_H
 
-#include "mir/input/input_event_transformer.h"
+#include "mir/input/transformer.h"
+
+#include <chrono>
 
 namespace mir
 {
 namespace shell
 {
-class SimulatedSecondaryClickTransformer : public mir::input::InputEventTransformer::Transformer
+class SimulatedSecondaryClickTransformer : public mir::input::Transformer
 {
 public:
     virtual void hold_duration(std::chrono::milliseconds delay) = 0;

--- a/src/include/server/mir/shell/slow_keys_transformer.h
+++ b/src/include/server/mir/shell/slow_keys_transformer.h
@@ -17,15 +17,16 @@
 #ifndef MIR_SHELL_SLOW_KEYS_TRANSFORMER
 #define MIR_SHELL_SLOW_KEYS_TRANSFORMER
 
-#include "mir/input/input_event_transformer.h"
+#include "mir/input/transformer.h"
 
+#include <chrono>
 
 namespace mir
 {
 class MainLoop;
 namespace shell
 {
-class SlowKeysTransformer : public mir::input::InputEventTransformer::Transformer
+class SlowKeysTransformer : public mir::input::Transformer
 {
 public:
     virtual void on_key_down(std::function<void(unsigned int)>&&) = 0;

--- a/src/include/server/mir/shell/sticky_keys_transformer.h
+++ b/src/include/server/mir/shell/sticky_keys_transformer.h
@@ -17,13 +17,13 @@
 #ifndef MIR_SHELL_STICKY_KEYS_TRANSFORMER_H
 #define MIR_SHELL_STICKY_KEYS_TRANSFORMER_H
 
-#include "mir/input/input_event_transformer.h"
+#include "mir/input/transformer.h"
 #include <functional>
 
 namespace mir::shell
 {
 
-class StickyKeysTransformer : public input::InputEventTransformer::Transformer
+class StickyKeysTransformer : public input::Transformer
 {
 public:
     virtual void should_disable_if_two_keys_are_pressed_together(bool) = 0;

--- a/src/server/shell/basic_accessibility_manager.cpp
+++ b/src/server/shell/basic_accessibility_manager.cpp
@@ -31,12 +31,11 @@ namespace msh = mir::shell;
 
 namespace
 {
-using miet = mir::input::InputEventTransformer;
 void toggle_transformer(
     bool should_turn_on,
     bool& is_enabled,
-    std::shared_ptr<miet::Transformer> const& transformer,
-    std::shared_ptr<miet> const& event_transformer)
+    std::shared_ptr<mir::input::Transformer> const& transformer,
+    std::shared_ptr<mir::input::InputEventTransformer> const& event_transformer)
 {
     if (should_turn_on && !is_enabled)
     {

--- a/src/server/shell/basic_hover_click_transformer.cpp
+++ b/src/server/shell/basic_hover_click_transformer.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "basic_hover_click_transformer.h"
+#include "mir/geometry/displacement.h"
 #include "mir/input/cursor_observer.h"
 #include "mir/input/cursor_observer_multiplexer.h"
 #include "mir/input/event_builder.h"
@@ -100,7 +101,7 @@ msh::BasicHoverClickTransformer::BasicHoverClickTransformer(
 }
 
 bool msh::BasicHoverClickTransformer::transform_input_event(
-    mi::InputEventTransformer::EventDispatcher const& dispatcher,
+    mi::Transformer::EventDispatcher const& dispatcher,
     mi::EventBuilder* builder,
     MirEvent const&)
 {
@@ -139,7 +140,7 @@ void msh::BasicHoverClickTransformer::on_click_dispatched(std::function<void()>&
 }
 
 void msh::BasicHoverClickTransformer::initialize_click_dispatcher(
-    mi::InputEventTransformer::EventDispatcher const& dispatcher, mi::EventBuilder& builder)
+    mi::Transformer::EventDispatcher const& dispatcher, mi::EventBuilder& builder)
 {
     auto state = mutable_state.lock();
     if (!state->click_dispatcher)

--- a/src/server/shell/basic_hover_click_transformer.h
+++ b/src/server/shell/basic_hover_click_transformer.h
@@ -41,7 +41,7 @@ public:
         std::shared_ptr<input::CursorObserverMultiplexer> const& cursor_observer_multiplexer);
 
     bool transform_input_event(
-        mir::input::InputEventTransformer::EventDispatcher const& dispatcher,
+        mir::input::Transformer::EventDispatcher const& dispatcher,
         mir::input::EventBuilder* builder,
         MirEvent const& event) override;
 
@@ -55,7 +55,7 @@ public:
 
 private:
     void initialize_click_dispatcher(
-        mir::input::InputEventTransformer::EventDispatcher const& dispatcher, mir::input::EventBuilder& builder);
+        mir::input::Transformer::EventDispatcher const& dispatcher, mir::input::EventBuilder& builder);
 
     auto initialize_hover_initializer(std::shared_ptr<mir::MainLoop> const& main_loop) -> std::unique_ptr<mir::time::Alarm>;
 

--- a/src/server/shell/basic_simulated_secondary_click_transformer.cpp
+++ b/src/server/shell/basic_simulated_secondary_click_transformer.cpp
@@ -27,7 +27,7 @@
 namespace
 {
 void click(
-    mir::input::InputEventTransformer::EventDispatcher const& dispatcher,
+    mir::input::Transformer::EventDispatcher const& dispatcher,
     mir::input::EventBuilder* builder,
     MirPointerButton button)
 {
@@ -59,7 +59,7 @@ mir::shell::BasicSimulatedSecondaryClickTransformer::BasicSimulatedSecondaryClic
 }
 
 bool mir::shell::BasicSimulatedSecondaryClickTransformer::transform_input_event(
-    input::InputEventTransformer::EventDispatcher const& dispatcher,
+    input::Transformer::EventDispatcher const& dispatcher,
     input::EventBuilder* builder,
     MirEvent const& event)
 {

--- a/src/server/shell/basic_simulated_secondary_click_transformer.h
+++ b/src/server/shell/basic_simulated_secondary_click_transformer.h
@@ -36,7 +36,7 @@ public:
     BasicSimulatedSecondaryClickTransformer(std::shared_ptr<mir::MainLoop> const& main_loop);
 
     bool transform_input_event(
-        input::InputEventTransformer::EventDispatcher const& dispatcher,
+        input::Transformer::EventDispatcher const& dispatcher,
         input::EventBuilder*,
         MirEvent const&) override;
 

--- a/src/server/shell/basic_slow_keys_transformer.cpp
+++ b/src/server/shell/basic_slow_keys_transformer.cpp
@@ -28,7 +28,7 @@ msh::BasicSlowKeysTransformer::BasicSlowKeysTransformer(std::shared_ptr<MainLoop
 }
 
 bool msh::BasicSlowKeysTransformer::transform_input_event(
-    mi::InputEventTransformer::EventDispatcher const& dispatcher,
+    mi::Transformer::EventDispatcher const& dispatcher,
     mi::EventBuilder*,
     MirEvent const& event)
 {

--- a/src/server/shell/basic_slow_keys_transformer.h
+++ b/src/server/shell/basic_slow_keys_transformer.h
@@ -35,7 +35,7 @@ public:
     BasicSlowKeysTransformer(std::shared_ptr<MainLoop> const& main_loop);
 
     virtual bool transform_input_event(
-        input::InputEventTransformer::EventDispatcher const&, input::EventBuilder*, MirEvent const&) override;
+        input::Transformer::EventDispatcher const&, input::EventBuilder*, MirEvent const&) override;
 
     void on_key_down(std::function<void(unsigned int)>&& okd) override;
     void on_key_rejected(std::function<void(unsigned int)>&& okr) override;

--- a/src/server/shell/basic_sticky_keys_transformer.cpp
+++ b/src/server/shell/basic_sticky_keys_transformer.cpp
@@ -71,7 +71,7 @@ struct msh::BasicStickyKeysTransformer::Self
     bool try_dispatch_pending(
         MirEvent const& event,
         bool is_up_event,
-        mi::InputEventTransformer::EventDispatcher const& dispatcher)
+        mi::Transformer::EventDispatcher const& dispatcher)
     {
         if (!is_up_event)
             return false;
@@ -93,7 +93,7 @@ msh::BasicStickyKeysTransformer::BasicStickyKeysTransformer()
 }
 
 bool msh::BasicStickyKeysTransformer::transform_input_event(
-    mi::InputEventTransformer::EventDispatcher const& dispatcher,
+    mi::Transformer::EventDispatcher const& dispatcher,
     input::EventBuilder*,
     MirEvent const& event)
 {

--- a/src/server/shell/basic_sticky_keys_transformer.h
+++ b/src/server/shell/basic_sticky_keys_transformer.h
@@ -27,7 +27,7 @@ class BasicStickyKeysTransformer : public StickyKeysTransformer
 public:
     BasicStickyKeysTransformer();
     bool transform_input_event(
-       input::InputEventTransformer::EventDispatcher const&,
+       input::Transformer::EventDispatcher const&,
        input::EventBuilder*,
        MirEvent const&) override;
     void should_disable_if_two_keys_are_pressed_together(bool on) override;

--- a/src/server/shell/mouse_keys_transformer.cpp
+++ b/src/server/shell/mouse_keys_transformer.cpp
@@ -60,7 +60,7 @@ mir::shell::BasicMouseKeysTransformer::BasicMouseKeysTransformer(
 }
 
 bool mir::shell::BasicMouseKeysTransformer::transform_input_event(
-    mir::input::InputEventTransformer::EventDispatcher const& dispatcher,
+    mir::input::Transformer::EventDispatcher const& dispatcher,
     mir::input::EventBuilder* builder,
     MirEvent const& event)
 {

--- a/src/server/shell/mouse_keys_transformer.h
+++ b/src/server/shell/mouse_keys_transformer.h
@@ -14,11 +14,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "mir/input/input_event_transformer.h"
+#include "mir/input/transformer.h"
 
 #include "mir/geometry/displacement.h"
 #include "mir/input/mousekeys_keymap.h"
 #include "mir/synchronised.h"
+#include "mir_toolkit/events/enums.h"
 
 #include <memory>
 #include <xkbcommon/xkbcommon-keysyms.h>
@@ -37,7 +38,7 @@ class Clock;
 }
 namespace shell
 {
-class MouseKeysTransformer: public mir::input::InputEventTransformer::Transformer
+class MouseKeysTransformer: public mir::input::Transformer
 {
 public:
     virtual void keymap(mir::input::MouseKeysKeymap const& new_keymap) = 0;
@@ -52,7 +53,7 @@ public:
         std::shared_ptr<mir::MainLoop> const& main_loop, std::shared_ptr<time::Clock> const& clock);
 
     bool transform_input_event(
-        mir::input::InputEventTransformer::EventDispatcher const& dispatcher,
+        mir::input::Transformer::EventDispatcher const& dispatcher,
         mir::input::EventBuilder* builder,
         MirEvent const& event) override;
 
@@ -61,7 +62,7 @@ public:
     void max_speed(double x_axis, double y_axis) override;
 
 private:
-    using Dispatcher = mir::input::InputEventTransformer::EventDispatcher;
+    using Dispatcher = mir::input::Transformer::EventDispatcher;
 
     bool handle_motion(
         MirKeyboardAction keyboard_action,

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -398,7 +398,6 @@ global:
     mir::input::InputDispatcher::?InputDispatcher*;
     mir::input::InputEventTransformer::?InputEventTransformer*;
     mir::input::InputEventTransformer::InputEventTransformer*;
-    mir::input::InputEventTransformer::Transformer::?Transformer*;
     mir::input::InputEventTransformer::add_device*;
     mir::input::InputEventTransformer::append*;
     mir::input::InputEventTransformer::bounding_rectangle*;
@@ -997,7 +996,6 @@ global:
     non-virtual?thunk?to?mir::input::InputDeviceObserver::?InputDeviceObserver*;
     non-virtual?thunk?to?mir::input::InputDispatcher::?InputDispatcher*;
     non-virtual?thunk?to?mir::input::InputEventTransformer::?InputEventTransformer*;
-    non-virtual?thunk?to?mir::input::InputEventTransformer::Transformer::?Transformer*;
     non-virtual?thunk?to?mir::input::InputEventTransformer::add_device*;
     non-virtual?thunk?to?mir::input::InputEventTransformer::append*;
     non-virtual?thunk?to?mir::input::InputEventTransformer::bounding_rectangle*;
@@ -1335,7 +1333,6 @@ global:
     typeinfo?for?mir::input::InputDeviceHub;
     typeinfo?for?mir::input::InputDeviceObserver;
     typeinfo?for?mir::input::InputDispatcher;
-    typeinfo?for?mir::input::InputEventTransformer::Transformer;
     typeinfo?for?mir::input::InputEventTransformer;
     typeinfo?for?mir::input::InputManager;
     typeinfo?for?mir::input::KeyboardObserver;
@@ -1551,7 +1548,6 @@ global:
     vtable?for?mir::input::InputDeviceHub;
     vtable?for?mir::input::InputDeviceObserver;
     vtable?for?mir::input::InputDispatcher;
-    vtable?for?mir::input::InputEventTransformer::Transformer;
     vtable?for?mir::input::InputEventTransformer;
     vtable?for?mir::input::InputManager;
     vtable?for?mir::input::KeyboardObserver;

--- a/tests/unit-tests/input/test_input_event_transformer.cpp
+++ b/tests/unit-tests/input/test_input_event_transformer.cpp
@@ -20,6 +20,7 @@
 #include "mir/input/input_device_hub.h"
 #include "mir/input/input_device_registry.h"
 #include "mir/input/input_event_transformer.h"
+#include "mir/input/transformer.h"
 #include "mir/input/virtual_input_device.h"
 #include "src/server/input/default_input_device_hub.h"
 
@@ -81,12 +82,12 @@ struct TestInputEventTransformer : testing::Test
     mir::input::InputEventTransformer input_event_transformer{mt::fake_shared(mock_seat), mt::fake_shared(clock)};
 };
 
-struct MockTransformer : public mir::input::InputEventTransformer::Transformer
+struct MockTransformer : public mir::input::Transformer
 {
     MOCK_METHOD(
         (bool),
         transform_input_event,
-        (mir::input::InputEventTransformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
+        (mir::input::Transformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
         (override));
 };
 

--- a/tests/unit-tests/shell/test_basic_accessibility_manager.cpp
+++ b/tests/unit-tests/shell/test_basic_accessibility_manager.cpp
@@ -58,7 +58,7 @@ struct MockMouseKeysTransformer : public mir::shell::MouseKeysTransformer
     MOCK_METHOD(
         bool,
         transform_input_event,
-        (mir::input::InputEventTransformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
+        (mir::input::Transformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
         (override));
 };
 
@@ -69,7 +69,7 @@ struct MockSimulatedSecondaryClickTransformer : public mir::shell::SimulatedSeco
     MOCK_METHOD(
         bool,
         transform_input_event,
-        (mir::input::InputEventTransformer::EventDispatcher const& dispatcher,
+        (mir::input::Transformer::EventDispatcher const& dispatcher,
          mir::input::EventBuilder*,
          MirEvent const&),
         (override));
@@ -88,8 +88,8 @@ struct MockInputEventTransformer: public mir::input::InputEventTransformer
     {
     }
 
-    MOCK_METHOD(void, append, (std::weak_ptr<Transformer> const&), (override));
-    MOCK_METHOD(void, remove, (std::shared_ptr<Transformer> const&), (override));
+    MOCK_METHOD(void, append, (std::weak_ptr<mir::input::Transformer> const&), (override));
+    MOCK_METHOD(void, remove, (std::shared_ptr<mir::input::Transformer> const&), (override));
 };
 
 struct MockHoverClickTransformer : public mir::shell::HoverClickTransformer
@@ -99,7 +99,7 @@ struct MockHoverClickTransformer : public mir::shell::HoverClickTransformer
     MOCK_METHOD(
         bool,
         transform_input_event,
-        (mir::input::InputEventTransformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
+        (mir::input::Transformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
         (override));
 
     MOCK_METHOD(void, hover_duration,(std::chrono::milliseconds delay), (override));
@@ -115,7 +115,7 @@ struct MockSlowKeysTransformer : public mir::shell::SlowKeysTransformer
     MOCK_METHOD(
         bool,
         transform_input_event,
-        (mir::input::InputEventTransformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
+        (mir::input::Transformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
         (override));
 
     MOCK_METHOD(void, on_key_down, (std::function<void(unsigned int)>&&), (override));
@@ -129,7 +129,7 @@ struct MockStickyKeysTransformer : mir::shell::StickyKeysTransformer
     MOCK_METHOD(
         bool,
         transform_input_event,
-        (mir::input::InputEventTransformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
+        (mir::input::Transformer::EventDispatcher const&, mir::input::EventBuilder*, MirEvent const&),
         (override));
     MOCK_METHOD(void, should_disable_if_two_keys_are_pressed_together, (bool), (override));
     MOCK_METHOD(void, on_modifier_clicked, (std::function<void(int32_t)>&&), (override));
@@ -362,7 +362,7 @@ struct TestArbitraryEnablesAndDisables :
     public TestBasicAccessibilityManager,
     public WithParamInterface<TransformerToTest>
 {
-    auto get_transformer() -> std::shared_ptr<mir::input::InputEventTransformer::Transformer>
+    auto get_transformer() -> std::shared_ptr<mir::input::Transformer>
     {
         switch (GetParam())
         {

--- a/tools/symbols_map_generator/main.py
+++ b/tools/symbols_map_generator/main.py
@@ -42,6 +42,10 @@ HIDDEN_SYMBOLS = {
     "miral::SimulatedSecondaryClick::enable*;",
     "miral::SimulatedSecondaryClick::enabled*;",
     "miral::SimulatedSecondaryClick::operator*;",
+    "mir::input::Transformer::?Transformer*;",
+    "non-virtual?thunk?to?mir::input::Transformer::?Transformer*;",
+    "typeinfo?for?mir::input::Transformer;",
+    "vtable?for?mir::input::Transformer;",
 }
 
 class HeaderDirectory(TypedDict):


### PR DESCRIPTION
Prerequisite to test `MouseKeysConfig` properly in #4071. 

In the aforementioned PR, I wanted to add tests for `miral::MouseKeyConfig`, which required that I implement a `MockMouseKeysTransformer`, which requires the definition of `Transformer`. That is defined in `input_event_transformer.h`. Unfortunately, since `InputEventTransformer` inherits from `Seat`, it also includes `seat.h`, which transitively includes headers that can't be included in miral. The solution was to split the definition of `Transformer` so that these headers are not included.