### PR TITLE
Ensure ApplicationSwitcher always has CopyAssign symbols defined

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -664,12 +664,14 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++|arch-bits=64)"miral::live_config::IniFile::add_strings_attribute(miral::live_config::Key const&, std::basic_string_view<char, std::char_traits<char> >, std::span<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, 18446744073709551615ul>, std::function<void (miral::live_config::Key const&, std::optional<std::span<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, 18446744073709551615ul> >)>)@MIRAL_5.5" 5.5.0
  MIRAL_5.6@MIRAL_5.6 5.6.0
  (c++)"miral::ApplicationSwitcher::ApplicationSwitcher()@MIRAL_5.6" 5.6.0
+ (c++)"miral::ApplicationSwitcher::ApplicationSwitcher(miral::ApplicationSwitcher const&)@MIRAL_5.6" 5.6.0
  (c++)"miral::ApplicationSwitcher::cancel() const@MIRAL_5.6" 5.6.0
  (c++)"miral::ApplicationSwitcher::confirm() const@MIRAL_5.6" 5.6.0
  (c++)"miral::ApplicationSwitcher::next_app() const@MIRAL_5.6" 5.6.0
  (c++)"miral::ApplicationSwitcher::next_window() const@MIRAL_5.6" 5.6.0
  (c++)"miral::ApplicationSwitcher::operator()(std::weak_ptr<mir::scene::Session> const&) const@MIRAL_5.6" 5.6.0
  (c++)"miral::ApplicationSwitcher::operator()(wl_display*)@MIRAL_5.6" 5.6.0
+ (c++)"miral::ApplicationSwitcher::operator=(miral::ApplicationSwitcher const&)@MIRAL_5.6" 5.6.0
  (c++)"miral::ApplicationSwitcher::prev_app() const@MIRAL_5.6" 5.6.0
  (c++)"miral::ApplicationSwitcher::prev_window() const@MIRAL_5.6" 5.6.0
  (c++)"miral::ApplicationSwitcher::stop() const@MIRAL_5.6" 5.6.0

--- a/include/miral/miral/application_switcher.h
+++ b/include/miral/miral/application_switcher.h
@@ -51,6 +51,9 @@ public:
     ApplicationSwitcher();
     ~ApplicationSwitcher();
 
+    ApplicationSwitcher(ApplicationSwitcher const&);
+    ApplicationSwitcher& operator=(ApplicationSwitcher const&);
+
     void operator()(wl_display* display);
     void operator()(std::weak_ptr<mir::scene::Session> const& session) const;
 

--- a/src/miral/application_switcher.cpp
+++ b/src/miral/application_switcher.cpp
@@ -794,6 +794,10 @@ miral::ApplicationSwitcher::~ApplicationSwitcher()
     self->stop();
 }
 
+miral::ApplicationSwitcher::ApplicationSwitcher(ApplicationSwitcher const&) = default;
+
+miral::ApplicationSwitcher& miral::ApplicationSwitcher::operator=(ApplicationSwitcher const&) = default;
+
 void miral::ApplicationSwitcher::operator()(wl_display* display)
 {
     self->run_client(display);


### PR DESCRIPTION

C.f. https://github.com/canonical/mir/pull/4382#discussion_r2538495879