### PR TITLE
wayland: avoid modify_window if size didn't change

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -364,6 +364,13 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
 
         if (pending_changes)
         {
+            // TODO: The whole size handling needs to be straightened out
+            if (!pending_explicit_width && !pending_explicit_height)
+            {
+                auto content_size = scene_surface->content_size();
+                clear_pending_if_unchanged(pending_changes->width, content_size.width);
+                clear_pending_if_unchanged(pending_changes->height, content_size.height);
+            }
             clear_pending_if_unchanged(pending_changes->min_width,  committed_min_size.width);
             clear_pending_if_unchanged(pending_changes->min_height, committed_min_size.height);
             clear_pending_if_unchanged(pending_changes->max_width,  committed_max_size.width);


### PR DESCRIPTION
Fixes #4282

## What's new?
Avoid window management handling window changes if size didn't, actually, change.

## How to test
Enable `--window-management-trace` and see that `handle_modify_window` doesn't run on every frame.

## Checklist
- [ ] Tests added and pass
  No testing harness yet.
- [ ] ~~Adequate documentation added~~
- [ ] ~~(optional) Added Screenshots or videos~~