### PR TITLE
Don't try to run the hosted Wayland platform unless there's a current desktop

### DIFF
--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -54,7 +54,7 @@ then
   run_tests x11
 fi
 
-if [ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]
+if [ -n "${XDG_CURRENT_DESKTOP}" ] && [ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]
 then
   echo Test Wayland platform
   MIR_SERVER_WAYLAND_HOST="${WAYLAND_DISPLAY:-wayland-0}" run_tests wayland


### PR DESCRIPTION
If there's a Wayland session open on VT2 and this is run on VT4 the Wayland platform will hang waiting for the "host" to respond.

## What's new?

We detect we're not running on a host desktop

## How to test

Leave a Wayland session open on VT2 and on VT4 (as the same user) run `mir-smoke-test-runner`