### PR TITLE
tests: Use LLD as the linker for the ubuntu/clang task

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -36,6 +36,8 @@ environment:
     BUILD_TYPE/asan,asan_clang: AddressSanitizer
     BUILD_TYPE/tsan,tsan_clang: ThreadSanitizer
     BUILD_TYPE/ubsan,ubsan_clang: UBSanitizer
+    LINKER: ld
+    LINKER/clang: lld
     DEB_BUILD_EXTRA:
     DEB_BUILD_EXTRA/asan,asan_clang,ubsan,ubsan_clang: nostrip optimize=-lto
     DEB_BUILD_EXTRA/tsan,tsan_clang: nostrip nocheck

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -40,6 +40,12 @@ execute: |
       echo "OVERRIDE_CONFIGURE_OPTIONS += -DCMAKE_CXX_FLAGS=-fpch-validate-input-files-content" >> debian/opts.mk
     fi
 
+    # Set up linker
+    if [ "${LINKER}" -eq "lld" ]; then
+      apt-get install --yes --no-install-recommends lld
+    fi
+    echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_USE_LD=${LINKER}"
+
     # enable valgrind
     if [ "${VALGRIND}" -eq 1 ]; then
       echo "OVERRIDE_CONFIGURE_OPTIONS += -DENABLE_MEMCHECK_OPTION=ON" >> debian/opts.mk


### PR DESCRIPTION
Like clang, LLD warns/errors for more types of
incorrect/unexpected behaviour than GNU ld; use
it in the clang build to pick those up in CI