### PR TITLE
static_display_config: add display properties to output

### DIFF
--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -473,10 +473,12 @@ void miral::YamlFileDisplayConfig::serialize_configuration(std::ostream& out, mg
            "\n    # a list of cards (currently matched by card-id)";
 
     std::map<mg::DisplayConfigurationCardId, std::ostringstream> card_map;
+    std::ostringstream displays;
 
-    conf.for_each_output([&card_map](mg::UserDisplayConfigurationOutput const& conf_output)
+    conf.for_each_output([&card_map, &displays](mg::UserDisplayConfigurationOutput const& conf_output)
         {
             serialize_output_configuration(card_map[conf_output.card_id], conf_output);
+            serialize_display_info(displays, conf_output);
         });
 
     for (auto const& co : card_map)
@@ -484,6 +486,24 @@ void miral::YamlFileDisplayConfig::serialize_configuration(std::ostream& out, mg
         out << "\n"
                "\n    - card-id: " << co.first.as_value()
             << co.second.str();
+    }
+
+    out << "\n"
+           "\n    # displays:"
+           "\n    # A list of display configurations matched by the displays' properties"
+           "\n    #"
+           "\n    # These take the same display options as above,"
+           "\n    # and take precedence over the port-based configuration."
+           "\n    #";
+
+    if (displays.str().empty())
+    {
+        out << "\n    # No display properties could be determined."
+               "\n";
+    }
+    else
+    {
+        out << displays.str() << "\n";
     }
 }
 
@@ -536,6 +556,26 @@ void miral::YamlFileDisplayConfig::serialize_output_configuration(
     }
 
     out << "\n";
+}
+
+void miral::YamlFileDisplayConfig::serialize_display_info(
+    std::ostream& out, mg::UserDisplayConfigurationOutput const& conf_output)
+{
+    using mir::graphics::Edid;
+    if (conf_output.edid.size() >= Edid::minimum_size)
+    {
+        auto const edid = reinterpret_cast<Edid const*>(conf_output.edid.data());
+        Edid::Manufacturer man;
+        edid->get_manufacturer(man);
+        Edid::MonitorName name;
+        edid->get_monitor_name(name);
+
+        out << "\n    # - vendor: " << man
+            << "\n    #   model: " << name
+            << "\n    #   product: " << edid->product_code()
+            << "\n    #   serial: " << edid->serial_number()
+            << "\n    #";
+    }
 }
 
 void miral::YamlFileDisplayConfig::apply_to_output(mg::UserDisplayConfigurationOutput& conf_output, Config const& conf)

--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -119,6 +119,8 @@ private:
 
     static void serialize_output_configuration(
         std::ostream& out, mir::graphics::UserDisplayConfigurationOutput const& conf_output);
+    static void serialize_display_info(
+        std::ostream& out, mir::graphics::UserDisplayConfigurationOutput const& conf_output);
 };
 
 class ReloadingYamlFileDisplayConfig : public YamlFileDisplayConfig

--- a/tests/miral/static_display_config.cpp
+++ b/tests/miral/static_display_config.cpp
@@ -657,7 +657,7 @@ TEST_F(StaticDisplayConfig, empty_display_is_error)
     EXPECT_THROW((sdc.load_config(stream, "")), mir::AbnormalExit);
 }
 
-struct PropertyValueTest : public StaticDisplayConfig, public WithParamInterface<std::string>
+struct PropertyValueTest : public StaticDisplayConfig, public WithParamInterface<std::pair<std::string, std::string>>
 {
 };
 
@@ -667,7 +667,7 @@ TEST_P(PropertyValueTest, invalid_display_property_value_is_error)
         "layouts:\n"
         "  default:\n"
         "    displays:\n"
-        "    - " + GetParam() + ": null\n"};
+        "    - " + GetParam().first + ": null\n"};
 
     EXPECT_THROW((sdc.load_config(stream, "")), mir::AbnormalExit);
 }
@@ -678,15 +678,10 @@ TEST_P(PropertyValueTest, empty_display_property_value_is_error)
         "layouts:\n"
         "  default:\n"
         "    displays:\n"
-        "    - " + GetParam() + ": ""\n"};
+        "    - " + GetParam().first + ": ""\n"};
 
     EXPECT_THROW((sdc.load_config(stream, "")), mir::AbnormalExit);
 }
-
-INSTANTIATE_TEST_SUITE_P(
-    EDIDValues,
-    PropertyValueTest,
-    Values("vendor", "product", "model", "serial"));
 
 TEST_F(StaticDisplayConfig, no_matcher_matches_all)
 {
@@ -874,3 +869,34 @@ TEST_F(StaticDisplayConfig, cards_apply_on_unmatched_displays)
     EXPECT_THAT(hdmi1.orientation, Eq(mir_orientation_left));
     EXPECT_THAT(vga1.orientation, Eq(mir_orientation_right));
 }
+
+TEST_F(StaticDisplayConfig, serialize_output_with_no_edids)
+{
+    std::ostringstream out;
+
+    miral::YamlFileDisplayConfig::serialize_configuration(out, dc);
+
+    ASSERT_THAT(out.str(), HasSubstr("# No display properties could be determined."));
+}
+
+TEST_P(PropertyValueTest, serialize_properties_for_outputs)
+{
+    std::ostringstream out;
+
+    hdmi1.edid = basic_edid;
+
+    miral::YamlFileDisplayConfig::serialize_configuration(out, dc);
+
+    ASSERT_THAT(out.str(), ContainsRegex("# [ -] " + GetParam().first + ": " + GetParam().second));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EDIDValues,
+    PropertyValueTest,
+    Values(
+        std::make_pair("vendor", "APP"),
+        std::make_pair("model", "Color LCD"),
+        std::make_pair("product", "40178"),
+        std::make_pair("serial", "0")
+    )
+);


### PR DESCRIPTION
This brings back a feature reverted inadvertently through:
- #3930

---

Adds to the default config:

```yaml
    # displays:
    # A list of display configurations matched by the displays' properties
    #
    # These take the same display options as above,
    # and take precedence over the port-based configuration.
    #
    # - vendor: BOE
    #   model: 
    #   product: 2399
    #   serial: 0
```