### PR TITLE
mrs::{Read,Write,RW}MappableBuffer: Standardise on std::byte for raw-memory type

### DIFF
--- a/include/platform/mir/renderer/sw/pixel_source.h
+++ b/include/platform/mir/renderer/sw/pixel_source.h
@@ -88,7 +88,7 @@ public:
      *          after unmap.
      * \return  A CPU-mapped view of the buffer.
      */
-    virtual std::unique_ptr<Mapping<unsigned char>> map_writeable() = 0;
+    virtual auto map_writeable() -> std::unique_ptr<Mapping<std::byte>> = 0;
 };
 
 /**
@@ -106,7 +106,7 @@ public:
      *          of the mapping are not guaranteed to be visible.
      * \return  A CPU-mapped view of the buffer.
      */
-    virtual std::unique_ptr<Mapping<unsigned char const>> map_readable() = 0;
+    virtual auto map_readable() -> std::unique_ptr<Mapping<std::byte const>> = 0;
 };
 
 /**
@@ -129,7 +129,7 @@ public:
      *          guaranteed to be visible to the GPU until the mapping is destroyed.
      * \return A CPU-mapped view of the buffer.
      */
-    virtual std::unique_ptr<Mapping<unsigned char>> map_rw() = 0;
+    virtual auto map_rw() -> std::unique_ptr<Mapping<std::byte>> = 0;
 };
 
 class ReadTransferableBuffer : public virtual BufferDescriptor
@@ -137,7 +137,7 @@ class ReadTransferableBuffer : public virtual BufferDescriptor
 public:
     virtual ~ReadTransferableBuffer() = default;
 
-    virtual void transfer_from_buffer(unsigned char* destination) const = 0;
+    virtual void transfer_from_buffer(std::byte* destination) const = 0;
 };
 
 class WriteTransferableBuffer : public virtual BufferDescriptor
@@ -145,7 +145,7 @@ class WriteTransferableBuffer : public virtual BufferDescriptor
 public:
     virtual ~WriteTransferableBuffer() = default;
 
-    virtual void transfer_into_buffer(unsigned char const* source) = 0;
+    virtual void transfer_into_buffer(std::byte const* source) = 0;
 };
 
 auto as_read_mappable_buffer(

--- a/src/platform/graphics/cpu_buffers.cpp
+++ b/src/platform/graphics/cpu_buffers.cpp
@@ -32,15 +32,15 @@ namespace
 template<
     typename BufferType,
     typename DataType,
-    void(*Initialise)(BufferType&, unsigned char*),
-    void(*Finalise)(BufferType&, unsigned char const*)>
+    void(*Initialise)(BufferType&, std::byte*),
+    void(*Finalise)(BufferType&, std::byte const*)>
 class CopyMap : public mrs::Mapping<DataType>
 {
 public:
     CopyMap(std::shared_ptr<BufferType> buffer)
         : buffer{std::move(buffer)},
           bounce_buffer{
-              std::make_unique<unsigned char[]>(
+              std::make_unique<std::byte[]>(
                   this->buffer->stride().as_uint32_t() * this->buffer->size().height.as_uint32_t())}
     {
         Initialise(*this->buffer, bounce_buffer.get());
@@ -77,15 +77,15 @@ public:
     }
 private:
     std::shared_ptr<BufferType> const buffer;
-    std::unique_ptr<unsigned char[]> const bounce_buffer;
+    std::unique_ptr<std::byte[]> const bounce_buffer;
 };
 
-void read_from_buffer(mrs::ReadTransferableBuffer& buffer, unsigned char* scratch_buffer)
+void read_from_buffer(mrs::ReadTransferableBuffer& buffer, std::byte* scratch_buffer)
 {
     buffer.transfer_from_buffer(scratch_buffer);
 }
 
-void write_to_buffer(mrs::WriteTransferableBuffer& buffer, unsigned char const* scratch_buffer)
+void write_to_buffer(mrs::WriteTransferableBuffer& buffer, std::byte const* scratch_buffer)
 {
     buffer.transfer_into_buffer(scratch_buffer);
 }
@@ -108,12 +108,12 @@ auto mrs::as_read_mappable_buffer(
         {
         }
 
-        std::unique_ptr<Mapping<unsigned char const>> map_readable() override
+        std::unique_ptr<Mapping<std::byte const>> map_readable() override
         {
             return std::make_unique<
                 CopyMap<
                     ReadTransferableBuffer,
-                    unsigned char const,
+                    std::byte const,
                     &read_from_buffer,
                     &noop>>(buffer);
         }
@@ -151,12 +151,12 @@ auto mrs::as_write_mappable_buffer(
         {
         }
 
-        std::unique_ptr<mrs::Mapping<unsigned char>> map_writeable() override
+        std::unique_ptr<mrs::Mapping<std::byte>> map_writeable() override
         {
             return std::make_unique<
                 CopyMap<
                     mrs::WriteTransferableBuffer,
-                    unsigned char,
+                    std::byte,
                     &noop,
                     &write_to_buffer>>(buffer);
         }
@@ -210,4 +210,3 @@ auto mrs::alloc_buffer_with_content(
     }
     return buffer;
 }
-

--- a/src/platforms/atomic-kms/server/kms/cursor.cpp
+++ b/src/platforms/atomic-kms/server/kms/cursor.cpp
@@ -189,13 +189,13 @@ void mga::Cursor::pad_and_write_image_data_locked(
     auto const buffer_height = std::max(min_height, gbm_bo_get_height(gbm_buffer));
     size_t const padded_size = buffer_stride * buffer_height;
 
-    auto padded = std::unique_ptr<uint8_t[]>(new uint8_t[padded_size]);
+    auto padded = std::make_unique<std::byte[]>(padded_size);
     size_t rhs_padding = buffer_stride - 4*image_width;
 
     auto const filler = 0; // 0x3f; is useful to make buffer visible for debugging
     auto const mapping = buffer->map_readable();
-    uint8_t const* src = mapping->data();
-    uint8_t* dest = &padded[0];
+    std::byte const* src = mapping->data();
+    std::byte* dest = &padded[0];
 
     switch (orientation)
     {

--- a/src/platforms/common/server/cpu_addressable_fb.cpp
+++ b/src/platforms/common/server/cpu_addressable_fb.cpp
@@ -126,33 +126,33 @@ public:
             new Buffer{std::move(drm_fd), params, format}};
     }
 
-    auto map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>> override
+    auto map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<std::byte>> override
     {
         auto const data = mmap_buffer(PROT_WRITE);
-        return std::make_unique<Mapping<unsigned char>>(
+        return std::make_unique<Mapping<std::byte>>(
             width(), height(),
             pitch(),
             format(),
-            static_cast<unsigned char*>(data),
+            static_cast<std::byte*>(data),
             size_);
     }
-    auto map_readable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char const>> override
+    auto map_readable() -> std::unique_ptr<mir::renderer::software::Mapping<std::byte const>> override
     {
         auto const data = mmap_buffer(PROT_READ);
-        return std::make_unique<Mapping<unsigned char const>>(
+        return std::make_unique<Mapping<std::byte const>>(
             width(), height(), pitch(), format(),
-            static_cast<unsigned char const*>(data),
+            static_cast<std::byte const*>(data),
             size_);
     }
 
-    auto map_rw() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>> override
+    auto map_rw() -> std::unique_ptr<mir::renderer::software::Mapping<std::byte>> override
     {
         auto const data = mmap_buffer(PROT_READ | PROT_WRITE);
-        return std::make_unique<Mapping<unsigned char>>(
+        return std::make_unique<Mapping<std::byte>>(
             width(), height(),
             pitch(),
             format(),
-            static_cast<unsigned char*>(data),
+            static_cast<std::byte*>(data),
             size_);
     }
 
@@ -271,7 +271,7 @@ mg::CPUAddressableFB::CPUAddressableFB(
 {
 }
 
-auto mg::CPUAddressableFB::map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>>
+auto mg::CPUAddressableFB::map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<std::byte>>
 {
     return buffer->map_writeable();
 }
@@ -345,8 +345,8 @@ auto mg::CPUAddressableFB::fb_id_for_buffer(
                 std::system_category(),
                 "Failed to create DRM framebuffer from CPU-accessible buffer"}));
         }
-    
-    
+
+
     }
     return fb_id;
 }

--- a/src/platforms/common/server/cpu_addressable_fb.h
+++ b/src/platforms/common/server/cpu_addressable_fb.h
@@ -34,14 +34,14 @@ public:
         mir::geometry::Size const& size);
     ~CPUAddressableFB() override;
 
-    auto map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>> override;
+    auto map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<std::byte>> override;
 
     auto format() const -> MirPixelFormat override;
     auto stride() const -> geometry::Stride override;
-    auto size() const -> geometry::Size override; 
+    auto size() const -> geometry::Size override;
 
     operator uint32_t() const override;
-    
+
     CPUAddressableFB(CPUAddressableFB const&) = delete;
     CPUAddressableFB& operator=(CPUAddressableFB const&) = delete;
 private:

--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -273,7 +273,7 @@ mgc::MemoryBackedShmBuffer::MemoryBackedShmBuffer(
     MirPixelFormat const& pixel_format)
     : ShmBuffer(size, pixel_format),
       stride_{MIR_BYTES_PER_PIXEL(pixel_format) * size.width.as_uint32_t()},
-      pixels{new unsigned char[stride_.as_int() * size.height.as_int()]}
+      pixels{std::make_unique<std::byte[]>(stride_.as_int() * size.height.as_int())}
 {
 }
 
@@ -340,19 +340,19 @@ private:
     std::conditional_t<std::is_const_v<T>, MemoryBackedShmBuffer const*, MemoryBackedShmBuffer*> buffer;
 };
 
-auto mgc::MemoryBackedShmBuffer::map_writeable() -> std::unique_ptr<mrs::Mapping<unsigned char>>
+auto mgc::MemoryBackedShmBuffer::map_writeable() -> std::unique_ptr<mrs::Mapping<std::byte>>
 {
-    return std::make_unique<Mapping<unsigned char>>(this);
+    return std::make_unique<Mapping<std::byte>>(this);
 }
 
-auto mgc::MemoryBackedShmBuffer::map_readable() -> std::unique_ptr<mrs::Mapping<unsigned char const>>
+auto mgc::MemoryBackedShmBuffer::map_readable() -> std::unique_ptr<mrs::Mapping<std::byte const>>
 {
-    return std::make_unique<Mapping<unsigned char const>>(this);
+    return std::make_unique<Mapping<std::byte const>>(this);
 }
 
-auto mgc::MemoryBackedShmBuffer::map_rw() -> std::unique_ptr<mrs::Mapping<unsigned char>>
+auto mgc::MemoryBackedShmBuffer::map_rw() -> std::unique_ptr<mrs::Mapping<std::byte>>
 {
-    return std::make_unique<Mapping<unsigned char>>(this);
+    return std::make_unique<Mapping<std::byte>>(this);
 }
 
 mgc::MappableBackedShmBuffer::MappableBackedShmBuffer(
@@ -362,17 +362,17 @@ mgc::MappableBackedShmBuffer::MappableBackedShmBuffer(
 {
 }
 
-auto mgc::MappableBackedShmBuffer::map_writeable() -> std::unique_ptr<mrs::Mapping<unsigned char>>
+auto mgc::MappableBackedShmBuffer::map_writeable() -> std::unique_ptr<mrs::Mapping<std::byte>>
 {
     return data->map_writeable();
 }
 
-auto mgc::MappableBackedShmBuffer::map_readable() -> std::unique_ptr<mrs::Mapping<unsigned char const>>
+auto mgc::MappableBackedShmBuffer::map_readable() -> std::unique_ptr<mrs::Mapping<std::byte const>>
 {
     return data->map_readable();
 }
 
-auto mgc::MappableBackedShmBuffer::map_rw() -> std::unique_ptr<mrs::Mapping<unsigned char>>
+auto mgc::MappableBackedShmBuffer::map_rw() -> std::unique_ptr<mrs::Mapping<std::byte>>
 {
     return data->map_rw();
 }
@@ -425,19 +425,19 @@ void mgc::NotifyingMappableBackedShmBuffer::notify_consumed()
     on_consumed = [](){};
 }
 
-auto mgc::NotifyingMappableBackedShmBuffer::map_readable() -> std::unique_ptr<mrs::Mapping<unsigned char const>>
+auto mgc::NotifyingMappableBackedShmBuffer::map_readable() -> std::unique_ptr<mrs::Mapping<std::byte const>>
 {
     notify_consumed();
     return MappableBackedShmBuffer::map_readable();
 }
 
-auto mgc::NotifyingMappableBackedShmBuffer::map_writeable() -> std::unique_ptr<mrs::Mapping<unsigned char>>
+auto mgc::NotifyingMappableBackedShmBuffer::map_writeable() -> std::unique_ptr<mrs::Mapping<std::byte>>
 {
     notify_consumed();
     return MappableBackedShmBuffer::map_writeable();
 }
 
-auto mgc::NotifyingMappableBackedShmBuffer::map_rw() -> std::unique_ptr<mrs::Mapping<unsigned char>>
+auto mgc::NotifyingMappableBackedShmBuffer::map_rw() -> std::unique_ptr<mrs::Mapping<std::byte>>
 {
     notify_consumed();
     return MappableBackedShmBuffer::map_rw();

--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -82,9 +82,9 @@ public:
         geometry::Size const& size,
         MirPixelFormat const& pixel_format);
 
-    auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
-    auto map_readable() -> std::unique_ptr<renderer::software::Mapping<unsigned char const>> override;
-    auto map_rw() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
+    auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override;
+    auto map_readable() -> std::unique_ptr<renderer::software::Mapping<std::byte const>> override;
+    auto map_rw() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override;
 
     auto format() const -> MirPixelFormat override { return ShmBuffer::pixel_format(); }
     auto stride() const -> geometry::Stride override { return stride_; }
@@ -105,7 +105,7 @@ private:
     friend class Mapping;
 
     geometry::Stride const stride_;
-    std::unique_ptr<unsigned char[]> const pixels;
+    std::unique_ptr<std::byte[]> const pixels;
 };
 
 class MappableBackedShmBuffer :
@@ -116,9 +116,9 @@ public:
     MappableBackedShmBuffer(
         std::shared_ptr<RWMappableBuffer> data);
 
-    auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
-    auto map_readable() -> std::unique_ptr<renderer::software::Mapping<unsigned char const>> override;
-    auto map_rw() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
+    auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override;
+    auto map_readable() -> std::unique_ptr<renderer::software::Mapping<std::byte const>> override;
+    auto map_rw() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override;
 
     auto format() const -> MirPixelFormat override;
     auto stride() const -> geometry::Stride override;
@@ -144,9 +144,9 @@ public:
 
     ~NotifyingMappableBackedShmBuffer() override;
 
-    auto map_readable() -> std::unique_ptr<renderer::software::Mapping<unsigned char const>> override;
-    auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
-    auto map_rw() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override;
+    auto map_readable() -> std::unique_ptr<renderer::software::Mapping<std::byte const>> override;
+    auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override;
+    auto map_rw() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override;
 
 protected:
     void on_texture_accessed(std::shared_ptr<ShmBufferTexture> const&) override;

--- a/src/platforms/gbm-kms/server/kms/cursor.cpp
+++ b/src/platforms/gbm-kms/server/kms/cursor.cpp
@@ -190,13 +190,13 @@ void mgg::Cursor::pad_and_write_image_data_locked(
     auto const buffer_height = std::max(min_height, gbm_bo_get_height(gbm_buffer));
     size_t const padded_size = buffer_stride * buffer_height;
 
-    auto padded = std::unique_ptr<uint8_t[]>(new uint8_t[padded_size]);
+    auto padded = std::make_unique<std::byte[]>(padded_size);
     size_t rhs_padding = buffer_stride - 4*image_width;
 
     auto const filler = 0; // 0x3f; is useful to make buffer visible for debugging
     auto const mapping = buffer->map_readable();
-    uint8_t const* src = mapping->data();
-    uint8_t* dest = &padded[0];
+    std::byte const* src = mapping->data();
+    std::byte* dest = &padded[0];
 
     switch (orientation)
     {
@@ -550,4 +550,3 @@ auto mir::graphics::gbm::Cursor::needs_compositing() const -> bool
 {
     return false;
 }
-

--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -49,7 +49,7 @@ public:
         {
         }
 
-        auto map_writeable() -> std::unique_ptr<mrs::Mapping<unsigned char>> override
+        auto map_writeable() -> std::unique_ptr<mrs::Mapping<std::byte>> override
         {
             return buffer->map_writeable();
         }

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -67,9 +67,9 @@ public:
     auto stride() const -> mir::geometry::Stride override;
     auto format() const -> MirPixelFormat override;
 
-    auto map_readable() -> std::unique_ptr<mrs::Mapping<unsigned char const>> override;
-    auto map_writeable() -> std::unique_ptr<mrs::Mapping<unsigned char>> override;
-    auto map_rw() -> std::unique_ptr<mrs::Mapping<unsigned char>> override;
+    auto map_readable() -> std::unique_ptr<mrs::Mapping<std::byte const>> override;
+    auto map_writeable() -> std::unique_ptr<mrs::Mapping<std::byte>> override;
+    auto map_rw() -> std::unique_ptr<mrs::Mapping<std::byte>> override;
 
     void notify_access_error() const;
 private:
@@ -184,19 +184,19 @@ auto ErrorNotifyingRWMappableBuffer::format() const -> MirPixelFormat
     return format_;
 }
 
-auto ErrorNotifyingRWMappableBuffer::map_rw() -> std::unique_ptr<mrs::Mapping<unsigned char>>
+auto ErrorNotifyingRWMappableBuffer::map_rw() -> std::unique_ptr<mrs::Mapping<std::byte>>
 {
-    return std::make_unique<ErrorNotifyingMapping<unsigned char>>(data->map_rw(), *this);
+    return std::make_unique<ErrorNotifyingMapping<std::byte>>(data->map_rw(), *this);
 }
 
-auto ErrorNotifyingRWMappableBuffer::map_readable() -> std::unique_ptr<mrs::Mapping<unsigned char const>>
+auto ErrorNotifyingRWMappableBuffer::map_readable() -> std::unique_ptr<mrs::Mapping<std::byte const>>
 {
-    return std::make_unique<ErrorNotifyingMapping<unsigned char const>>(data->map_ro(), *this);
+    return std::make_unique<ErrorNotifyingMapping<std::byte const>>(data->map_ro(), *this);
 }
 
-auto ErrorNotifyingRWMappableBuffer::map_writeable() -> std::unique_ptr<mrs::Mapping<unsigned char>>
+auto ErrorNotifyingRWMappableBuffer::map_writeable() -> std::unique_ptr<mrs::Mapping<std::byte>>
 {
-    return std::make_unique<ErrorNotifyingMapping<unsigned char>>(data->map_wo(), *this);
+    return std::make_unique<ErrorNotifyingMapping<std::byte>>(data->map_wo(), *this);
 }
 }
 

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -72,16 +72,16 @@ public:
     }
 
 private:
-    BufferCursorImage(std::unique_ptr<mrs::Mapping<unsigned char const>> mapping, geom::Displacement const& hotspot)
+    BufferCursorImage(std::unique_ptr<mrs::Mapping<std::byte const>> mapping, geom::Displacement const& hotspot)
         : size_{mapping->size()},
-          data{std::make_unique<unsigned char[]>(mapping->len())},
+          data{std::make_unique<std::byte[]>(mapping->len())},
           hotspot_{hotspot}
     {
         ::memcpy(data.get(), mapping->data(), mapping->len());
     }
 
     static auto buffer_to_mapping_if_possible(std::shared_ptr<mg::Buffer> const& buffer)
-        -> std::unique_ptr<mrs::Mapping<unsigned char const>>
+        -> std::unique_ptr<mrs::Mapping<std::byte const>>
     {
         auto const mappable_buffer = mrs::as_read_mappable_buffer(buffer);
         if (!mappable_buffer)
@@ -94,7 +94,7 @@ private:
     }
 
     geom::Size const size_;
-    std::unique_ptr<unsigned char[]> const data;
+    std::unique_ptr<std::byte[]> const data;
     geom::Displacement const hotspot_;
 };
 

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -653,7 +653,7 @@ struct CursorImageFromBuffer : public mg::CursorImage
     }
 
     std::shared_ptr<mrs::ReadMappableBuffer> const buffer;
-    std::unique_ptr<mrs::Mapping<unsigned char const>> const mapping;
+    std::unique_ptr<mrs::Mapping<std::byte const>> const mapping;
     geom::Displacement const hotspot_;
 };
 }

--- a/tests/include/mir/test/doubles/stub_buffer.h
+++ b/tests/include/mir/test/doubles/stub_buffer.h
@@ -154,19 +154,19 @@ public:
     template<typename T>
     friend class Mapping;
 
-    auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override
+    auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override
     {
-        return std::make_unique<Mapping<unsigned char>>(this);
+        return std::make_unique<Mapping<std::byte>>(this);
     }
 
-    auto map_readable() -> std::unique_ptr<renderer::software::Mapping<unsigned char const>> override
+    auto map_readable() -> std::unique_ptr<renderer::software::Mapping<std::byte const>> override
     {
-        return std::make_unique<Mapping<unsigned char const>>(this);
+        return std::make_unique<Mapping<std::byte const>>(this);
     }
 
-    auto map_rw() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override
+    auto map_rw() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override
     {
-        return std::make_unique<Mapping<unsigned char>>(this);
+        return std::make_unique<Mapping<std::byte>>(this);
     }
 
     NativeBufferBase* native_buffer_base() override
@@ -178,7 +178,7 @@ public:
     MirPixelFormat const buf_pixel_format;
     geometry::Stride const buf_stride;
     graphics::BufferID const buf_id;
-    std::vector<unsigned char> written_pixels;
+    std::vector<std::byte> written_pixels;
 };
 }
 }

--- a/tests/include/mir/test/doubles/stub_display_sink.h
+++ b/tests/include/mir/test/doubles/stub_display_sink.h
@@ -42,7 +42,7 @@ class DummyCPUAddressableDisplayAllocator : public graphics::CPUAddressableDispl
         {
         }
 
-        auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<unsigned char>> override
+        auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override
         {
             return buffer->map_writeable();
         }

--- a/tests/unit-tests/graphics/test_shm_buffer.cpp
+++ b/tests/unit-tests/graphics/test_shm_buffer.cpp
@@ -82,7 +82,7 @@ struct PlatformlessShmBuffer : mgc::MemoryBackedShmBuffer
     {
     }
 
-    auto pixel_buffer() -> unsigned char const*
+    auto pixel_buffer() -> std::byte const*
     {
         // This uses the fact that MemoryBackedShmBuffer always returns the same backing store when mapping
         auto const read_mapping = map_readable();

--- a/tests/unit-tests/graphics/test_software_cursor.cpp
+++ b/tests/unit-tests/graphics/test_software_cursor.cpp
@@ -45,7 +45,7 @@ struct StubCursorImage : mg::CursorImage
         : hotspot_{hotspot},
           pixels(
             size().width.as_uint32_t() * size().height.as_uint32_t() * bytes_per_pixel,
-            0x55)
+            std::byte{0x55})
     {
     }
 
@@ -85,7 +85,7 @@ struct StubCursorImage : mg::CursorImage
 private:
     static size_t const bytes_per_pixel = 4;
     geom::Displacement const hotspot_;
-    std::vector<unsigned char> pixels;
+    std::vector<std::byte> pixels;
 };
 
 class MockBufferAllocator : public mtd::StubBufferAllocator
@@ -238,7 +238,7 @@ TEST_F(SoftwareCursor, creates_renderable_with_filled_buffer)
         4 * stub_cursor_image->size().width.as_uint32_t() *
         stub_cursor_image->size().height.as_uint32_t();
     auto const image_data =
-        static_cast<unsigned char const*>(stub_cursor_image->as_argb_8888());
+        static_cast<std::byte const*>(stub_cursor_image->as_argb_8888());
 
     cursor.show(stub_cursor_image);
 


### PR DESCRIPTION
This is both shorter than `unsigned char`, and more semantically clear than `unsigned char` (avoiding questions like: why isn't it `char`?)

## Checklist
- ~~[ ] Tests added and pass~~
- ~~[ ] Adequate documentation added~~
- ~~[ ] (optional) Added Screenshots or videos~~
