### PR TITLE
fix: destroy xcb window with xcb_destroy_window

### DIFF
--- a/src/platforms/x11/x11_resources.cpp
+++ b/src/platforms/x11/x11_resources.cpp
@@ -177,7 +177,7 @@ public:
 
     void destroy_window(xcb_window_t window) const override
     {
-        xcb_map_window(conn, window);
+        xcb_destroy_window(conn, window);
     }
 
     void flush() const override


### PR DESCRIPTION
Closes #4560

<!-- Mention the issue this closes if applicable -->

Related: #4560

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

## What's new?

Previously, instead of destroying xcb window, we were mapping it, this PR aiming to fix it.

## How to test

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
