### PR TITLE
debian: enable Rust builds

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -49,10 +49,7 @@ jobs:
                 "lxd:...:ubuntu_arm64"
                 "lxd:...:ubuntu_armhf"
                 "lxd:...:ubuntu_devel"
-                "lxd:...:ubuntu_plucky"
                 "lxd:...:ubuntu_proposed"
-                "lxd:...:ubuntu_questing"
-                "lxd:alpine-3.20:...:amd64"
                 "lxd:alpine-3.21:...:amd64"
                 "lxd:alpine-edge:...:amd64"'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,8 +245,6 @@ foreach(platform IN LISTS MIR_PLATFORM)
   endif()
 endforeach(platform)
 
-set(MIR_ENABLE_RUST ON CACHE BOOL "Enable Rust support")
-
 pkg_check_modules(GLM glm)
 if(NOT GLM_FOUND)
   find_package(glm REQUIRED)  # There's no glm.pc on Fedora, but find_package(glm) fails on Ubuntu...

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.75.0"
 
 [workspace.dependencies]
-cxx = "1.0"
+cxx = "1.0.167"
 cxx-build = "1.0"
 input = { version = ">=0.8.3, <0.10", features = ["libinput_1_19"] }
 libc = "0.2.175"

--- a/debian/control
+++ b/debian/control
@@ -59,7 +59,16 @@ Build-Depends: cmake,
                wlcs (>= 1.8~),
                libapparmor-dev,
                libpixman-1-dev,
-               xwayland
+               xwayland,
+               cargo:native,
+               rustc:native (>= 1.81.0),
+               libstd-rust-dev,
+               librust-cxx-1+default-dev (>= 1.0.167-~~),
+               librust-cxx-build-1+default-dev,
+               librust-input-0.9+default-dev (>= 0.9.0-~~),
+               librust-libc-0.2+default-dev (>= 0.2.175-~~),
+               librust-nix-0.30+default-dev (>= 0.30-~~),
+               librust-nix-0.30+poll-dev (>= 0.30-~~)
 Standards-Version: 4.6.1
 Homepage: https://mir-server.io/
 Vcs-Browser: https://github.com/canonical/mir/

--- a/debian/mir-platform-input-evdev10.install
+++ b/debian/mir-platform-input-evdev10.install
@@ -1,1 +1,1 @@
-usr/lib/*/mir/server-platform/input-evdev.so.10
+usr/lib/*/mir/server-platform/input-evdev*.so.10

--- a/debian/rules
+++ b/debian/rules
@@ -2,8 +2,16 @@
 
 include /usr/share/dpkg/default.mk
 include debian/opts.mk
+include /usr/share/rustc/architecture.mk
 
 export DPKG_GENSYMBOLS_CHECK_LEVEL = 4
+export DEB_HOST_RUST_TYPE DEB_HOST_GNU_TYPE
+export PATH := /usr/share/cargo/bin:$(PATH)
+export CARGO=/usr/share/cargo/bin/cargo
+export CARGO_HOME=$(CURDIR)/debian/cargo_home
+export CARGO_REGISTRY=$(CURDIR)/debian/cargo_registry
+export DEB_CARGO_CRATE=$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)
+export DEB_BUILD_MAINT_OPTIONS=hardening=+bindnow
 
 # Needed for ccache to work in case the build directory changed
 # (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=810871)
@@ -27,7 +35,6 @@ else
 endif
 
 COMMON_CONFIGURE_OPTIONS = \
-  -DMIR_ENABLE_RUST=OFF\
   -DCMAKE_INSTALL_LIBEXECDIR="lib/$(DEB_HOST_MULTIARCH)/mir"\
   -DMIR_BUILD_INTERPROCESS_TESTS=OFF\
 
@@ -113,3 +120,10 @@ override_dh_shlibdeps:
 override_dh_gencontrol:
 	dh_gencontrol -Nlibmiral7 -Nlibmiral-dev
 	dh_gencontrol -plibmiral7 -plibmiral-dev -- -v$(MIRAL_VERSION) -V'libmiral7:Version=$(MIRAL_VERSION)'
+
+execute_after_dh_auto_clean:
+	rm -rf debian/cargo_registry
+
+execute_before_dh_auto_configure:
+	$(CARGO) prepare-debian debian/cargo_registry --link-from-system
+	rm -f Cargo.lock

--- a/spread.yaml
+++ b/spread.yaml
@@ -9,7 +9,8 @@ backends:
             - alpine-3.20
             - alpine-3.21
             - alpine-edge
-            - ubuntu-24.04
+            - ubuntu-devel:
+                image: ubuntu-daily:devel
             - fedora-43
 
 environment:
@@ -18,8 +19,8 @@ environment:
     ARCH/ubuntu_armhf: armhf
     DISTRO: ubuntu
     DISTRO/debian_sid: debian
-    RELEASE: noble
-    RELEASE/ubuntu: noble
+    RELEASE: resolute
+    RELEASE/ubuntu: resolute
     RELEASE/ubuntu_plucky: plucky
     RELEASE/ubuntu_questing: questing
     RELEASE/ubuntu_devel: resolute

--- a/spread/alpine/task.yaml
+++ b/spread/alpine/task.yaml
@@ -53,7 +53,6 @@ execute: |
         -DCMAKE_C_COMPILER_LAUNCHER=ccache
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
     )
-    [ "${SPREAD_SYSTEM}" == "alpine-3.20" ] && CMAKE_OPTIONS+=( -DMIR_ENABLE_RUST=OFF )
     cmake "${CMAKE_OPTIONS[@]}"
     export VERBOSE=1
     cmake --build $BUILD_DIR -- -j`nproc`

--- a/spread/sbuild/task.yaml
+++ b/spread/sbuild/task.yaml
@@ -25,9 +25,9 @@ execute: |
         fakeroot \
         nullmailer \
         qemu-user-static \
-        sbuild \
-        schroot \
-        ubuntu-dev-tools
+        sbuild-schroot \
+        ubuntu-dev-tools \
+        util-linux-extra
 
     printf "\$mailto = 'null@example.com';\n1;\n" > ~/.sbuildrc
 
@@ -54,6 +54,7 @@ execute: |
     )
 
     SBUILD_OPTS=(
+      --chroot-mode=schroot
       --no-clean-source
       --jobs=$(nproc)
       --verbose

--- a/spread/sbuild/task.yaml
+++ b/spread/sbuild/task.yaml
@@ -54,6 +54,7 @@ execute: |
     )
 
     SBUILD_OPTS=(
+      --no-clean-source
       --jobs=$(nproc)
       --verbose
       --dist=${RELEASE}

--- a/src/platforms/CMakeLists.txt
+++ b/src/platforms/CMakeLists.txt
@@ -55,6 +55,4 @@ endif()
 
 add_subdirectory(virtual)
 add_subdirectory(evdev/)
-if (MIR_ENABLE_RUST)
-  add_subdirectory(evdev-rs/)
-endif()
+add_subdirectory(evdev-rs/)

--- a/src/platforms/evdev-rs/CMakeLists.txt
+++ b/src/platforms/evdev-rs/CMakeLists.txt
@@ -1,6 +1,5 @@
 include(RustLibrary)
 
-add_compile_definitions(MIR_ENABLE_RUST)
 add_definitions(-DMIR_LOG_COMPONENT_FALLBACK="evdev-input-rs")
 
 add_library(mirplatforminputevdevrsobjects OBJECT

--- a/tests/unit-tests/input/CMakeLists.txt
+++ b/tests/unit-tests/input/CMakeLists.txt
@@ -36,14 +36,9 @@ list(APPEND UMOCK_UNIT_TEST_SOURCES
 )
 list(APPEND UMOCK_UNIT_TEST_REFERENCES
     mirplatformserverx11sharedresources
+    mirplatforminputevdevrsobjects
     mirplatforminputx11objects
 )
-endif()
-
-if (MIR_ENABLE_RUST)
-  list(APPEND UMOCK_UNIT_TEST_REFERENCES
-    mirplatforminputevdevrsobjects
-  )
 endif()
 
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/input/test_input_platform_probing.cpp
+++ b/tests/unit-tests/input/test_input_platform_probing.cpp
@@ -188,7 +188,6 @@ TEST_F(InputPlatformProbe, allows_forcing_stub_input_platform)
     EXPECT_THAT(platform, OfPtrType<mtf::StubInputPlatform>());
 }
 
-#ifdef MIR_ENABLE_RUST
 TEST_F(InputPlatformProbe, allows_forcing_of_evdev_rs_platform)
 {
     ON_CALL(mock_options, is_set(StrEq(platform_input_lib))).WillByDefault(Return(true));
@@ -205,4 +204,3 @@ TEST_F(InputPlatformProbe, allows_forcing_of_evdev_rs_platform)
             *stub_prober_report);
     EXPECT_THAT(platform, OfPtrType<miers::Platform>());
 }
-#endif


### PR DESCRIPTION
## What's new?

Package `evdev-rs` into the evdev platform package.

## How to test

CI

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos