### PR TITLE
spread: drop mk-build-deps

### DIFF
--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -18,11 +18,10 @@ execute: |
     # (Currently: a newer version of WLCS)
     add-apt-repository ppa:mir-team/dev --component "main $( $NODBG || echo main/debug )"
 
-    # to get dpkg-architecture and mk-build-deps
+    # to get dpkg-architecture
     apt-get install \
       --yes \
       ccache \
-      devscripts \
       dpkg-dev \
       $( $NODBG || echo wlcs-dbgsym )
 


### PR DESCRIPTION
## What's new?
Drop unused `devscripts`.

## How to test
CI

## TODO (for PR authors)
- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos