### PR TITLE
tics: provide clang deps

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -72,11 +72,13 @@ jobs:
         sudo --preserve-env apt-add-repository --yes ppa:mir-team/dev
         sudo --preserve-env apt-get install --yes --no-install-recommends \
           cargo-1.82 \
+          clang \
           dmz-cursor-theme \
           flake8 \
           glmark2-es2 \
           glmark2-es2-wayland \
           lcov \
+          libclang-rt-dev \
           mesa-utils \
           ninja-build \
           pylint \


### PR DESCRIPTION
## What's new?
Install `clang` in TICS builds to support new metric configuration.

## How to test
CI/tics

## Checklist

- [x] Tests added and pass
- [ ] ~~Adequate documentation added~~
- [ ] ~~(optional) Added Screenshots or videos~~
