### PR TITLE
mirwayland should not have public dependencies on mircommon

### DIFF
--- a/src/wayland/generator/wrapper_generator.cpp
+++ b/src/wayland/generator/wrapper_generator.cpp
@@ -61,7 +61,6 @@ Emitter impl_includes(std::string const& protocol_name)
         "#include <boost/exception/diagnostic_information.hpp>",
         "#include <wayland-server-core.h>",
         empty_line,
-        "#include \"mir/log.h\"",
         "#include \"mir/wayland/protocol_error.h\"",
         "#include \"mir/wayland/client.h\"",
     };

--- a/src/wayland/mirwayland.pc.in
+++ b/src/wayland/mirwayland.pc.in
@@ -5,6 +5,6 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mirwayland
 Name: mirwayland
 Description: Mir Wayland library
 Version: @MIR_VERSION@
-Requires: mircommon mircore wayland-server
+Requires: mircore wayland-server
 Libs: -L${libdir} -lmirwayland
 Cflags: -I${includedir}

--- a/tests/acceptance-tests/wayland-generator/expected.cpp
+++ b/tests/acceptance-tests/wayland-generator/expected.cpp
@@ -9,7 +9,6 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <wayland-server-core.h>
 
-#include "mir/log.h"
 #include "mir/wayland/protocol_error.h"
 #include "mir/wayland/client.h"
 


### PR DESCRIPTION
Similar to #4303

In this case `debian/control` _correctly_ doesn't `Depends: libmircommon-dev`, but the .pc says it is needed.

That breaks the miriway Snap build. C.f. https://github.com/Miriway/Miriway/pull/179

