### PR TITLE
doc: disable PDF builds

### DIFF
--- a/doc/sphinx/.readthedocs.yaml
+++ b/doc/sphinx/.readthedocs.yaml
@@ -59,10 +59,6 @@ sphinx:
   configuration: doc/sphinx/conf.py
   fail_on_warning: false
 
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
-
 # Optionally declare the Python requirements required to build your docs
 python:
    install:


### PR DESCRIPTION
## What's new?
Disable PDF docs - building them takes ages, and doesn't actually produce working PDFs.

## How to test
See that the doc build takes under 5 minutes.

## Checklist

- [x] Tests added and pass
- [x] Adequate documentation added
- [ ] ~~(optional) Added Screenshots or videos~~
