### PR TITLE
doc: include internal APIs in documentation

### DIFF
--- a/doc/sphinx/Doxyfile.in
+++ b/doc/sphinx/Doxyfile.in
@@ -852,6 +852,9 @@ INPUT                  = @CMAKE_SOURCE_DIR@/README.md \
                          @CMAKE_SOURCE_DIR@/include/core \
                          @CMAKE_SOURCE_DIR@/include/miral \
                          @CMAKE_SOURCE_DIR@/include/miroil \
+                         @CMAKE_SOURCE_DIR@/include/server \
+                         @CMAKE_SOURCE_DIR@/include/platform \
+                         @CMAKE_SOURCE_DIR@/src/include \
                          @MIR_GENERATED_INCLUDE_DIRECTORIES_FLATTENED@
 
 # This tag can be used to specify the character encoding of the source files
@@ -918,10 +921,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @CMAKE_SOURCE_DIR@/include/server \
-                         @CMAKE_SOURCE_DIR@/include/platform \
-                         @CMAKE_SOURCE_DIR@/include/platforms \
-                         @CMAKE_SOURCE_DIR@/doc \
+EXCLUDE                = @CMAKE_SOURCE_DIR@/doc \
                          @CMAKE_SOURCE_DIR@/HACKING.md \
                          @CMAKE_SOURCE_DIR@/README.md
 
@@ -1154,7 +1154,19 @@ CLANG_ADD_INC_PATHS    = YES
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          = -std=c++23
+CLANG_OPTIONS          = -std=c++23 \
+                         -I@CMAKE_SOURCE_DIR@/include/core \
+                         -I@CMAKE_SOURCE_DIR@/include/common \
+                         -I@CMAKE_SOURCE_DIR@/include/miral \
+                         -I@CMAKE_SOURCE_DIR@/include/miroil \
+                         -I@CMAKE_SOURCE_DIR@/include/platform \
+                         -I@CMAKE_SOURCE_DIR@/include/renderer \
+                         -I@CMAKE_SOURCE_DIR@/include/renderers/gl \
+                         -I@CMAKE_SOURCE_DIR@/include/server \
+                         -I@CMAKE_SOURCE_DIR@/include/wayland \
+                         -I@CMAKE_SOURCE_DIR@/src/include/common \
+                         -I@CMAKE_SOURCE_DIR@/src/include/gl \
+                         -I@CMAKE_SOURCE_DIR@/src/include/server
 
 # If clang assisted parsing is enabled you can provide the clang parser with the
 # path to the directory containing a file called compile_commands.json. This
@@ -1167,7 +1179,7 @@ CLANG_OPTIONS          = -std=c++23
 # Note: The availability of this option depends on whether or not doxygen was
 # generated with the -Duse_libclang=ON option for CMake.
 
-CLANG_DATABASE_PATH    =
+#CLANG_DATABASE_PATH    = @CMAKE_BINARY_DIR@
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index

--- a/include/platform/mir/input/input_sink.h
+++ b/include/platform/mir/input/input_sink.h
@@ -21,6 +21,7 @@
 #include "mir/geometry/rectangle.h"
 #include "mir/geometry/point.h"
 
+#include <memory>
 #include <vector>
 #include <array>
 

--- a/src/include/common/mir/events/xkb_modifiers.h
+++ b/src/include/common/mir/events/xkb_modifiers.h
@@ -17,6 +17,8 @@
 #ifndef MIR_COMMON_XKB_MODIFIERS_H_
 #define MIR_COMMON_XKB_MODIFIERS_H_
 
+#include <cstdint>
+
 struct MirXkbModifiers
 {
     uint32_t depressed{0};

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -361,8 +361,6 @@ protected:
 
     virtual std::shared_ptr<scene::MediatingDisplayChanger> the_mediating_display_changer();
 
-    /** @} */
-
     /** @Convenience wrapper functions
      *  @{ */
     virtual std::shared_ptr<graphics::DisplayConfigurationPolicy> wrap_display_configuration_policy(


### PR DESCRIPTION
This adds the internal headers to the Doxygen API docs build.

I had looked at trying to build this as a separate build to the public headers, but while the breathe extension supports multiple projects, the exhale extension we're using does not. It also [doesn't support Doxygen's grouping feature](https://exhale.readthedocs.io/en/latest/faq.html#my-documentation-is-setup-using-groups-how-can-i-use-exhale), so that is also not an option.

I also noticed a few errors in the build process that I've corrected too:

* add a bunch of `-I` arguments to help Doxygen parse headers with clang. As is, many files failed to parse on unknown `#include` directives.
* Update a couple of headers that were missing includes.