### PR TITLE
Provide a custom library_root file for doxygen

### DIFF
--- a/doc/sphinx/api/library_root.rst
+++ b/doc/sphinx/api/library_root.rst
@@ -1,0 +1,8 @@
+=======================
+Mir C++ API Documentation
+=======================
+
+This is the C++ API documentation for Mir, generated from the source code
+using Doxygen and Sphinx.
+
+.. include:: unabridged_api.rst.include

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -334,7 +334,7 @@ doxyfile_contents = read_doxyfile(cmake_build_dir / 'doc/sphinx/Doxyfile')
 exhale_args = {
     # These arguments are required
     "containmentFolder": "./api",
-    "rootFileName": "library_root.rst",
+    "rootFileName": "EXCLUDE",
     "doxygenStripFromPath": "..",
     # Heavily encouraged optional argument (see docs)
     "rootFileTitle": "Mir API",


### PR DESCRIPTION
# What's new?
* Removed a bunch of cruft that was added by the default library root file
