### PR TITLE
spread/build/fedora: Drop unneeded "dnf update" call

### DIFF
--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -40,7 +40,6 @@ execute: |
        --set=priority=90 \
        --set=enabled=1 \
        --save-filename=mirpr.repo
-    dnf update
 
     # [doc:first-compositor:fedora-dependencies-install]
     dnf install 'pkgconfig(miral)'


### PR DESCRIPTION
DNF automatically refreshes repositories when repository configuration changes on the next transaction call (e.g. "dnf install"), so this is redundant and slows down the jobs unnecessarily.
