### PR TITLE
Update `live_config`'s remark to 5.5 since 5.4 was nuked

### DIFF
--- a/include/miral/miral/live_config.h
+++ b/include/miral/miral/live_config.h
@@ -64,7 +64,7 @@ private:
 ///
 /// This could be supported by various backends (an ini file, a YAML node, etc)
 ///
-/// \remark Since MirAL 5.4
+/// \remark Since MirAL 5.5
 class Store
 {
 public:


### PR DESCRIPTION
Does what it says on the tin.