### PR TITLE
Remove --enable-input

### DIFF
--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -28,7 +28,6 @@ class SharedLibrary;
 namespace options
 {
 extern char const* const arw_server_socket_opt;
-extern char const* const enable_input_opt;
 extern char const* const shared_library_prober_report_opt;
 extern char const* const shell_report_opt;
 extern char const* const compositor_report_opt;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -27,7 +27,6 @@
 namespace mo = mir::options;
 
 char const* const mo::arw_server_socket_opt       = "arw-file";
-char const* const mo::enable_input_opt            = "enable-input,i";
 char const* const mo::compositor_report_opt       = "compositor-report";
 char const* const mo::display_report_opt          = "display-report";
 char const* const mo::scene_report_opt            = "scene-report";
@@ -67,11 +66,6 @@ char const* const mo::auto_console = "auto";
 char const* const mo::vt_option_name = "vt";
 char const* const mo::vt_switching_option_name = "vt-switching";
 
-
-namespace
-{
-bool const enable_input_default        = true;
-}
 
 mo::DefaultConfiguration::DefaultConfiguration(int argc, char const* argv[]) :
     DefaultConfiguration(argc, argv, std::string{})
@@ -153,8 +147,6 @@ mo::DefaultConfiguration::DefaultConfiguration(
             "Library to use for platform input support (default: input-stub.so)")
         (platform_path, po::value<std::string>()->default_value(MIR_SERVER_PLATFORM_PATH),
             "Directory to look for platform libraries (default: " MIR_SERVER_PLATFORM_PATH ")")
-        (enable_input_opt, po::value<bool>()->default_value(enable_input_default),
-            "Enable input.")
         (compositor_report_opt, po::value<std::string>()->default_value(off_opt_value),
             "Compositor reporting [{log,lttng,off}]")
         (display_report_opt, po::value<std::string>()->default_value(off_opt_value),

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -132,7 +132,6 @@ MIR_PLATFORM_2.22 {
     mir::options::debug_opt*;
     mir::options::display_report_opt*;
     mir::options::drop_wayland_extensions_opt;
-    mir::options::enable_input_opt*;
     mir::options::enable_key_repeat_opt*;
     mir::options::fatal_except_opt*;
     mir::options::idle_timeout_opt;

--- a/tests/acceptance-tests/server_configuration_options.cpp
+++ b/tests/acceptance-tests/server_configuration_options.cpp
@@ -119,7 +119,7 @@ TEST_F(ServerConfigurationOptions, unknown_command_line_options_are_passed_to_ha
     const int argc = 7;
     char const* argv[argc] = {
         __PRETTY_FUNCTION__,
-        "--enable-input", "no",
+        "--compositor-report", "off",
         "--hello",
         "world",
         "--answer", "42"

--- a/tests/acceptance-tests/test_command_line_handling.cpp
+++ b/tests/acceptance-tests/test_command_line_handling.cpp
@@ -37,7 +37,7 @@ struct CommandLineHandling : mir_test_framework::HeadlessTest
 TEST_F(CommandLineHandling, valid_options_are_accepted_by_default_callback)
 {
     char const* argv[] =
-     { "dummy-exe-name", "--enable-input", "off"};
+     { "dummy-exe-name", "--compositor-report", "off"};
 
     int const argc = std::distance(std::begin(argv), std::end(argv));
 
@@ -49,7 +49,7 @@ TEST_F(CommandLineHandling, valid_options_are_accepted_by_default_callback)
 TEST_F(CommandLineHandling, unrecognised_tokens_cause_default_callback_to_throw)
 {
     char const* argv[] =
-     { "dummy-exe-name", "--file", "test", "--hello", "world", "--enable-input", "off"};
+     { "dummy-exe-name", "--file", "test", "--hello", "world", "--compositor-report", "off"};
 
     int const argc = std::distance(std::begin(argv), std::end(argv));
 
@@ -61,7 +61,7 @@ TEST_F(CommandLineHandling, unrecognised_tokens_cause_default_callback_to_throw)
 TEST_F(CommandLineHandling, valid_options_are_not_passed_to_callback)
 {
     char const* argv[] =
-     { "dummy-exe-name", "--enable-input", "off"};
+     { "dummy-exe-name", "--compositor-report", "off"};
 
     int const argc = std::distance(std::begin(argv), std::end(argv));
 
@@ -76,7 +76,7 @@ TEST_F(CommandLineHandling, valid_options_are_not_passed_to_callback)
 TEST_F(CommandLineHandling, unrecognised_tokens_are_passed_to_callback)
 {
     char const* argv[] =
-     { "dummy-exe-name", "--hello", "world", "--enable-input", "off"};
+     { "dummy-exe-name", "--hello", "world", "--compositor-report", "off"};
 
     int const argc = std::distance(std::begin(argv), std::end(argv));
 


### PR DESCRIPTION
This option was added in 2013 in f864944fc3de3b6a4953c90189a503349f0e60a5 and defaulted to false at the time. It was later changed to default to true.

Removing as it doesn't seem useful and adds confusion to the active options. If no input is required it is probably better to use an input platform that provides this behaviour.
