### PR TITLE
Fix program return value of 1 when run with --help/--version

### DIFF
--- a/src/miral/runner.cpp
+++ b/src/miral/runner.cpp
@@ -180,6 +180,12 @@ try
         fd_manager->set_main_loop(main_loop);
     });
 
+    // If only informational output requested, stop here.
+    if (server->get_options()->is_set("help") || server->get_options()->is_set("version"))
+    {
+        return EXIT_SUCCESS;
+    }
+
     server->run();
 
     return server->exited_normally() ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -23,6 +23,7 @@
 #include "mir/logging/null_shared_library_prober_report.h"
 
 #include <format>
+#include <iostream>
 
 namespace mo = mir::options;
 
@@ -389,7 +390,6 @@ void mo::DefaultConfiguration::parse_arguments(
 
         if (!tokens.empty()) unparsed_arguments_handler(tokens.size(), tokens.data());
 
-        // See the ExitWithOutput documentation for information about its usage.
         if (options.is_set("help"))
         {
             std::ostringstream help_text;
@@ -402,14 +402,12 @@ void mo::DefaultConfiguration::parse_arguments(
                     help_text << module_desc;
                 }
             }
-            BOOST_THROW_EXCEPTION(mir::ExitWithOutput(help_text.str()));
+            std::cout << help_text.str() << std::endl;
         }
 
         if (options.is_set("version"))
         {
-            std::ostringstream mir_version;
-            mir_version << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << std::endl;
-            BOOST_THROW_EXCEPTION(mir::ExitWithOutput(mir_version.str()));
+            std::cout << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << std::endl;
         }
     }
     catch (po::error const& error)


### PR DESCRIPTION
Since the output of --help and --version are generated using exceptions, 1 is returned from main which looks like an error to the shell.

Instead, print this information to stdout and then exit before running the server.
