### PR TITLE
Rename the graphics support docs to platform support

### DIFF
--- a/doc/sphinx/explanation/contributing-index.md
+++ b/doc/sphinx/explanation/contributing-index.md
@@ -3,7 +3,7 @@ These pages provide additional detail about contributing to Mir.
 
 - [Architecture](architecture.md): an overview of Mir's architecture for contributors
 - [Libraries](libraries.md): an overview of Mir's libraries and how they depend on one another
-- [Graphics support](mir-graphics-support.md): what's required to run Mir compositors
+- [Platform support](platform-support.md): what's required to run Mir compositors
 - [Security](security.md): a deep dive into the security aspects of Mir compositors
 - [Performance](performance.md): a discussion of the performance aspects of Mir compositors
 - [Energy efficiency](energy-efficiency.md): a deep dive into the security aspects of Mir compositors
@@ -14,7 +14,7 @@ These pages provide additional detail about contributing to Mir.
 
 architecture.md
 libraries.md
-mir-graphics-support.md
+platform-support.md
 security.md
 performance.md
 energy-efficiency.md

--- a/doc/sphinx/explanation/index.md
+++ b/doc/sphinx/explanation/index.md
@@ -1,7 +1,7 @@
 # Explanation
 These pages provide additional detail about a number of aspects related to using Mir.
 
-- [Graphics support](mir-graphics-support.md): what's required to run Mir compositors
+- [Platform support](platform-support.md): what's required to run Mir compositors
 - [Security](security.md): a deep dive into the security aspects of Mir compositors
 - [Performance](performance.md): a discussion of the performance aspects of Mir compositors
 - [Energy efficiency](energy-efficiency.md): a deep dive into the security aspects of Mir compositors
@@ -14,7 +14,7 @@ These pages provide additional detail about a number of aspects related to using
 ```{toctree}
 :hidden:
 
-mir-graphics-support.md
+platform-support.md
 security.md
 performance.md
 energy-efficiency.md

--- a/doc/sphinx/explanation/platform-support.md
+++ b/doc/sphinx/explanation/platform-support.md
@@ -2,7 +2,7 @@
 discourse: 13185
 ---
 
-# Mir graphics support
+# Platform support
 
 This document describes the requirements for running Mir.
 


### PR DESCRIPTION
We're working on a specific graphics and input documentation and this name confuses with that. The documentation already describes platforms (including mentioning input) so this name seems a better fit.
