### PR TITLE
graphics: pass correct options to manually-selected platforms

### DIFF
--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -237,7 +237,7 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
                         graphics::probe_rendering_module(
                             display_targets,
                             *platform,
-                            *the_options(),
+                            *the_options_provider()->options_for(*platform),
                             the_console_services());
 
                     bool found_supported_device{false};


### PR DESCRIPTION
Fixes #4130

## What's new?
* pass module-specific options to manually-selected platforms

# How to test
* #4130

...

# TODO (for PR authors)
- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos