### PR TITLE
Fix mir-compositor-smoke-test

### DIFF
--- a/tools/mir-compositor-smoke-test.bash
+++ b/tools/mir-compositor-smoke-test.bash
@@ -8,7 +8,7 @@ timeout=3
 options="--test-timeout=${timeout}"
 
 root="$( dirname "${BASH_SOURCE[0]}" )"
-compositor_list="`find ${root} -name miral* | grep -v -e bin$ -e test -e terminal -e app`"
+compositor_list="`find ${root} -name 'miral*' | grep -v -e bin$ -e test -e terminal -e app`"
 
 unset MIR_SERVER_LOGGING
 


### PR DESCRIPTION
If there's a matching file in the current directory shell expansion breaks the find command

