### PR TITLE
Rename `{Read,Write,RW}MappbleBuffer` to `*Mappable`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -81,7 +81,7 @@ Description: Display server for Ubuntu - server library
  .
  Contains the shared library needed by server applications for Mir.
 
-Package: libmirplatform32
+Package: libmirplatform33
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -145,7 +145,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirplatform32 (= ${binary:Version}),
+Depends: libmirplatform33 (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libboost-program-options-dev,
          ${misc:Depends},

--- a/debian/libmirplatform32.install
+++ b/debian/libmirplatform32.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirplatform.so.32

--- a/debian/libmirplatform33.install
+++ b/debian/libmirplatform33.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirplatform.so.33

--- a/include/platform/mir/graphics/graphic_buffer_allocator.h
+++ b/include/platform/mir/graphics/graphic_buffer_allocator.h
@@ -32,7 +32,7 @@ class Executor;
 
 namespace renderer::software
 {
-class RWMappableBuffer;
+class RWMappable;
 }
 
 namespace graphics
@@ -87,7 +87,7 @@ public:
         std::function<void()>&& on_release) = 0;
 
     virtual auto buffer_from_shm(
-        std::shared_ptr<renderer::software::RWMappableBuffer> shm_data,
+        std::shared_ptr<renderer::software::RWMappable> shm_data,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<Buffer> = 0;
 

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -45,7 +45,7 @@ class Option;
 }
 namespace renderer::software
 {
-class WriteMappableBuffer;
+class WriteMappable;
 }
 
 namespace udev
@@ -388,13 +388,13 @@ public:
 
     class MappableFB :
         public Framebuffer,
-        public mir::renderer::software::WriteMappableBuffer
+        public mir::renderer::software::WriteMappable
     {
     public:
         MappableFB() = default;
         virtual ~MappableFB() override = default;
 
-        using renderer::software::WriteMappableBuffer::size;
+        using renderer::software::WriteMappable::size;
     };
 
     virtual auto supported_formats() const

--- a/include/platform/mir/renderer/sw/pixel_source.h
+++ b/include/platform/mir/renderer/sw/pixel_source.h
@@ -72,10 +72,10 @@ public:
 /**
  * A Buffer that can be mapped into CPU-accessible memory and directly written to.
  */
-class WriteMappableBuffer : public virtual BufferDescriptor
+class WriteMappable : public virtual BufferDescriptor
 {
 public:
-    virtual ~WriteMappableBuffer() = default;
+    virtual ~WriteMappable() = default;
 
     /**
      * Map the buffer into CPU-writeable memory.
@@ -94,10 +94,10 @@ public:
 /**
  * A Buffer that can be mapped into CPU-readable memory.
  */
-class ReadMappableBuffer : public virtual BufferDescriptor
+class ReadMappable : public virtual BufferDescriptor
 {
 public:
-    virtual ~ReadMappableBuffer() = default;
+    virtual ~ReadMappable() = default;
 
     /**
      * Map the buffer into CPU-readable memory.
@@ -112,12 +112,12 @@ public:
 /**
  * A buffer that can be mapped into CPU-accessible memory for both reading and writing.
  */
-class RWMappableBuffer :
-    public ReadMappableBuffer,
-    public WriteMappableBuffer
+class RWMappable :
+    public ReadMappable,
+    public WriteMappable
 {
 public:
-    ~RWMappableBuffer() override = default;
+    ~RWMappable() override = default;
 
     /**
      * Map the buffer into CPU-accessible memory for both reading and writing.
@@ -132,27 +132,27 @@ public:
     virtual auto map_rw() -> std::unique_ptr<Mapping<std::byte>> = 0;
 };
 
-class ReadTransferableBuffer : public virtual BufferDescriptor
+class ReadTransferable : public virtual BufferDescriptor
 {
 public:
-    virtual ~ReadTransferableBuffer() = default;
+    virtual ~ReadTransferable() = default;
 
     virtual void transfer_from_buffer(std::byte* destination) const = 0;
 };
 
-class WriteTransferableBuffer : public virtual BufferDescriptor
+class WriteTransferable : public virtual BufferDescriptor
 {
 public:
-    virtual ~WriteTransferableBuffer() = default;
+    virtual ~WriteTransferable() = default;
 
     virtual void transfer_into_buffer(std::byte const* source) = 0;
 };
 
-auto as_read_mappable_buffer(
-    std::shared_ptr<graphics::Buffer> const& buffer) -> std::shared_ptr<ReadMappableBuffer>;
+auto as_read_mappable(
+    std::shared_ptr<graphics::Buffer> const& buffer) -> std::shared_ptr<ReadMappable>;
 
-auto as_write_mappable_buffer(
-    std::shared_ptr<graphics::Buffer> const& buffer) -> std::shared_ptr<WriteMappableBuffer>;
+auto as_write_mappable(
+    std::shared_ptr<graphics::Buffer> const& buffer) -> std::shared_ptr<WriteMappable>;
 
 auto alloc_buffer_with_content(
     graphics::GraphicBufferAllocator& allocator,

--- a/rpm/mir.spec
+++ b/rpm/mir.spec
@@ -25,7 +25,7 @@
 %global mircommon_sover 11
 %global mircore_sover 2
 %global miroil_sover 8
-%global mirplatform_sover 32
+%global mirplatform_sover 33
 %global mirserver_sover 65
 %global mirwayland_sover 5
 %global mirplatformgraphics_sover 23

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # We need MIRPLATFORM_ABI in both libmirplatform and the platform implementations.
-set(MIRPLATFORM_ABI 32)
+set(MIRPLATFORM_ABI 33)
 
 set(MIRAL_VERSION_MAJOR 5)
 set(MIRAL_VERSION_MINOR 5)

--- a/src/include/server/mir/compositor/screen_shooter.h
+++ b/src/include/server/mir/compositor/screen_shooter.h
@@ -32,7 +32,7 @@ namespace renderer
 {
 namespace software
 {
-class WriteMappableBuffer;
+class WriteMappable;
 }
 }
 namespace compositor
@@ -52,7 +52,7 @@ public:
     /// The [callback] may be called on a different thread. It will be given the timestamp
     /// of the capture if it succeeds or nullopt if there was an error.
     virtual void capture(
-        std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
+        std::shared_ptr<renderer::software::WriteMappable> const& buffer,
         geometry::Rectangle const& area,
         glm::mat2 const& transform,
         bool overlay_cursor,

--- a/src/miral/render_scene_into_surface.cpp
+++ b/src/miral/render_scene_into_surface.cpp
@@ -201,7 +201,7 @@ public:
 
         std::lock_guard lock{mutex};
         auto buffer = pool.claim();
-        auto const mapping = mrs::as_write_mappable_buffer(buffer);
+        auto const mapping = mrs::as_write_mappable(buffer);
         screen_shooter->capture(
             mapping,
             capture_rect,

--- a/src/platform/graphics/cpu_buffers.cpp
+++ b/src/platform/graphics/cpu_buffers.cpp
@@ -80,12 +80,12 @@ private:
     std::unique_ptr<std::byte[]> const bounce_buffer;
 };
 
-void read_from_buffer(mrs::ReadTransferableBuffer& buffer, std::byte* scratch_buffer)
+void read_from_buffer(mrs::ReadTransferable& buffer, std::byte* scratch_buffer)
 {
     buffer.transfer_from_buffer(scratch_buffer);
 }
 
-void write_to_buffer(mrs::WriteTransferableBuffer& buffer, std::byte const* scratch_buffer)
+void write_to_buffer(mrs::WriteTransferable& buffer, std::byte const* scratch_buffer)
 {
     buffer.transfer_into_buffer(scratch_buffer);
 }
@@ -97,13 +97,13 @@ void noop(Buffer&, DataType*)
 
 }
 
-auto mrs::as_read_mappable_buffer(
-    std::shared_ptr<mg::Buffer> const& buffer) -> std::shared_ptr<ReadMappableBuffer>
+auto mrs::as_read_mappable(
+    std::shared_ptr<mg::Buffer> const& buffer) -> std::shared_ptr<ReadMappable>
 {
-    class CopyingWrapper : public ReadMappableBuffer
+    class CopyingWrapper : public ReadMappable
     {
     public:
-        explicit CopyingWrapper(std::shared_ptr<ReadTransferableBuffer> underlying_buffer)
+        explicit CopyingWrapper(std::shared_ptr<ReadTransferable> underlying_buffer)
             : buffer{std::move(underlying_buffer)}
         {
         }
@@ -112,7 +112,7 @@ auto mrs::as_read_mappable_buffer(
         {
             return std::make_unique<
                 CopyMap<
-                    ReadTransferableBuffer,
+                    ReadTransferable,
                     std::byte const,
                     &read_from_buffer,
                     &noop>>(buffer);
@@ -123,30 +123,30 @@ auto mrs::as_read_mappable_buffer(
         auto size() const -> geometry::Size override { return buffer->size(); }
 
     private:
-        std::shared_ptr<ReadTransferableBuffer> const buffer;
+        std::shared_ptr<ReadTransferable> const buffer;
 
     };
 
-    if (auto mappable_buffer = dynamic_cast<ReadMappableBuffer*>(buffer->native_buffer_base()))
+    if (auto mappable_buffer = dynamic_cast<ReadMappable*>(buffer->native_buffer_base()))
     {
-        return std::shared_ptr<ReadMappableBuffer>{buffer, mappable_buffer};
+        return std::shared_ptr<ReadMappable>{buffer, mappable_buffer};
     }
-    else if (auto transferable_buffer = dynamic_cast<ReadTransferableBuffer*>(buffer->native_buffer_base()))
+    else if (auto transferable_buffer = dynamic_cast<ReadTransferable*>(buffer->native_buffer_base()))
     {
         return std::make_shared<CopyingWrapper>(
-            std::shared_ptr<ReadTransferableBuffer>{buffer, transferable_buffer});
+            std::shared_ptr<ReadTransferable>{buffer, transferable_buffer});
     }
 
     BOOST_THROW_EXCEPTION((std::runtime_error{"Buffer does not support CPU access"}));
 }
 
-auto mrs::as_write_mappable_buffer(
-    std::shared_ptr<mg::Buffer> const& buffer) -> std::shared_ptr<mrs::WriteMappableBuffer>
+auto mrs::as_write_mappable(
+    std::shared_ptr<mg::Buffer> const& buffer) -> std::shared_ptr<mrs::WriteMappable>
 {
-    class CopyingWrapper : public mrs::WriteMappableBuffer
+    class CopyingWrapper : public mrs::WriteMappable
     {
     public:
-        explicit CopyingWrapper(std::shared_ptr<mrs::WriteTransferableBuffer> underlying_buffer)
+        explicit CopyingWrapper(std::shared_ptr<mrs::WriteTransferable> underlying_buffer)
             : buffer{std::move(underlying_buffer)}
         {
         }
@@ -155,7 +155,7 @@ auto mrs::as_write_mappable_buffer(
         {
             return std::make_unique<
                 CopyMap<
-                    mrs::WriteTransferableBuffer,
+                    mrs::WriteTransferable,
                     std::byte,
                     &noop,
                     &write_to_buffer>>(buffer);
@@ -166,17 +166,17 @@ auto mrs::as_write_mappable_buffer(
         auto size() const -> geom::Size override { return buffer->size(); }
 
     private:
-        std::shared_ptr<mrs::WriteTransferableBuffer> const buffer;
+        std::shared_ptr<mrs::WriteTransferable> const buffer;
     };
 
-    if (auto mappable_buffer = dynamic_cast<mrs::WriteMappableBuffer*>(buffer->native_buffer_base()))
+    if (auto mappable_buffer = dynamic_cast<mrs::WriteMappable*>(buffer->native_buffer_base()))
     {
-        return std::shared_ptr<mrs::WriteMappableBuffer>{buffer, mappable_buffer};
+        return std::shared_ptr<mrs::WriteMappable>{buffer, mappable_buffer};
     }
-    else if (auto transferable_buffer = dynamic_cast<mrs::WriteTransferableBuffer*>(buffer->native_buffer_base()))
+    else if (auto transferable_buffer = dynamic_cast<mrs::WriteTransferable*>(buffer->native_buffer_base()))
     {
         return std::make_shared<CopyingWrapper>(
-            std::shared_ptr<mrs::WriteTransferableBuffer>{buffer, transferable_buffer});
+            std::shared_ptr<mrs::WriteTransferable>{buffer, transferable_buffer});
     }
     BOOST_THROW_EXCEPTION((std::runtime_error{"Buffer does not support CPU access"}));
 }
@@ -190,7 +190,7 @@ auto mrs::alloc_buffer_with_content(
 {
     auto const buffer = allocator.alloc_software_buffer(size, src_format);
 
-    auto mapping = as_write_mappable_buffer(buffer)->map_writeable();
+    auto mapping = as_write_mappable(buffer)->map_writeable();
     if (mapping->stride() == src_stride)
     {
         // Happy case: Buffer is packed, like the cursor_image; we can just blit.

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -1,4 +1,4 @@
-MIR_PLATFORM_2.22 {
+MIR_PLATFORM_2.23 {
  global:
   extern "C++" {
     mir::graphics::AtomicFrame::increment*;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -161,8 +161,8 @@ MIR_PLATFORM_2.22 {
     mir::options::x11_display_opt;
     mir::options::x11_scale_opt;
     mir::renderer::software::alloc_buffer_with_content*;
-    mir::renderer::software::as_read_mappable_buffer*;
-    mir::renderer::software::as_write_mappable_buffer*;
+    mir::renderer::software::as_read_mappable*;
+    mir::renderer::software::as_write_mappable*;
     mir::udev::Context::?Context*;
     mir::udev::Context::Context*;
     mir::udev::Context::char_device_from_devnum*;

--- a/src/platforms/common/server/cpu_addressable_fb.cpp
+++ b/src/platforms/common/server/cpu_addressable_fb.cpp
@@ -26,7 +26,7 @@
 
 namespace mg = mir::graphics;
 
-class mg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappableBuffer
+class mg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappable
 {
     template<typename T>
     class Mapping : public mir::renderer::software::Mapping<T>

--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -356,7 +356,7 @@ auto mgc::MemoryBackedShmBuffer::map_rw() -> std::unique_ptr<mrs::Mapping<std::b
 }
 
 mgc::MappableBackedShmBuffer::MappableBackedShmBuffer(
-    std::shared_ptr<mrs::RWMappableBuffer> data)
+    std::shared_ptr<mrs::RWMappable> data)
     : ShmBuffer(data->size(), data->format()),
       data{std::move(data)}
 {
@@ -404,7 +404,7 @@ auto mgc::MappableBackedShmBuffer::size() const -> geometry::Size
 }
 
 mgc::NotifyingMappableBackedShmBuffer::NotifyingMappableBackedShmBuffer(
-    std::shared_ptr<mrs::RWMappableBuffer> data,
+    std::shared_ptr<mrs::RWMappable> data,
     std::function<void()>&& on_consumed,
     std::function<void()>&& on_release)
     :  MappableBackedShmBuffer(std::move(data)),

--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -75,7 +75,7 @@ private:
 
 class MemoryBackedShmBuffer :
     public ShmBuffer,
-    public renderer::software::RWMappableBuffer
+    public renderer::software::RWMappable
 {
 public:
     MemoryBackedShmBuffer(
@@ -110,11 +110,11 @@ private:
 
 class MappableBackedShmBuffer :
     public ShmBuffer,
-    public renderer::software::RWMappableBuffer
+    public renderer::software::RWMappable
 {
 public:
     MappableBackedShmBuffer(
-        std::shared_ptr<RWMappableBuffer> data);
+        std::shared_ptr<RWMappable> data);
 
     auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override;
     auto map_readable() -> std::unique_ptr<renderer::software::Mapping<std::byte const>> override;
@@ -131,14 +131,14 @@ protected:
     void on_texture_accessed(std::shared_ptr<ShmBufferTexture> const&) override;
 
 private:
-    std::shared_ptr<RWMappableBuffer> const data;
+    std::shared_ptr<RWMappable> const data;
 };
 
 class NotifyingMappableBackedShmBuffer : public MappableBackedShmBuffer
 {
 public:
     NotifyingMappableBackedShmBuffer(
-        std::shared_ptr<renderer::software::RWMappableBuffer> data,
+        std::shared_ptr<renderer::software::RWMappable> data,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release);
 

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -545,7 +545,7 @@ mir::graphics::eglstream::BufferAllocator::buffer_from_resource(
 }
 
 auto mge::BufferAllocator::buffer_from_shm(
-    std::shared_ptr<renderer::software::RWMappableBuffer> data,
+    std::shared_ptr<renderer::software::RWMappable> data,
     std::function<void()>&& on_consumed,
     std::function<void()>&& on_release) -> std::shared_ptr<Buffer>
 {

--- a/src/platforms/eglstream-kms/server/buffer_allocator.h
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.h
@@ -68,7 +68,7 @@ public:
         std::function<void()>&& on_release) override;
 
     auto buffer_from_shm(
-        std::shared_ptr<renderer::software::RWMappableBuffer> shm_data,
+        std::shared_ptr<renderer::software::RWMappable> shm_data,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<Buffer> override;
 

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -201,7 +201,7 @@ std::shared_ptr<mg::Buffer> mgg::BufferAllocator::buffer_from_resource(
 }
 
 auto mgg::BufferAllocator::buffer_from_shm(
-    std::shared_ptr<renderer::software::RWMappableBuffer> data,
+    std::shared_ptr<renderer::software::RWMappable> data,
     std::function<void()>&& on_consumed,
     std::function<void()>&& on_release) -> std::shared_ptr<Buffer>
 {

--- a/src/platforms/gbm-kms/server/buffer_allocator.h
+++ b/src/platforms/gbm-kms/server/buffer_allocator.h
@@ -72,7 +72,7 @@ public:
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<Buffer> override;
     auto buffer_from_shm(
-        std::shared_ptr<renderer::software::RWMappableBuffer> data,
+        std::shared_ptr<renderer::software::RWMappable> data,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<Buffer> override;
 

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -293,7 +293,7 @@ std::shared_ptr<mg::Buffer> mge::BufferAllocator::buffer_from_resource(
 }
 
 auto mge::BufferAllocator::buffer_from_shm(
-    std::shared_ptr<renderer::software::RWMappableBuffer> data,
+    std::shared_ptr<renderer::software::RWMappable> data,
     std::function<void()>&& on_consumed,
     std::function<void()>&& on_release) -> std::shared_ptr<Buffer>
 {

--- a/src/platforms/renderer-generic-egl/buffer_allocator.h
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.h
@@ -67,7 +67,7 @@ public:
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<Buffer> override;
     auto buffer_from_shm(
-        std::shared_ptr<renderer::software::RWMappableBuffer> data,
+        std::shared_ptr<renderer::software::RWMappable> data,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<Buffer> override;
 

--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -44,7 +44,7 @@ public:
     class FB : public mg::CPUAddressableDisplayAllocator::MappableFB
     {
     public:
-        FB(std::shared_ptr<mrs::WriteMappableBuffer> buffer)
+        FB(std::shared_ptr<mrs::WriteMappable> buffer)
             : buffer{std::move(buffer)}
         {
         }
@@ -66,7 +66,7 @@ public:
             return buffer->stride();
         }
     private:
-        std::shared_ptr<mrs::WriteMappableBuffer> const buffer;
+        std::shared_ptr<mrs::WriteMappable> const buffer;
     };
 
     auto supported_formats() const -> std::vector<graphics::DRMFormat> override
@@ -96,7 +96,7 @@ public:
         return next_buffer->size();
     }
 
-    void set_next_buffer(std::shared_ptr<mrs::WriteMappableBuffer> buffer)
+    void set_next_buffer(std::shared_ptr<mrs::WriteMappable> buffer)
     {
         if (next_buffer)
         {
@@ -105,7 +105,7 @@ public:
         next_buffer = std::move(buffer);
     }
 private:
-    std::shared_ptr<mrs::WriteMappableBuffer> next_buffer;
+    std::shared_ptr<mrs::WriteMappable> next_buffer;
 };
 
 class OffscreenDisplaySink : public mg::DisplaySink
@@ -174,7 +174,7 @@ mc::BasicScreenShooter::Self::Self(
 }
 
 auto mc::BasicScreenShooter::Self::render(
-    std::shared_ptr<mrs::WriteMappableBuffer> const& buffer,
+    std::shared_ptr<mrs::WriteMappable> const& buffer,
     geom::Rectangle const& area,
     glm::mat2 const& transform,
     bool overlay_cursor) -> time::Timestamp
@@ -213,7 +213,7 @@ auto mc::BasicScreenShooter::Self::render(
     return captured_time;
 }
 
-auto mc::BasicScreenShooter::Self::renderer_for_buffer(std::shared_ptr<mrs::WriteMappableBuffer> buffer)
+auto mc::BasicScreenShooter::Self::renderer_for_buffer(std::shared_ptr<mrs::WriteMappable> buffer)
     -> mr::Renderer&
 {
     auto const buffer_size = buffer->size();
@@ -283,7 +283,7 @@ mc::BasicScreenShooter::BasicScreenShooter(
 }
 
 void mc::BasicScreenShooter::capture(
-    std::shared_ptr<mrs::WriteMappableBuffer> const& buffer,
+    std::shared_ptr<mrs::WriteMappable> const& buffer,
     geom::Rectangle const& area,
     glm::mat2 const& transform,
     bool overlay_cursor,

--- a/src/server/compositor/basic_screen_shooter.h
+++ b/src/server/compositor/basic_screen_shooter.h
@@ -58,7 +58,7 @@ public:
         std::shared_ptr<graphics::Cursor> const& cursor);
 
     void capture(
-        std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
+        std::shared_ptr<renderer::software::WriteMappable> const& buffer,
         geometry::Rectangle const& area,
         glm::mat2 const& transform,
         bool overlay_cursor,
@@ -81,12 +81,12 @@ private:
 std::shared_ptr<graphics::Cursor> const& cursor);
 
         auto render(
-            std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
+            std::shared_ptr<renderer::software::WriteMappable> const& buffer,
             geometry::Rectangle const& area,
             glm::mat2 const& transform,
             bool overlay_cursor) -> time::Timestamp;
 
-        auto renderer_for_buffer(std::shared_ptr<renderer::software::WriteMappableBuffer> buffer)
+        auto renderer_for_buffer(std::shared_ptr<renderer::software::WriteMappable> buffer)
             -> renderer::Renderer&;
 
         std::mutex mutex;

--- a/src/server/compositor/null_screen_shooter.cpp
+++ b/src/server/compositor/null_screen_shooter.cpp
@@ -28,7 +28,7 @@ mc::NullScreenShooter::NullScreenShooter(Executor& executor)
 }
 
 void mc::NullScreenShooter::capture(
-    std::shared_ptr<mrs::WriteMappableBuffer> const&,
+    std::shared_ptr<mrs::WriteMappable> const&,
     geom::Rectangle const&,
     glm::mat2 const&,
     bool,

--- a/src/server/compositor/null_screen_shooter.h
+++ b/src/server/compositor/null_screen_shooter.h
@@ -34,7 +34,7 @@ public:
     NullScreenShooter(Executor& executor);
 
     void capture(
-        std::shared_ptr<renderer::software::WriteMappableBuffer> const& buffer,
+        std::shared_ptr<renderer::software::WriteMappable> const& buffer,
         geometry::Rectangle const& area,
         glm::mat2 const& transform,
         bool overlay_cursor,

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -52,7 +52,7 @@ mf::ShmBuffer::ShmBuffer(
 
 namespace
 {
-class ErrorNotifyingRWMappableBuffer : public mrs::RWMappableBuffer
+class ErrorNotifyingRWMappableBuffer : public mrs::RWMappable
 {
 public:
     ErrorNotifyingRWMappableBuffer(
@@ -200,7 +200,7 @@ auto ErrorNotifyingRWMappableBuffer::map_writeable() -> std::unique_ptr<mrs::Map
 }
 }
 
-auto mf::ShmBuffer::data() -> std::shared_ptr<mrs::RWMappableBuffer>
+auto mf::ShmBuffer::data() -> std::shared_ptr<mrs::RWMappable>
 {
     return std::make_shared<ErrorNotifyingRWMappableBuffer>(
         wayland::make_weak<mf::ShmBuffer>(this),

--- a/src/server/frontend_wayland/shm.h
+++ b/src/server/frontend_wayland/shm.h
@@ -37,7 +37,7 @@ class ReadWritePool;
 
 namespace mir::renderer::software
 {
-class RWMappableBuffer;
+class RWMappable;
 }
 
 namespace mir::frontend
@@ -48,7 +48,7 @@ class ShmPool;
 class ShmBuffer : public wayland::Buffer
 {
 public:
-    auto data() -> std::shared_ptr<renderer::software::RWMappableBuffer>;
+    auto data() -> std::shared_ptr<renderer::software::RWMappable>;
 
     static auto from(wl_resource* resource) -> ShmBuffer*;
 private:

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -83,7 +83,7 @@ private:
     static auto buffer_to_mapping_if_possible(std::shared_ptr<mg::Buffer> const& buffer)
         -> std::unique_ptr<mrs::Mapping<std::byte const>>
     {
-        auto const mappable_buffer = mrs::as_read_mappable_buffer(buffer);
+        auto const mappable_buffer = mrs::as_read_mappable(buffer);
         if (!mappable_buffer)
         {
             BOOST_THROW_EXCEPTION(

--- a/src/server/frontend_wayland/wlr_screencopy_v1.cpp
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.cpp
@@ -176,7 +176,7 @@ private:
     /// @{
     bool copy_has_been_called{false};
     bool should_send_damage{false};
-    std::shared_ptr<renderer::software::WriteMappableBuffer> target;
+    std::shared_ptr<renderer::software::WriteMappable> target;
     /// @}
 };
 }
@@ -497,7 +497,7 @@ void mf::WlrScreencopyFrameV1::prepare_target(wl_resource* buffer)
             stride.as_int()));
     }
 
-    target = std::shared_ptr<mir::renderer::software::WriteMappableBuffer>{
+    target = std::shared_ptr<mir::renderer::software::WriteMappable>{
         shm_data.get(),
         [shm_data, weak_buffer = mw::make_weak(shm_buffer), executor = ctx->wayland_executor](auto*)
         {

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -632,7 +632,7 @@ struct CursorImageFromBuffer : public mg::CursorImage
     CursorImageFromBuffer(
         std::shared_ptr<mg::Buffer> buffer,
         geom::Displacement const& hotspot)
-        : buffer{mrs::as_read_mappable_buffer(std::move(buffer))},
+        : buffer{mrs::as_read_mappable(std::move(buffer))},
           mapping{this->buffer->map_readable()},
           hotspot_(hotspot)
     {
@@ -652,7 +652,7 @@ struct CursorImageFromBuffer : public mg::CursorImage
         return hotspot_;
     }
 
-    std::shared_ptr<mrs::ReadMappableBuffer> const buffer;
+    std::shared_ptr<mrs::ReadMappable> const buffer;
     std::unique_ptr<mrs::Mapping<std::byte const>> const mapping;
     geom::Displacement const hotspot_;
 };

--- a/tests/include/mir/test/doubles/stub_buffer.h
+++ b/tests/include/mir/test/doubles/stub_buffer.h
@@ -35,7 +35,7 @@ namespace doubles
 class StubBuffer :
     public graphics::BufferBasic,
     public graphics::NativeBufferBase,
-    public renderer::software::RWMappableBuffer
+    public renderer::software::RWMappable
 {
 public:
     StubBuffer()

--- a/tests/include/mir/test/doubles/stub_buffer_allocator.h
+++ b/tests/include/mir/test/doubles/stub_buffer_allocator.h
@@ -42,7 +42,7 @@ public:
         -> std::shared_ptr<graphics::Buffer> override;
 
     auto buffer_from_shm(
-        std::shared_ptr<renderer::software::RWMappableBuffer> data,
+        std::shared_ptr<renderer::software::RWMappable> data,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<graphics::Buffer>;
 };

--- a/tests/mir_test_doubles/stub_buffer_allocator.cpp
+++ b/tests/mir_test_doubles/stub_buffer_allocator.cpp
@@ -57,7 +57,7 @@ auto mtd::StubBufferAllocator::buffer_from_resource(wl_resource*, std::function<
 }
 
 auto mtd::StubBufferAllocator::buffer_from_shm(
-    std::shared_ptr<mir::renderer::software::RWMappableBuffer> data,
+    std::shared_ptr<mir::renderer::software::RWMappable> data,
     std::function<void()>&& on_consumed,
     std::function<void()>&& on_release) -> std::shared_ptr<mg::Buffer>
 {

--- a/tests/unit-tests/graphics/test_software_cursor.cpp
+++ b/tests/unit-tests/graphics/test_software_cursor.cpp
@@ -327,7 +327,7 @@ TEST_F(SoftwareCursor, handles_argb_8888_cursor_surface)
     unsigned char const a = 0xaa;
     test_image->fill_with(r, g, b, a);
 
-    std::shared_ptr<mrs::ReadMappableBuffer> cursor_buffer;
+    std::shared_ptr<mrs::ReadMappable> cursor_buffer;
     EXPECT_CALL(mock_buffer_allocator, alloc_software_buffer(_,mir_pixel_format_argb_8888))
         .Times(1)
         .WillOnce(
@@ -335,7 +335,7 @@ TEST_F(SoftwareCursor, handles_argb_8888_cursor_surface)
                 [this, &cursor_buffer](auto sz, auto pf)
                 {
                    auto buffer = mock_buffer_allocator.mtd::StubBufferAllocator::alloc_software_buffer(sz, pf);
-                   cursor_buffer = mrs::as_read_mappable_buffer(buffer);
+                   cursor_buffer = mrs::as_read_mappable(buffer);
                    return buffer;
                 }));
 
@@ -380,7 +380,7 @@ TEST_F(SoftwareCursor, handles_argb_8888_buffer_with_stride)
     unsigned char const a = 0xdf;
     test_image->fill_with(r, g, b, a);
 
-    std::shared_ptr<mrs::ReadMappableBuffer> cursor_buffer;
+    std::shared_ptr<mrs::ReadMappable> cursor_buffer;
     EXPECT_CALL(mock_buffer_allocator, alloc_software_buffer(_,mir_pixel_format_argb_8888))
         .Times(1)
         .WillOnce(
@@ -399,7 +399,7 @@ TEST_F(SoftwareCursor, handles_argb_8888_buffer_with_stride)
                             mg::BufferUsage::hardware
                         },
                         stride);
-                    cursor_buffer = mrs::as_read_mappable_buffer(buffer);
+                    cursor_buffer = mrs::as_read_mappable(buffer);
                     return buffer;
                 }));
 

--- a/tests/unit-tests/input/test_touchspot_controller.cpp
+++ b/tests/unit-tests/input/test_touchspot_controller.cpp
@@ -140,7 +140,7 @@ TEST_F(TestTouchspotController, handles_stride_mismatch_in_buffer)
     ASSERT_THAT(scene->overlays, Not(IsEmpty()));
 
     auto touchspot_buffer = scene->overlays[0]->buffer();
-    auto const mapping = mir::renderer::software::as_read_mappable_buffer(touchspot_buffer)->map_readable();
+    auto const mapping = mir::renderer::software::as_read_mappable(touchspot_buffer)->map_readable();
 
     // Verify that each row of the touchspot buffer starts with the corresponding row of the touchspot image
     // We don't care what else is in the buffer; the content of the padding in the stride doesn't matter.

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_configuration.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_configuration.cpp
@@ -128,7 +128,7 @@ public:
         // Caution: non-local state!
         // This works because standard-drm-devices contains a udev device with 226:0 and devnode /dev/dri/card0
         auto device = ctx.char_device_from_devnum(makedev(226, 0));
-       
+
         return std::make_shared<mgg::Platform>(
             *device,
             mir::report::null_display_report(),


### PR DESCRIPTION
Closes #4292 

The naming of `*MappableBuffer` implies that the class inherits from `mg::Buffer`, which is not the case. This caused me a bit of confusion when working on #4272. I think dropping the `Buffer` suffix should be enough to make it clear that *it does not inherit from `mg::Buffer`*

## What's new?
- Rename `{Read,Write,RW}MappbleBuffer` to `*Mappable`
- Rename `{Read,Write}TransferrableBuffer` to `*Transferrable`
- Rename `as_{read,write}_mappable_buffer` to `as_{read,write}_mappable`
- Bump mirplatform ABI to 33
- Bump mirplatform symbols to 2.23