### PR TITLE
Replace atoi with std::from_chars (#4569)

### DIFF
--- a/examples/client/mir_shell_demo.cpp
+++ b/examples/client/mir_shell_demo.cpp
@@ -74,6 +74,10 @@ void parse_options(int argc, char* argv[])
                 {
                     main_width = parsed_value;
                 }
+                else
+                {
+                    printf("Could not parse option %s with arg %s\n", long_options[option_index].name, optarg);
+                }
             }
             else if (option_main_height == long_options[option_index].name)
             {
@@ -82,6 +86,10 @@ void parse_options(int argc, char* argv[])
                 if (ec == std::errc())
                 {
                     main_height = parsed_value;
+                }
+                else
+                {
+                    printf("Could not parse option %s with arg %s\n", long_options[option_index].name, optarg);
                 }
             }
             else

--- a/src/server/frontend_xwayland/xwayland_cursors.cpp
+++ b/src/server/frontend_xwayland/xwayland_cursors.cpp
@@ -132,6 +132,10 @@ auto mf::XWaylandCursors::Loader::get_xcursor_size() -> int
         {
             result = parsed_value;
         }
+        else
+        {
+            log_warning("Could not parse XCURSOR_SIZE='%s'", size_env_var_string);
+        }
     }
     if (result == 0)
     {


### PR DESCRIPTION
- Use std::from_chars instead of atoi to use a more modern conversion
- Add proper validation for integer conversion
- Fixes issue #4569"

Closes #4569

<!-- Mention the issue this closes if applicable -->

Related: https://github.com/canonical/mir/issues/4569

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

## What's new?

<!-- List the major changes of this PR -->

Use std::from_chars instead of atoi to use modern C++ and add proper error handling for it.
In case of errors the default values are used.

## How to test

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
