### PR TITLE
Add docs for `mg::Framebuffer`

### DIFF
--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -358,10 +358,9 @@ public:
 ///
 ///
 /// \sa
-/// - #mir::graphics::RenderingProvider::FramebufferProvider::buffer_to_framebuffer
-/// - Converts a buffer to a framebuffer
+/// - #mir::graphics::RenderingProvider::FramebufferProvider::buffer_to_framebuffer - Converts a buffer to a framebuffer
 /// - #mir::graphics::DisplaySink::set_next_image - Displays the given
-/// framebuffer if it's suitable for the display sink.
+///   framebuffer if it's suitable for the display sink.
 class Framebuffer
 {
 public:


### PR DESCRIPTION
## What's new?
- Adds some initial docs for `mg::Framebuffer`. Wouldn't say I'm 100% happy with how it is, but it's a start.