### PR TITLE
tools: fix PPA upload to copy binaries

### DIFF
--- a/tools/ppa-upload.sh
+++ b/tools/ppa-upload.sh
@@ -69,7 +69,7 @@ else
   # look for a release tag within parents 2..n
   PARENT=2
   while git rev-parse HEAD^${PARENT} >/dev/null 2>&1; do
-    if [[ "$( git describe --exact-match HEAD^${PARENT} )" =~ ^${VERSION_RE}$ ]]; then
+    if [[ "$( git describe --tags --exact-match HEAD^${PARENT} )" =~ ^${VERSION_RE}$ ]]; then
       # copy packages from ppa:mir-team/rc to ppa:mir-team/release_ppa
       RELEASE_VERSION=${BASH_REMATCH[1]}-0ubuntu${UBUNTU_VERSION}
       echo "Copying mir_${RELEASE_VERSION} from ppa:mir-team/rc to ppa:mir-team/release…"


### PR DESCRIPTION
## What's new?

No annotated tags any more, needs `--tags` all over the place.

## How to test

`RELEASE=noble ./tools/ppa-upload.sh lp_creds`

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
