### PR TITLE
WaylandExecutor::spawn() - do not try to lock the queue unless the execution state is Running

### DIFF
--- a/src/server/frontend_wayland/wayland_executor.cpp
+++ b/src/server/frontend_wayland/wayland_executor.cpp
@@ -136,6 +136,13 @@ public:
 private:
     static thread_local bool on_wayland_thread;
     std::mutex mutex;
+    /*
+     * `state` is atomic because it is used in a double-checked locking pattern in `enqueue()`.
+     * The first check of `state` (outside the mutex) allows fast-path rejection of work when
+     * the executor is not running, avoiding unnecessary locking. The second check (inside the mutex)
+     * ensures correctness in the presence of concurrent state changes. This pattern requires `state`
+     * to be atomic to prevent data races and ensure thread safety.
+     */
     std::atomic<ExecutionState> state{ExecutionState::Running};
     wl_event_loop* const loop;
     std::deque<std::function<void()>> workqueue;


### PR DESCRIPTION
Closes: #4406

## What's new?

When new work is enqueued first check that the queue is running before locking the queue.

This avoids a deadlock when the queue is being drained

## How to test

Run an XFCE/Miriway session and close it.  There should be no deadlock

