### PR TITLE
Replace usage of tmpnam() for creating a temporary output file by creating an empty directory with mkdtemp()

### DIFF
--- a/tests/miral/external_client.cpp
+++ b/tests/miral/external_client.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <filesystem>
 #include <fstream>
 
 using namespace testing;


### PR DESCRIPTION
The former generates a warning:
warning: the use of `tmpnam' is dangerous, better use `mkstemp'