### PR TITLE
Use PROJECT_VERSION instead of the old MIR_VERSION variables

### DIFF
--- a/src/common/mircommon-internal.pc.in
+++ b/src/common/mircommon-internal.pc.in
@@ -3,6 +3,6 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mircommon-internal
 
 Name: mircommon-internal
 Description: Mir common internal headers
-Version: @MIR_VERSION@
+Version: @PROJECT_VERSION@
 Requires: mircommon mircore
 Cflags: -I${includedir}

--- a/src/common/mircommon.pc.in
+++ b/src/common/mircommon.pc.in
@@ -4,7 +4,7 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mircommon
 
 Name: mircommon
 Description: Mir server library
-Version: @MIR_VERSION@
+Version: @PROJECT_VERSION@
 Requires: mircore, xkbcommon
 Libs: -L${libdir} -lmircommon
 Cflags: -I${includedir}

--- a/src/core/mircore.pc.in
+++ b/src/core/mircore.pc.in
@@ -4,6 +4,6 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mircore
 
 Name: mircore
 Description: Mir core library
-Version: @MIR_VERSION@
+Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lmircore
 Cflags: -I${includedir}

--- a/src/platform/mirplatform.pc.in
+++ b/src/platform/mirplatform.pc.in
@@ -4,7 +4,7 @@ includedir=@PKGCONFIG_INCLUDEDIR@
 
 Name: mirplatform
 Description: Mir platform library
-Version: @MIR_VERSION@
+Version: @PROJECT_VERSION@
 Requires: mircommon, mircore
 Libs: -L${libdir} -lmirplatform
 Cflags: -I${includedir}/mirplatform

--- a/src/server/mirserver-internal.pc.in
+++ b/src/server/mirserver-internal.pc.in
@@ -3,6 +3,6 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mirserver-internal
 
 Name: mirserver-internal
 Description: Mir server internal headers
-Version: @MIR_VERSION@
+Version: @PROJECT_VERSION@
 Requires: mirserver mircommon mirplatform mircore
 Cflags: -I${includedir}

--- a/src/server/mirserver.pc.in
+++ b/src/server/mirserver.pc.in
@@ -4,7 +4,7 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mirserver
 
 Name: mirserver
 Description: Mir server library
-Version: @MIR_VERSION@
+Version: @PROJECT_VERSION@
 Requires.private: mircommon
 Requires: mirplatform uuid mircore
 Libs: -L${libdir} -lmirserver

--- a/src/server/version.h.in
+++ b/src/server/version.h.in
@@ -31,7 +31,7 @@
  *
  * See also: http://semver.org/
  */
-#define MIR_SERVER_MAJOR_VERSION (@MIR_VERSION_MAJOR@)
+#define MIR_SERVER_MAJOR_VERSION (@PROJECT_VERSION_MAJOR@)
 
 /**
  * MIR_SERVER_MINOR_VERSION
@@ -41,7 +41,7 @@
  *
  * See also: http://semver.org/
  */
-#define MIR_SERVER_MINOR_VERSION (@MIR_VERSION_MINOR@)
+#define MIR_SERVER_MINOR_VERSION (@PROJECT_VERSION_MINOR@)
 
 /**
  * MIR_SERVER_MICRO_VERSION
@@ -52,7 +52,7 @@
  *
  * This corresponds to the PATCH field of http://semver.org/
  */
-#define MIR_SERVER_MICRO_VERSION (@MIR_VERSION_PATCH@)
+#define MIR_SERVER_MICRO_VERSION (@PROJECT_VERSION_PATCH@)
 
 /**
  * MIR_SERVER_VERSION

--- a/src/wayland/mirwayland.pc.in
+++ b/src/wayland/mirwayland.pc.in
@@ -4,7 +4,7 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mirwayland
 
 Name: mirwayland
 Description: Mir Wayland library
-Version: @MIR_VERSION@
+Version: @PROJECT_VERSION@
 Requires: mircore wayland-server
 Libs: -L${libdir} -lmirwayland
 Cflags: -I${includedir}

--- a/tests/mirtest-internal.pc.in
+++ b/tests/mirtest-internal.pc.in
@@ -4,7 +4,7 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mirtest-internal
 
 Name: mirtest-internal
 Description: Mir test assist internal library
-Version: @MIR_VERSION@
+Version: @PROJECT_VERSION@
 Requires: mirtest mirserver mirserver-internal
 Libs: -L${libdir} -lmir-test-assist -lmir-test-assist-internal -ldl -lboost_filesystem -lboost_system
 Cflags: -I${includedir}

--- a/tests/mirtest.pc.in
+++ b/tests/mirtest.pc.in
@@ -4,7 +4,7 @@ includedir=@PKGCONFIG_INCLUDEDIR@/mirtest
 
 Name: mirtest
 Description: Mir test assist library
-Version: @MIR_VERSION@
+Version: @PROJECT_VERSION@
 Requires: miral mirserver mirplatform mircommon
 Libs: -L${libdir} -lmir-test-assist -ldl -lboost_filesystem -lboost_system
 Cflags: -I${includedir}


### PR DESCRIPTION

## What's new?
- Mir's version strings are broken, so I am unable to inspect the version in both CMake and code in Miracle
- Mir expects to replace @VARIABLE_NAME@ in spaces, so we should ensure that that can still happen

Caused by: https://github.com/canonical/mir/commit/e79ad7107880896700274e06405b334ef9bebd51

## Checklist

- [x] Tests added and pass
- [x] Adequate documentation added
- [x] (optional) Added Screenshots or videos
