### PR TITLE
spread: add openSUSE CI

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -49,6 +49,7 @@ jobs:
                 "lxd:...:fedora_43"
                 "lxd:...:fedora_clang"
                 "lxd:...:fedora_rawhide"
+                "lxd:...:opensuse_tumbleweed"
                 "lxd:ubuntu-24.04:spread/build/sbuild:ubuntu_devel"
                 "lxd:ubuntu-24.04:spread/build/sbuild:ubuntu_proposed"
                 "lxd:ubuntu-24.04:spread/build/ubuntu:asan"

--- a/spread.yaml
+++ b/spread.yaml
@@ -24,10 +24,11 @@ environment:
     RELEASE/ubuntu_questing: questing
     RELEASE/ubuntu_devel: resolute
     RELEASE/debian_sid: sid
-    RELEASE/fedora_42: 42
-    RELEASE/fedora_43: 43
-    RELEASE/fedora_rawhide: rawhide
-    RELEASE/fedora_clang: 43
+    RELEASE/fedora_42: fedora-42
+    RELEASE/fedora_43: fedora-43
+    RELEASE/fedora_rawhide: fedora-rawhide
+    RELEASE/fedora_clang: fedora-43
+    RELEASE/opensuse_tumbleweed: opensuse-tumbleweed
     PROPOSED: false
     PROPOSED/ubuntu_proposed: true
     CLANG: 0

--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -1,6 +1,6 @@
 summary: Build Fedora packages
 systems: [fedora-*]
-variants: [fedora_*]
+variants: [fedora_*, opensuse_*]
 kill-timeout: 60m
 
 execute: |
@@ -33,7 +33,7 @@ execute: |
     rpmbuild -bs ~/rpmbuild/SPECS/mir.spec
 
     mock \
-      --root fedora-${RELEASE}-x86_64 \
+      --root ${RELEASE}-x86_64 \
       --resultdir ~/rpmbuild/RPMS \
       --verbose \
       --enable-plugin=ccache \

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -7,6 +7,7 @@ variants:
 - -ubuntu*
 - -debian*
 - -fedora*
+- -opensuse*
 
 summary: Build Ubuntu packages
 


### PR DESCRIPTION
## What's new?

Add openSUSE Tumbleweed builds through Mock on Fedora.
This is currently broken, @sfalken and @Conan-Kudo if you could help get a portable `mir.spec` going, would be great :)

## How to test

CI

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos