### PR TITLE
mircommon: Add xkbcommon to pkgconfig dependency

### DIFF
--- a/src/common/mircommon.pc.in
+++ b/src/common/mircommon.pc.in
@@ -5,6 +5,6 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mircommon
 Name: mircommon
 Description: Mir server library
 Version: @MIR_VERSION@
-Requires: mircore
+Requires: mircore, xkbcommon
 Libs: -L${libdir} -lmircommon
 Cflags: -I${includedir}


### PR DESCRIPTION
This is needed in practice for building against mircommon, so declare it in the pkgconfig file so it is automatically set up as a dependency.