### PR TITLE
doc: add options reference

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -6,6 +6,14 @@ set(MAKEOPTS
 )
 set(SPHINXDIR ${CMAKE_CURRENT_SOURCE_DIR}/sphinx)
 
+set(OPTIONS_REFERENCE ${SPHINXDIR}/configuring/reference/options.md.include)
+add_custom_target(
+  COMMAND
+    ${CMAKE_BINARY_DIR}/bin/miral-shell --help-markdown
+    > ${OPTIONS_REFERENCE}
+  BYPRODUCTS ${OPTIONS_REFERENCE}
+)
+
 option(
   BUILD_DOXYGEN
   "Build Doxygen documentation as part of the default build"
@@ -45,6 +53,7 @@ foreach(target IN LISTS SPHINX_TARGETS)
     COMMAND ${CMAKE_COMMAND} -E env "MIR_BUILD_DIR=${CMAKE_BINARY_DIR}"
             make -C ${SPHINXDIR} ${target} ${MAKEOPTS}
     USES_TERMINAL
+    DEPENDS ${OPTIONS_REFERENCE}
   )
 endforeach()
 

--- a/doc/sphinx/.gitignore
+++ b/doc/sphinx/.gitignore
@@ -17,6 +17,7 @@
 _build
 api
 !api/library_root.rst
+configuring/reference/options.md.include
 
 # Node.js
 package*.json

--- a/doc/sphinx/configuring/index.md
+++ b/doc/sphinx/configuring/index.md
@@ -40,4 +40,5 @@ hidden:
 ---
 how-to/index
 explanation/index
+reference/index
 ```

--- a/doc/sphinx/configuring/reference/index.md
+++ b/doc/sphinx/configuring/reference/index.md
@@ -1,0 +1,17 @@
+(configuring-reference-index)=
+
+# Reference
+
+These pages provide detailed reference on configuring Mir compositors.
+
+## Configuring Mir
+
+- [Mir options](options)
+
+```{toctree}
+---
+hidden:
+glob:
+---
+*
+```

--- a/doc/sphinx/configuring/reference/options.md
+++ b/doc/sphinx/configuring/reference/options.md
@@ -1,0 +1,11 @@
+(options-reference)=
+
+# Mir configuration options
+
+Mir compostiros can usually be configured (in the order of preference) on the command line, in the environment, or in a configuration file.
+
+Different compositors will expose different options, but the below is a common set.
+
+```{include} options.md.include
+
+```


### PR DESCRIPTION
## What's new?
Add an options reference under `configuring/reference`

## How to test
RTD

## Checklist
- [ ] ~Tests added and pass~
- [X] Adequate documentation added
- [ ] ~(optional) Added Screenshots or videos~
