### PR TITLE
Fix window size constraints with ssd

### DIFF
--- a/src/include/server/mir/scene/basic_surface.h
+++ b/src/include/server/mir/scene/basic_surface.h
@@ -172,6 +172,15 @@ public:
     Flags<MirTiledEdge> tiled_edges() const override;
     void set_tiled_edges(Flags<MirTiledEdge> flags) override;
 
+    auto min_width() const -> geometry::Width override;
+    auto max_width() const -> geometry::Width override;
+    auto min_height() const -> geometry::Height override;
+    auto max_height() const -> geometry::Height override;
+    void set_min_width(geometry::Width width) override;
+    void set_max_width(geometry::Width width) override;
+    void set_min_height(geometry::Height height) override;
+    void set_max_height(geometry::Height height) override;
+
 private:
     struct State;
     class DisplayConfigurationEarlyListener;
@@ -228,6 +237,11 @@ private:
 
         MirFocusMode focus_mode = mir_focus_mode_focusable;
         Flags<MirTiledEdge> tiled_edges = Flags(mir_tiled_edge_none);
+
+        mir::geometry::Width min_width{0};
+        mir::geometry::Height min_height{0};
+        mir::geometry::Width max_width{std::numeric_limits<int>::max()};
+        mir::geometry::Height max_height{std::numeric_limits<int>::max()};
     };
     mir::Synchronised<State> synchronised_state;
 

--- a/src/include/server/mir/scene/surface.h
+++ b/src/include/server/mir/scene/surface.h
@@ -167,6 +167,18 @@ public:
     virtual auto tiled_edges() const -> Flags<MirTiledEdge> = 0;
     virtual void set_tiled_edges(Flags<MirTiledEdge> flags) = 0;
     ///@}
+
+    /// Manage the size bounds
+    /// @{
+    virtual auto min_width() const -> geometry::Width = 0;
+    virtual auto max_width() const -> geometry::Width = 0;
+    virtual auto min_height() const -> geometry::Height = 0;
+    virtual auto max_height() const -> geometry::Height = 0;
+    virtual void set_min_width(geometry::Width width) = 0;
+    virtual void set_max_width(geometry::Width width) = 0;
+    virtual void set_min_height(geometry::Height height) = 0;
+    virtual void set_max_height(geometry::Height height) = 0;
+    ///@}
 };
 }
 }

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -303,7 +303,8 @@ auto miral::WindowInfo::restore_rect() const -> mir::geometry::Rectangle
         }
 
         // Halfway between current size and min size is reasonable for a maximized/fullscreen window
-        auto const min_size_disp = Displacement{as_delta(self->min_width), as_delta(self->min_height)};
+        std::shared_ptr<mir::scene::Surface> const surface{self->window};
+        auto const min_size_disp = Displacement{as_delta(surface->min_width()), as_delta(surface->min_height())};
         Size const reasonable_size{as_size(
             (as_displacement(self->window.size()) - min_size_disp) * 0.5
             + min_size_disp)};
@@ -341,22 +342,26 @@ auto miral::WindowInfo::children() const -> std::vector <Window> const&
 
 auto miral::WindowInfo::min_width() const -> mir::geometry::Width
 {
-    return self->min_width;
+    std::shared_ptr<mir::scene::Surface> const surface{self->window};
+    return surface->min_width();
 }
 
 auto miral::WindowInfo::min_height() const -> mir::geometry::Height
 {
-    return self->min_height;
+    std::shared_ptr<mir::scene::Surface> const surface{self->window};
+    return surface->min_height();
 }
 
 auto miral::WindowInfo::max_width() const -> mir::geometry::Width
 {
-    return self->max_width;
+    std::shared_ptr<mir::scene::Surface> const surface{self->window};
+    return surface->max_width();
 }
 
 auto miral::WindowInfo::max_height() const -> mir::geometry::Height
 {
-    return self->max_height;
+    std::shared_ptr<mir::scene::Surface> const surface{self->window};
+    return surface->max_height();
 }
 
 auto miral::WindowInfo::userdata() const -> std::shared_ptr<void>

--- a/src/miral/window_info_internal.cpp
+++ b/src/miral/window_info_internal.cpp
@@ -65,10 +65,6 @@ miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) 
     type{params.type().value_or(mir_window_type_normal)},
     state{params.state().value_or(mir_window_state_restored)},
     restore_rect{},
-    min_width{params.min_width().value_or(miral::default_min_width)},
-    min_height{params.min_height().value_or(miral::default_min_height)},
-    max_width{params.max_width().value_or(miral::default_max_width)},
-    max_height{params.max_height().value_or(miral::default_max_height)},
     preferred_orientation{params.preferred_orientation().value_or(mir_orientation_mode_any)},
     confine_pointer(params.confine_pointer().value_or(mir_pointer_unconfined)),
     width_inc{params.width_inc().value_or(default_width_inc)},
@@ -88,6 +84,12 @@ miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) 
 
     if (params.userdata().is_set())
         userdata = params.userdata().value();
+
+    std::shared_ptr<mir::scene::Surface> const surface{window};
+    surface->set_min_width(params.min_width().value_or(miral::default_min_width));
+    surface->set_min_height(params.min_height().value_or(miral::default_min_height));
+    surface->set_max_width(params.max_width().value_or(miral::default_max_width));
+    surface->set_max_height(params.max_height().value_or(miral::default_max_height));
 }
 
 miral::WindowInfo::Self::Self() :
@@ -144,22 +146,26 @@ void miral::WindowInfo::remove_child(Window const& child)
 
 void miral::WindowInfo::min_width(mir::geometry::Width min_width)
 {
-    self->min_width = clamp(min_width);
+    std::shared_ptr<mir::scene::Surface> const surface{self->window};
+    surface->set_min_width(clamp(min_width));
 }
 
 void miral::WindowInfo::min_height(mir::geometry::Height min_height)
 {
-    self->min_height = clamp(min_height);
+    std::shared_ptr<mir::scene::Surface> const surface{self->window};
+    surface->set_min_height(clamp(min_height));
 }
 
 void miral::WindowInfo::max_width(mir::geometry::Width max_width)
 {
-    self->max_width = clamp(max_width);
+    std::shared_ptr<mir::scene::Surface> const surface{self->window};
+    surface->set_max_width(clamp(max_width));
 }
 
 void miral::WindowInfo::max_height(mir::geometry::Height max_height)
 {
-    self->max_height = clamp(max_height);
+    std::shared_ptr<mir::scene::Surface> const surface{self->window};
+    surface->set_max_height(clamp(max_height));
 }
 
 void miral::WindowInfo::width_inc(DeltaX width_inc)

--- a/src/miral/window_info_internal.h
+++ b/src/miral/window_info_internal.h
@@ -33,10 +33,6 @@ struct miral::WindowInfo::Self
     std::optional<mir::geometry::Rectangle> restore_rect;
     Window parent;
     std::vector <Window> children;
-    mir::geometry::Width min_width;
-    mir::geometry::Height min_height;
-    mir::geometry::Width max_width;
-    mir::geometry::Height max_height;
     MirOrientationMode preferred_orientation;
     MirPointerConfinementState confine_pointer;
 

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -1025,42 +1025,80 @@ void mir::scene::BasicSurface::set_tiled_edges(Flags<MirTiledEdge> edges)
 
 auto mir::scene::BasicSurface::min_width() const -> geometry::Width
 {
-    return synchronised_state.lock()->min_width;
+    auto state = synchronised_state.lock();
+    return state->min_width + state->margins.left + state->margins.right;
 }
 
 auto mir::scene::BasicSurface::max_width() const -> geometry::Width
 {
-    return synchronised_state.lock()->max_width;
+    auto state = synchronised_state.lock();
+    if (state->max_width < geom::Width{std::numeric_limits<int>::max()} - state->margins.left - state->margins.right)
+    {
+        return state->max_width + state->margins.left + state->margins.right;
+    }
+    else
+    {
+        return geom::Width{std::numeric_limits<int>::max()};
+    }
 }
 
 auto mir::scene::BasicSurface::min_height() const -> geometry::Height
 {
-    return synchronised_state.lock()->min_height;
+    auto state = synchronised_state.lock();
+    return state->min_height + state->margins.top + state->margins.bottom;
 }
 
 auto mir::scene::BasicSurface::max_height() const -> geometry::Height
 {
-    return synchronised_state.lock()->max_height;
+    auto state = synchronised_state.lock();
+    if (state->max_height < geom::Height{std::numeric_limits<int>::max()} - state->margins.top - state->margins.bottom)
+    {
+        return state->max_height + state->margins.top + state->margins.bottom;
+    }
+    else
+    {
+        return geom::Height{std::numeric_limits<int>::max()};
+    }
 }
 
 void mir::scene::BasicSurface::set_min_width(geometry::Width width)
 {
-    synchronised_state.lock()->min_width = width;
+    auto state = synchronised_state.lock();
+    state->min_width = std::max(geom::Width{0}, width - state->margins.left - state->margins.right);
 }
 
 void mir::scene::BasicSurface::set_max_width(geometry::Width width)
 {
-    synchronised_state.lock()->max_width = width;
+    auto state = synchronised_state.lock();
+
+    if (width < geom::Width{std::numeric_limits<int>::max()} - state->margins.left - state->margins.right)
+    {
+        state->max_width = width - state->margins.left - state->margins.right;
+    }
+    else
+    {
+        state->max_width = geom::Width{std::numeric_limits<int>::max()};
+    }
 }
 
 void mir::scene::BasicSurface::set_min_height(geometry::Height height)
 {
-    synchronised_state.lock()->min_height = height;
+    auto state = synchronised_state.lock();
+    state->min_height = std::max(geom::Height{0}, height - state->margins.top - state->margins.bottom);
 }
 
 void mir::scene::BasicSurface::set_max_height(geometry::Height height)
 {
-    synchronised_state.lock()->max_height = height;
+    auto state = synchronised_state.lock();
+
+    if (height < geom::Height{std::numeric_limits<int>::max()} - state->margins.top - state->margins.bottom)
+    {
+        state->max_height = height - state->margins.top - state->margins.bottom;
+    }
+    else
+    {
+        state->max_height = geom::Height{std::numeric_limits<int>::max()};
+    }
 }
 
 void mir::scene::BasicSurface::clear_frame_posted_callbacks(State& state)

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -1023,6 +1023,46 @@ void mir::scene::BasicSurface::set_tiled_edges(Flags<MirTiledEdge> edges)
     observers->tiled_edges(this, edges);
 }
 
+auto mir::scene::BasicSurface::min_width() const -> geometry::Width
+{
+    return synchronised_state.lock()->min_width;
+}
+
+auto mir::scene::BasicSurface::max_width() const -> geometry::Width
+{
+    return synchronised_state.lock()->max_width;
+}
+
+auto mir::scene::BasicSurface::min_height() const -> geometry::Height
+{
+    return synchronised_state.lock()->min_height;
+}
+
+auto mir::scene::BasicSurface::max_height() const -> geometry::Height
+{
+    return synchronised_state.lock()->max_height;
+}
+
+void mir::scene::BasicSurface::set_min_width(geometry::Width width)
+{
+    synchronised_state.lock()->min_width = width;
+}
+
+void mir::scene::BasicSurface::set_max_width(geometry::Width width)
+{
+    synchronised_state.lock()->max_width = width;
+}
+
+void mir::scene::BasicSurface::set_min_height(geometry::Height height)
+{
+    synchronised_state.lock()->min_height = height;
+}
+
+void mir::scene::BasicSurface::set_max_height(geometry::Height height)
+{
+    synchronised_state.lock()->max_height = height;
+}
+
 void mir::scene::BasicSurface::clear_frame_posted_callbacks(State& state)
 {
     for (auto& layer : state.layers)

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1067,6 +1067,10 @@ global:
     non-virtual?thunk?to?mir::scene::BasicSurface::initial_placement_done*;
     non-virtual?thunk?to?mir::scene::BasicSurface::input_area_contains*;
     non-virtual?thunk?to?mir::scene::BasicSurface::input_bounds*;
+    non-virtual?thunk?to?mir::scene::BasicSurface::max_height*;
+    non-virtual?thunk?to?mir::scene::BasicSurface::max_width*;
+    non-virtual?thunk?to?mir::scene::BasicSurface::min_height*;
+    non-virtual?thunk?to?mir::scene::BasicSurface::min_width*;
     non-virtual?thunk?to?mir::scene::BasicSurface::move_to*;
     non-virtual?thunk?to?mir::scene::BasicSurface::name*;
     non-virtual?thunk?to?mir::scene::BasicSurface::parent*;
@@ -1088,6 +1092,10 @@ global:
     non-virtual?thunk?to?mir::scene::BasicSurface::set_focus_mode*;
     non-virtual?thunk?to?mir::scene::BasicSurface::set_focus_state*;
     non-virtual?thunk?to?mir::scene::BasicSurface::set_input_region*;
+    non-virtual?thunk?to?mir::scene::BasicSurface::set_max_height*;
+    non-virtual?thunk?to?mir::scene::BasicSurface::set_max_width*;
+    non-virtual?thunk?to?mir::scene::BasicSurface::set_min_height*;
+    non-virtual?thunk?to?mir::scene::BasicSurface::set_min_width*;
     non-virtual?thunk?to?mir::scene::BasicSurface::set_mirror_mode*;
     non-virtual?thunk?to?mir::scene::BasicSurface::set_orientation*;
     non-virtual?thunk?to?mir::scene::BasicSurface::set_reception_mode*;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -490,6 +490,10 @@ global:
     mir::scene::BasicSurface::initial_placement_done*;
     mir::scene::BasicSurface::input_area_contains*;
     mir::scene::BasicSurface::input_bounds*;
+    mir::scene::BasicSurface::max_height*;
+    mir::scene::BasicSurface::max_width*;
+    mir::scene::BasicSurface::min_height*;
+    mir::scene::BasicSurface::min_width*;
     mir::scene::BasicSurface::move_to*;
     mir::scene::BasicSurface::name*;
     mir::scene::BasicSurface::parent*;
@@ -514,6 +518,10 @@ global:
     mir::scene::BasicSurface::set_focus_state*;
     mir::scene::BasicSurface::set_hidden*;
     mir::scene::BasicSurface::set_input_region*;
+    mir::scene::BasicSurface::set_max_height*;
+    mir::scene::BasicSurface::set_max_width*;
+    mir::scene::BasicSurface::set_min_height*;
+    mir::scene::BasicSurface::set_min_width*;
     mir::scene::BasicSurface::set_mirror_mode*;
     mir::scene::BasicSurface::set_orientation*;
     mir::scene::BasicSurface::set_reception_mode*;

--- a/tests/include/mir/test/doubles/stub_surface.h
+++ b/tests/include/mir/test/doubles/stub_surface.h
@@ -94,14 +94,20 @@ struct StubSurface : scene::Surface
     void set_focus_mode(MirFocusMode) override {}
     auto tiled_edges() const -> Flags<MirTiledEdge> { return Flags(mir_tiled_edge_none); }
     void set_tiled_edges(Flags<MirTiledEdge>) {}
-    auto min_width() const -> geometry::Width { return {}; }
-    auto max_width() const -> geometry::Width { return geometry::Width{std::numeric_limits<int>::max()}; }
-    auto min_height() const -> geometry::Height { return {}; }
-    auto max_height() const -> geometry::Height { return geometry::Height{std::numeric_limits<int>::max()}; }
-    void set_min_width(geometry::Width) {}
-    void set_max_width(geometry::Width) {}
-    void set_min_height(geometry::Height) {}
-    void set_max_height(geometry::Height) {}
+    auto min_width() const -> geometry::Width { return min_width_; }
+    auto max_width() const -> geometry::Width { return max_width_; }
+    auto min_height() const -> geometry::Height { return min_height_; }
+    auto max_height() const -> geometry::Height { return max_height_; }
+    void set_min_width(geometry::Width w) { min_width_ = w; }
+    void set_max_width(geometry::Width w) { max_width_ = w; }
+    void set_min_height(geometry::Height h) { min_height_ = h; }
+    void set_max_height(geometry::Height h) { max_height_ = h; }
+
+private:
+    mir::geometry::Width min_width_{0};
+    mir::geometry::Height min_height_{0};
+    mir::geometry::Width max_width_{std::numeric_limits<int>::max()};
+    mir::geometry::Height max_height_{std::numeric_limits<int>::max()};
 };
 }
 }

--- a/tests/include/mir/test/doubles/stub_surface.h
+++ b/tests/include/mir/test/doubles/stub_surface.h
@@ -94,6 +94,14 @@ struct StubSurface : scene::Surface
     void set_focus_mode(MirFocusMode) override {}
     auto tiled_edges() const -> Flags<MirTiledEdge> { return Flags(mir_tiled_edge_none); }
     void set_tiled_edges(Flags<MirTiledEdge>) {}
+    auto min_width() const -> geometry::Width { return {}; }
+    auto max_width() const -> geometry::Width { return geometry::Width{std::numeric_limits<int>::max()}; }
+    auto min_height() const -> geometry::Height { return {}; }
+    auto max_height() const -> geometry::Height { return geometry::Height{std::numeric_limits<int>::max()}; }
+    void set_min_width(geometry::Width) {}
+    void set_max_width(geometry::Width) {}
+    void set_min_height(geometry::Height) {}
+    void set_max_height(geometry::Height) {}
 };
 }
 }

--- a/tests/miral/window_info.cpp
+++ b/tests/miral/window_info.cpp
@@ -18,6 +18,8 @@
 
 #include "mir_test_framework/process.h"
 
+#include <mir/test/doubles/stub_surface.h>
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -37,7 +39,8 @@ TEST(WindowInfo, negative_window_size_does_not_divide_by_zero)
 {
     auto p = mtf::fork_and_run_in_a_different_process(
         [] {
-            Window window;
+            auto const surface = std::make_shared<mir::test::doubles::StubSurface>();
+            Window window{Application{}, surface};
             WindowSpecification params;
 
             Point p{0, 0};


### PR DESCRIPTION
The size constraints need to reflect the SSD margins

This was not possible as the Surface was responsible for the margins and the WindowInfo was responsible for the size constraints. So move the latter to the surface and fixup all around

Fixes: #4129 