### PR TITLE
Stop the app switcher only when `Self` is destroyed.

### DIFF
--- a/src/miral/application_switcher.cpp
+++ b/src/miral/application_switcher.cpp
@@ -688,6 +688,11 @@ public:
             mir::log_error("Failed to create shutdown notifier");
     }
 
+    ~Self()
+    {
+        stop();
+    }
+
     void run_client(wl_display* display)
     {
         {
@@ -795,7 +800,6 @@ miral::ApplicationSwitcher::ApplicationSwitcher()
 
 miral::ApplicationSwitcher::~ApplicationSwitcher()
 {
-    self->stop();
 }
 
 miral::ApplicationSwitcher::ApplicationSwitcher(ApplicationSwitcher const&) = default;


### PR DESCRIPTION
Fixes a bug introduced in 91844b9560965fc83a64ba1d91bcf631323939a2 where the app switcher was assumed to act like a `shared_ptr`. Instead, on destruction, it would call `self->stop()` which should have been called in `~Self` instead.

Related: #4488 (found this bug when investigating that)

## What's new?

- Makes the app switcher truly copyable by making `self->stop()` get called only when all instances of `self` are destroyed.

## How to test

- Try using the application switcher before and after applying this patch.

## Checklist

- [ ] Tests added and pass
- [ ] ~Adequate documentation added~
- [ ] ~(optional) Added Screenshots or videos~
