### PR TITLE
Drop `cassert`

### DIFF
--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -53,9 +53,6 @@
 #include <boost/throw_exception.hpp>
 #include <boost/exception/errinfo_errno.hpp>
 
-#include <cassert>
-
-
 namespace mg  = mir::graphics;
 namespace mge = mg::eglstream;
 namespace mgc = mg::common;

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -52,7 +52,6 @@
 #include <memory>
 #include <optional>
 #include <stdexcept>
-#include <cassert>
 #include <fcntl.h>
 #include <xf86drm.h>
 #include <drm_fourcc.h>

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -50,7 +50,6 @@
 #include <optional>
 #include <stdexcept>
 #include <system_error>
-#include <cassert>
 #include <fcntl.h>
 
 #include <wayland-server.h>

--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -28,7 +28,6 @@
 #include <atomic>
 #include <mutex>
 #include <csignal>
-#include <cassert>
 #include <unistd.h>
 #include <boost/throw_exception.hpp>
 #include <errno.h>
@@ -227,8 +226,9 @@ void mir::run_mir(
         terminator_ :
         [&server_ptr](int)
         {
-          assert(server_ptr);
-          server_ptr->stop();
+            if (!server_ptr)
+                fatal_error_abort("Logic error in mir::run_mir() server_ptr is nullptr");
+            server_ptr->stop();
         };
 
     struct sigaction old_action{};

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -32,7 +32,6 @@
 
 #include <stdexcept>
 #include <memory>
-#include <cassert>
 #include <algorithm>
 #include <cstring>
 

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -28,7 +28,6 @@
 #include <boost/throw_exception.hpp>
 
 #include <algorithm>
-#include <cassert>
 #include <functional>
 #include <memory>
 #include <ranges>

--- a/src/server/shell/basic_simulated_secondary_click_transformer.cpp
+++ b/src/server/shell/basic_simulated_secondary_click_transformer.cpp
@@ -20,7 +20,6 @@
 #include "mir/input/event_builder.h"
 #include "mir/main_loop.h"
 
-#include <cassert>
 #include <cmath>
 #include <utility>
 

--- a/tests/mir_test_framework/process.cpp
+++ b/tests/mir_test_framework/process.cpp
@@ -81,7 +81,6 @@ mtf::Process::Process(pid_t pid)
     , terminated(false)
     , detached(false)
 {
-    assert(pid > 0);
 }
 
 mtf::Process::~Process()


### PR DESCRIPTION
The `assert` macro intentionally expands differently according to `NDEBUG` - a feature we don't want and shouldn't be using.

There are some remaining uses of `<assert.h>` in test and example code.

There's still a use of `<cassert>` in process.cpp - which should be replaced with a `pre` condition in the constructor (once we can move to C++26).