### PR TITLE
Fix inconsistent capitalization of program option descriptions

### DIFF
--- a/src/miral/set_window_management_policy.cpp
+++ b/src/miral/set_window_management_policy.cpp
@@ -37,7 +37,7 @@ miral::SetWindowManagementPolicy::~SetWindowManagementPolicy() = default;
 
 void miral::SetWindowManagementPolicy::operator()(mir::Server& server) const
 {
-    server.add_configuration_option(trace_option, "log trace message", mir::OptionType::null);
+    server.add_configuration_option(trace_option, "Log trace message", mir::OptionType::null);
 
     server.override_the_window_manager_builder([this, &server](msh::FocusController* focus_controller)
         -> std::shared_ptr<msh::WindowManager>

--- a/src/miral/window_management_options.cpp
+++ b/src/miral/window_management_options.cpp
@@ -49,7 +49,7 @@ void miral::WindowManagerOptions::operator()(mir::Server& server) const
     description += "}]";
 
     server.add_configuration_option(wm_option, description, policies.begin()->name);
-    server.add_configuration_option(trace_option, "log trace message", mir::OptionType::null);
+    server.add_configuration_option(trace_option, "Log trace message", mir::OptionType::null);
 
     server.override_the_window_manager_builder([this, &server](msh::FocusController* focus_controller)
         -> std::shared_ptr<msh::WindowManager>

--- a/src/miral/x11_support.cpp
+++ b/src/miral/x11_support.cpp
@@ -65,7 +65,7 @@ void miral::X11Support::operator()(mir::Server& server) const
 
     server.add_configuration_option(
         x11_displayfd_opt,
-        "file descriptor to write X11 DISPLAY number to when ready to connect", mir::OptionType::integer);
+        "File descriptor to write X11 DISPLAY number to when ready to connect", mir::OptionType::integer);
 
     server.add_init_callback([this, &server]
         {

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -345,9 +345,9 @@ void mo::DefaultConfiguration::parse_arguments(
     try
     {
         desc.add_options()
-            ("help,h", "this help text");
+            ("help,h", "Show command line help");
         desc.add_options()
-            ("version,V", "display Mir version and exit");
+            ("version,V", "Display Mir version and exit");
 
         options.parse_arguments(desc, argc, argv);
 

--- a/src/platforms/atomic-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/atomic-kms/server/kms/platform_symbols.cpp
@@ -87,7 +87,7 @@ void add_graphics_platform_options(boost::program_options::options_description& 
     config.add_options()
         (bypass_option_name,
          boost::program_options::value<bool>()->default_value(false),
-         "[platform-specific] utilize the bypass optimization for fullscreen surfaces.");
+         "[platform-specific] Utilize the bypass optimization for fullscreen surfaces.");
     mga::Quirks::add_quirks_option(config);
 }
 

--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -94,7 +94,7 @@ void add_graphics_platform_options(boost::program_options::options_description& 
     config.add_options()
         (bypass_option_name,
          boost::program_options::value<bool>()->default_value(false),
-         "[platform-specific] utilize the bypass optimization for fullscreen surfaces.");
+         "[platform-specific] Utilize the bypass optimization for fullscreen surfaces.");
     mgg::Quirks::add_quirks_option(config);
 }
 


### PR DESCRIPTION
Also reword --help description context as it may be shown in the documentation.