### PR TITLE
HACK: Use `map_readable` for all cross-GPU DMABUF uploads

### DIFF
--- a/include/platform/mir/graphics/linux_dmabuf.h
+++ b/include/platform/mir/graphics/linux_dmabuf.h
@@ -85,7 +85,7 @@ public:
     void validate_import(DMABufBuffer const& dma_buf);
 
     auto as_texture(
-        std::shared_ptr<NativeBufferBase> buffer)
+        std::shared_ptr<Buffer> buffer)
         -> std::shared_ptr<gl::Texture>;
 
      auto supported_formats() const -> DmaBufFormatDescriptors const&;

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <complex.h>
 #include <mir/graphics/linux_dmabuf.h>
 #include <mir/anonymous_shm_file.h>
 #include <mir/fd.h>
@@ -357,83 +358,83 @@ private:
     geom::Size const size_;
 };
 
-auto export_egl_image(
-    mg::EGLExtensions::MESADmaBufExport const& ext,
-    EGLDisplay dpy,
-    EGLImage image,
-    geom::Size size) -> std::unique_ptr<mg::DMABufBuffer>
-{
-    constexpr int const max_planes = 4;
+// auto export_egl_image(
+//     mg::EGLExtensions::MESADmaBufExport const& ext,
+//     EGLDisplay dpy,
+//     EGLImage image,
+//     geom::Size size) -> std::unique_ptr<mg::DMABufBuffer>
+// {
+//     constexpr int const max_planes = 4;
 
-    int fourcc;
-    int num_planes;
-    std::array<uint64_t, max_planes> modifiers;
-    if (ext.eglExportDMABUFImageQueryMESA(dpy, image, &fourcc, &num_planes, modifiers.data()) != EGL_TRUE)
-    {
-        BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query EGLImage for dma-buf export")));
-    }
+//     int fourcc;
+//     int num_planes;
+//     std::array<uint64_t, max_planes> modifiers;
+//     if (ext.eglExportDMABUFImageQueryMESA(dpy, image, &fourcc, &num_planes, modifiers.data()) != EGL_TRUE)
+//     {
+//         BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query EGLImage for dma-buf export")));
+//     }
 
-    /* There's only a single modifier for a logical buffer. For some reason the EGL interface
-     * decided to return one modifier per plane, but they are always the same.
-     *
-     * We handle DRM_FORMAT_MOD_INVALID as an empty modifier; fix that up here if we get it.
-     */
-    auto modifier =
-        [](uint64_t egl_modifier) -> std::optional<uint64_t>
-        {
-            if (egl_modifier == DRM_FORMAT_MOD_INVALID)
-            {
-                return std::nullopt;
-            }
-            return egl_modifier;
-        }(modifiers[0]);
+//     /* There's only a single modifier for a logical buffer. For some reason the EGL interface
+//      * decided to return one modifier per plane, but they are always the same.
+//      *
+//      * We handle DRM_FORMAT_MOD_INVALID as an empty modifier; fix that up here if we get it.
+//      */
+//     auto modifier =
+//         [](uint64_t egl_modifier) -> std::optional<uint64_t>
+//         {
+//             if (egl_modifier == DRM_FORMAT_MOD_INVALID)
+//             {
+//                 return std::nullopt;
+//             }
+//             return egl_modifier;
+//         }(modifiers[0]);
 
-    std::array<int, max_planes> fds;
-    std::array<EGLint, max_planes> strides;
-    std::array<EGLint, max_planes> offsets;
+//     std::array<int, max_planes> fds;
+//     std::array<EGLint, max_planes> strides;
+//     std::array<EGLint, max_planes> offsets;
 
-    if (ext.eglExportDMABUFImageMESA(dpy, image, fds.data(), strides.data(), offsets.data()) != EGL_TRUE)
-    {
-        BOOST_THROW_EXCEPTION((mg::egl_error("Failed to export EGLImage to dma-buf(s)")));
-    }
+//     if (ext.eglExportDMABUFImageMESA(dpy, image, fds.data(), strides.data(), offsets.data()) != EGL_TRUE)
+//     {
+//         BOOST_THROW_EXCEPTION((mg::egl_error("Failed to export EGLImage to dma-buf(s)")));
+//     }
 
-    std::vector<PlaneInfo> planes;
-    planes.reserve(num_planes);
-    for (int i = 0; i < num_planes; ++i)
-    {
-        mir::Fd fd;
-        // If multiple planes use the same buffer, the fds array will be filled with -1 for subsequent
-        // planes.
-        if (fds[i] == -1)
-        {
-            // Paranoia
-            if (i == 0)
-            {
-                BOOST_THROW_EXCEPTION((std::runtime_error{"Driver has a broken EGL_MESA_image_dma_buf_export extension"}));
-            }
-            fds[i] = fds[i - 1];
-            fd = mir::Fd{mir::IntOwnedFd{fds[i]}};
-        }
-        else
-        {
-            // We own these FDs now.
-            fd = mir::Fd{fds[i]};
-        }
-        planes.push_back(
-            PlaneInfo {
-                .dma_buf = std::move(fd),
-                .stride = static_cast<uint32_t>(strides[i]),
-                .offset = static_cast<uint32_t>(offsets[i])
-            });
-    }
+//     std::vector<PlaneInfo> planes;
+//     planes.reserve(num_planes);
+//     for (int i = 0; i < num_planes; ++i)
+//     {
+//         mir::Fd fd;
+//         // If multiple planes use the same buffer, the fds array will be filled with -1 for subsequent
+//         // planes.
+//         if (fds[i] == -1)
+//         {
+//             // Paranoia
+//             if (i == 0)
+//             {
+//                 BOOST_THROW_EXCEPTION((std::runtime_error{"Driver has a broken EGL_MESA_image_dma_buf_export extension"}));
+//             }
+//             fds[i] = fds[i - 1];
+//             fd = mir::Fd{mir::IntOwnedFd{fds[i]}};
+//         }
+//         else
+//         {
+//             // We own these FDs now.
+//             fd = mir::Fd{fds[i]};
+//         }
+//         planes.push_back(
+//             PlaneInfo {
+//                 .dma_buf = std::move(fd),
+//                 .stride = static_cast<uint32_t>(strides[i]),
+//                 .offset = static_cast<uint32_t>(offsets[i])
+//             });
+//     }
 
-    return std::make_unique<DMABuf>(
-        mg::DRMFormat{static_cast<uint32_t>(fourcc)},
-        modifier,
-        std::move(planes),
-        mg::gl::Texture::Layout::TopRowFirst,
-        size);
-}
+//     return std::make_unique<DMABuf>(
+//         mg::DRMFormat{static_cast<uint32_t>(fourcc)},
+//         modifier,
+//         std::move(planes),
+//         mg::gl::Texture::Layout::TopRowFirst,
+//         size);
+// }
 
 /**
  * Reimport dmabufs into EGL
@@ -1135,12 +1136,14 @@ public:
             format().as_mir_format().has_value())
         {
             // Fastpath; we can just mmap the memory
+            mir::log_debug("LinuxDMABuf::map_readable: %p read using direct mmap", static_cast<void const*>(this));
             return std::unique_ptr<DmaBufMapping>{new DmaBufMapping{*this}};
         }
         else if (auto const info = format().info())
         {
             if (info->components().has_value())
             {
+                mir::log_debug("LinuxDMABuf::map_readable: %p read using GL upload", static_cast<void const*>(this));
                 return std::unique_ptr<GLMapping>(new GLMapping{*this});
             }
         }
@@ -1538,125 +1541,372 @@ void mg::DMABufEGLProvider::validate_import(DMABufBuffer const& dma_buf)
     }
 }
 
-auto mg::DMABufEGLProvider::as_texture(std::shared_ptr<NativeBufferBase> buffer)
+namespace
+{
+GLuint new_texture()
+{
+    GLuint tex;
+    glGenTextures(1, &tex);
+
+    glBindTexture(GL_TEXTURE_2D, tex);
+    // The ShmBuffer *should* be immutable, so we can just set up the properties once
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    return tex;
+}
+
+bool get_gl_pixel_format(MirPixelFormat mir_format,
+                         GLenum& gl_format, GLenum& gl_type)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    GLenum const argb = GL_BGRA_EXT;
+    GLenum const abgr = GL_RGBA;
+#elif __BYTE_ORDER == __BIG_ENDIAN
+    // TODO: Big endian support
+    GLenum const argb = GL_INVALID_ENUM;
+    GLenum const abgr = GL_INVALID_ENUM;
+    //GLenum const rgba = GL_RGBA;
+    //GLenum const bgra = GL_BGRA_EXT;
+#endif
+
+    static const struct
+    {
+        MirPixelFormat mir_format;
+        GLenum gl_format, gl_type;
+    } mapping[mir_pixel_formats] =
+    {
+        {mir_pixel_format_invalid,   GL_INVALID_ENUM, GL_INVALID_ENUM},
+        {mir_pixel_format_abgr_8888, abgr,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_xbgr_8888, abgr,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_argb_8888, argb,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_xrgb_8888, argb,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_bgr_888,   GL_INVALID_ENUM, GL_INVALID_ENUM},
+        {mir_pixel_format_rgb_888,   GL_RGB,          GL_UNSIGNED_BYTE},
+        {mir_pixel_format_rgb_565,   GL_RGB,          GL_UNSIGNED_SHORT_5_6_5},
+        {mir_pixel_format_rgba_5551, GL_RGBA,         GL_UNSIGNED_SHORT_5_5_5_1},
+        {mir_pixel_format_rgba_4444, GL_RGBA,         GL_UNSIGNED_SHORT_4_4_4_4},
+    };
+
+    if (mir_format > mir_pixel_format_invalid &&
+        mir_format < mir_pixel_formats &&
+        mapping[mir_format].mir_format == mir_format) // just a sanity check
+    {
+        gl_format = mapping[mir_format].gl_format;
+        gl_type = mapping[mir_format].gl_type;
+    }
+    else
+    {
+        gl_format = GL_INVALID_ENUM;
+        gl_type = GL_INVALID_ENUM;
+    }
+
+    return gl_format != GL_INVALID_ENUM && gl_type != GL_INVALID_ENUM;
+}
+
+class ShmBufferTexture : public mg::gl::Texture
+{
+public:
+    explicit ShmBufferTexture(std::shared_ptr<mgc::EGLContextExecutor> const& egl_delegate)
+        : egl_delegate(egl_delegate),
+            tex_id_(new_texture())
+    {
+    }
+
+    ~ShmBufferTexture() override
+    {
+        egl_delegate->spawn(
+            [id=tex_id()]
+            {
+                glDeleteTextures(1, &id);
+            });
+    }
+
+    void bind() override
+    {
+        glBindTexture(GL_TEXTURE_2D, tex_id());
+    }
+
+    auto tex_id() const -> GLuint override
+    {
+        return tex_id_;
+    }
+
+    mg::gl::Program const& shader(mg::gl::ProgramFactory& cache) const override
+    {
+        static int argb_shader{0};
+        return cache.compile_fragment_shader(
+            &argb_shader,
+            "",
+            "uniform sampler2D tex;\n"
+            "vec4 sample_to_rgba(in vec2 texcoord)\n"
+            "{\n"
+            "    return texture2D(tex, texcoord);\n"
+            "}\n");
+    }
+
+    Layout layout() const override
+    {
+        return Layout::GL;
+    }
+
+    void add_syncpoint() override
+    {
+    }
+
+    void try_upload_to_texture(
+        mg::BufferID id, void const* pixels, geom::Size const& size,
+        geom::Stride const& stride, MirPixelFormat pixel_format)
+    {
+        std::lock_guard lock{uploaded_mutex};
+        if (uploaded)
+            return;
+
+        bind();
+        GLenum format, type;
+
+        if (get_gl_pixel_format(pixel_format, format, type))
+        {
+            auto const stride_in_px =
+                stride.as_int() / MIR_BYTES_PER_PIXEL(pixel_format);
+            /*
+                * We assume (as does Weston, AFAICT) that stride is
+                * a multiple of whole pixels, but it need not be.
+                *
+                * TODO: Handle non-pixel-multiple strides.
+                * This should be possible by calculating GL_UNPACK_ALIGNMENT
+                * to match the size of the partial-pixel-stride().
+                */
+
+            glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride_in_px);
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+            glTexImage2D(
+                GL_TEXTURE_2D,
+                0,
+                format,
+                size.width.as_int(), size.height.as_int(),
+                0,
+                format,
+                type,
+                pixels);
+
+            // Be nice to other users of the GL context by reverting our changes to shared state
+            glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0);     // 0 is default, meaning “use width”
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 4);          // 4 is default; word alignment.
+            glFinish();
+        }
+        else
+        {
+            mir::log_error(
+                "Buffer %i has non-GL-compatible pixel format %i; rendering will be incomplete",
+                id.as_value(),
+                pixel_format);
+        }
+
+        uploaded = true;
+    }
+
+    void mark_dirty()
+    {
+        std::lock_guard lock{uploaded_mutex};
+        uploaded = false;
+    }
+
+private:
+    std::shared_ptr<mgc::EGLContextExecutor> egl_delegate;
+    GLuint tex_id_;
+    std::mutex uploaded_mutex;
+    bool uploaded = false;
+};
+
+std::byte fill_colour_for(int x, int y)
+{
+
+    if ((x / 20) % 2 == 1)
+    {
+        if ((y / 20) % 2 == 1)
+        {
+            return std::byte{0xff};
+        }
+        else
+        {
+            return std::byte{0};
+        }
+    }
+    else
+    {
+        if ((y / 20) % 2 == 1)
+        {
+            return std::byte{0x0};
+        }
+        else
+        {
+            return std::byte{0xff};
+        }
+    }
+}
+
+auto fill_checkerboard(geom::Size size) -> std::unique_ptr<std::byte[]>
+{
+    auto checkerboard = std::make_unique<std::byte[]>(size.width.as<size_t>() * size.height.as<size_t>() * 4);
+
+    for (int x = 0; x < size.width.as<int>(); ++x)
+    {
+        for (int y = 0; y < size.height.as<int>(); ++y)
+        {
+            auto const fill = fill_colour_for(x, y);
+
+            auto pixel_start = checkerboard.get() + ((y * size.width.as<int>()) + x) * 4;
+            *pixel_start = fill;
+            *(pixel_start + 1) = fill;
+            *(pixel_start + 2) = fill;
+            *(pixel_start + 3) = fill;
+        }
+    }
+    return checkerboard;
+}
+}
+
+auto mg::DMABufEGLProvider::as_texture(std::shared_ptr<Buffer> buffer)
     -> std::shared_ptr<gl::Texture>
 {
-    if (auto dmabuf_tex = std::dynamic_pointer_cast<DmabufTexBuffer>(buffer))
+    auto native_buf = std::shared_ptr<NativeBufferBase>(buffer, buffer->native_buffer_base());
+
+    if (auto dmabuf_tex = std::dynamic_pointer_cast<DmabufTexBuffer>(native_buf))
     {
         if (dmabuf_tex->on_same_egl_display(dpy))
         {
+            mir::log_debug("Buffer %p on same GPU; using direct DMABufTex", static_cast<void*>(buffer.get()));
             auto tex = dmabuf_tex->as_texture();
             return std::shared_ptr<gl::Texture>(std::move(dmabuf_tex), tex);
         }
-        else if (auto descriptor = descriptor_for_format_and_modifiers(
-                    dmabuf_tex->format(),
-                    dmabuf_tex->modifier().value_or(DRM_FORMAT_MOD_INVALID),
-                    *this))
+        else
         {
-            // Cross-GPU import requires explicit modifiers; MOD_INVALID will not work
-            if (dmabuf_tex->modifier().value_or(DRM_FORMAT_MOD_INVALID) != DRM_FORMAT_MOD_INVALID)
-            {
-                /* We're being naughty here and using the fact that `as_texture()` has a side-effect
-                 * of invoking the buffer's `on_consumed()` callback.
-                 */
-                dmabuf_tex->as_texture();
-                return std::make_shared<DMABufTex>(
-                    dpy,
-                    *egl_extensions,
-                    *dmabuf_tex,
-                    *descriptor,
-                    egl_delegate);
-            }
+            mir::log_debug("Buffer %p on different GPU, uploading via CPU mapping", static_cast<void*>(buffer.get()));
+            auto buf = std::make_shared<ShmBufferTexture>(egl_delegate);
+
+            auto checkerboard = fill_checkerboard(buffer->size());
+
+            buf->try_upload_to_texture(
+                BufferID{0xfade},
+                checkerboard.get(),
+                buffer->size(),
+                geom::Stride{buffer->size().width.as<int>() * 4},
+                mir_pixel_format_argb_8888);
+
+            return buf;
         }
-        /* Oh, no. We've got a dma-buf in a format that our rendering GPU can't handle.
-         *
-         * In this case we'll need to get the *importing* GPU to blit to a format
-         * we *can* handle.
-         */
-        auto importing_provider = dmabuf_tex->provider();
+        // else if (auto descriptor = descriptor_for_format_and_modifiers(
+        //             dmabuf_tex->format(),
+        //             dmabuf_tex->modifier().value_or(DRM_FORMAT_MOD_INVALID),
+        //             *this))
+        // {
+        //     // Cross-GPU import requires explicit modifiers; MOD_INVALID will not work
+        //     if (dmabuf_tex->modifier().value_or(DRM_FORMAT_MOD_INVALID) != DRM_FORMAT_MOD_INVALID)
+        //     {
+        //         /* We're being naughty here and using the fact that `as_texture()` has a side-effect
+        //          * of invoking the buffer's `on_consumed()` callback.
+        //          */
+        //         dmabuf_tex->as_texture();
+        //         return std::make_shared<DMABufTex>(
+        //             dpy,
+        //             *egl_extensions,
+        //             *dmabuf_tex,
+        //             *descriptor,
+        //             egl_delegate);
+        //     }
+        // }
+        // /* Oh, no. We've got a dma-buf in a format that our rendering GPU can't handle.
+        //  *
+        //  * In this case we'll need to get the *importing* GPU to blit to a format
+        //  * we *can* handle.
+        //  */
+        // auto importing_provider = dmabuf_tex->provider();
 
-        if (!importing_provider->dmabuf_export_ext)
-        {
-            mir::log_warning("EGL implementation does not handle cross-GPU buffer export");
-            return nullptr;
-        }
+        // if (!importing_provider->dmabuf_export_ext)
+        // {
+        //     mir::log_warning("EGL implementation does not handle cross-GPU buffer export");
+        //     return nullptr;
+        // }
 
-        /* TODO: Be smarter about finding a shared pixel format; everything *should* do
-         * ARGB8888, but if the buffer is in a higher bitdepth this will lose colour information
-         */
-        auto const& supported_formats = *formats;
-        auto const& modifiers =
-            [&supported_formats]() -> std::vector<uint64_t> const&
-            {
-                for (size_t i = 0; i < supported_formats.num_formats(); ++i)
-                {
-                    if (supported_formats[i].format == DRM_FORMAT_ARGB8888)
-                    {
-                        return supported_formats[i].modifiers;
-                    }
-                }
-                BOOST_THROW_EXCEPTION((std::runtime_error{"Platform doesn't support ARGB8888?!"}));
-            }();
+        // /* TODO: Be smarter about finding a shared pixel format; everything *should* do
+        //  * ARGB8888, but if the buffer is in a higher bitdepth this will lose colour information
+        //  */
+        // auto const& supported_formats = *formats;
+        // auto const& modifiers =
+        //     [&supported_formats]() -> std::vector<uint64_t> const&
+        //     {
+        //         for (size_t i = 0; i < supported_formats.num_formats(); ++i)
+        //         {
+        //             if (supported_formats[i].format == DRM_FORMAT_ARGB8888)
+        //             {
+        //                 return supported_formats[i].modifiers;
+        //             }
+        //         }
+        //         BOOST_THROW_EXCEPTION((std::runtime_error{"Platform doesn't support ARGB8888?!"}));
+        //     }();
 
-        auto importable_buf = importing_provider->allocate_importable_image(
-            mg::DRMFormat{DRM_FORMAT_ARGB8888},
-            std::span<uint64_t const>{modifiers.data(), modifiers.size()},
-            dmabuf_tex->size());
+        // auto importable_buf = importing_provider->allocate_importable_image(
+        //     mg::DRMFormat{DRM_FORMAT_ARGB8888},
+        //     std::span<uint64_t const>{modifiers.data(), modifiers.size()},
+        //     dmabuf_tex->size());
 
-        if (!importable_buf)
-        {
-            mir::log_warning("Failed to allocate common-format buffer for cross-GPU buffer import");
-            return nullptr;
-        }
+        // if (!importable_buf)
+        // {
+        //     mir::log_warning("Failed to allocate common-format buffer for cross-GPU buffer import");
+        //     return nullptr;
+        // }
 
-        auto src_image = import_egl_image(
-            dmabuf_tex->size().width.as_int(), dmabuf_tex->size().height.as_int(),
-            dmabuf_tex->format(),
-            dmabuf_tex->modifier(),
-            dmabuf_tex->planes(),
-            importing_provider->dpy,
-            *importing_provider->egl_extensions);
-        auto importable_image = import_egl_image(
-            importable_buf->size().width.as_int(), importable_buf->size().height.as_int(),
-            importable_buf->format(),
-            importable_buf->modifier(),
-            importable_buf->planes(),
-            importing_provider->dpy,
-            *importing_provider->egl_extensions);
-        auto sync = importing_provider->blitter->blit(src_image, importable_image, dmabuf_tex->size());
-        if (sync)
-        {
-            BOOST_THROW_EXCEPTION((std::logic_error{"EGL_ANDROID_native_fence_sync support not implemented yet"}));
-        }
-        auto importable_dmabuf = export_egl_image(*importing_provider->dmabuf_export_ext, importing_provider->dpy, importable_image, dmabuf_tex->size());
+        // auto src_image = import_egl_image(
+        //     dmabuf_tex->size().width.as_int(), dmabuf_tex->size().height.as_int(),
+        //     dmabuf_tex->format(),
+        //     dmabuf_tex->modifier(),
+        //     dmabuf_tex->planes(),
+        //     importing_provider->dpy,
+        //     *importing_provider->egl_extensions);
+        // auto importable_image = import_egl_image(
+        //     importable_buf->size().width.as_int(), importable_buf->size().height.as_int(),
+        //     importable_buf->format(),
+        //     importable_buf->modifier(),
+        //     importable_buf->planes(),
+        //     importing_provider->dpy,
+        //     *importing_provider->egl_extensions);
+        // auto sync = importing_provider->blitter->blit(src_image, importable_image, dmabuf_tex->size());
+        // if (sync)
+        // {
+        //     BOOST_THROW_EXCEPTION((std::logic_error{"EGL_ANDROID_native_fence_sync support not implemented yet"}));
+        // }
+        // auto importable_dmabuf = export_egl_image(*importing_provider->dmabuf_export_ext, importing_provider->dpy, importable_image, dmabuf_tex->size());
 
-        auto base_extension = importing_provider->egl_extensions->base(importing_provider->dpy);
-        base_extension.eglDestroyImageKHR(importing_provider->dpy, src_image);
-        base_extension.eglDestroyImageKHR(importing_provider->dpy, importable_image);
+        // auto base_extension = importing_provider->egl_extensions->base(importing_provider->dpy);
+        // base_extension.eglDestroyImageKHR(importing_provider->dpy, src_image);
+        // base_extension.eglDestroyImageKHR(importing_provider->dpy, importable_image);
 
-        if (auto descriptor = descriptor_for_format_and_modifiers(
-                    importable_dmabuf->format(),
-                    importable_dmabuf->modifier().value_or(DRM_FORMAT_MOD_INVALID),
-                    *this))
-        {
-            /* We're being naughty here and using the fact that `as_texture()` has a side-effect
-             * of invoking the buffer's `on_consumed()` callback.
-             */
-            dmabuf_tex->as_texture();
-            return std::make_shared<DMABufTex>(
-                dpy,
-                *egl_extensions,
-                *importable_dmabuf,
-                *descriptor,
-                egl_delegate);
-        }
+        // if (auto descriptor = descriptor_for_format_and_modifiers(
+        //             importable_dmabuf->format(),
+        //             importable_dmabuf->modifier().value_or(DRM_FORMAT_MOD_INVALID),
+        //             *this))
+        // {
+        //     /* We're being naughty here and using the fact that `as_texture()` has a side-effect
+        //      * of invoking the buffer's `on_consumed()` callback.
+        //      */
+        //     dmabuf_tex->as_texture();
+        //     return std::make_shared<DMABufTex>(
+        //         dpy,
+        //         *egl_extensions,
+        //         *importable_dmabuf,
+        //         *descriptor,
+        //         egl_delegate);
+        // }
 
-        /* To get here we have to have failed to find the format/modifier descriptor for a
-         * buffer that we've explicitly allocated to be importable by us.
-         *
-         * This is a logic bug, so go noisily.
-         */
-        BOOST_THROW_EXCEPTION((std::logic_error{"Failed to find import parameterns for buffer we explicitly allocated for import"}));
+        // /* To get here we have to have failed to find the format/modifier descriptor for a
+        //  * buffer that we've explicitly allocated to be importable by us.
+        //  *
+        //  * This is a logic bug, so go noisily.
+        //  */
+        // BOOST_THROW_EXCEPTION((std::logic_error{"Failed to find import parameterns for buffer we explicitly allocated for import"}));
     }
     return nullptr;
 }

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -218,7 +218,7 @@ auto mgg::BufferAllocator::shared_egl_context() -> EGLContext
 auto mgg::GLRenderingProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std::shared_ptr<gl::Texture>
 {
     std::shared_ptr<NativeBufferBase> native_buffer{buffer, buffer->native_buffer_base()};
-    if (auto dmabuf_texture = dmabuf_provider->as_texture(native_buffer))
+    if (auto dmabuf_texture = dmabuf_provider->as_texture(buffer))
     {
         return dmabuf_texture;
     }

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -287,7 +287,7 @@ auto gbm_bo_with_modifiers_or_linear(
         size.width.as_uint32_t(), size.height.as_uint32_t(),
         format,
         modifiers.data(), modifiers.size(),
-        GBM_BO_USE_RENDERING);
+        0);
     if (!gbm_bo && errno != ENOSYS)
     {
         BOOST_THROW_EXCEPTION((

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -312,7 +312,7 @@ auto mge::GLRenderingProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std
     std::shared_ptr<NativeBufferBase> native_buffer{buffer, buffer->native_buffer_base()};
     if (dmabuf_provider)
     {
-        if (auto tex = dmabuf_provider->as_texture(native_buffer))
+        if (auto tex = dmabuf_provider->as_texture(buffer))
         {
             return tex;
         }


### PR DESCRIPTION
PR'ing to get snaps out.