### PR TITLE
Remove 'mir-renderer-gl-dev' from mirtest's Requires

### DIFF
--- a/tests/mirtest.pc.in
+++ b/tests/mirtest.pc.in
@@ -5,6 +5,6 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mirtest
 Name: mirtest
 Description: Mir test assist library
 Version: @MIR_VERSION@
-Requires: miral mirserver mirplatform mircommon mir-renderer-gl-dev
+Requires: miral mirserver mirplatform mircommon
 Libs: -L${libdir} -lmir-test-assist -ldl -lboost_filesystem -lboost_system
 Cflags: -I${includedir}


### PR DESCRIPTION
Related: #4475

## What's new?

This module is gone.

## How to test

Build Miracle from this

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
