### PR TITLE
spread: fix broken references to `spread/build`

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -30,8 +30,8 @@ jobs:
         set -euo pipefail
 
         if ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}; then
-          TASKS='"lxd:ubuntu-24.04:spread/build/ubuntu:tsan"
-                 "lxd:ubuntu-24.04:spread/build/ubuntu:tsan_clang"'
+          TASKS='"lxd:...:spread/ubuntu:tsan"
+                 "lxd:...:spread/ubuntu:tsan_clang"'
         fi
 
         TASKS+='"lxd:...:debian_sid"

--- a/doc/sphinx/contributing/how-to/getting-involved-in-mir.md
+++ b/doc/sphinx/contributing/how-to/getting-involved-in-mir.md
@@ -49,7 +49,7 @@ sudo dnf --assumeyes builddep --allowerasing rpm/mir.spec
 :sync: alpine
 
 As we build Alpine in Mir's CI you can copy the `apk add` command
-from `spread/build/alpine/task.yaml`.
+from `spread/alpine/task.yaml`.
 
 `````
 

--- a/doc/sphinx/contributing/reference/continuous-integration.md
+++ b/doc/sphinx/contributing/reference/continuous-integration.md
@@ -23,7 +23,7 @@ is correct by building the code and running our test suite. To facilitate this, 
 [lightly patched version](https://snapcraft.io/spread-mir-ci)) to build Mir across a number of
 environments. [`spread.yaml`](https://github.com/canonical/mir/blob/main/spread.yaml) holds
 environment definitions, while the actual build tasks are maintained under
-[`spread/build`](https://github.com/canonical/mir/tree/main/spread/build).
+[`spread`](https://github.com/canonical/mir/tree/main/spread).
 
 Our focus of development is the most recent Ubuntu LTS, and we maintain builds for any more recent,
 supported Ubuntu releases. We also build for stable releases of other Linux distributions that

--- a/doc/sphinx/tutorial/write-your-first-wayland-compositor.md
+++ b/doc/sphinx/tutorial/write-your-first-wayland-compositor.md
@@ -31,7 +31,7 @@ For Debian and its derivatives, we only need two small packages:
   different graphics drivers
 * `bomber` - a Qt-based game we'll use to validate the compositor
 
-```{literalinclude} ../../../spread/build/sbuild/task.yaml
+```{literalinclude} ../../../spread/sbuild/task.yaml
 :language: bash
 :start-after: [doc:first-compositor:debian-dependencies-install]
 :end-before: [doc:first-compositor:debian-dependencies-install-end]
@@ -42,7 +42,7 @@ For Debian and its derivatives, we only need two small packages:
 ````{tab-item} Fedora
 :sync: fedora
 
-```{literalinclude} ../../../spread/build/fedora/task.yaml
+```{literalinclude} ../../../spread/fedora/task.yaml
 :language: bash
 :start-after: [doc:first-compositor:fedora-dependencies-install]
 :end-before: [doc:first-compositor:fedora-dependencies-install-end]
@@ -103,7 +103,7 @@ screen capture, pointer confinement, and so on.
 
 Finally, build the cmake project:
 
-```{literalinclude} ../../../spread/build/sbuild/task.yaml
+```{literalinclude} ../../../spread/sbuild/task.yaml
 ---
 language: bash
 start-after: [doc:first-compositor:build]
@@ -121,7 +121,7 @@ Mir](getting-started-with-mir.md).
 For development, it is very useful to run your compositor within an existing
 Wayland session, so let's do that first. To do this, run:
 
-```{literalinclude} ../../../spread/build/sbuild/task.yaml
+```{literalinclude} ../../../spread/sbuild/task.yaml
 ---
 language: bash
 start-after: [doc:first-compositor:run]
@@ -136,7 +136,7 @@ Next, let's open up an application in our compositor, namely the `bomber` arcade
 game.
 From another terminal, run:
 
-```{literalinclude} ../../../spread/build/sbuild/task.yaml
+```{literalinclude} ../../../spread/sbuild/task.yaml
 ---
 language: bash
 start-after: [doc:first-compositor:run-client]


### PR DESCRIPTION
## What's new?

We dropped the `/build` part… and Sphinx doesn't error out on missing include files :facepalm:.

## How to test

CI

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
