### PR TITLE
tools: don't smoke gbm-kms on Nvidia-only HW

### DIFF
--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -68,8 +68,11 @@ else
 
   if [ -z "$XDG_CURRENT_DESKTOP" ]
   then
-    echo Test gbm-kms platform
-    run_tests gbm-kms
+    if readlink -f /sys/class/drm/*/device/driver | grep -vq nvidia$
+    then
+      echo Test gbm-kms platform
+      run_tests gbm-kms
+    fi
 
     echo Test atomic-kms platform
     run_tests atomic-kms


### PR DESCRIPTION
## How to test

Run smoke-test on Nvidia-only HW.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos