### PR TITLE
Hover click cleanup

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -556,10 +556,12 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::CursorScale::CursorScale(miral::live_config::Store&)@MIRAL_5.5" 5.5.0
  (c++)"miral::DisplayConfiguration::Node::Node(miral::DisplayConfiguration::Node&&)@MIRAL_5.3" 5.5.0
  (c++)"miral::DisplayConfiguration::Node::Node(miral::DisplayConfiguration::Node&&)@MIRAL_5.5" 5.5.0
- (c++)"miral::HoverClick::HoverClick(bool)@MIRAL_5.5" 5.5.0
+ (c++)"miral::HoverClick::HoverClick(std::shared_ptr<miral::HoverClick::Self>)@MIRAL_5.5" 5.5.0
  (c++)"miral::HoverClick::cancel_displacement_threshold(int)@MIRAL_5.5" 5.5.0
  (c++)"miral::HoverClick::disable()@MIRAL_5.5" 5.5.0
+ (c++)"miral::HoverClick::disabled()@MIRAL_5.5" 5.5.0
  (c++)"miral::HoverClick::enable()@MIRAL_5.5" 5.5.0
+ (c++)"miral::HoverClick::enabled()@MIRAL_5.5" 5.5.0
  (c++)"miral::HoverClick::on_click_dispatched(std::function<void ()>&&)@MIRAL_5.5" 5.5.0
  (c++)"miral::HoverClick::on_hover_cancel(std::function<void ()>&&)@MIRAL_5.5" 5.5.0
  (c++)"miral::HoverClick::on_hover_start(std::function<void ()>&&)@MIRAL_5.5" 5.5.0

--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -556,6 +556,7 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::CursorScale::CursorScale(miral::live_config::Store&)@MIRAL_5.5" 5.5.0
  (c++)"miral::DisplayConfiguration::Node::Node(miral::DisplayConfiguration::Node&&)@MIRAL_5.3" 5.5.0
  (c++)"miral::DisplayConfiguration::Node::Node(miral::DisplayConfiguration::Node&&)@MIRAL_5.5" 5.5.0
+ (c++)"miral::HoverClick::HoverClick(miral::live_config::Store&)@MIRAL_5.5" 5.5.0
  (c++)"miral::HoverClick::HoverClick(std::shared_ptr<miral::HoverClick::Self>)@MIRAL_5.5" 5.5.0
  (c++)"miral::HoverClick::cancel_displacement_threshold(int)@MIRAL_5.5" 5.5.0
  (c++)"miral::HoverClick::disable()@MIRAL_5.5" 5.5.0

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -33,6 +33,7 @@
 #include <miral/output_filter.h>
 #include <miral/bounce_keys.h>
 #include <miral/slow_keys.h>
+#include <miral/hover_click.h>
 
 #include "mir/abnormal_exit.h"
 #include "mir/main_loop.h"
@@ -134,6 +135,7 @@ try
     miral::BounceKeys bounce_keys{config_store};
     miral::SlowKeys slow_keys{config_store};
     miral::StickyKeys sticky_keys{config_store};
+    miral::HoverClick hover_click{config_store};
 
     miral::ConfigFile config_file{
         runner,
@@ -167,7 +169,8 @@ try
         cursor_scale,
         bounce_keys,
         slow_keys,
-        sticky_keys
+        sticky_keys,
+        hover_click
     });
 
     // Propagate any test failure

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -193,7 +193,7 @@ int main(int argc, char const* argv[])
                                 .displacement_threshold(30)
                                 .hold_duration(std::chrono::milliseconds{2000});
 
-    miral::HoverClick hover_click_config{false};
+    auto hover_click_config = miral::HoverClick::disabled();
 
     float magnification = 2.f;
     Size capture_size{100, 100};

--- a/include/miral/miral/hover_click.h
+++ b/include/miral/miral/hover_click.h
@@ -38,6 +38,11 @@ class HoverClick
 {
 public:
     explicit HoverClick(bool enabled_by_default);
+    /// Creates a `HoverClick` instance that's enabled by default.
+    auto static enabled() -> HoverClick;
+
+    /// Creates a `HoverClick` instance that's disabled by default.
+    auto static disabled() -> HoverClick;
 
     void operator()(mir::Server& server);
 
@@ -79,6 +84,7 @@ public:
 
 private:
     struct Self;
+    HoverClick(std::shared_ptr<Self> self);
     std::shared_ptr<Self> const self;
 };
 }

--- a/include/miral/miral/hover_click.h
+++ b/include/miral/miral/hover_click.h
@@ -24,7 +24,15 @@ namespace mir { class Server; }
 
 namespace miral
 {
-/// Enable configuring hover click at runtime.
+/// Enables configuring hover click at runtime.
+///
+/// Hover click is an accessibility feature that allows users to dispatch primary
+/// clicks by holding the pointer still for some configurable period of time.
+/// The pointer may move by a configurable distance to accommodate users with
+/// disabilities. After a hover click, no further clicks are dispatched until
+/// the cursor moves by a configurable distance from the position of the
+/// previous click.
+/// 
 /// \remark Since MirAL 5.5
 class HoverClick
 {

--- a/include/miral/miral/hover_click.h
+++ b/include/miral/miral/hover_click.h
@@ -24,6 +24,7 @@ namespace mir { class Server; }
 
 namespace miral
 {
+namespace live_config { class Store; }
 /// Enables configuring hover click at runtime.
 ///
 /// Hover click is an accessibility feature that allows users to dispatch primary
@@ -37,7 +38,9 @@ namespace miral
 class HoverClick
 {
 public:
-    explicit HoverClick(bool enabled_by_default);
+    /// Construct a `HoverClick` instance with access to a live config store.
+    explicit HoverClick(live_config::Store& config_store);
+
     /// Creates a `HoverClick` instance that's enabled by default.
     auto static enabled() -> HoverClick;
 

--- a/src/miral/hover_click.cpp
+++ b/src/miral/hover_click.cpp
@@ -50,9 +50,19 @@ struct miral::HoverClick::Self
     std::weak_ptr<mir::shell::AccessibilityManager> accessibility_manager;
 };
 
-miral::HoverClick::HoverClick(bool enabled_by_default)
-    : self{std::make_shared<Self>(enabled_by_default)}
+miral::HoverClick::HoverClick(std::shared_ptr<Self> self)
+    : self{std::move(self)}
 {
+}
+
+miral::HoverClick miral::HoverClick::enabled()
+{
+    return HoverClick{std::make_shared<Self>(true)};
+}
+
+miral::HoverClick miral::HoverClick::disabled()
+{
+    return HoverClick{std::make_shared<Self>(false)};
 }
 
 miral::HoverClick& miral::HoverClick::enable()

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -594,7 +594,9 @@ global:
     miral::HoverClick::HoverClick*;
     miral::HoverClick::cancel_displacement_threshold*;
     miral::HoverClick::disable*;
+    miral::HoverClick::disabled*;
     miral::HoverClick::enable*;
+    miral::HoverClick::enabled*;
     miral::HoverClick::hover_duration*;
     miral::HoverClick::on_click_dispatched*;
     miral::HoverClick::on_hover_cancel*;

--- a/src/server/shell/basic_hover_click_transformer.cpp
+++ b/src/server/shell/basic_hover_click_transformer.cpp
@@ -45,14 +45,14 @@ public:
         // If a click already occured in the past. Only start a new hover click if
         // the cursor moved "significantly" from the last position.
         auto const hover_click_origin = state->hover_click_origin;
-        auto const cancel_displacement = state->cancel_displacement_threshold;
 
         if (hover_click_origin)
         {
             auto const distance_from_last_click =
                 (*hover_click_origin - state->potential_position).length_squared();
-            auto const reclick_threshold = state->reclick_displacement_threshold;
 
+
+            auto const cancel_displacement = state->cancel_displacement_threshold;
             // If we've moved too far, cancel the click.
             if (distance_from_last_click >= cancel_displacement * cancel_displacement &&
                 state->click_dispatcher.value()->state() == time::Alarm::State::pending)
@@ -62,6 +62,7 @@ public:
                 return;
             }
 
+            auto const reclick_threshold = state->reclick_displacement_threshold;
             // If we've moved too little, don't dispatch a new click
             if (distance_from_last_click <= (reclick_threshold * reclick_threshold))
                 return;

--- a/src/server/shell/basic_hover_click_transformer.cpp
+++ b/src/server/shell/basic_hover_click_transformer.cpp
@@ -65,6 +65,8 @@ public:
             // If we've moved too little, don't dispatch a new click
             if (distance_from_last_click <= (reclick_threshold * reclick_threshold))
                 return;
+
+            state->hover_click_origin.reset();
         }
 
         // Cancel and reschedule to give users a grace period before the hover
@@ -173,7 +175,6 @@ void msh::BasicHoverClickTransformer::initialize_click_dispatcher(
 
                 auto const state = mutable_state.lock();
                 state->on_click_dispatched();
-                state->hover_click_origin.reset();
             });
     }
 }


### PR DESCRIPTION
### What's new
1. Removes the old `HoverClick(bool)` constrcutor, replacing it with `enabled()` and `disabled()`
2. Adds a live config constructor, which adds the following options:
    - hover_click_enable
    - hover_click_hover_duration
    - hover_click_cancel_displacement
    - hover_click_reclick_displacement
3. Adds a comment that explains to users what hover click is
4. Fixed a bug where hover clicks would continuously be initiated regardless of whether the pointer moved `hover_click_reclick_displacement` pixels away or not

### How to test
You can add the following options `~/.config/mir_demo_server.live-config`:
```
hover_click_enable=true
hover_click_hover_duration=3000
hover_click_cancel_displacement=100
hover_click_reclick_displacement=100
```

Hover click does not start dispatching clicks until the cursor first moves. After that, if the cursor stays still  for the hover duration, a click is dispatched. The cursor can additionally move slightly once the click is initiated without cancelling the click. The amount of movement to cancel the click can be customized through `hover_click_cancel_displacement`. This displacement is computed as the distance between where the cursor was when the hover click was initiated, and the current position of the cursor. If a click is dispatched through hover click, no more clicks will be initiated unless the cursor moves from the last click position. The distance in pixels can be customized through `hover_click_reclick_displacement`. This displacement is computed in the same way as the cancel displacement.