### PR TITLE
Add eglstream-kms to mir-smoke-test-runner script

### DIFF
--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -67,6 +67,12 @@ then
 
   echo Test atomic-kms platform
   run_tests atomic-kms
+
+  if readlink -f /sys/class/drm/*/device/driver | grep -q nvidia$
+  then
+    echo Test eglstream-kms platform
+    run_tests eglstream-kms
+  fi
 fi
 
 date --utc --iso-8601=seconds | xargs echo "[timestamp] End time :"


### PR DESCRIPTION
Closes #4351

## What's new?

- Runs tests for `eglstream-kms` in the smoke test runner.

## How to test

- Run `mir-smoke-test-runner`
- Observe as it tests eglstream-kms 
