### PR TITLE
finalize,ppa: use non-native versions, retain release changelog

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -95,7 +95,7 @@ jobs:
             { print }
           ' debian/changelog
 
-          dch --newversion "${{ steps.version.outputs.version }}" \
+          dch --newversion "${{ steps.version.outputs.version }}-0ubuntu24.04" \
               --distribution noble \
               --force-distribution \
               ""

--- a/tools/ppa-upload.sh
+++ b/tools/ppa-upload.sh
@@ -133,6 +133,9 @@ PPA_VERSION=${MIR_VERSION}-0ubuntu${UBUNTU_VERSION}
 echo "Setting version to:"
 echo "  ${PPA_VERSION}"
 
+# unrelease the latest entry to retain release changelog
+awk --include=inplace 'BEGIN { getline; print $1, $2, "UNRELEASED;", $4 }; { print }' debian/changelog
+
 debchange \
   --newversion ${PPA_VERSION} \
   --force-bad-version \


### PR DESCRIPTION
## What's new?

Because we actually `dch --release` now, for PPA uploads we were adding a new entry at the top of the changelog when pushing to the PPA. This brings back the previous behaviour of keeping the release changelog.

While at it, ensure we always use a non-native version in the changelog.

## How to test

We'll need a new release for that.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos