### PR TITLE
Fix cursor size getting truncated after scaling.

### DIFF
--- a/src/platforms/atomic-kms/server/kms/cursor.cpp
+++ b/src/platforms/atomic-kms/server/kms/cursor.cpp
@@ -263,9 +263,9 @@ void mga::Cursor::show(std::shared_ptr<CursorImage> const& cursor_image)
 
     current_cursor_image = cursor_image;
 
-    size = current_cursor_image->size() * current_scale;
     auto const scaled_cursor_buf = mg::scale_cursor_image(*current_cursor_image, current_scale);
     auto const buf_size_bytes = scaled_cursor_buf.size.width.as_value() * scaled_cursor_buf.size.height.as_value() * 4;
+    size = scaled_cursor_buf.size;
 
     buffer = std::make_shared<mgc::MemoryBackedShmBuffer>(
         size,

--- a/src/platforms/gbm-kms/server/kms/cursor.cpp
+++ b/src/platforms/gbm-kms/server/kms/cursor.cpp
@@ -264,9 +264,9 @@ void mgg::Cursor::show(std::shared_ptr<CursorImage> const& cursor_image)
 
     current_cursor_image = cursor_image;
 
-    size = current_cursor_image->size() * current_scale;
     auto const scaled_cursor_buf = mg::scale_cursor_image(*current_cursor_image, current_scale);
     auto const buf_size_bytes = scaled_cursor_buf.size.width.as_value() * scaled_cursor_buf.size.height.as_value() * 4;
+    size = scaled_cursor_buf.size;
 
     buffer = std::make_shared<mgc::MemoryBackedShmBuffer>(
         size,


### PR DESCRIPTION
Inside `mg::scale_cursor_image`, we round the width and height after scaling as this is a precondition required by pixman. But outside, the width and height would be _truncated_. Thus, the size we'd allocate would sometimes be smaller than the actual buffer we get from pixman, and this would cause buffer overruns when copying the pixman buffer into the buffer used for display.

Example:
At scale 2.51, pixman's buffer size would be scaled and round _up_ so the buffer could accomodate the scaled image, but the size outside would be scaled and _truncated_ (effectively rounded down). When copying the data over, the smaller buffer would get overrun.

Closes #4377 

## What's new?

- Ensures the `MemoryBackedShmBuffer` has the same size as the pixman buffer to avoid buffer overruns when data is copied from the latter to the former.

## How to test

- Run `miral-app` on bare metal
- Hold down `Ctrl` to invoke Locate Pointer
- Observer as Mir does _not_ crash.