### PR TITLE
spread: `--assumeyes` by default on Fedora

### DIFF
--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -4,18 +4,20 @@ variants: [amd64]
 kill-timeout: 60m
 
 execute: |
+    echo "defaultyes=True" >> /etc/dnf/dnf.conf
+
     if [[ "${SPREAD_SYSTEM}" == "fedora-rawhide" ]]; then
-      dnf --refresh --assumeyes upgrade
-      dnf --assumeyes install fedora-repos-rawhide
-      dnf --refresh --assumeyes --enablerepo=rawhide distro-sync
+      dnf --refresh upgrade
+      dnf install fedora-repos-rawhide
+      dnf --refresh --enablerepo=rawhide distro-sync
     fi
 
-    dnf --assumeyes install @buildsys-build ccache 'dnf5-command(builddep)'
+    dnf install @buildsys-build ccache 'dnf5-command(builddep)'
     if [ "${CLANG}" -eq 1 ]; then
-        dnf --assumeyes install clang
+        dnf install clang
     fi
 
-    dnf --assumeyes builddep --allowerasing ${SPREAD_PATH}/rpm/mir.spec
+    dnf builddep --allowerasing ${SPREAD_PATH}/rpm/mir.spec
 
     pushd ${SPREAD_PATH}
     rpmbuild --build-in-place \
@@ -29,7 +31,7 @@ execute: |
     ccache --show-stats --zero-stats > ${CCACHE_DIR}/ccache.stats
 
     # build the local repository for end-to-end tests
-    dnf --assumeyes install createrepo
+    dnf install createrepo
     createrepo /root/rpmbuild
     dnf config-manager addrepo \
        --id=mirpr \
@@ -39,7 +41,6 @@ execute: |
        --set=enabled=1 \
        --save-filename=mirpr.repo
     dnf update
-    echo "defaultyes=True" >> /etc/dnf/dnf.conf
 
     # [doc:first-compositor:fedora-dependencies-install]
     dnf install 'pkgconfig(miral)'


### PR DESCRIPTION
## What's new?
Avoid the need for `--assumeyes` everywhere.

## How to test
CI

## Checklist
- [x] Tests added and pass
- [ ] ~~Adequate documentation added~~
- [ ] ~~(optional) Added Screenshots or videos~~