### PR TITLE
MIRENG-1361-Many-input-configuration-options-are-missing-from-live_config

### DIFF
--- a/src/miral/input_configuration.cpp
+++ b/src/miral/input_configuration.cpp
@@ -422,7 +422,7 @@ miral::InputConfiguration::InputConfiguration(live_config::Store& config_store) 
 
     config_store.add_int_attribute(
         {"keyboard", "repeat_delay"},
-        "Number of millisecond to hold down a key before generating repeat events",
+        "Number of milliseconds to hold down a key before generating repeat events",
         [self=self](auto... args) { self->config.keyboard_repeat_delay(args...); });
 
     config_store.add_string_attribute(


### PR DESCRIPTION
Closes #4133

## What's new?
Fills out missing input options in live config

## How to test
These options are exposed in mir_demo_server

## Checklist
- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
