### PR TITLE
Split documentation by audience

### DIFF
--- a/doc/sphinx/configuring-index.md
+++ b/doc/sphinx/configuring-index.md
@@ -3,9 +3,6 @@
 Mir is a compositor library designed to operate across a variety of Linux-based
 devices, including traditional desktops, IoT and embedded systems.
 
-As a library, Mir helps to build Wayland compositors that are commonly used in Linux
-desktop environments.
-
 Mir is a modern way to build Wayland compositors, providing
 a well-defined, efficient, flexible and secure platform for graphical environments
 that makes it an ideal choice for both device manufacturers and desktop users.

--- a/doc/sphinx/configuring-index.md
+++ b/doc/sphinx/configuring-index.md
@@ -39,7 +39,7 @@ Mir is a member of the Ubuntu family. It’s an open source project that warmly 
 * [Get support](https://discourse.ubuntu.com/c/mir/15)
 * [Join our online chat](https://matrix.to/#/#mir-server:matrix.org)
 * {ref}`Contribute <howto-contribute>`
-* Thinking about using Mir for your next project? [Get in touch](https://canonical.com/)!
+* Thinking about using Mir for your next project? [Get in touch](https://canonical.com/mir)!
 
 
 ```{toctree}

--- a/doc/sphinx/configuring-index.md
+++ b/doc/sphinx/configuring-index.md
@@ -1,4 +1,4 @@
-# Mir documentation
+# Configuring Mir
 
 Mir is a compositor library designed to operate across a variety of Linux-based
 devices, including traditional desktops, IoT and embedded systems.
@@ -12,25 +12,24 @@ that makes it an ideal choice for both device manufacturers and desktop users.
 
 ## In this documentation
 
+These pages cover the key aspects of configuring Mir based compositors. 
 
 ````{grid} 1 1 2 2
-```{grid-item-card} [Tutorials](/tutorial/index.md)
-**Start here**
-- {ref}`Getting started with Mir <tutorial-getting-started>`
+```{grid-item-card} [Tutorials](/tutorial/configuring-index.md)
+**Start here** - hands-on introductions to configuring Mir for new developers
 ```
 
-```{grid-item-card} [How-to guides](/howto/index.md)
-**Key operations and common tasks**
-- {ref}`Develop a Wayland compositor <howto-develop-wayland-compositor>`
+```{grid-item-card} [How-to guides](/howto/configuring-index.md)
+**How-to guides** - step-by-step guides covering key operations and common tasks
 ```
 ````
 ````{grid} 1 1 2 2
 :reverse:
-```{grid-item-card} [Reference](/reference/index.md)
+```{grid-item-card} [Reference](/reference/configuring-index.md)
  **Technical information** - specifications, APIs, architecture
 ```
 
-```{grid-item-card} [Explanation](/explanation/index.md)
+```{grid-item-card} [Explanation](/explanation/configuring-index.md)
  **Discussion and clarification** of key topics
 ```
 ````
@@ -49,10 +48,8 @@ Mir is a member of the Ubuntu family. It’s an open source project that warmly 
 ```{toctree}
 :hidden:
 
-tutorial/index
-how-to/index
-explanation/index
-reference/index
-contributing-index
-configuring-index
+tutorial/configuring-index
+how-to/configuring-index
+explanation/configuring-index
+reference/configuring-index
 ```

--- a/doc/sphinx/contributing-index.md
+++ b/doc/sphinx/contributing-index.md
@@ -3,9 +3,6 @@
 Mir is a compositor library designed to operate across a variety of Linux-based
 devices, including traditional desktops, IoT and embedded systems.
 
-As a library, Mir helps to build Wayland compositors that are commonly used in Linux
-desktop environments.
-
 Mir is a modern way to build Wayland compositors, providing
 a well-defined, efficient, flexible and secure platform for graphical environments
 that makes it an ideal choice for both device manufacturers and desktop users.

--- a/doc/sphinx/contributing-index.md
+++ b/doc/sphinx/contributing-index.md
@@ -40,7 +40,7 @@ Mir is a member of the Ubuntu family. It’s an open source project that warmly 
 * [Get support](https://discourse.ubuntu.com/c/mir/15)
 * [Join our online chat](https://matrix.to/#/#mir-server:matrix.org)
 * {ref}`Contribute <howto-contribute>`
-* Thinking about using Mir for your next project? [Get in touch](https://canonical.com/)!
+* Thinking about using Mir for your next project? [Get in touch](https://canonical.com/mir)!
 
 
 ```{toctree}

--- a/doc/sphinx/contributing-index.md
+++ b/doc/sphinx/contributing-index.md
@@ -14,7 +14,6 @@ These pages cover the key aspects of working on Mir
 ````{grid} 1 1 2 2
 ```{grid-item-card} [Tutorials](/tutorial/contributing-index.md)
 **Start here**
-- {ref}`Getting started with Mir <tutorial-getting-started>`
 ```
 
 ```{grid-item-card} [How-to guides](/howto/contributing-index.md)

--- a/doc/sphinx/contributing-index.md
+++ b/doc/sphinx/contributing-index.md
@@ -1,4 +1,4 @@
-# Mir documentation
+# Contributing to Mir
 
 Mir is a compositor library designed to operate across a variety of Linux-based
 devices, including traditional desktops, IoT and embedded systems.
@@ -12,25 +12,26 @@ that makes it an ideal choice for both device manufacturers and desktop users.
 
 ## In this documentation
 
+These pages cover the key aspects of working on Mir
 
 ````{grid} 1 1 2 2
-```{grid-item-card} [Tutorials](/tutorial/index.md)
+```{grid-item-card} [Tutorials](/tutorial/contributing-index.md)
 **Start here**
 - {ref}`Getting started with Mir <tutorial-getting-started>`
 ```
 
-```{grid-item-card} [How-to guides](/howto/index.md)
+```{grid-item-card} [How-to guides](/howto/contributing-index.md)
 **Key operations and common tasks**
-- {ref}`Develop a Wayland compositor <howto-develop-wayland-compositor>`
+- {ref}`Getting Involved in Mir <howto-contribute>`
 ```
 ````
 ````{grid} 1 1 2 2
 :reverse:
-```{grid-item-card} [Reference](/reference/index.md)
+```{grid-item-card} [Reference](/reference/configuring-index.md)
  **Technical information** - specifications, APIs, architecture
 ```
 
-```{grid-item-card} [Explanation](/explanation/index.md)
+```{grid-item-card} [Explanation](/explanation/configuring-index.md)
  **Discussion and clarification** of key topics
 ```
 ````
@@ -49,9 +50,8 @@ Mir is a member of the Ubuntu family. It’s an open source project that warmly 
 ```{toctree}
 :hidden:
 
-tutorial/index
-how-to/index
-explanation/index
-reference/index
-contributing-index
+tutorial/contributing-index
+how-to/contributing-index
+explanation/contributing-index
+reference/contributing-index
 ```

--- a/doc/sphinx/explanation/configuring-index.md
+++ b/doc/sphinx/explanation/configuring-index.md
@@ -1,0 +1,10 @@
+# Explanation
+These pages provide additional detail about a number of aspects related to using Mir.
+
+- [Component reports](component_reports.md): information on Mir's debug and performance reporting infrastructure
+
+```{toctree}
+:hidden:
+
+component_reports.md
+```

--- a/doc/sphinx/explanation/contributing-index.md
+++ b/doc/sphinx/explanation/contributing-index.md
@@ -1,5 +1,5 @@
 # Explanation
-These pages provide additional detail about a number of aspects related to using Mir.
+These pages provide additional detail about contributing to Mir.
 
 - [Architecture](architecture.md): an overview of Mir's architecture for contributors
 - [Libraries](libraries.md): an overview of Mir's libraries and how they depend on one another

--- a/doc/sphinx/explanation/contributing-index.md
+++ b/doc/sphinx/explanation/contributing-index.md
@@ -1,0 +1,22 @@
+# Explanation
+These pages provide additional detail about a number of aspects related to using Mir.
+
+- [Architecture](architecture.md): an overview of Mir's architecture for contributors
+- [Libraries](libraries.md): an overview of Mir's libraries and how they depend on one another
+- [Graphics support](mir-graphics-support.md): what's required to run Mir compositors
+- [Security](security.md): a deep dive into the security aspects of Mir compositors
+- [Performance](performance.md): a discussion of the performance aspects of Mir compositors
+- [Energy efficiency](energy-efficiency.md): a deep dive into the security aspects of Mir compositors
+- [Component reports](component_reports.md): information on Mir's debug and performance reporting infrastructure
+
+```{toctree}
+:hidden:
+
+architecture.md
+libraries.md
+mir-graphics-support.md
+security.md
+performance.md
+energy-efficiency.md
+component_reports.md
+```

--- a/doc/sphinx/explanation/index.md
+++ b/doc/sphinx/explanation/index.md
@@ -1,7 +1,6 @@
 # Explanation
 These pages provide additional detail about a number of aspects related to using Mir.
 
-- [Architecture](architecture.md): an overview of Mir's architecture for contributors
 - [Libraries](libraries.md): an overview of Mir's libraries and how they depend on one another
 - [Graphics support](mir-graphics-support.md): what's required to run Mir compositors
 - [Security](security.md): a deep dive into the security aspects of Mir compositors
@@ -14,7 +13,6 @@ These pages provide additional detail about a number of aspects related to using
 ```{toctree}
 :hidden:
 
-architecture.md
 libraries.md
 mir-graphics-support.md
 security.md

--- a/doc/sphinx/how-to/configuring-index.md
+++ b/doc/sphinx/how-to/configuring-index.md
@@ -1,5 +1,5 @@
 # How-to guides
-These how-to guides cover the key aspects of working with Mir.
+These how-to guides cover the key aspects of using Mir based compositors.
 
 - [Calibrating a touchscreen device](how-to-calibrate-a-touchscreen-device.md): creating and using a calibration matrix using [the libinput snap](https://snapcraft.io/libinput)
 

--- a/doc/sphinx/how-to/configuring-index.md
+++ b/doc/sphinx/how-to/configuring-index.md
@@ -2,9 +2,15 @@
 These how-to guides cover the key aspects of using Mir based compositors.
 
 - [Calibrating a touchscreen device](how-to-calibrate-a-touchscreen-device.md): creating and using a calibration matrix using [the libinput snap](https://snapcraft.io/libinput)
+- [How to enable remote desktop](how-to-enable-remote-desktop.md): Set up remote desktop for
+  your Mir based compositor using `wayvnc`
+- [How to use on-screen keyboards](how-to-use-on-screen-keyboards.md): Set up an
+  on-screen keyboard for Mir
 
 ```{toctree}
 :hidden:
 
 how-to-calibrate-a-touchscreen-device.md
+how-to-enable-remote-desktop.md
+how-to-use-on-screen-keyboards.md
 ```

--- a/doc/sphinx/how-to/configuring-index.md
+++ b/doc/sphinx/how-to/configuring-index.md
@@ -1,0 +1,10 @@
+# How-to guides
+These how-to guides cover the key aspects of working with Mir.
+
+- [Calibrating a touchscreen device](how-to-calibrate-a-touchscreen-device.md): creating and using a calibration matrix using [the libinput snap](https://snapcraft.io/libinput)
+
+```{toctree}
+:hidden:
+
+how-to-calibrate-a-touchscreen-device.md
+```

--- a/doc/sphinx/how-to/contributing-index.md
+++ b/doc/sphinx/how-to/contributing-index.md
@@ -1,0 +1,14 @@
+# How-to guides
+These how-to guides cover the key aspects of working on Mir.
+
+- [Getting involved in Mir](getting_involved_in_mir.md): first steps to contributing to Mir
+- [How to test Mir for a release](how-to-test-mir-for-a-release.md): The testing procedure followed for each Mir release to ensure quality
+- [How to update symbols maps](how-to-update-symbols-map.md): Symbol maps determine the symbols exported from each library in Mir and are important for ABI stability
+
+```{toctree}
+:hidden:
+
+getting_involved_in_mir.md
+how-to-test-mir-for-a-release.md
+how-to-update-symbols-map.md
+```

--- a/doc/sphinx/how-to/contributing-index.md
+++ b/doc/sphinx/how-to/contributing-index.md
@@ -5,6 +5,7 @@ These how-to guides cover the key aspects of working on Mir.
 - [How to test Mir for a release](how-to-test-mir-for-a-release.md): The testing procedure followed for each Mir release to ensure quality
 - [How to update symbols maps](how-to-update-symbols-map.md): Symbol maps determine the symbols exported from each library in Mir and are important for ABI stability
 - [Using checkbox-mir](how-to-use-checkbox-mir.md): validating your environment using [checkbox-mir](https://snapcraft.io/checkbox-mir)
+- [Enabling graphics on a device](how-to-enable-graphics-for-snaps-on-a-device.md): creating a graphics userspace provider snap for a new board
 
 ```{toctree}
 :hidden:

--- a/doc/sphinx/how-to/contributing-index.md
+++ b/doc/sphinx/how-to/contributing-index.md
@@ -4,6 +4,7 @@ These how-to guides cover the key aspects of working on Mir.
 - [Getting involved in Mir](getting_involved_in_mir.md): first steps to contributing to Mir
 - [How to test Mir for a release](how-to-test-mir-for-a-release.md): The testing procedure followed for each Mir release to ensure quality
 - [How to update symbols maps](how-to-update-symbols-map.md): Symbol maps determine the symbols exported from each library in Mir and are important for ABI stability
+- [Using checkbox-mir](how-to-use-checkbox-mir.md): validating your environment using [checkbox-mir](https://snapcraft.io/checkbox-mir)
 
 ```{toctree}
 :hidden:
@@ -11,4 +12,6 @@ These how-to guides cover the key aspects of working on Mir.
 getting_involved_in_mir.md
 how-to-test-mir-for-a-release.md
 how-to-update-symbols-map.md
+how-to-use-checkbox-mir.md
+how-to-enable-graphics-for-snaps-on-a-device.md
 ```

--- a/doc/sphinx/how-to/index.md
+++ b/doc/sphinx/how-to/index.md
@@ -3,12 +3,6 @@ These how-to guides cover the key aspects of working with Mir.
 
 - [Developing a Compositor](developing-a-wayland-compositor-using-mir.md): build your own, custom compositor with Mir
 - [Developing protocol extensions for Mir](developing-wayland-extension-protocols-for-mir-servers.md): extend your compositor with support for a custom protocol extension
-- [Getting involved in Mir](getting_involved_in_mir.md): first steps to contributing to Mir
-- [Using checkbox-mir](how-to-use-checkbox-mir.md): validating your environment using [checkbox-mir](https://snapcraft.io/checkbox-mir)
-- [Calibrating a touchscreen device](how-to-calibrate-a-touchscreen-device.md): creating and using a calibration matrix using [the libinput snap](https://snapcraft.io/libinput)
-- [Enabling graphics on a device](how-to-enable-graphics-for-snaps-on-a-device.md): creating a graphics userspace provider snap for a new board
-- [How to test Mir for a release](how-to-test-mir-for-a-release.md): The testing procedure followed for each Mir release to ensure quality
-- [How to update symbols maps](how-to-update-symbols-map.md): Symbol maps determine the symbols exported from each library in Mir and are important for ABI stability
 - [How to specify start up applications](how-to-specify-startup-apps.md)
 - [How to handle user input](how-to-handle-keyboard-input.md)
 - [Specifying CSD/SSD Preference](specifying-csd-ssd-preference.md)
@@ -19,13 +13,6 @@ These how-to guides cover the key aspects of working with Mir.
 
 developing-a-wayland-compositor-using-mir.md
 developing-wayland-extension-protocols-for-mir-servers.md
-getting_involved_in_mir.md
-how-to-use-checkbox-mir.md
-how-to-calibrate-a-touchscreen-device.md
-how-to-enable-graphics-for-snaps-on-a-device.md
-how-to-test-mir-for-a-release.md
-how-to-update-symbols-map.md
-how-to-specify-startup-apps.md
 how-to-handle-keyboard-input.md
 specifying-csd-ssd-preference.md
 how-to-enable-screencasting.md

--- a/doc/sphinx/how-to/index.md
+++ b/doc/sphinx/how-to/index.md
@@ -7,10 +7,6 @@ These how-to guides cover the key aspects of working with Mir.
 - [How to handle user input](how-to-handle-keyboard-input.md)
 - [Specifying CSD/SSD Preference](specifying-csd-ssd-preference.md)
 - [Enable screencasting](how-to-enable-screencasting.md)
-- [How to enable remote desktop](how-to-enable-remote-desktop.md): Set up remote desktop for
-  your Mir based compositor using `wayvnc`
-- [How to use on-screen keyboards](how-to-use-on-screen-keyboards.md): Set up an
-  on-screen keyboard for Mir
 
 ```{toctree}
 :hidden:
@@ -20,6 +16,4 @@ developing-wayland-extension-protocols-for-mir-servers.md
 how-to-handle-keyboard-input.md
 specifying-csd-ssd-preference.md
 how-to-enable-screencasting.md
-how-to-enable-remote-desktop.md
-how-to-use-on-screen-keyboards.md
 ```

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -41,7 +41,7 @@ Mir is a member of the Ubuntu family. It’s an open source project that warmly 
 * [Get support](https://discourse.ubuntu.com/c/mir/15)
 * [Join our online chat](https://matrix.to/#/#mir-server:matrix.org)
 * {ref}`Contribute <howto-contribute>`
-* Thinking about using Mir for your next project? [Get in touch](https://canonical.com/)!
+* Thinking about using Mir for your next project? [Get in touch](https://canonical.com/mir)!
 
 
 ```{toctree}

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -3,9 +3,6 @@
 Mir is a compositor library designed to operate across a variety of Linux-based
 devices, including traditional desktops, IoT and embedded systems.
 
-As a library, Mir helps to build Wayland compositors that are commonly used in Linux
-desktop environments.
-
 Mir is a modern way to build Wayland compositors, providing
 a well-defined, efficient, flexible and secure platform for graphical environments
 that makes it an ideal choice for both device manufacturers and desktop users.

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -14,7 +14,7 @@ These pages cover the key aspects of developing a compositor using Mir
 ````{grid} 1 1 2 2
 ```{grid-item-card} [Tutorials](/tutorial/index.md)
 **Start here**
-- {ref}`Getting started with Mir <tutorial-getting-started>`
+- [Write Your First Wayland Compositor](/tutorial/write-your-first-wayland-compositor.md): A guide through writing a simple compositor
 ```
 
 ```{grid-item-card} [How-to guides](/howto/index.md)

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -12,6 +12,7 @@ that makes it an ideal choice for both device manufacturers and desktop users.
 
 ## In this documentation
 
+These pages cover the key aspects of developing a compositor using Mir
 
 ````{grid} 1 1 2 2
 ```{grid-item-card} [Tutorials](/tutorial/index.md)
@@ -53,6 +54,6 @@ tutorial/index
 how-to/index
 explanation/index
 reference/index
-contributing-index
 configuring-index
+contributing-index
 ```

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -26,6 +26,7 @@ These pages cover the key aspects of developing a compositor using Mir
 :reverse:
 ```{grid-item-card} [Reference](/reference/index.md)
  **Technical information** - specifications, APIs, architecture
+- [Introducing the MirAL API](introducing_the_miral_api.md): The primary external interface for compositor authors
 ```
 
 ```{grid-item-card} [Explanation](/explanation/index.md)

--- a/doc/sphinx/reference/configuring-index.md
+++ b/doc/sphinx/reference/configuring-index.md
@@ -1,5 +1,5 @@
 # Reference
-These pages provide detailed reference to the Mir's programming and other interfaces.
+These pages provide detailed reference to the Mir configuration options.
 
 
 ```{toctree}

--- a/doc/sphinx/reference/configuring-index.md
+++ b/doc/sphinx/reference/configuring-index.md
@@ -1,0 +1,8 @@
+# Reference
+These pages provide detailed reference to the Mir's programming and other interfaces.
+
+
+```{toctree}
+:hidden:
+
+```

--- a/doc/sphinx/reference/contributing-index.md
+++ b/doc/sphinx/reference/contributing-index.md
@@ -1,5 +1,5 @@
 # Reference
-These pages provide detailed reference to the Mir's programming and other interfaces.
+These pages provide detailed reference to Mir's development practices.
 
 - [Continuous integration](continuous-integration.md): A detailed guide through Mir's testing infrastructure
 - [DSO Versioning guide](dso_versioning_guide.md): How is ABI managed in the Mir project

--- a/doc/sphinx/reference/contributing-index.md
+++ b/doc/sphinx/reference/contributing-index.md
@@ -1,0 +1,15 @@
+# Reference
+These pages provide detailed reference to the Mir's programming and other interfaces.
+
+- [Continuous integration](continuous-integration.md): A detailed guide through Mir's testing infrastructure
+- [DSO Versioning guide](dso_versioning_guide.md): How is ABI managed in the Mir project
+- [Kernel requirements](kernel_requirements.md): The kernel features required to run Mir-based compositors
+
+
+```{toctree}
+:hidden:
+
+dso_versioning_guide.md
+continuous-integration.md
+kernel_requirements.md
+```

--- a/doc/sphinx/reference/index.md
+++ b/doc/sphinx/reference/index.md
@@ -1,5 +1,5 @@
 # Reference
-These pages provide detailed reference to the Mir's programming and other interfaces.
+These pages provide detailed reference to Mir APIs and other interfaces.
 
 - [API](/api/library_root): Mir API reference
 - [Introducing the MirAL API](introducing_the_miral_api.md): The primary external interface for compositor authors

--- a/doc/sphinx/reference/index.md
+++ b/doc/sphinx/reference/index.md
@@ -3,8 +3,6 @@ These pages provide detailed reference to the Mir's programming and other interf
 
 - [API](/api/library_root): Mir API reference
 - [Introducing the MirAL API](introducing_the_miral_api.md): The primary external interface for compositor authors
-- [Continuous integration](continuous-integration.md): A detailed guide through Mir's testing infrastructure
-- [DSO Versioning guide](dso_versioning_guide.md): How is ABI managed in the Mir project
 - [Kernel requirements](kernel_requirements.md): The kernel features required to run Mir-based compositors
 
 
@@ -13,7 +11,5 @@ These pages provide detailed reference to the Mir's programming and other interf
 
 /api/library_root
 introducing_the_miral_api.md
-dso_versioning_guide.md
-continuous-integration.md
 kernel_requirements.md
 ```

--- a/doc/sphinx/tutorial/configuring-index.md
+++ b/doc/sphinx/tutorial/configuring-index.md
@@ -1,5 +1,5 @@
 # Tutorials
-These pages provide first-time introductions to Mir development
+These pages provide first-time introductions to configuring Mir based compositors.
 
 
 ```{toctree}

--- a/doc/sphinx/tutorial/configuring-index.md
+++ b/doc/sphinx/tutorial/configuring-index.md
@@ -1,0 +1,8 @@
+# Tutorials
+These pages provide first-time introductions to Mir development
+
+
+```{toctree}
+:hidden:
+
+```

--- a/doc/sphinx/tutorial/contributing-index.md
+++ b/doc/sphinx/tutorial/contributing-index.md
@@ -1,10 +1,8 @@
 # Tutorials
 These pages provide first-time introductions to Mir development
 
-- [Getting started with Mir](/tutorial/getting-started-with-mir.md): A showcase of Mir's capabilities
 
 ```{toctree}
 :hidden:
 
-/tutorial/getting-started-with-mir.md
 ```

--- a/doc/sphinx/tutorial/contributing-index.md
+++ b/doc/sphinx/tutorial/contributing-index.md
@@ -1,0 +1,10 @@
+# Tutorials
+These pages provide first-time introductions to Mir development
+
+- [Getting started with Mir](/tutorial/getting-started-with-mir.md): A showcase of Mir's capabilities
+
+```{toctree}
+:hidden:
+
+/tutorial/getting-started-with-mir.md
+```

--- a/doc/sphinx/tutorial/index.md
+++ b/doc/sphinx/tutorial/index.md
@@ -1,12 +1,10 @@
 # Tutorials
 These pages provide first-time introductions to key Mir aspects
 
-- [Getting started with Mir](/tutorial/getting-started-with-mir.md): A showcase of Mir's capabilities
 - [Write Your First Wayland Compositor](/tutorial/write-your-first-wayland-compositor.md): A guide through writing a simple compositor
 
 ```{toctree}
 :hidden:
 
-/tutorial/getting-started-with-mir.md
 /tutorial/write-your-first-wayland-compositor.md
 ```


### PR DESCRIPTION
Leaves the main landing page for "consumers" of the Mir libraries.

Splits off content for:

1. Configuring compositors based on Mir
2. Contributing to Mir

The former is a handy reference for users of Ubuntu Frame, Miriway, miracle-wm, Lomiri _etc_