### PR TITLE
Rtd build on src include changes

### DIFF
--- a/doc/sphinx/.readthedocs.yaml
+++ b/doc/sphinx/.readthedocs.yaml
@@ -45,7 +45,7 @@ build:
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
     - |
-      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- 'doc/' 'doc/sphinx/.readthedocs.yaml' 'src/' 'include';
+      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- 'doc/' 'doc/sphinx/.readthedocs.yaml' 'include/' 'src/include/';
       then
         exit 183;
       fi

--- a/doc/sphinx/.readthedocs.yaml
+++ b/doc/sphinx/.readthedocs.yaml
@@ -43,7 +43,7 @@ build:
       # Cancel building pull requests when there aren't changed in the docs directory.
       # If there are no changes (git diff exits with 0) we force the command to return with 183.
       # This is a special exit code on Read the Docs that will cancel the build immediately.
-      # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition  
+      # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
     - |
       if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- 'doc/' 'doc/sphinx/.readthedocs.yaml' 'src/' 'include';
       then

--- a/doc/sphinx/.readthedocs.yaml
+++ b/doc/sphinx/.readthedocs.yaml
@@ -45,7 +45,7 @@ build:
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition  
     - |
-      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- 'doc/' 'doc/sphinx/.readthedocs.yaml';
+      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- 'doc/' 'doc/sphinx/.readthedocs.yaml' 'src/' 'include';
       then
         exit 183;
       fi


### PR DESCRIPTION
## What's new?
- RTD should now build with changes inside `include/` and `src/`

## How to test
- Commits with changes outside the specified directories should cancel RTD builds (they give a 404 page in that case)