### PR TITLE
pre-commit: add initial config and workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,4 @@ repos:
     - mdformat-beautysh
     - mdformat-gfm
     - mdformat-myst
+    - setuptools # Necessary until beautysh fix their stuff, see: https://github.com/hukkin/mdformat/issues/442


### PR DESCRIPTION
## What's new?
This introduces a https://pre-commit.com/ config, and an action

## How to test
```
pip install pre-commit
pre-commit install
# proceed as normal
```

## TODO (for PR authors)
- [x] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos