### PR TITLE
`const&` a bunch of `shared_ptr` parameters

### DIFF
--- a/src/server/frontend_wayland/input_method_v1.cpp
+++ b/src/server/frontend_wayland/input_method_v1.cpp
@@ -36,8 +36,8 @@ class mf::InputMethodV1::Instance : wayland::InputMethodV1
 {
 public:
     Instance(wl_resource* new_resource,
-         std::shared_ptr<scene::TextInputHub> const text_input_hub,
-         std::shared_ptr<Executor> const wayland_executor)
+         std::shared_ptr<scene::TextInputHub> const& text_input_hub,
+         std::shared_ptr<Executor> const& wayland_executor)
         : InputMethodV1{new_resource, Version<1>()},
           text_input_hub(text_input_hub),
           state_observer{std::make_shared<StateObserver>(this)}
@@ -168,7 +168,7 @@ private:
     public:
         InputMethodContextV1(
             mf::InputMethodV1::Instance* method,
-            std::shared_ptr<scene::TextInputHub> const text_input_hub)
+            std::shared_ptr<scene::TextInputHub> const& text_input_hub)
             : wayland::InputMethodContextV1(*static_cast<wayland::InputMethodV1*>(method)),
               text_input_hub(text_input_hub)
         {
@@ -381,8 +381,8 @@ private:
 
 mf::InputMethodV1::InputMethodV1(
     wl_display *display,
-    std::shared_ptr<Executor> const wayland_executor,
-    std::shared_ptr<scene::TextInputHub> const text_input_hub)
+    std::shared_ptr<Executor> const& wayland_executor,
+    std::shared_ptr<scene::TextInputHub> const& text_input_hub)
     : Global(display, Version<1>()),
       wayland_executor(wayland_executor),
       text_input_hub(text_input_hub)
@@ -400,18 +400,18 @@ class mf::InputPanelV1::Instance : wayland::InputPanelV1
 {
 public:
     Instance(
-        std::shared_ptr<Executor> const wayland_executor,
-        std::shared_ptr<shell::Shell> const shell,
+        std::shared_ptr<Executor> const& wayland_executor,
+        std::shared_ptr<shell::Shell> const& shell,
         WlSeat* seat,
         OutputManager* const output_manager,
         wl_resource* new_resource,
-        std::shared_ptr<scene::TextInputHub> const text_input_hub)
-        : InputPanelV1{new_resource, Version<1>()},
-          wayland_executor{wayland_executor},
-          shell{shell},
-          seat{seat},
-          output_manager{output_manager},
-          text_input_hub{text_input_hub}
+        std::shared_ptr<scene::TextInputHub> const& text_input_hub) :
+        InputPanelV1{new_resource, Version<1>()},
+        wayland_executor{wayland_executor},
+        shell{shell},
+        seat{seat},
+        output_manager{output_manager},
+        text_input_hub{text_input_hub}
     {}
 
 private:
@@ -422,12 +422,12 @@ private:
     public:
         InputPanelSurfaceV1(
             wl_resource* id,
-            std::shared_ptr<Executor> const wayland_executor,
+            std::shared_ptr<Executor> const& wayland_executor,
             WlSeat* seat,
             WlSurface* surface,
-            std::shared_ptr<shell::Shell> shell,
+            std::shared_ptr<shell::Shell> const& shell,
             OutputManager* const output_manager,
-            std::shared_ptr<scene::TextInputHub> text_input_hub)
+            std::shared_ptr<scene::TextInputHub> const& text_input_hub)
             : wayland::InputPanelSurfaceV1(id, Version<1>()),
               WindowWlSurfaceRole(
                   *wayland_executor,
@@ -571,11 +571,11 @@ private:
 
 mf::InputPanelV1::InputPanelV1(
     wl_display* display,
-    std::shared_ptr<Executor> const wayland_executor,
-    std::shared_ptr<shell::Shell> const shell,
+    std::shared_ptr<Executor> const& wayland_executor,
+    std::shared_ptr<shell::Shell> const& shell,
     WlSeat* seat,
     OutputManager* const output_manager,
-    std::shared_ptr<scene::TextInputHub> const text_input_hub)
+    std::shared_ptr<scene::TextInputHub> const& text_input_hub)
     : Global(display, Version<1>()),
       wayland_executor{wayland_executor},
       shell{shell},

--- a/src/server/frontend_wayland/input_method_v1.h
+++ b/src/server/frontend_wayland/input_method_v1.h
@@ -45,8 +45,8 @@ class InputMethodV1 : public wayland::InputMethodV1::Global
 public:
     InputMethodV1(
         wl_display* display,
-        std::shared_ptr<Executor> const wayland_executor,
-        std::shared_ptr<scene::TextInputHub> const text_input_hub);
+        std::shared_ptr<Executor> const& wayland_executor,
+        std::shared_ptr<scene::TextInputHub> const& text_input_hub);
 
 private:
     class Instance;
@@ -62,11 +62,11 @@ class InputPanelV1 : public wayland::InputPanelV1::Global
 public:
     InputPanelV1(
         wl_display *display,
-        std::shared_ptr<Executor> const wayland_executor,
-        std::shared_ptr<shell::Shell> shell,
+        std::shared_ptr<Executor> const& wayland_executor,
+        std::shared_ptr<shell::Shell> const& shell,
         WlSeat* seat,
         OutputManager* output_manager,
-        std::shared_ptr<scene::TextInputHub> const text_input_hub);
+        std::shared_ptr<scene::TextInputHub> const& text_input_hub);
 
 private:
     class Instance;

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -220,7 +220,7 @@ private:
 mf::LayerShellV1::LayerShellV1(
     struct wl_display* display,
     Executor& wayland_executor,
-    std::shared_ptr<msh::Shell> shell,
+    std::shared_ptr<msh::Shell> const& shell,
     WlSeat& seat,
     OutputManager* output_manager)
     : Global(display, Version<4>()),

--- a/src/server/frontend_wayland/layer_shell_v1.h
+++ b/src/server/frontend_wayland/layer_shell_v1.h
@@ -42,7 +42,7 @@ public:
     LayerShellV1(
         wl_display* display,
         Executor& wayland_executor,
-        std::shared_ptr<shell::Shell> shell,
+        std::shared_ptr<shell::Shell> const& shell,
         WlSeat& seat,
         OutputManager* output_manager);
 

--- a/src/server/frontend_wayland/session_lock_v1.cpp
+++ b/src/server/frontend_wayland/session_lock_v1.cpp
@@ -120,11 +120,11 @@ private:
 mf::SessionLockManagerV1::SessionLockManagerV1(
     struct wl_display* display,
     Executor& wayland_executor,
-    std::shared_ptr<msh::Shell> shell,
-    std::shared_ptr<ms::SessionLock> session_lock,
+    std::shared_ptr<msh::Shell> const& shell,
+    std::shared_ptr<ms::SessionLock> const& session_lock,
     WlSeat& seat,
     OutputManager* output_manager,
-    std::shared_ptr<SurfaceStack> surface_stack)
+    std::shared_ptr<SurfaceStack> const& surface_stack)
     : Global(display, Version<1>()),
       wayland_executor{wayland_executor},
       shell{std::move(shell)},

--- a/src/server/frontend_wayland/session_lock_v1.h
+++ b/src/server/frontend_wayland/session_lock_v1.h
@@ -43,11 +43,11 @@ public:
     SessionLockManagerV1(
         wl_display* display,
         Executor& wayland_executor,
-        std::shared_ptr<shell::Shell> shell,
-        std::shared_ptr<scene::SessionLock> session_lock,
+        std::shared_ptr<shell::Shell> const& shell,
+        std::shared_ptr<scene::SessionLock> const& session_lock,
         WlSeat& seat,
         OutputManager* output_manager,
-        std::shared_ptr<SurfaceStack> surface_stack);
+        std::shared_ptr<SurfaceStack> const& surface_stack);
 
     Executor& wayland_executor;
     std::shared_ptr<shell::Shell> const shell;

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -116,7 +116,7 @@ private:
 mf::XdgShellStable::XdgShellStable(
     struct wl_display* display,
     Executor& wayland_executor,
-    std::shared_ptr<msh::Shell> shell,
+    std::shared_ptr<msh::Shell> const& shell,
     WlSeat& seat,
     OutputManager* output_manager)
     : Global(display, Version<5>()),

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -41,7 +41,7 @@ public:
     XdgShellStable(
         wl_display* display,
         Executor& wayland_executor,
-        std::shared_ptr<shell::Shell> shell,
+        std::shared_ptr<shell::Shell> const& shell,
         WlSeat& seat,
         OutputManager* output_manager);
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -192,7 +192,7 @@ void mf::XdgShellV6::Instance::pong(uint32_t serial)
 mf::XdgShellV6::XdgShellV6(
     struct wl_display* display,
     Executor& wayland_executor,
-    std::shared_ptr<msh::Shell> shell,
+    std::shared_ptr<msh::Shell> const& shell,
     WlSeat& seat,
     OutputManager* output_manager) :
     Global(display, Version<1>()),

--- a/src/server/frontend_wayland/xdg_shell_v6.h
+++ b/src/server/frontend_wayland/xdg_shell_v6.h
@@ -41,7 +41,7 @@ public:
     XdgShellV6(
         wl_display* display,
         Executor& wayland_executor,
-        std::shared_ptr<shell::Shell> shell,
+        std::shared_ptr<shell::Shell> const& shell,
         WlSeat& seat,
         OutputManager* output_manager);
 


### PR DESCRIPTION
Related: #4371 

## What's new?

- Converts a bunch of `std::shared_ptr<.*>` parameters to `std::shared_ptr<.*> const&`

## How to test
- Compile the project.