### PR TITLE
bugfix: make the evdev-rs platform unsupported for the time being

### DIFF
--- a/src/platforms/evdev-rs/platform_factory.cpp
+++ b/src/platforms/evdev-rs/platform_factory.cpp
@@ -58,7 +58,7 @@ mi::PlatformPriority probe_input_platform(
     mir::ConsoleServices& /*console*/)
 {
     mir::assert_entry_point_signature<mi::ProbePlatform>(&probe_input_platform);
-    return mi::PlatformPriority::supported;
+    return mi::PlatformPriority::unsupported;
 }
 
 mir::ModuleProperties const* describe_input_module()


### PR DESCRIPTION
## What's new?
Always return unsupported for the evdev-rs platform while it is in transit.

## Checklist

- [x] Tests added and pass
- [x] Adequate documentation added
- [x] (optional) Added Screenshots or videos
