### PR TITLE
tics: deal with cancelled runs

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -16,6 +16,11 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+    inputs:
+      detach:
+        description: "Detach TICS QServer before the run"
+        required: false
+        default: "false"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number && format('pr{0}', github.event.number) || github.ref }}
@@ -30,6 +35,7 @@ jobs:
     runs-on: [self-hosted, reactive, amd64, 2xlarge-tiobe, noble]
 
     env:
+      PROJECT: mir
       CCACHE_DIR: "/tmp/ccache"
       NEEDRESTART_SUSPEND: yes
       DEBIAN_FRONTEND: noninteractive
@@ -120,17 +126,31 @@ jobs:
         # Every merge_group event runs for one pull request, so we can diff against parent
         git diff --name-only ${{ github.sha }}~1 ${{ github.sha }} >> $TICS_CHANGED_LIST
 
+    - if: ${{ github.event.inputs.detach == 'true' }}
+      name: Detach TICS QServer to prevent "project already connected" issue
+      env:
+        TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}
+      run: &tics-detach |
+        source ~/.profile
+        TICSMaintenance -project ${PROJECT} -detach
+
     - name: Run TICS analysis
       uses: tiobe/tics-github-action@v3
       with:
         mode: ${{ contains(fromJSON('["pull_request", "merge_group"]'), github.event_name) && 'client' || 'qserver' }}
-        project: mir
+        project: ${{ env.PROJECT }}
         viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
         ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
         installTics: true
         filelist: ${{ github.event_name == 'merge_group' && env.TICS_CHANGED_LIST || '' }}
         # FIXME: workaround for a TICS bug
         additionalFlags: ${{ contains(fromJSON('["pull_request", "merge_group"]'), github.event_name) && '-resultdir build' || '' }}
+
+    - if: ${{ github.event_name == 'push' && cancelled() }}
+      name: Detach TICS QServer to prevent "project already connected" issue
+      env:
+        TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}
+      run: *tics-detach
 
     - if: ${{ failure() && runner.debug }}
       name: Setup tmate session


### PR DESCRIPTION
## What's new?

TICS will now (try and) deal with interrupted runs - and we'll have an option to do it manually, too.

## How to test

https://github.com/canonical/mir/actions/runs/19730626747 shouldn't hit "Project database 'mir' already is connected…" error.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos