### PR TITLE
use-pkgconfig-better

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -47,7 +47,6 @@ target_link_libraries(mirplatform
     miroptions
     mirudev
     PkgConfig::EPOXY
-    PkgConfig::LIBDISPLAY_INFO
 )
 
 set_target_properties(

--- a/src/platform/graphics/CMakeLists.txt
+++ b/src/platform/graphics/CMakeLists.txt
@@ -118,6 +118,7 @@ target_link_libraries(
   PUBLIC
     mirwayland
     PkgConfig::EGL
+    PkgConfig::LIBDISPLAY_INFO
   PRIVATE
     mircommon
     PkgConfig::PIXMAN

--- a/tests/mir_test_doubles/CMakeLists.txt
+++ b/tests/mir_test_doubles/CMakeLists.txt
@@ -36,6 +36,8 @@ target_link_libraries(mir-protected-test-doubles
     mirplatform
     mircommon
     mircore
+
+    PkgConfig::LIBINPUT
 )
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -144,6 +146,11 @@ target_link_libraries(mir-public-test-doubles-platform
     mircore
   PRIVATE
     PkgConfig::DRM
+)
+
+target_include_directories(mir-public-test-doubles-platform
+  PUBLIC
+    ${LIBINPUT_INCLUDE_DIRS}
 )
 
 add_library(mir-test-doubles-platform-static STATIC)

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(mir-public-test-framework
     mircore
   PRIVATE
     PkgConfig::UMOCKDEV
+    PkgConfig::LIBINPUT
 )
 
 set_property(
@@ -95,6 +96,7 @@ target_link_libraries(mir-libinput-test-framework
   PUBLIC
     mircommon
     mircore
+    mir-public-test-doubles-platform
 )
 
 add_library(mir-umock-test-framework OBJECT udev_environment.cpp)


### PR DESCRIPTION
Fix problems reported on #miriway:matrix.org: someone packaging for openSUSE moves the header files for libinput and libdisplay-info