### PR TITLE
Disable boost_system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ enable_testing()
 find_package(PkgConfig)
 
 # Check for boost
-find_package(Boost 1.48.0 COMPONENTS system program_options filesystem iostreams REQUIRED)
+find_package(Boost 1.48.0 COMPONENTS program_options filesystem iostreams REQUIRED)
 
 add_compile_definitions(EGL_NO_X11)
 

--- a/examples/mir_demo_server/CMakeLists.txt
+++ b/examples/mir_demo_server/CMakeLists.txt
@@ -26,5 +26,4 @@ mir_add_wrapped_executable(mir_demo_server
 target_link_libraries(mir_demo_server
   example-shell-lib
   exampleserverconfig
-  Boost::system
 )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -36,11 +36,6 @@ target_include_directories(mircore
 )
 
 
-target_link_libraries(mircore
-  PRIVATE
-    Boost::system
-)
-
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 
 set_target_properties(mircore

--- a/src/platforms/common/server/CMakeLists.txt
+++ b/src/platforms/common/server/CMakeLists.txt
@@ -33,6 +33,5 @@ target_link_libraries(server_platform_common
     mircommon
     mircore
     ${KMS_UTILS_STATIC_LIBRARY}
-    Boost::system
     PkgConfig::WAYLAND_SERVER
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,7 +138,6 @@ PUBLIC
   mir-public-test-doubles
   mir-public-test-framework
 
-  Boost::system
   ${GTEST_BOTH_LIBRARIES}
 PRIVATE
   ${GMOCK_MAIN_LIBRARY}
@@ -152,7 +151,6 @@ PUBLIC
   mir-protected-test-framework
   mir-protected-test-doubles
 
-  Boost::system
   ${GTEST_BOTH_LIBRARIES}
 PRIVATE
   ${GMOCK_MAIN_LIBRARY}

--- a/tests/integration-tests/CMakeLists.txt
+++ b/tests/integration-tests/CMakeLists.txt
@@ -56,7 +56,6 @@ target_link_libraries(
 
   ${MIR_PLATFORM_REFERENCES}
   ${MIR_SERVER_REFERENCES}
-  Boost::system
   # GBM platform dependencies
   PkgConfig::DRM
   # Shared platform dependencies

--- a/tests/mir_test_doubles/CMakeLists.txt
+++ b/tests/mir_test_doubles/CMakeLists.txt
@@ -130,7 +130,6 @@ target_link_libraries(mir-test-doubles-static
   mir-protected-test-doubles
   mir-test-framework-static
 
-  Boost::system
   ${GMOCK_LIBRARIES}
   ${GMOCK_MAIN_LIBRARY}
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -116,7 +116,6 @@ target_link_libraries(mir-test-framework-static
   mir-stub-input-platform
   mir-protected-test-framework
   mir-public-test
-  Boost::system
   ${GTEST_BOTH_LIBRARIES}
   ${GMOCK_LIBRARIES}
   PkgConfig::UMOCKDEV

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -184,7 +184,6 @@ target_link_libraries(
 
   mircommon
 
-  Boost::system
   PkgConfig::LIBINPUT
   PkgConfig::WAYLAND_SERVER
   ${MIR_SERVER_REFERENCES}
@@ -218,7 +217,6 @@ target_link_libraries(
   mir-test-framework-static
   mir-umock-test-framework
 
-  Boost::system
   PkgConfig::UMOCKDEV
   PkgConfig::LIBINPUT
   ${MIR_SERVER_REFERENCES}

--- a/tests/window_management_tests/CMakeLists.txt
+++ b/tests/window_management_tests/CMakeLists.txt
@@ -30,7 +30,6 @@ target_link_libraries(mir_window_management_tests
   mircommon
   miral
 
-  Boost::system
   # GBM platform dependencies
   PkgConfig::DRM
   # Shared platform dependencies


### PR DESCRIPTION
No longer used in Boost > 1.69

## What's new?

Disables Boost::System for Boost > 1.69

See: https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/N5O2U76SQS3VNIFEBCFGLW3IHVFT5Y7K/#Y5F4JM2OPE4KQ5B2EB7VBXKKUXXDS37H

