### PR TITLE
`Renderer::render` should return a `Buffer` rather than a `Framebuffer`

### DIFF
--- a/include/platform/mir/graphics/buffer.h
+++ b/include/platform/mir/graphics/buffer.h
@@ -26,7 +26,18 @@ namespace mir
 {
 namespace graphics
 {
-class Framebuffer;
+class Framebuffer
+{
+public:
+    Framebuffer() = default;
+    virtual ~Framebuffer() = default;
+
+    /**
+     * The size of this framebuffer, in pixels
+     */
+    virtual auto size() const -> geometry::Size = 0;
+};
+
 class NativeBufferBase
 {
 protected:

--- a/include/platform/mir/graphics/buffer.h
+++ b/include/platform/mir/graphics/buffer.h
@@ -45,7 +45,7 @@ public:
     virtual geometry::Size size() const = 0;
     virtual MirPixelFormat pixel_format() const = 0;
 
-    virtual NativeBufferBase* native_buffer_base() = 0;
+    virtual NativeBufferBase* native_buffer_base() { return nullptr; }
 
     virtual auto to_framebuffer() -> std::unique_ptr<Framebuffer> { return nullptr; }
 

--- a/include/platform/mir/graphics/buffer.h
+++ b/include/platform/mir/graphics/buffer.h
@@ -20,12 +20,13 @@
 #include "mir/graphics/buffer_id.h"
 #include "mir/geometry/size.h"
 #include "mir_toolkit/common.h"
+#include <memory>
 
 namespace mir
 {
 namespace graphics
 {
-
+class Framebuffer;
 class NativeBufferBase
 {
 protected:
@@ -45,6 +46,8 @@ public:
     virtual MirPixelFormat pixel_format() const = 0;
 
     virtual NativeBufferBase* native_buffer_base() = 0;
+
+    virtual auto to_framebuffer() -> std::unique_ptr<Framebuffer> { return nullptr; }
 
 protected:
     Buffer() = default;

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -315,13 +315,13 @@ public:
     {
     };
 
-    class MappableFB :
-        public Framebuffer,
+    class MappableBuffer : 
+        public Buffer, 
         public mir::renderer::software::WriteMappableBuffer
     {
     public:
-        MappableFB() = default;
-        virtual ~MappableFB() override = default;
+        MappableBuffer() = default;
+        virtual ~MappableBuffer() override = default;
 
         using renderer::software::WriteMappableBuffer::size;
     };
@@ -329,8 +329,8 @@ public:
     virtual auto supported_formats() const
         -> std::vector<DRMFormat> = 0;
 
-    virtual auto alloc_fb(DRMFormat format)
-        -> std::unique_ptr<MappableFB> = 0;
+    virtual auto alloc_buffer(DRMFormat format) 
+        -> std::unique_ptr<MappableBuffer> = 0;
 
     virtual auto output_size() const -> geometry::Size = 0;
 };
@@ -397,7 +397,7 @@ public:
          * of buffers available and attempting to claim a framebuffer when no buffers
          * are free will result in an EBUSY std::system_error being raised.
          */
-        virtual auto claim_framebuffer() -> std::unique_ptr<Framebuffer> = 0;
+        virtual auto claim_buffer() -> std::unique_ptr<Buffer> = 0;
     };
 
     virtual auto make_surface(DRMFormat format, std::span<uint64_t> modifiers) -> std::unique_ptr<GBMSurface> = 0;
@@ -464,6 +464,7 @@ public:
         virtual void make_current() = 0;
         virtual void release_current() = 0;
         virtual auto clone_handle() -> std::unique_ptr<EGLFramebuffer> = 0;
+        virtual auto format() const -> MirPixelFormat = 0;
     };
 
     virtual auto alloc_framebuffer(GLConfig const& config, EGLContext share_context) -> std::unique_ptr<EGLFramebuffer> = 0;

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -288,18 +288,6 @@ public:
     virtual ~DisplayAllocator() = default;
 };
 
-class Framebuffer
-{
-public:
-    Framebuffer() = default;
-    virtual ~Framebuffer() = default;
-
-    /**
-     * The size of this framebuffer, in pixels
-     */
-    virtual auto size() const -> geometry::Size = 0;
-};
-
 class CPUAddressableDisplayProvider : public DisplayProvider
 {
 public:

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -458,16 +458,15 @@ public:
     {
     };
 
-    class EGLFramebuffer : public graphics::Framebuffer
+    class EGLBuffer : public graphics::Buffer
     {
     public:
         virtual void make_current() = 0;
         virtual void release_current() = 0;
-        virtual auto clone_handle() -> std::unique_ptr<EGLFramebuffer> = 0;
-        virtual auto format() const -> MirPixelFormat = 0;
+        virtual auto clone_handle() -> std::unique_ptr<EGLBuffer> = 0;
     };
 
-    virtual auto alloc_framebuffer(GLConfig const& config, EGLContext share_context) -> std::unique_ptr<EGLFramebuffer> = 0;
+    virtual auto alloc_buffer(GLConfig const& config, EGLContext share_context) -> std::unique_ptr<EGLBuffer> = 0;
 };
 
 class DisplayPlatform

--- a/include/platform/mir/renderer/gl/gl_surface.h
+++ b/include/platform/mir/renderer/gl/gl_surface.h
@@ -24,7 +24,7 @@ namespace mir
 {
 namespace graphics
 {
-class Framebuffer;
+class Buffer;
 
 namespace gl
 {
@@ -39,7 +39,7 @@ public:
     virtual void release_current() = 0;
 
     // Naming: SwapBuffers? Commit? Claim current buffer?
-    virtual auto commit() -> std::unique_ptr<graphics::Framebuffer> = 0;
+    virtual auto commit() -> std::unique_ptr<graphics::Buffer> = 0;
 
     /// Size, in pixels, of the underlying surface
     virtual auto size() const -> mir::geometry::Size = 0;

--- a/include/renderer/mir/renderer/renderer.h
+++ b/include/renderer/mir/renderer/renderer.h
@@ -41,7 +41,7 @@ public:
     virtual void set_viewport(geometry::Rectangle const& rect) = 0;
     virtual void set_output_transform(glm::mat2 const&) = 0;
     virtual void set_output_filter(MirOutputFilter filter) = 0;
-    virtual auto render(graphics::RenderableList const&) const -> std::unique_ptr<graphics::Framebuffer> = 0;
+    virtual auto render(graphics::RenderableList const&) const -> std::unique_ptr<graphics::Buffer> = 0;
     virtual void suspend() = 0; // called when render() is skipped
 
 protected:

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -235,11 +235,6 @@ MirPixelFormat mir::graphics::atomic::GBMBuffer::pixel_format() const
     return mir_pixel_format_invalid;
 }
 
-mir::graphics::NativeBufferBase* mir::graphics::atomic::GBMBuffer::native_buffer_base()
-{
-    return this;
-}
-
 auto mga::GBMBuffer::to_framebuffer() -> std::unique_ptr<Framebuffer>
 {
     if (auto cached_fb = static_cast<std::shared_ptr<uint32_t const>*>(gbm_bo_get_user_data(front_buffer.get())))

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -59,45 +59,6 @@ using LockedFrontBuffer = std::unique_ptr<gbm_bo, std::function<void(gbm_bo*)>>;
 class GBMBoFramebuffer : public mg::FBHandle
 {
 public:
-    static auto framebuffer_for_frontbuffer(mir::Fd const& drm_fd, LockedFrontBuffer bo) -> std::unique_ptr<GBMBoFramebuffer>
-    {
-        if (auto cached_fb = static_cast<std::shared_ptr<uint32_t const>*>(gbm_bo_get_user_data(bo.get())))
-        {
-            return std::unique_ptr<GBMBoFramebuffer>{new GBMBoFramebuffer{std::move(bo), *cached_fb}};
-        }
-
-        auto fb_id = std::shared_ptr<uint32_t>{
-            new uint32_t{0},
-            [drm_fd](uint32_t* fb_id)
-            {
-                if (*fb_id)
-                {
-                    drmModeRmFB(drm_fd, *fb_id);
-                }
-                delete fb_id;
-            }};
-        uint32_t handles[4] = {gbm_bo_get_handle(bo.get()).u32, 0, 0, 0};
-        uint32_t strides[4] = {gbm_bo_get_stride(bo.get()), 0, 0, 0};
-        uint32_t offsets[4] = {gbm_bo_get_offset(bo.get(), 0), 0, 0, 0};
-
-        auto format = gbm_bo_get_format(bo.get());
-
-        auto const width = gbm_bo_get_width(bo.get());
-        auto const height = gbm_bo_get_height(bo.get());
-
-        /* Create a KMS FB object with the gbm_bo attached to it. */
-        auto ret = drmModeAddFB2(drm_fd, width, height, format,
-                                 handles, strides, offsets, fb_id.get(), 0);
-        if (ret)
-            return nullptr;
-
-        // It is weird allocating a smart pointer on the heap, but we delete it
-        // via gbm_bo_set_user_data()'s destroy_user_data parameter.
-        gbm_bo_set_user_data(bo.get(), new std::shared_ptr<uint32_t>(fb_id), [](gbm_bo*, void* fb_ptr) { delete static_cast<std::shared_ptr<uint32_t const>*>(fb_ptr); });
-
-        return std::make_unique<GBMBoFramebuffer>(std::move(bo), std::move(fb_id));
-    }
-
     operator uint32_t() const override
     {
         return *fb_id;

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -54,7 +54,6 @@ auto mga::GBMDisplayAllocator::modifiers_for_format(DRMFormat /*format*/) const 
 
 namespace
 {
-using LockedFrontBuffer = std::unique_ptr<gbm_bo, std::function<void(gbm_bo*)>>;
 
 class GBMBoFramebuffer : public mg::FBHandle
 {
@@ -72,13 +71,13 @@ public:
                 gbm_bo_get_height(bo.get())};
     }
 
-    GBMBoFramebuffer(LockedFrontBuffer bo, std::shared_ptr<uint32_t const> fb)
+    GBMBoFramebuffer(mga::LockedFrontBuffer bo, std::shared_ptr<uint32_t const> fb)
         : bo{std::move(bo)},
           fb_id{std::move(fb)}
     {
     }
 private:
-    LockedFrontBuffer const bo;
+    mga::LockedFrontBuffer const bo;
     std::shared_ptr<uint32_t const> const fb_id;
 };
 
@@ -174,7 +173,7 @@ public:
                     "Too many buffers consumed from GBM surface"}));
         }
 
-        LockedFrontBuffer bo{
+        mga::LockedFrontBuffer bo{
             gbm_surface_lock_front_buffer(surface.get()),
             [shared_surface = surface](gbm_bo* bo) { gbm_surface_release_buffer(shared_surface.get(), bo); }};
 
@@ -183,56 +182,7 @@ public:
             BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to acquire GBM front buffer"}));
         }
 
-        class GBMBuffer : public mg::Buffer, public mg::NativeBufferBase
-        {
-        public:
-            GBMBuffer(LockedFrontBuffer front_buffer)
-                : front_buffer{std::move(front_buffer)}
-            {
-            }
-
-            mg::BufferID id() const override
-            {
-                // https://stackoverflow.com/a/21574751
-                return mg::BufferID{static_cast<uint32_t>(reinterpret_cast<uintptr_t>(front_buffer.get()))};
-            }
-
-            geom::Size size() const override
-            {
-                return geom::Size{gbm_bo_get_width(front_buffer.get()), gbm_bo_get_height(front_buffer.get())};
-            }
-
-            MirPixelFormat pixel_format() const override
-            {
-                auto const mapping = std::unordered_map<uint32_t, MirPixelFormat>{
-                    {GBM_FORMAT_ABGR8888, mir_pixel_format_abgr_8888},
-                    {GBM_FORMAT_XBGR8888, mir_pixel_format_xbgr_8888},
-                    {GBM_FORMAT_ARGB8888, mir_pixel_format_argb_8888},
-                    {GBM_FORMAT_XRGB8888, mir_pixel_format_xrgb_8888},
-                    {GBM_FORMAT_BGR888, mir_pixel_format_bgr_888},
-                    {GBM_FORMAT_RGB888, mir_pixel_format_rgb_888},
-                    {GBM_FORMAT_RGB565, mir_pixel_format_rgb_565},
-                    {GBM_FORMAT_RGBA5551, mir_pixel_format_rgba_5551},
-                    {GBM_FORMAT_RGBA4444, mir_pixel_format_rgba_4444},
-                };
-
-                auto const gbm_format = gbm_bo_get_format(front_buffer.get());
-                if(auto iter = mapping.find(gbm_format); iter != mapping.end())
-                    return iter->second;
-
-                return mir_pixel_format_invalid;
-            }
-
-            mg::NativeBufferBase* native_buffer_base() override
-            {
-                return this;
-            }
-
-        private:
-            LockedFrontBuffer const front_buffer;
-        };
-
-        return std::make_unique<GBMBuffer>(std::move(bo));
+        return std::make_unique<mga::GBMBuffer>(drm_fd, std::move(bo));
     }
 private:
     mir::Fd const drm_fd;
@@ -247,3 +197,84 @@ auto mga::GBMDisplayAllocator::make_surface(DRMFormat format, std::span<uint64_t
     return std::make_unique<GBMSurfaceImpl>(fd, gbm.get(), size, format, modifiers, gbm_quirks);
 }
 
+mir::graphics::atomic::GBMBuffer::GBMBuffer(mir::Fd drm_fd, LockedFrontBuffer front_buffer) :
+    front_buffer{std::move(front_buffer)},
+    drm_fd{drm_fd}
+{
+}
+
+mir::graphics::BufferID mir::graphics::atomic::GBMBuffer::id() const
+{
+    // https://stackoverflow.com/a/21574751
+    return mir::graphics::BufferID{static_cast<uint32_t>(reinterpret_cast<uintptr_t>(front_buffer.get()))};
+}
+
+mir::geometry::Size mir::graphics::atomic::GBMBuffer::size() const
+{
+    return geometry::Size{gbm_bo_get_width(front_buffer.get()), gbm_bo_get_height(front_buffer.get())};
+}
+
+MirPixelFormat mir::graphics::atomic::GBMBuffer::pixel_format() const
+{
+    auto const mapping = std::unordered_map<uint32_t, MirPixelFormat>{
+        {GBM_FORMAT_ABGR8888, mir_pixel_format_abgr_8888},
+        {GBM_FORMAT_XBGR8888, mir_pixel_format_xbgr_8888},
+        {GBM_FORMAT_ARGB8888, mir_pixel_format_argb_8888},
+        {GBM_FORMAT_XRGB8888, mir_pixel_format_xrgb_8888},
+        {GBM_FORMAT_BGR888, mir_pixel_format_bgr_888},
+        {GBM_FORMAT_RGB888, mir_pixel_format_rgb_888},
+        {GBM_FORMAT_RGB565, mir_pixel_format_rgb_565},
+        {GBM_FORMAT_RGBA5551, mir_pixel_format_rgba_5551},
+        {GBM_FORMAT_RGBA4444, mir_pixel_format_rgba_4444},
+    };
+
+    auto const gbm_format = gbm_bo_get_format(front_buffer.get());
+    if (auto iter = mapping.find(gbm_format); iter != mapping.end())
+        return iter->second;
+
+    return mir_pixel_format_invalid;
+}
+
+mir::graphics::NativeBufferBase* mir::graphics::atomic::GBMBuffer::native_buffer_base()
+{
+    return this;
+}
+
+auto mga::GBMBuffer::to_framebuffer() -> std::unique_ptr<Framebuffer>
+{
+    if (auto cached_fb = static_cast<std::shared_ptr<uint32_t const>*>(gbm_bo_get_user_data(front_buffer.get())))
+    {
+        return std::unique_ptr<GBMBoFramebuffer>{new GBMBoFramebuffer{std::move(front_buffer), *cached_fb}};
+    }
+
+    auto fb_id = std::shared_ptr<uint32_t>{
+        new uint32_t{0},
+        [this](uint32_t* fb_id)
+        {
+            if (*fb_id)
+            {
+                drmModeRmFB(drm_fd, *fb_id);
+            }
+            delete fb_id;
+        }};
+    uint32_t handles[4] = {gbm_bo_get_handle(front_buffer.get()).u32, 0, 0, 0};
+    uint32_t strides[4] = {gbm_bo_get_stride(front_buffer.get()), 0, 0, 0};
+    uint32_t offsets[4] = {gbm_bo_get_offset(front_buffer.get(), 0), 0, 0, 0};
+
+    auto format = gbm_bo_get_format(front_buffer.get());
+
+    auto const width = gbm_bo_get_width(front_buffer.get());
+    auto const height = gbm_bo_get_height(front_buffer.get());
+
+    /* Create a KMS FB object with the gbm_bo attached to it. */
+    auto ret = drmModeAddFB2(drm_fd, width, height, format,
+                             handles, strides, offsets, fb_id.get(), 0);
+    if (ret)
+        return nullptr;
+
+    // It is weird allocating a smart pointer on the heap, but we delete it
+    // via gbm_bo_set_user_data()'s destroy_user_data parameter.
+    gbm_bo_set_user_data(front_buffer.get(), new std::shared_ptr<uint32_t>(fb_id), [](gbm_bo*, void* fb_ptr) { delete static_cast<std::shared_ptr<uint32_t const>*>(fb_ptr); });
+
+    return std::make_unique<GBMBoFramebuffer>(std::move(front_buffer), std::move(fb_id));
+}

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.cpp
@@ -202,7 +202,7 @@ public:
         return surface.get();
     }
 
-    auto claim_framebuffer() -> std::unique_ptr<mg::Framebuffer> override
+    auto claim_buffer() -> std::unique_ptr<mg::Buffer> override
     {
         if (!gbm_quirks->gbm_surface_has_free_buffers(surface.get()))
         {
@@ -222,12 +222,56 @@ public:
             BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to acquire GBM front buffer"}));
         }
 
-        auto fb = GBMBoFramebuffer::framebuffer_for_frontbuffer(drm_fd, std::move(bo));
-        if (!fb)
+        class GBMBuffer : public mg::Buffer, public mg::NativeBufferBase
         {
-            BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to make DRM FB"}));
-        }
-        return fb;
+        public:
+            GBMBuffer(LockedFrontBuffer front_buffer)
+                : front_buffer{std::move(front_buffer)}
+            {
+            }
+
+            mg::BufferID id() const override
+            {
+                // https://stackoverflow.com/a/21574751
+                return mg::BufferID{static_cast<uint32_t>(reinterpret_cast<uintptr_t>(front_buffer.get()))};
+            }
+
+            geom::Size size() const override
+            {
+                return geom::Size{gbm_bo_get_width(front_buffer.get()), gbm_bo_get_height(front_buffer.get())};
+            }
+
+            MirPixelFormat pixel_format() const override
+            {
+                auto const mapping = std::unordered_map<uint32_t, MirPixelFormat>{
+                    {GBM_FORMAT_ABGR8888, mir_pixel_format_abgr_8888},
+                    {GBM_FORMAT_XBGR8888, mir_pixel_format_xbgr_8888},
+                    {GBM_FORMAT_ARGB8888, mir_pixel_format_argb_8888},
+                    {GBM_FORMAT_XRGB8888, mir_pixel_format_xrgb_8888},
+                    {GBM_FORMAT_BGR888, mir_pixel_format_bgr_888},
+                    {GBM_FORMAT_RGB888, mir_pixel_format_rgb_888},
+                    {GBM_FORMAT_RGB565, mir_pixel_format_rgb_565},
+                    {GBM_FORMAT_RGBA5551, mir_pixel_format_rgba_5551},
+                    {GBM_FORMAT_RGBA4444, mir_pixel_format_rgba_4444},
+                };
+
+                auto const gbm_format = gbm_bo_get_format(front_buffer.get());
+                if(auto iter = mapping.find(gbm_format); iter != mapping.end())
+                    return iter->second;
+
+                return mir_pixel_format_invalid;
+            }
+
+            mg::NativeBufferBase* native_buffer_base() override
+            {
+                return this;
+            }
+
+        private:
+            LockedFrontBuffer const front_buffer;
+        };
+
+        return std::make_unique<GBMBuffer>(std::move(bo));
     }
 private:
     mir::Fd const drm_fd;

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.h
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.h
@@ -43,7 +43,7 @@ private:
 
 using LockedFrontBuffer = std::unique_ptr<gbm_bo, std::function<void(gbm_bo*)>>;
 
-class GBMBuffer : public mir::graphics::Buffer, public mir::graphics::NativeBufferBase
+class GBMBuffer : public mir::graphics::Buffer
 {
 public:
     GBMBuffer(mir::Fd drm_fd, LockedFrontBuffer front_buffer);
@@ -53,8 +53,6 @@ public:
     geometry::Size size() const override;
 
     MirPixelFormat pixel_format() const override;
-
-    mir::graphics::NativeBufferBase* native_buffer_base() override;
 
     auto to_framebuffer() -> std::unique_ptr<Framebuffer> override;
 

--- a/src/platforms/atomic-kms/server/gbm_display_allocator.h
+++ b/src/platforms/atomic-kms/server/gbm_display_allocator.h
@@ -40,4 +40,26 @@ private:
     geometry::Size const size;
     std::shared_ptr<GbmQuirks> const gbm_quirks;
 };
+
+using LockedFrontBuffer = std::unique_ptr<gbm_bo, std::function<void(gbm_bo*)>>;
+
+class GBMBuffer : public mir::graphics::Buffer, public mir::graphics::NativeBufferBase
+{
+public:
+    GBMBuffer(mir::Fd drm_fd, LockedFrontBuffer front_buffer);
+
+    mir::graphics::BufferID id() const override;
+
+    geometry::Size size() const override;
+
+    MirPixelFormat pixel_format() const override;
+
+    mir::graphics::NativeBufferBase* native_buffer_base() override;
+
+    auto to_framebuffer() -> std::unique_ptr<Framebuffer> override;
+
+private:
+    LockedFrontBuffer front_buffer;
+    mir::Fd drm_fd;
+};
 }

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -72,7 +72,7 @@ mga::DisplaySink::DisplaySink(
     {
         mir::log_info("Clearing screen due to differing encountered and target modes");
         // TODO: Pull a supported format out of KMS rather than assuming XRGB8888
-        auto initial_fb = std::make_shared<graphics::CPUAddressableBuffer>(
+        auto initial_fb = std::make_unique<graphics::CPUAddressableBuffer>(
             std::move(drm_fd),
             false,
             DRMFormat{DRM_FORMAT_XRGB8888},
@@ -81,7 +81,7 @@ mga::DisplaySink::DisplaySink(
         auto mapping = initial_fb->map_writeable();
         ::memset(mapping->data(), 24, mapping->len());
 
-        visible_fb = CPUAddressableBuffer::to_fb_handle(initial_fb);
+        visible_fb = initial_fb->to_fb_handle();
         this->output->set_crtc(*visible_fb);
         listener->report_successful_drm_mode_set_crtc_on_construction();
     }

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -72,7 +72,7 @@ mga::DisplaySink::DisplaySink(
     {
         mir::log_info("Clearing screen due to differing encountered and target modes");
         // TODO: Pull a supported format out of KMS rather than assuming XRGB8888
-        auto initial_fb = std::make_shared<graphics::CPUAddressableFB>(
+        auto initial_fb = std::make_shared<graphics::CPUAddressableBuffer>(
             std::move(drm_fd),
             false,
             DRMFormat{DRM_FORMAT_XRGB8888},

--- a/src/platforms/atomic-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/atomic-kms/server/kms/display_buffer.cpp
@@ -81,7 +81,7 @@ mga::DisplaySink::DisplaySink(
         auto mapping = initial_fb->map_writeable();
         ::memset(mapping->data(), 24, mapping->len());
 
-        visible_fb = std::move(initial_fb);
+        visible_fb = CPUAddressableBuffer::to_fb_handle(initial_fb);
         this->output->set_crtc(*visible_fb);
         listener->report_successful_drm_mode_set_crtc_on_construction();
     }

--- a/src/platforms/common/server/cpu_addressable_fb.cpp
+++ b/src/platforms/common/server/cpu_addressable_fb.cpp
@@ -306,11 +306,6 @@ MirPixelFormat mir::graphics::CPUAddressableBuffer::pixel_format() const
     return format();
 }
 
-mir::graphics::NativeBufferBase* mir::graphics::CPUAddressableBuffer::native_buffer_base()
-{
-    return this;
-}
-
 auto mg::CPUAddressableBuffer::fb_id_for_buffer(
     mir::Fd const &drm_fd,
     bool supports_modifiers,

--- a/src/platforms/common/server/cpu_addressable_fb.cpp
+++ b/src/platforms/common/server/cpu_addressable_fb.cpp
@@ -26,7 +26,7 @@
 
 namespace mg = mir::graphics;
 
-class mg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappableBuffer
+class mg::CPUAddressableBuffer::Buffer : public mir::renderer::software::RWMappableBuffer
 {
     template<typename T>
     class Mapping : public mir::renderer::software::Mapping<T>
@@ -246,21 +246,21 @@ private:
     size_t const size_;
 };
 
-mg::CPUAddressableFB::CPUAddressableFB(
+mg::CPUAddressableBuffer::CPUAddressableBuffer(
     mir::Fd const& drm_fd,
     bool supports_modifiers,
     DRMFormat format,
     mir::geometry::Size const& size)
-    : CPUAddressableFB(drm_fd, supports_modifiers, format, Buffer::create_kms_dumb_buffer(drm_fd, format, size))
+    : CPUAddressableBuffer(drm_fd, supports_modifiers, format, Buffer::create_kms_dumb_buffer(drm_fd, format, size))
 {
 }
 
-mg::CPUAddressableFB::~CPUAddressableFB()
+mg::CPUAddressableBuffer::~CPUAddressableBuffer()
 {
     drmModeRmFB(drm_fd, fb_id);
 }
 
-mg::CPUAddressableFB::CPUAddressableFB(
+mg::CPUAddressableBuffer::CPUAddressableBuffer(
     mir::Fd drm_fd,
     bool supports_modifiers,
     DRMFormat format,
@@ -271,32 +271,47 @@ mg::CPUAddressableFB::CPUAddressableFB(
 {
 }
 
-auto mg::CPUAddressableFB::map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>>
+auto mg::CPUAddressableBuffer::map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>>
 {
     return buffer->map_writeable();
 }
 
-auto mg::CPUAddressableFB::format() const -> MirPixelFormat
+auto mg::CPUAddressableBuffer::format() const -> MirPixelFormat
 {
     return buffer->format();
 }
 
-auto mg::CPUAddressableFB::stride() const -> geometry::Stride
+auto mg::CPUAddressableBuffer::stride() const -> geometry::Stride
 {
     return buffer->stride();
 }
 
-auto mg::CPUAddressableFB::size() const -> geometry::Size
+auto mg::CPUAddressableBuffer::size() const -> geometry::Size
 {
     return buffer->size();
 }
 
-mg::CPUAddressableFB::operator uint32_t() const
+mg::CPUAddressableBuffer::operator uint32_t() const
 {
     return fb_id;
 }
 
-auto mg::CPUAddressableFB::fb_id_for_buffer(
+mir::graphics::BufferID mir::graphics::CPUAddressableBuffer::id() const
+{
+    return BufferID{operator uint32_t()};
+}
+
+MirPixelFormat mir::graphics::CPUAddressableBuffer::pixel_format() const
+{
+    return format();
+}
+
+mir::graphics::NativeBufferBase* mir::graphics::CPUAddressableBuffer::native_buffer_base()
+{
+    return this;
+}
+
+auto mg::CPUAddressableBuffer::fb_id_for_buffer(
     mir::Fd const &drm_fd,
     bool supports_modifiers,
     DRMFormat format,

--- a/src/platforms/common/server/cpu_addressable_fb.h
+++ b/src/platforms/common/server/cpu_addressable_fb.h
@@ -24,34 +24,42 @@
 
 namespace mir::graphics
 {
-class CPUAddressableFB : public FBHandle, public CPUAddressableDisplayAllocator::MappableFB
+class CPUAddressableBuffer : 
+    public FBHandle,
+    public CPUAddressableDisplayAllocator::MappableBuffer,
+    public NativeBufferBase
 {
 public:
-    CPUAddressableFB(
+    CPUAddressableBuffer(
         mir::Fd const& drm_fd,
         bool supports_modifiers,
         DRMFormat format,
         mir::geometry::Size const& size);
-    ~CPUAddressableFB() override;
+    ~CPUAddressableBuffer() override;
 
     auto map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>> override;
 
     auto format() const -> MirPixelFormat override;
     auto stride() const -> geometry::Stride override;
-    auto size() const -> geometry::Size override; 
+    auto size() const -> geometry::Size override;
 
     operator uint32_t() const override;
+
+    BufferID id() const override;
+    MirPixelFormat pixel_format() const override;
+    NativeBufferBase* native_buffer_base() override;
     
-    CPUAddressableFB(CPUAddressableFB const&) = delete;
-    CPUAddressableFB& operator=(CPUAddressableFB const&) = delete;
+    CPUAddressableBuffer(CPUAddressableBuffer const&) = delete;
+    CPUAddressableBuffer& operator=(CPUAddressableBuffer const&) = delete;
 private:
     class Buffer;
 
-    CPUAddressableFB(
+    CPUAddressableBuffer(
         mir::Fd drm_fd,
         bool supports_modifiers,
         DRMFormat format,
         std::unique_ptr<Buffer> buffer);
+
     static auto fb_id_for_buffer(
         mir::Fd const& drm_fd,
         bool supports_modifiers,

--- a/src/platforms/common/server/cpu_addressable_fb.h
+++ b/src/platforms/common/server/cpu_addressable_fb.h
@@ -50,6 +50,7 @@ public:
     CPUAddressableBuffer& operator=(CPUAddressableBuffer const&) = delete;
 private:
     class Buffer;
+    class FBHandle;
 
     CPUAddressableBuffer(
         mir::Fd drm_fd,

--- a/src/platforms/common/server/cpu_addressable_fb.h
+++ b/src/platforms/common/server/cpu_addressable_fb.h
@@ -26,8 +26,7 @@ namespace mir::graphics
 {
 class CPUAddressableBuffer : 
     public FBHandle,
-    public CPUAddressableDisplayAllocator::MappableBuffer,
-    public NativeBufferBase
+    public CPUAddressableDisplayAllocator::MappableBuffer
 {
 public:
     CPUAddressableBuffer(
@@ -47,7 +46,6 @@ public:
 
     BufferID id() const override;
     MirPixelFormat pixel_format() const override;
-    NativeBufferBase* native_buffer_base() override;
     
     CPUAddressableBuffer(CPUAddressableBuffer const&) = delete;
     CPUAddressableBuffer& operator=(CPUAddressableBuffer const&) = delete;

--- a/src/platforms/common/server/cpu_addressable_fb.h
+++ b/src/platforms/common/server/cpu_addressable_fb.h
@@ -33,7 +33,6 @@ public:
         bool supports_modifiers,
         DRMFormat format,
         mir::geometry::Size const& size);
-    ~CPUAddressableBuffer() override;
 
     auto map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>> override;
 
@@ -44,8 +43,8 @@ public:
     BufferID id() const override;
     MirPixelFormat pixel_format() const override;
 
-    static auto to_framebuffer(std::shared_ptr<CPUAddressableBuffer> buf) -> std::unique_ptr<Framebuffer>;
-    static auto to_fb_handle(std::shared_ptr<CPUAddressableBuffer> buf) -> std::unique_ptr<FBHandle>;
+    auto to_framebuffer() -> std::unique_ptr<Framebuffer> override;
+    auto to_fb_handle() -> std::unique_ptr<FBHandle>;
 
     CPUAddressableBuffer(CPUAddressableBuffer const&) = delete;
     CPUAddressableBuffer& operator=(CPUAddressableBuffer const&) = delete;
@@ -64,9 +63,15 @@ private:
         DRMFormat format,
         Buffer const& buf) -> uint32_t;
 
-    mir::Fd const drm_fd;
-    uint32_t const fb_id;
-    std::unique_ptr<Buffer> buffer;
+    struct State
+    {
+        uint32_t const fb_id;
+        mir::Fd const drm_fd;
+        std::unique_ptr<Buffer> buffer;
+        ~State();
+    };
+
+    std::shared_ptr<State> const state;
 };
 
 }

--- a/src/platforms/common/server/cpu_addressable_fb.h
+++ b/src/platforms/common/server/cpu_addressable_fb.h
@@ -25,7 +25,6 @@
 namespace mir::graphics
 {
 class CPUAddressableBuffer : 
-    public FBHandle,
     public CPUAddressableDisplayAllocator::MappableBuffer
 {
 public:
@@ -42,11 +41,12 @@ public:
     auto stride() const -> geometry::Stride override;
     auto size() const -> geometry::Size override;
 
-    operator uint32_t() const override;
-
     BufferID id() const override;
     MirPixelFormat pixel_format() const override;
-    
+
+    static auto to_framebuffer(std::shared_ptr<CPUAddressableBuffer> buf) -> std::unique_ptr<Framebuffer>;
+    static auto to_fb_handle(std::shared_ptr<CPUAddressableBuffer> buf) -> std::unique_ptr<FBHandle>;
+
     CPUAddressableBuffer(CPUAddressableBuffer const&) = delete;
     CPUAddressableBuffer& operator=(CPUAddressableBuffer const&) = delete;
 private:
@@ -66,7 +66,7 @@ private:
 
     mir::Fd const drm_fd;
     uint32_t const fb_id;
-    std::unique_ptr<Buffer> const buffer;
+    std::unique_ptr<Buffer> buffer;
 };
 
 }

--- a/src/platforms/common/server/cpu_copy_output_surface.cpp
+++ b/src/platforms/common/server/cpu_copy_output_surface.cpp
@@ -136,7 +136,7 @@ public:
     void make_current();
     void release_current();
 
-    auto commit() -> std::unique_ptr<mg::Framebuffer>;
+    auto commit() -> std::unique_ptr<mg::Buffer>;
 
     auto size() const -> geom::Size;
     auto layout() const -> Layout;
@@ -201,7 +201,7 @@ void mgc::CPUCopyOutputSurface::release_current()
     impl->release_current();
 }
 
-auto mgc::CPUCopyOutputSurface::commit() -> std::unique_ptr<mg::Framebuffer>
+auto mgc::CPUCopyOutputSurface::commit() -> std::unique_ptr<mg::Buffer>
 {
     return impl->commit();
 }
@@ -298,9 +298,9 @@ void mgc::CPUCopyOutputSurface::Impl::release_current()
     }
 }
 
-auto mgc::CPUCopyOutputSurface::Impl::commit() -> std::unique_ptr<mg::Framebuffer>
+auto mgc::CPUCopyOutputSurface::Impl::commit() -> std::unique_ptr<mg::Buffer>
 {
-    auto fb = allocator.alloc_fb(format);
+    auto buffer = allocator.alloc_buffer(format);
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
     {
         /* TODO: We can usefully put this *into* DRMFormat */
@@ -313,7 +313,7 @@ auto mgc::CPUCopyOutputSurface::Impl::commit() -> std::unique_ptr<mg::Framebuffe
         {
             pixel_layout = GL_RGBA;
         }
-        auto mapping = fb->map_writeable();
+        auto mapping = buffer->map_writeable();
         /*
          * TODO: This introduces a pipeline stall; GL must wait for all previous rendering commands
          * to complete before glReadPixels returns. We could instead do something fancy with
@@ -324,10 +324,10 @@ auto mgc::CPUCopyOutputSurface::Impl::commit() -> std::unique_ptr<mg::Framebuffe
          */
         glReadPixels(
             0, 0,
-            fb->size().width.as_uint32_t(), fb->size().height.as_uint32_t(),
+            buffer->size().width.as_uint32_t(), buffer->size().height.as_uint32_t(),
             pixel_layout, GL_UNSIGNED_BYTE, mapping->data());
     }
-    return fb;
+    return buffer;
 }
 
 auto mgc::CPUCopyOutputSurface::Impl::size() const -> geom::Size

--- a/src/platforms/common/server/cpu_copy_output_surface.h
+++ b/src/platforms/common/server/cpu_copy_output_surface.h
@@ -45,7 +45,7 @@ public:
 
     void release_current() override;
 
-    auto commit() -> std::unique_ptr<Framebuffer> override;
+    auto commit() -> std::unique_ptr<Buffer> override;
 
     auto size() const -> geometry::Size override;
 

--- a/src/platforms/common/server/kms_cpu_addressable_display_provider.cpp
+++ b/src/platforms/common/server/kms_cpu_addressable_display_provider.cpp
@@ -53,9 +53,10 @@ auto mg::kms::CPUAddressableDisplayAllocator::supported_formats() const
     return {mg::DRMFormat{DRM_FORMAT_XRGB8888}, mg::DRMFormat{DRM_FORMAT_ARGB8888}};
 }
 
-auto mg::kms::CPUAddressableDisplayAllocator::alloc_fb(DRMFormat format) -> std::unique_ptr<MappableFB>
+auto mg::kms::CPUAddressableDisplayAllocator::alloc_buffer(DRMFormat format) 
+-> std::unique_ptr<MappableBuffer>
 {
-    return std::make_unique<mg::CPUAddressableFB>(drm_fd, supports_modifiers, format, size);
+    return std::make_unique<mg::CPUAddressableBuffer>(drm_fd, supports_modifiers, format, size);
 }
 
 auto mg::kms::CPUAddressableDisplayAllocator::output_size() const -> geom::Size

--- a/src/platforms/common/server/kms_cpu_addressable_display_provider.h
+++ b/src/platforms/common/server/kms_cpu_addressable_display_provider.h
@@ -37,8 +37,8 @@ public:
     auto supported_formats() const
         -> std::vector<DRMFormat> override;
 
-    auto alloc_fb(DRMFormat format)
-        -> std::unique_ptr<MappableFB> override;
+    auto alloc_buffer(DRMFormat format) 
+        -> std::unique_ptr<MappableBuffer> override;
 
     auto output_size() const -> geometry::Size override;
 private:

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -816,11 +816,8 @@ auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)
         {
             // It is safe to return nullptr; this will be treated as “this buffer cannot be used as
             // a framebuffer”.
-            if(auto cpu_buffer = std::dynamic_pointer_cast<CPUAddressableBuffer>(buffer))
-            {
-                return CPUAddressableBuffer::to_framebuffer(cpu_buffer);
-            }
-            return {};
+
+            return buffer->to_framebuffer();
         }
     };
     return std::make_unique<DefaultFramebufferProvider>();

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -818,26 +818,7 @@ auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)
             // a framebuffer”.
             if(auto cpu_buffer = std::dynamic_pointer_cast<CPUAddressableBuffer>(buffer))
             {
-                struct Wrapper :  public FBHandle
-                {
-                    Wrapper(std::shared_ptr<FBHandle> fb) :
-                        wrapped{fb}
-                    {
-                    }
-
-                    auto size() const -> geom::Size override
-                    {
-                        return wrapped->size();
-                    }
-
-                    operator uint32_t() const override
-                    {
-                        return wrapped->operator uint32_t();
-                    }
-
-                    std::shared_ptr<FBHandle> const wrapped;
-                };
-                return make_unique<Wrapper>(cpu_buffer);
+                return CPUAddressableBuffer::to_framebuffer(cpu_buffer);
             }
             return {};
         }

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -809,7 +809,7 @@ auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)
     -> std::unique_ptr<FramebufferProvider>
 {
     // TODO: *Can* we provide overlay support?
-    class NullFramebufferProvider : public FramebufferProvider
+    class DefaultFramebufferProvider : public FramebufferProvider
     {
     public:
         auto buffer_to_framebuffer(std::shared_ptr<Buffer> buffer) -> std::unique_ptr<Framebuffer> override
@@ -823,5 +823,5 @@ auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)
             return {};
         }
     };
-    return std::make_unique<NullFramebufferProvider>();
+    return std::make_unique<DefaultFramebufferProvider>();
 }

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -670,7 +670,7 @@ public:
         }
     }
 
-    auto commit() -> std::unique_ptr<mg::Framebuffer> override
+    auto commit() -> std::unique_ptr<mg::Buffer> override
     {
         if (eglSwapBuffers(dpy, surface) != EGL_TRUE)
         {

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -564,10 +564,10 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
 {
     if(auto* allocator = sink.acquire_compatible_allocator<DmaBufDisplayAllocator>())
     {
-        struct FooFramebufferProvider: public FramebufferProvider
+        struct DmaBufFramebufferProvider: public FramebufferProvider
         {
         public:
-            FooFramebufferProvider(DmaBufDisplayAllocator* allocator) : allocator{allocator}
+            DmaBufFramebufferProvider(DmaBufDisplayAllocator* allocator) : allocator{allocator}
             {
             }
 
@@ -586,7 +586,7 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
             DmaBufDisplayAllocator* allocator;
         };
 
-        return std::make_unique<FooFramebufferProvider>(allocator);
+        return std::make_unique<DmaBufFramebufferProvider>(allocator);
     }
 
     // TODO: Make this not a null implementation, so bypass/overlays can work again

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -283,13 +283,13 @@ public:
         }
     }
 
-    auto commit() -> std::unique_ptr<mg::Framebuffer> override
+    auto commit() -> std::unique_ptr<mg::Buffer> override
     {
         if (eglSwapBuffers(dpy, egl_surf) != EGL_TRUE)
         {
             BOOST_THROW_EXCEPTION(mg::egl_error("eglSwapBuffers failed"));
         }
-        return surface->claim_framebuffer();
+        return surface->claim_buffer();
     }
 
     auto size() const -> geom::Size override

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -576,10 +576,7 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
                 if(auto dma_buf = std::dynamic_pointer_cast<mir::graphics::DMABufBuffer>(buffer))
                     return allocator->framebuffer_for(dma_buf);
 
-                if(auto framebuffer = buffer->to_framebuffer())
-                    return framebuffer;
-
-                return {};
+                return buffer->to_framebuffer();
             }
 
         private:

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -590,7 +590,7 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
     }
 
     // TODO: Make this not a null implementation, so bypass/overlays can work again
-    class NullFramebufferProvider : public FramebufferProvider
+    class DefaultFramebufferProvider : public FramebufferProvider
     {
     public:
         auto buffer_to_framebuffer(std::shared_ptr<Buffer> buf) -> std::unique_ptr<Framebuffer> override
@@ -603,7 +603,7 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
             return {};
         }
     };
-    return std::make_unique<NullFramebufferProvider>();
+    return std::make_unique<DefaultFramebufferProvider>();
 }
 
 mgg::GLRenderingProvider::GLRenderingProvider(

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -594,10 +594,7 @@ auto mgg::GLRenderingProvider::make_framebuffer_provider(DisplaySink& sink)
         {
             // It is safe to return nullptr; this will be treated as “this buffer cannot be used as
             // a framebuffer”.
-            if (auto mgg_gbm_buffer = std::dynamic_pointer_cast<mgg::GBMBuffer>(buf))
-                return mgg_gbm_buffer->to_framebuffer();
-
-            return {};
+            return buf->to_framebuffer();
         }
     };
     return std::make_unique<DefaultFramebufferProvider>();

--- a/src/platforms/gbm-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/gbm-kms/server/gbm_display_allocator.cpp
@@ -208,11 +208,6 @@ MirPixelFormat mir::graphics::gbm::GBMBuffer::pixel_format() const
     return mir_pixel_format_invalid;
 }
 
-mir::graphics::NativeBufferBase* mir::graphics::gbm::GBMBuffer::native_buffer_base()
-{
-    return this;
-}
-
 auto mgg::GBMBuffer::to_framebuffer() -> std::unique_ptr<Framebuffer>
 {
     if (auto cached_fb = static_cast<std::shared_ptr<uint32_t const>*>(gbm_bo_get_user_data(front_buffer.get())))

--- a/src/platforms/gbm-kms/server/gbm_display_allocator.h
+++ b/src/platforms/gbm-kms/server/gbm_display_allocator.h
@@ -49,8 +49,6 @@ public:
 
     MirPixelFormat pixel_format() const override;
 
-    NativeBufferBase* native_buffer_base() override;
-
     auto to_framebuffer() -> std::unique_ptr<Framebuffer> override;
 
 private:

--- a/src/platforms/gbm-kms/server/gbm_display_allocator.h
+++ b/src/platforms/gbm-kms/server/gbm_display_allocator.h
@@ -51,7 +51,7 @@ public:
 
     NativeBufferBase* native_buffer_base() override;
 
-    auto to_framebuffer() -> std::unique_ptr<Framebuffer>;
+    auto to_framebuffer() -> std::unique_ptr<Framebuffer> override;
 
 private:
     LockedFrontBuffer front_buffer;

--- a/src/platforms/gbm-kms/server/gbm_display_allocator.h
+++ b/src/platforms/gbm-kms/server/gbm_display_allocator.h
@@ -34,4 +34,27 @@ private:
     std::shared_ptr<struct gbm_device> const gbm;
     geometry::Size const size;
 };
+
+using LockedFrontBuffer = std::unique_ptr<gbm_bo, std::function<void(gbm_bo*)>>;
+
+// TODO: Dedup this
+class GBMBuffer : public Buffer, public NativeBufferBase
+{
+public:
+    GBMBuffer(mir::Fd drm_fd, LockedFrontBuffer front_buffer);
+
+    BufferID id() const override;
+
+    geometry::Size size() const override;
+
+    MirPixelFormat pixel_format() const override;
+
+    NativeBufferBase* native_buffer_base() override;
+
+    auto to_framebuffer() -> std::unique_ptr<Framebuffer>;
+
+private:
+    LockedFrontBuffer front_buffer;
+    mir::Fd const drm_fd;
+};
 }

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -80,7 +80,7 @@ mgg::DisplaySink::DisplaySink(
     {
         mir::log_info("Clearing screen due to differing encountered and target modes");
         // TODO: Pull a supported format out of KMS rather than assuming XRGB8888
-        auto initial_fb = std::make_shared<graphics::CPUAddressableBuffer>(
+        auto initial_fb = std::make_unique<graphics::CPUAddressableBuffer>(
             std::move(drm_fd),
             false,
             DRMFormat{DRM_FORMAT_XRGB8888},
@@ -89,7 +89,7 @@ mgg::DisplaySink::DisplaySink(
         auto mapping = initial_fb->map_writeable();
         ::memset(mapping->data(), 24, mapping->len());
 
-        visible_fb = CPUAddressableBuffer::to_fb_handle(initial_fb);
+        visible_fb = initial_fb->to_fb_handle();
         for (auto &output: outputs) {
             output->set_crtc(*visible_fb);
         }

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -80,7 +80,7 @@ mgg::DisplaySink::DisplaySink(
     {
         mir::log_info("Clearing screen due to differing encountered and target modes");
         // TODO: Pull a supported format out of KMS rather than assuming XRGB8888
-        auto initial_fb = std::make_shared<graphics::CPUAddressableFB>(
+        auto initial_fb = std::make_shared<graphics::CPUAddressableBuffer>(
             std::move(drm_fd),
             false,
             DRMFormat{DRM_FORMAT_XRGB8888},

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -89,7 +89,7 @@ mgg::DisplaySink::DisplaySink(
         auto mapping = initial_fb->map_writeable();
         ::memset(mapping->data(), 24, mapping->len());
 
-        visible_fb = std::move(initial_fb);
+        visible_fb = CPUAddressableBuffer::to_fb_handle(initial_fb);
         for (auto &output: outputs) {
             output->set_crtc(*visible_fb);
         }

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -438,12 +438,7 @@ auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)
         {
             // It is safe to return nullptr; this will be treated as “this buffer cannot be used as
             // a framebuffer”.
-            if (auto fb = std::dynamic_pointer_cast<mg::GenericEGLDisplayAllocator::EGLBuffer>(buf))
-            {
-                // TODO
-                return fb->to_framebuffer();
-            }
-            return {};
+            return buf->to_framebuffer();
         }
     };
     return std::make_unique<DefaultFramebufferProvider>();

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -458,7 +458,7 @@ auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)
     -> std::unique_ptr<FramebufferProvider>
 {
     // TODO: Work out under what circumstances the EGL renderer *can* provide overlayable framebuffers
-    class NullFramebufferProvider : public FramebufferProvider
+    class DefaultFramebufferProvider : public FramebufferProvider
     {
     public:
         auto buffer_to_framebuffer(std::shared_ptr<Buffer> buf) -> std::unique_ptr<Framebuffer> override
@@ -472,7 +472,7 @@ auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)
             return {};
         }
     };
-    return std::make_unique<NullFramebufferProvider>();
+    return std::make_unique<DefaultFramebufferProvider>();
 }
 
 mge::GLRenderingProvider::GLRenderingProvider(

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -355,12 +355,6 @@ public:
         return framebuffer->format();
     }
 
-    NativeBufferBase* native_buffer_base() override
-    {
-        return this;
-    }
-
-
     std::unique_ptr<EGLFramebuffer> framebuffer;
 };
 class EGLOutputSurface : public mg::gl::OutputSurface

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -342,7 +342,7 @@ public:
 
     mg::BufferID id() const override
     {
-        return mg::BufferID{0u};
+        return mg::BufferID{static_cast<uint32_t>(reinterpret_cast<uintptr_t>(framebuffer.get()))};
     }
 
     geom::Size size() const override

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -101,7 +101,7 @@ public:
 
 private:
     std::mutex mutex;
-    std::unique_ptr<WlDisplayAllocator::Framebuffer> next_frame;
+    std::unique_ptr<WlDisplayAllocator::Buffer> next_frame;
     std::shared_ptr<WlDisplayAllocator> provider;
 };
 
@@ -440,7 +440,8 @@ auto unique_ptr_cast(std::unique_ptr<From> ptr) -> std::unique_ptr<To>
 
 void mgw::DisplayClient::Output::set_next_image(std::unique_ptr<Framebuffer> content)
 {
-    if (auto wl_content = unique_ptr_cast<WlDisplayAllocator::Framebuffer>(std::move(content)))
+    auto framebuffer = unique_ptr_cast<WlDisplayAllocator::Framebuffer>(std::move(content));
+    if (auto wl_content = std::move(framebuffer->wrapped))
     {
         std::lock_guard lock{mutex};
         next_frame = std::move(wl_content);

--- a/src/platforms/wayland/wl_egl_display_provider.cpp
+++ b/src/platforms/wayland/wl_egl_display_provider.cpp
@@ -119,6 +119,22 @@ public:
             BOOST_THROW_EXCEPTION((mg::egl_error("eglSwapBuffers failed")));
         }
     }
+    
+    MirPixelFormat format() const
+    {
+        EGLint texture_format = -1;
+        eglQuerySurface(dpy, surf, EGL_TEXTURE_FORMAT, &texture_format);
+        
+        switch(texture_format)
+        {
+            case EGL_TEXTURE_RGB:
+                return mir_pixel_format_rgb_888;
+            case EGL_TEXTURE_RGBA:
+                return mir_pixel_format_argb_8888;
+            default:
+                return mir_pixel_format_invalid;
+        }
+    }
 
     EGLDisplay const dpy;
     EGLContext const ctx;
@@ -146,6 +162,11 @@ mgw::WlDisplayAllocator::Framebuffer::Framebuffer(Framebuffer const& that)
 auto mgw::WlDisplayAllocator::Framebuffer::size() const -> geom::Size
 {
     return size_;
+}
+
+auto mgw::WlDisplayAllocator::Framebuffer::format() const -> MirPixelFormat
+{
+    return state->format();
 }
 
 void mgw::WlDisplayAllocator::Framebuffer::make_current()

--- a/src/platforms/wayland/wl_egl_display_provider.h
+++ b/src/platforms/wayland/wl_egl_display_provider.h
@@ -59,6 +59,7 @@ public:
         Framebuffer(EGLDisplay dpy, EGLContext ctx, EGLSurface surf, std::shared_ptr<SurfaceState> ss, geometry::Size size);
 
         auto size() const -> geometry::Size override;
+        auto format() const -> MirPixelFormat override;
 
         void make_current() override;
         void release_current() override;

--- a/src/platforms/x11/graphics/display_sink.cpp
+++ b/src/platforms/x11/graphics/display_sink.cpp
@@ -14,13 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "mir/fatal.h"
 #include "platform.h"
 #include "display_sink.h"
-#include "display_configuration.h"
-#include "mir/graphics/display_report.h"
-#include "mir/graphics/transformation.h"
-#include "../x11_resources.h"
 #include <cstring>
 
 namespace mg=mir::graphics;

--- a/src/platforms/x11/graphics/display_sink.cpp
+++ b/src/platforms/x11/graphics/display_sink.cpp
@@ -32,8 +32,8 @@ public:
     {
     }
 
-    auto alloc_framebuffer(mg::GLConfig const& config, EGLContext share_context)
-    -> std::unique_ptr<EGLFramebuffer> override
+    auto alloc_buffer(mg::GLConfig const& config, EGLContext share_context)
+    -> std::unique_ptr<EGLBuffer> override
     {
         return egl->framebuffer_for_window(config, x11_connection, x11_win, share_context);
     }
@@ -88,7 +88,8 @@ auto unique_ptr_cast(std::unique_ptr<From> ptr) -> std::unique_ptr<To>
 
 void mgx::DisplaySink::set_next_image(std::unique_ptr<Framebuffer> content)
 {
-    next_frame = unique_ptr_cast<helpers::Framebuffer>(std::move(content));
+    auto helper_framebuffer = unique_ptr_cast<mgx::helpers::Framebuffer>(std::move(content));
+    next_frame = std::move(helper_framebuffer->wrapped);
 }
 
 glm::mat2 mgx::DisplaySink::transformation() const

--- a/src/platforms/x11/graphics/display_sink.h
+++ b/src/platforms/x11/graphics/display_sink.h
@@ -76,7 +76,7 @@ private:
     class Allocator;
     std::unique_ptr<Allocator> egl_allocator;
 
-    std::shared_ptr<helpers::Framebuffer> next_frame;
+    std::shared_ptr<helpers::Buffer> next_frame;
     geometry::Rectangle area;
     geometry::Size in_pixels;
     glm::mat2 transform;

--- a/src/platforms/x11/graphics/egl_helper.cpp
+++ b/src/platforms/x11/graphics/egl_helper.cpp
@@ -42,6 +42,22 @@ public:
         eglDestroyContext(dpy, ctx);
         eglDestroySurface(dpy, surf);
     }
+
+    auto format() const -> MirPixelFormat
+    {
+        EGLint texture_format = -1;
+        eglQuerySurface(dpy, surf, EGL_TEXTURE_FORMAT, &texture_format);
+        
+        switch(texture_format)
+        {
+            case EGL_TEXTURE_RGB:
+                return mir_pixel_format_rgb_888;
+            case EGL_TEXTURE_RGBA:
+                return mir_pixel_format_argb_8888;
+            default:
+                return mir_pixel_format_invalid;
+        }
+    }
     
     EGLDisplay const dpy;
     EGLContext const ctx;
@@ -62,6 +78,11 @@ mgxh::Framebuffer::Framebuffer(std::shared_ptr<EGLState const> state, geometry::
 auto mgxh::Framebuffer::size() const -> geometry::Size
 {
     return size_;
+}
+
+auto mgxh::Framebuffer::format() const -> MirPixelFormat
+{
+    return state->format();
 }
 
 void mgxh::Framebuffer::make_current()

--- a/src/platforms/x11/graphics/egl_helper.h
+++ b/src/platforms/x11/graphics/egl_helper.h
@@ -51,6 +51,7 @@ public:
     Framebuffer(EGLDisplay dpy, EGLContext ctx, EGLSurface surf, geometry::Size size);
 
     auto size() const -> geometry::Size override;
+    auto format() const -> MirPixelFormat override;
 
     void make_current() override;
     void release_current() override;

--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -377,7 +377,7 @@ public:
         output->release_current();
     }
 
-    auto commit() -> std::unique_ptr<mg::Framebuffer> override
+    auto commit() -> std::unique_ptr<mg::Buffer> override
     {
         // Bypass if no filter.
         if (filter == mir_output_filter_none)
@@ -629,7 +629,7 @@ void mrg::Renderer::tessellate(std::vector<mgl::Primitive>& primitives,
     primitives[0] = mgl::tessellate_renderable_into_rectangle(renderable, geom::Displacement{0,0});
 }
 
-auto mrg::Renderer::render(mg::RenderableList const& renderables) const -> std::unique_ptr<mg::Framebuffer>
+auto mrg::Renderer::render(mg::RenderableList const& renderables) const -> std::unique_ptr<mg::Buffer>
 {
     output_surface->make_current();
     output_surface->bind();

--- a/src/renderers/gl/renderer.h
+++ b/src/renderers/gl/renderer.h
@@ -47,7 +47,7 @@ public:
     void set_viewport(geometry::Rectangle const& rect) override;
     void set_output_transform(glm::mat2 const&) override;
     void set_output_filter(MirOutputFilter filter) override;
-    auto render(graphics::RenderableList const&) const -> std::unique_ptr<graphics::Framebuffer> override;
+    auto render(graphics::RenderableList const&) const -> std::unique_ptr<graphics::Buffer> override;
 
     // This is called _without_ a GL context:
     void suspend() override;

--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -42,8 +42,7 @@ public:
     OneShotBufferDisplayProvider() = default;
 
     class Buffer : 
-        public mg::CPUAddressableDisplayAllocator::MappableBuffer, 
-        public graphics::NativeBufferBase
+        public mg::CPUAddressableDisplayAllocator::MappableBuffer
     {
     public:
         Buffer(std::shared_ptr<mrs::WriteMappableBuffer> buffer)
@@ -76,11 +75,6 @@ public:
         MirPixelFormat pixel_format() const override
         {
             return format();
-        }
-
-        NativeBufferBase* native_buffer_base() override
-        {
-            return this;
         }
 
     private:

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -128,7 +128,7 @@ bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
         renderer->set_viewport(view_area);
         renderer->set_output_filter(output_filter->filter());
 
-        display_sink.set_next_image(renderer->render(renderable_list));
+        display_sink.set_next_image(fb_adaptor->buffer_to_framebuffer(renderer->render(renderable_list)));
 
         report->renderables_in_frame(this, renderable_list);
         report->rendered_frame(this);

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -128,7 +128,11 @@ bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
         renderer->set_viewport(view_area);
         renderer->set_output_filter(output_filter->filter());
 
-        display_sink.set_next_image(fb_adaptor->buffer_to_framebuffer(renderer->render(renderable_list)));
+        auto buffer = renderer->render(renderable_list);
+        assert(buffer!=nullptr);
+        auto framebuffer = fb_adaptor->buffer_to_framebuffer(std::move(buffer));
+        assert(framebuffer!=nullptr);
+        display_sink.set_next_image(std::move(framebuffer));
 
         report->renderables_in_frame(this, renderable_list);
         report->rendered_frame(this);

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -129,10 +129,8 @@ bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
         renderer->set_output_filter(output_filter->filter());
 
         auto buffer = renderer->render(renderable_list);
-        assert(buffer!=nullptr);
-        auto framebuffer = fb_adaptor->buffer_to_framebuffer(std::move(buffer));
-        assert(framebuffer!=nullptr);
-        display_sink.set_next_image(std::move(framebuffer));
+        if(auto framebuffer = fb_adaptor->buffer_to_framebuffer(std::move(buffer)))
+            display_sink.set_next_image(std::move(framebuffer));
 
         report->renderables_in_frame(this, renderable_list);
         report->rendered_frame(this);

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -129,8 +129,11 @@ bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
         renderer->set_output_filter(output_filter->filter());
 
         auto buffer = renderer->render(renderable_list);
-        if(auto framebuffer = fb_adaptor->buffer_to_framebuffer(std::move(buffer)))
-            display_sink.set_next_image(std::move(framebuffer));
+
+        // Account for EGLStream returning nullptr
+        if(buffer != nullptr)
+            if(auto framebuffer = fb_adaptor->buffer_to_framebuffer(std::move(buffer)))
+                display_sink.set_next_image(std::move(framebuffer));
 
         report->renderables_in_frame(this, renderable_list);
         report->rendered_frame(this);

--- a/tests/include/mir/test/doubles/mock_output_surface.h
+++ b/tests/include/mir/test/doubles/mock_output_surface.h
@@ -19,6 +19,7 @@
 
 #include <gmock/gmock.h>
 
+#include "mir/graphics/buffer.h"
 #include "mir/renderer/gl/gl_surface.h"
 
 namespace mir::test::doubles
@@ -29,7 +30,7 @@ public:
     MOCK_METHOD(void, bind, (), (override));
     MOCK_METHOD(void, make_current, (), (override));
     MOCK_METHOD(void, release_current, (), (override));
-    MOCK_METHOD(std::unique_ptr<graphics::Framebuffer>, commit, (), (override));
+    MOCK_METHOD(std::unique_ptr<graphics::Buffer>, commit, (), (override));
     MOCK_METHOD(mir::geometry::Size, size, (), (const override));
     MOCK_METHOD(Layout, layout, (), (const override));
 };

--- a/tests/include/mir/test/doubles/mock_renderer.h
+++ b/tests/include/mir/test/doubles/mock_renderer.h
@@ -33,7 +33,7 @@ struct MockRenderer : public renderer::Renderer
     MOCK_METHOD(void, set_viewport, (geometry::Rectangle const&));
     MOCK_METHOD(void, set_output_transform, (glm::mat2 const&));
     MOCK_METHOD(void, set_output_filter, (MirOutputFilter filter));
-    MOCK_METHOD(std::unique_ptr<graphics::Framebuffer>, render, (graphics::RenderableList const&), (const override));
+    MOCK_METHOD(std::unique_ptr<graphics::Buffer>, render, (graphics::RenderableList const&), (const override));
     MOCK_METHOD(void, suspend, ());
 
     ~MockRenderer() noexcept {}

--- a/tests/include/mir/test/doubles/stub_renderer.h
+++ b/tests/include/mir/test/doubles/stub_renderer.h
@@ -37,7 +37,7 @@ public:
     void set_output_filter(MirOutputFilter) override {};
     void suspend() override {}
 
-    auto render(graphics::RenderableList const& renderables) const -> std::unique_ptr<graphics::Framebuffer> override
+    auto render(graphics::RenderableList const& renderables) const -> std::unique_ptr<graphics::Buffer> override
     {
         for (auto const& r : renderables)
             r->buffer(); // We need to consume a buffer to unblock client tests

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -84,7 +84,7 @@ struct BasicScreenShooter : Test
                             .WillByDefault(
                                 [cpu_provider, format]()
                                 {
-                                    return cpu_provider->alloc_fb(format);
+                                    return cpu_provider->alloc_buffer(format);
                                 });
                         return surface;
                     }
@@ -243,7 +243,7 @@ TEST_F(BasicScreenShooter, throw_in_surface_for_output_handled_gracefully)
 
 TEST_F(BasicScreenShooter, throw_in_render_causes_graceful_failure)
 {
-    EXPECT_CALL(*next_renderer, render(_)).WillOnce([](auto) -> std::unique_ptr<mg::Framebuffer>
+    EXPECT_CALL(*next_renderer, render(_)).WillOnce([](auto) -> std::unique_ptr<mg::Buffer>
         {
             throw std::runtime_error{"throw in render()!"};
         });
@@ -273,7 +273,7 @@ TEST_F(BasicScreenShooter, ensures_renderer_is_current_on_only_one_thread)
 
     ON_CALL(*next_renderer, render(_))
         .WillByDefault(
-            [&](auto) -> std::unique_ptr<mg::Framebuffer>
+            [&](auto) -> std::unique_ptr<mg::Buffer>
             {
                 /* It's OK if we're being made current again on the same thread
                  * without having been released previously.

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
@@ -398,8 +398,8 @@ TEST_F(MesaDisplayMultiMonitorTest, flip_flips_all_connected_crtcs)
                 [](mg::DisplaySink& sink)
                 {
                     auto provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>();
-                    auto fb = provider->alloc_fb(mg::DRMFormat{DRM_FORMAT_ABGR8888});
-                    sink.set_next_image(std::move(fb));
+                    auto fb = provider->alloc_buffer(mg::DRMFormat{DRM_FORMAT_ABGR8888});
+                    sink.set_next_image(fb->to_framebuffer());
                 });
            group.post();
         });
@@ -413,8 +413,8 @@ TEST_F(MesaDisplayMultiMonitorTest, flip_flips_all_connected_crtcs)
                 [](mg::DisplaySink& sink)
                 {
                     auto provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>();
-                    auto fb = provider->alloc_fb(mg::DRMFormat{DRM_FORMAT_ARGB8888});
-                    sink.set_next_image(std::move(fb));
+                    auto fb = provider->alloc_buffer(mg::DRMFormat{DRM_FORMAT_ARGB8888});
+                    sink.set_next_image(fb->to_framebuffer());
                 });
            group.post();
         });

--- a/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
+++ b/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
@@ -330,7 +330,7 @@ TEST_F(GLRenderer, swaps_buffers_after_rendering)
     InSequence seq;
     EXPECT_CALL(mock_gl, glDrawArrays(_, _, _)).Times(AnyNumber());
     EXPECT_CALL(*mock_output_surface, commit())
-        .WillRepeatedly(testing::Invoke([]() { return std::unique_ptr<mg::Framebuffer>(); }));
+        .WillRepeatedly(testing::Invoke([]() { return std::unique_ptr<mg::Buffer>(); }));
 
     mrg::Renderer renderer(gl_platform, std::move(mock_output_surface));
     renderer.render(renderable_list);


### PR DESCRIPTION
Note: tests are failing intentionally. Build with `-DMIR_ENABLE_TESTS=off` if you want to run locally. Will fix tests once the core idea is validated.