### PR TITLE
doc: disable Sphinx cache when building API

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -19,6 +19,8 @@ if(BUILD_DOXYGEN)
   set(MAKEOPTS
     ${MAKEOPTS}
     MIR_BUILD_API_DOCS=1
+    # FIXME: Sphinx gets itself into a bind reading cached API state
+    EXTRA_SPHINXOPTS=-E
   )
 endif()
 

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -6,7 +6,7 @@
 # from the environment for the first two.
 SPHINXDIR       = .sphinx
 DOCTREESDIR     ?= $(SPHINXDIR)/.doctrees
-SPHINXOPTS      ?= -c . -d $(DOCTREESDIR) -j auto
+SPHINXOPTS      ?= -c . -d $(DOCTREESDIR) -j auto $(EXTRA_SPHINXOPTS)
 SPHINXBUILD     ?= $(VENVDIR)/bin/sphinx-build
 SOURCEDIR       = .
 BUILDDIR        = _build


### PR DESCRIPTION
## How to test
- `cmake -DBUILD_DOXYGEN=ON`
- `cmake --build . --target doc`
- `cmake --build . --target doc`
- observe how it's slow, but doesn't leak all the memories

## Checklist
- [ ] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos