### PR TITLE
Try using std::atomic for thread synchronization

### DIFF
--- a/tests/miral/test_bounce_keys.cpp
+++ b/tests/miral/test_bounce_keys.cpp
@@ -86,7 +86,7 @@ TEST_P(TestDifferentDelays, subsequent_keys_rejected_if_in_within_delay)
     virtual_keyboard->if_started_then(
         [this, press_delay](mi::InputSink* sink, mi::EventBuilder* builder)
         {
-            auto rejection_counter = 0;
+            std::atomic rejection_counter = 0;
             bounce_keys.on_press_rejected([&rejection_counter](auto) { rejection_counter++; });
 
             // Initial press, should pass


### PR DESCRIPTION
Closes #4339 

## What's new?

Uses `std::atomic` to ensure a consistent view of state across threads

## How to test

[BuildAndTest (lxd:fedora-42:spread/build/fedora:clang)](https://github.com/canonical/mir/actions/runs/18317300354/job/52160975204?pr=4340)
