### PR TITLE
Don't give up if specified cursor theme is not found

### DIFF
--- a/src/miral/cursor_theme.cpp
+++ b/src/miral/cursor_theme.cpp
@@ -71,6 +71,7 @@ void miral::CursorTheme::operator()(mir::Server& server) const
                 if ((i = j) != std::end(themes)) ++i;
             }
 
-            BOOST_THROW_EXCEPTION(std::runtime_error(("Failed to load cursor theme: " + themes).c_str()));
+            mir::log_warning("Failed to load any cursor theme! Using built-in cursors.");
+            return std::shared_ptr<mi::CursorImages>{};
         });
 }


### PR DESCRIPTION
Closes #4391

## What's new?

If none of the cursor themes specified in `cursor-theme` can be loaded, fall back to the internal default.

## How to test

    miral-app --cursor-theme=xx
