### PR TITLE
spread: make Cargo find the right Rust

### DIFF
--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -55,6 +55,7 @@ execute: |
     if [ "${ENABLE_RUST}" -eq 1 ]; then
       echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_ENABLE_RUST=ON" >> debian/opts.mk
       apt-get install --yes cargo rustc-1.82
+      export PATH=/usr/lib/rust-1.82/bin:$PATH
     fi
 
     # change the build type


### PR DESCRIPTION
## What's new?
- #4225 failed to actually make use of the newer Rust

## How to test
CI to pass the `ubuntu/rust` variant

## TODO (for PR authors)
- [x] Tests added and pass
- [ ] ~~Adequate documentation added~~
- [ ] ~~(optional) Added Screenshots or videos~~
