### PR TITLE
Make basic accessibility manager tests more generic and robust against programmer errors

### DIFF
--- a/tests/unit-tests/shell/test_basic_accessibility_manager.cpp
+++ b/tests/unit-tests/shell/test_basic_accessibility_manager.cpp
@@ -34,7 +34,6 @@
 #include <gtest/gtest.h>
 
 #include <memory>
-#include <unordered_set>
 
 #include "mir/shell/sticky_keys_transformer.h"
 
@@ -330,7 +329,7 @@ using AccessibilityManager = mir::shell::AccessibilityManager;
 using TransformerEnablerAndGetter =
     std::pair<std::function<void(AccessibilityManager&, bool)>, std::function<Transformer&(AccessibilityManager&)>>;
 
-auto const transformer_enablers_and_getters = std::initializer_list<TransformerEnablerAndGetter>{
+TransformerEnablerAndGetter const transformer_enablers_and_getters[] = {
     {&AccessibilityManager::mousekeys_enabled, &AccessibilityManager::mousekeys},
     {&AccessibilityManager::simulated_secondary_click_enabled, &AccessibilityManager::simulated_secondary_click},
     {&AccessibilityManager::hover_click_enabled, &AccessibilityManager::hover_click},


### PR DESCRIPTION
Closes #4083 
## What's new?

- Removed redundant tests where we expect a method to be called, and then call it.
  - Originally, we called a method on the accessibility manager and were testing if it called the appropriate method, but when things were simplified later in implementation, I hastily patched up the tests
- Moves the list of transformers enablers/getters to test into a shared list to make things easy to keep in sync and make it clear when a transformer is missing.

## How to test

- Run `./build/bin/mir_unit_tests --gtest_filter=TestBasicAccessibilityManager*`
