### PR TITLE
miral: don't make the generated files depend on ${GENERATED_DIR}

### DIFF
--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -61,27 +61,22 @@ function(add_wayland_protocol xml_file out_var)
     set(code   ${GENERATED_DIR}/${name}.c)
 
     add_custom_command(
-      OUTPUT ${GENERATED_DIR}
-      COMMAND ${CMAKE_COMMAND} -E make_directory -p ${GENERATED_DIR}
-    )
-
-    add_custom_command(
       OUTPUT ${header}
-      COMMAND "sh" "-c" "wayland-scanner client-header ${xml_file} ${header}.tmp"
-      COMMAND ${CMAKE_COMMAND} -E copy ${header}.tmp ${header}
-      COMMAND ${CMAKE_COMMAND} -E rm ${header}.tmp
-      COMMAND sed -i s/\\<namespace\\>/namespace_/g ${header}
-      DEPENDS ${GENERATED_DIR} ${xml_file}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${GENERATED_DIR}
+      COMMAND wayland-scanner client-header "${xml_file}" "${header}.tmp"
+      COMMAND sed -i s/\\<namespace\\>/namespace_/g "${header}.tmp"
+      COMMAND ${CMAKE_COMMAND} -E rename ${header}.tmp ${header}
+      DEPENDS ${xml_file}
       VERBATIM
     )
 
     add_custom_command(
       OUTPUT ${code}
-      COMMAND "sh" "-c" "wayland-scanner private-code ${xml_file} ${code}.tmp"
-      COMMAND ${CMAKE_COMMAND} -E copy ${code}.tmp ${code}
-      COMMAND ${CMAKE_COMMAND} -E rm ${code}.tmp
-      COMMAND sed -i s/\\<namespace\\>/namespace_/g ${code}
-      DEPENDS ${GENERATED_DIR} ${xml_file}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${GENERATED_DIR}
+      COMMAND wayland-scanner private-code "${xml_file}" "${code}.tmp"
+      COMMAND sed -i s/\\<namespace\\>/namespace_/g "${code}.tmp"
+      COMMAND ${CMAKE_COMMAND} -E rename ${code}.tmp ${code}
+      DEPENDS ${xml_file}
       VERBATIM
     )
 


### PR DESCRIPTION
## What's new?

The cmake rules used to run `wayland-scanner` to generate source and headers for miral listed `${GENERATED_DIR}` as a dependency. As the output of the command is within this directory, it's timestamp will be updated as a side effect of the command.

So by the end of the build all the generate commands will be out of date w.r.t. their dependencies and will be rebuilt on the next run. This causes anything depending on those generated files to be rebuilt again too.

To fix this, I've removed the directory as a dependency and have each command ensure the directory exists before running `wayland-scanner`. I've also adjusted the commands so the final command moves the generated file to the final location.

## How to test

Configure and build a mir source tree. Run `make` a second time and observe that nothing needs to be rebuilt.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
