### PR TITLE
Consolidate repeating alarm code

### DIFF
--- a/src/include/server/mir/time/alarm_factory.h
+++ b/src/include/server/mir/time/alarm_factory.h
@@ -61,6 +61,17 @@ public:
      */
     virtual std::unique_ptr<Alarm> create_alarm(std::unique_ptr<LockableCallback> callback) = 0;
 
+    /**
+     * \brief Create an Alarm that will not fire until scheduled and repeats
+     * itself with a certain delay.
+     *
+     * \param callback Function to call when the Alarm signals
+     * \param repeat_delay The delay between self-invocations
+     * \return A handle to an Alarm that can later be scheduled
+     */
+    auto create_repeating_alarm(std::function<void()> const& callback, std::chrono::milliseconds repeat_delay)
+        -> std::shared_ptr<Alarm>;
+
 protected:
     AlarmFactory() = default;
     AlarmFactory(AlarmFactory const&) = delete;

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -29,6 +29,7 @@ add_subdirectory(frontend_wayland/)
 add_subdirectory(frontend_xwayland/)
 add_subdirectory(shell/)
 add_subdirectory(console/)
+add_subdirectory(time/)
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/mirserver.pc.in
@@ -109,6 +110,7 @@ set(MIR_SERVER_REFERENCES
   mirlogging
   mirnullreport
   mirconsole
+  mirservertime
 
   mirrenderergl
   mirgl

--- a/src/server/input/key_repeat_dispatcher.cpp
+++ b/src/server/input/key_repeat_dispatcher.cpp
@@ -195,21 +195,8 @@ void mi::KeyRepeatDispatcher::handle_key_input(MirInputDeviceId id, MirKeyboardE
                  next_dispatcher->dispatch(std::move(new_event));
              };
 
-        // We need to provide the alarm lambda with the alarm (which doesn't exist yet) so
-        // that it can reschedule. This is a placeholder while we create the lambda & alarm.
-        auto const shared_weak_alarm = std::make_shared<std::weak_ptr<time::Alarm>>();
+        auto const alarm = alarm_factory->create_repeating_alarm(clone_event, repeat_delay);
 
-        std::shared_ptr<mir::time::Alarm> alarm = alarm_factory->create_alarm(
-            [clone_event, shared_weak_alarm, repeat_delay=repeat_delay]()
-            {
-                clone_event();
-
-                if (auto const& repeat_alarm = shared_weak_alarm->lock())
-                    repeat_alarm->reschedule_in(repeat_delay);
-            });
-
-        // Fulfill the placeholder before scheduling the alarm.
-        *shared_weak_alarm = alarm;
         alarm->reschedule_in(repeat_timeout);
         set_alarm_for_device(id, alarm);
     }

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1625,3 +1625,10 @@ global:
 local: *;
 };
 
+MIR_SERVER_INTERNAL_2.23 {
+global:
+  extern "C++" {
+    mir::time::AlarmFactory::create_repeating_alarm*;
+  };
+local: *;
+} MIR_SERVER_INTERNAL_2.22;

--- a/src/server/time/CMakeLists.txt
+++ b/src/server/time/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(
+  TIME_SOURCES
+
+  alarm_factory.cpp
+  ${CMAKE_SOURCE_DIR}/src/include/server/mir/time/alarm_factory.h
+)
+
+add_library(
+  mirservertime OBJECT
+
+  ${TIME_SOURCES}
+)
+
+target_link_libraries(mirservertime
+  PUBLIC
+    mircommon
+)

--- a/src/server/time/alarm_factory.cpp
+++ b/src/server/time/alarm_factory.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/time/alarm_factory.h"
+
+auto mir::time::AlarmFactory::create_repeating_alarm(
+    std::function<void()> const& callback, std::chrono::milliseconds repeat_delay) -> std::shared_ptr<Alarm>
+{
+    auto const shared_weak_alarm{std::make_shared<std::weak_ptr<time::Alarm>>()};
+
+    std::shared_ptr result = create_alarm(
+        [swk = shared_weak_alarm, cb = std::move(callback), repeat_delay]()
+        {
+            cb();
+
+            if (auto const& repeat_alarm = swk->lock())
+                repeat_alarm->reschedule_in(repeat_delay);
+        });
+
+    *shared_weak_alarm = result;
+
+    return result;
+}


### PR DESCRIPTION
* Moves the repeating alarm code duplicated between `KeyRepeatDispatcher` and `BasicMouseKeysTransformer` to `time::AlarmFactory::create_repeating_alarm`.
* Adds a new module `mirservertime` at `src/server/time/` to house the implementation of `time::AlarmFactory::create_repeating_alarm`