### PR TITLE
Check for `EGL_WL_bind_wayland_display` when probing EGLStream display platform

### DIFF
--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -211,7 +211,7 @@ private:
      * https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084046
      * https://github.com/canonical/mir/issues/3710
      */
-    mgc::AllowList completely_skip{{"nvidia", "ast", "simple-framebuffer"}};
+    mgc::AllowList completely_skip{{"ast", "simple-framebuffer"}};
 
     // We know this is currently useful for virtio_gpu, vc4-drm and v3d
     mgc::AllowList disable_kms_probe{{"virtio_gpu", "vc4-drm", "v3d"}};

--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -244,7 +244,8 @@ auto probe_rendering_platform(
             std::vector<char const*> missing_extensions;
             for (char const* extension : {
                 "EGL_KHR_stream_consumer_gltexture",
-                "EGL_NV_stream_attrib"})
+                "EGL_NV_stream_attrib",
+                "EGL_WL_bind_wayland_display"})
             {
                 if (!epoxy_has_egl_extension(display, extension))
                 {

--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -320,7 +320,7 @@ auto probe_display_platform(
     for (char const* extension : {
         "EGL_EXT_platform_base",
         "EGL_EXT_platform_device",
-        "EGL_EXT_device_base",})
+        "EGL_EXT_device_base"})
     {
         if (!epoxy_has_egl_extension(EGL_NO_DISPLAY, extension))
         {
@@ -540,6 +540,12 @@ auto probe_display_platform(
                             "Mir will not auto-load the eglstream-kms platform on this driver. To proceed anyway, manually specify the platform library.");
                         continue;
                     }
+                }
+
+                if(!epoxy_has_egl_extension(display, "EGL_WL_bind_wayland_display"))
+                {
+                    mir::log_warning("Display does not support EGL_WL_bind_wayland_display. Will skip this device.");
+                    continue;
                 }
 
                 if (epoxy_has_egl_extension(display, "EGL_EXT_output_base"))

--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -192,7 +192,7 @@ private:
      * https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084046
      * https://github.com/canonical/mir/issues/3710
      */
-    mgc::AllowList completely_skip{{"nvidia", "ast", "simple-framebuffer"}};
+    mgc::AllowList completely_skip{{"ast", "simple-framebuffer"}};
     // We know this is currently useful for virtio_gpu, vc4-drm and v3d
     mgc::AllowList disable_kms_probe{{"virtio_gpu", "vc4-drm", "v3d"}};
 


### PR DESCRIPTION
Closes #4147 