### PR TITLE
Reduce scope of _GNU_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 add_compile_definitions(MIR_VERSION_MAJOR=${PROJECT_VERSION_MAJOR})
 add_compile_definitions(MIR_VERSION_MINOR=${PROJECT_VERSION_MINOR})
 add_compile_definitions(MIR_VERSION_MICRO=${PROJECT_VERSION_PATCH})
-add_compile_definitions(_GNU_SOURCE)
 add_compile_definitions(_FILE_OFFSET_BITS=64)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(mir_demo_wayland_extensions STATIC
         ${MIR_SHELL_C} ${MIR_SHELL_H}
         make_shm_pool.c make_shm_pool.h
 )
+set_source_files_properties(make_shm_pool.c PROPERTIES COMPILE_DEFINITIONS _GNU_SOURCE)
 set_target_properties     (mir_demo_wayland_extensions PROPERTIES COMPILE_FLAGS "${CMAKE_CFLAGS}  -fvisibility=hidden")
 target_include_directories(mir_demo_wayland_extensions PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries     (mir_demo_wayland_extensions PUBLIC PkgConfig::WAYLAND_CLIENT)

--- a/examples/client/wayland_client.c
+++ b/examples/client/wayland_client.c
@@ -14,10 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>

--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -14,7 +14,6 @@
 
 include(CheckCXXSymbolExists)
 
-list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 
 check_cxx_symbol_exists("dlvsym" "dlfcn.h" HAS_DLVSYM)
 check_cxx_symbol_exists("dlsym" "dlfcn.h" HAS_DLSYM)


### PR DESCRIPTION
There are a few bits of code that depend on features enabled by `_GNU_SOURCE`, but there is no reason to enable it unless it is needed.