### PR TITLE
Work around warping on nvidia with Atomic KMS + GBM KMS

### DIFF
--- a/include/platform/mir/graphics/linux_dmabuf.h
+++ b/include/platform/mir/graphics/linux_dmabuf.h
@@ -85,7 +85,7 @@ public:
     void validate_import(DMABufBuffer const& dma_buf);
 
     auto as_texture(
-        std::shared_ptr<NativeBufferBase> buffer)
+        std::shared_ptr<Buffer> buffer)
         -> std::shared_ptr<gl::Texture>;
 
      auto supported_formats() const -> DmaBufFormatDescriptors const&;

--- a/include/platform/mir/graphics/linux_dmabuf.h
+++ b/include/platform/mir/graphics/linux_dmabuf.h
@@ -66,13 +66,16 @@ public:
         dma,
     };
 
+    using TransferStrategySelector =
+        std::function<BufferTransferStrategy(std::string_view source_vendor, std::string_view dest_vendor)>;
+
     DMABufEGLProvider(
         EGLDisplay dpy,
         std::shared_ptr<EGLExtensions> egl_extensions,
         EGLExtensions::EXTImageDmaBufImportModifiers const& dmabuf_ext,
         std::shared_ptr<common::EGLContextExecutor> egl_delegate,
         EGLImageAllocator allocate_importable_image,
-        BufferTransferStrategy buffer_transfer_strategy);
+        TransferStrategySelector strategy_selector);
 
     ~DMABufEGLProvider();
 
@@ -110,7 +113,7 @@ public:
      std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
      EGLImageAllocator allocate_importable_image;
      std::unique_ptr<EGLBufferCopier> const blitter;
-     BufferTransferStrategy const buffer_transfer_strategy;
+     TransferStrategySelector const strategy_selector_;
 };
 
 class LinuxDmaBuf : public mir::wayland::LinuxDmabufV1::Global

--- a/include/platform/mir/graphics/linux_dmabuf.h
+++ b/include/platform/mir/graphics/linux_dmabuf.h
@@ -106,6 +106,7 @@ public:
      auto dma_transfer(std::shared_ptr<DmabufTexBuffer> const& dmabuf_tex) -> std::shared_ptr<gl::Texture>;
 
      EGLDisplay const dpy;
+     std::string const vendor_drm_name;
      std::shared_ptr<EGLExtensions> const egl_extensions;
      std::optional<EGLExtensions::MESADmaBufExport> const dmabuf_export_ext;
      dev_t const devnum_;

--- a/include/platform/mir/graphics/quirk_common.h
+++ b/include/platform/mir/graphics/quirk_common.h
@@ -22,9 +22,7 @@
 
 #include <mir/udev/wrapper.h>
 
-#include <algorithm>
 #include <optional>
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -54,7 +52,21 @@ struct ValuedOption
     std::unordered_map<std::string, std::string> devnodes;
 };
 
-auto validate_structure(std::vector<std::string> const& tokens, std::set<std::string> const& available_options)
+struct OptionStructure
+{
+    static auto freeform(size_t expected_tokens) -> OptionStructure
+    {
+        return {
+            .expected_token_count = expected_tokens,
+            .check_specifiers = false,
+        };
+    }
+
+    size_t const expected_token_count{3}; // option name, specifier, specifier value
+    bool const  check_specifiers{true};
+};
+
+auto validate_structure(std::vector<std::string> const& tokens, std::unordered_map<std::string, OptionStructure> const& available_options)
     -> std::optional<std::tuple<std::string, std::string, std::string>>;
 
 auto matches(std::vector<std::string> tokens, std::string option_name, std::initializer_list<std::string> valid_values)

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -1852,7 +1852,7 @@ auto mg::DMABufEGLProvider::dma_transfer(std::shared_ptr<DmabufTexBuffer> const&
      * This is a logic bug, so go noisily.
      */
     BOOST_THROW_EXCEPTION(
-        (std::logic_error{"Failed to find import parameterns for buffer we explicitly allocated for import"}));
+        (std::logic_error{"Failed to find import parameters for buffer we explicitly allocated for import"}));
 }
 
 auto mg::DMABufEGLProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std::shared_ptr<gl::Texture>

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -1538,7 +1538,7 @@ void mg::DMABufEGLProvider::validate_import(DMABufBuffer const& dma_buf)
     }
 }
 
-auto mg::DMABufEGLProvider::as_texture(std::shared_ptr<NativeBufferBase> buffer)
+auto mg::DMABufEGLProvider::as_texture(std::shared_ptr<Buffer> buffer)
     -> std::shared_ptr<gl::Texture>
 {
     if (auto dmabuf_tex = std::dynamic_pointer_cast<DmabufTexBuffer>(buffer))

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -1268,7 +1268,15 @@ private:
                     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
                     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, parent.tex.tex_id(), 0);
 
-                    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels.get());
+                    if(auto const gl_pixel_format = get_gl_pixel_format(parent.pixel_format())) {
+                        auto const [format, type] = *gl_pixel_format;
+                        glReadPixels(0, 0, width, height, format, type, pixels.get());
+                    } else {
+                        mir::log_debug(
+                            "GLMapping: Unsupported pixel format %d, defaulting to RGBA8 readback",
+                            parent.pixel_format());
+                        glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels.get());
+                    }
 
                     glBindFramebuffer(GL_FRAMEBUFFER, 0);
                     glDeleteFramebuffers(1, &fbo);

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -1869,11 +1869,11 @@ auto mg::DMABufEGLProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std::s
 
     if (auto const dmabuf_tex = std::dynamic_pointer_cast<DmabufTexBuffer>(native_buf))
     {
-        auto const source_dpy = dpy;
-        auto const source_vendor = eglQueryString(dpy, EGL_VENDOR);
+        auto const source_dpy = dmabuf_tex->provider()->dpy;
+        auto const source_vendor = eglQueryString(source_dpy, EGL_VENDOR);
 
-        auto const importing_dpy = dmabuf_tex->provider()->dpy;
-        auto const importing_vendor = eglQueryString(dmabuf_tex->provider()->dpy, EGL_VENDOR);
+        auto const importing_dpy = dpy;
+        auto const importing_vendor = eglQueryString(importing_dpy, EGL_VENDOR);
 
         auto const importing_strategy = dmabuf_tex->provider()->buffer_transfer_strategy;
         auto const strategy_name =

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -270,6 +270,54 @@ BufferGLDescription const ExternalOES = {
     "}\n"
 };
 
+struct GLPixelFormat
+{
+    GLenum gl_format;
+    GLenum gl_type;
+};
+
+auto get_gl_pixel_format(MirPixelFormat mir_format) -> std::optional<GLPixelFormat>
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    GLenum const argb = GL_BGRA_EXT;
+    GLenum const abgr = GL_RGBA;
+#elif __BYTE_ORDER == __BIG_ENDIAN
+    // TODO: Big endian support
+    GLenum const argb = GL_INVALID_ENUM;
+    GLenum const abgr = GL_INVALID_ENUM;
+    // GLenum const rgba = GL_RGBA;
+    // GLenum const bgra = GL_BGRA_EXT;
+#endif
+
+    static const struct
+    {
+        MirPixelFormat mir_format;
+        GLenum gl_format, gl_type;
+    } mapping[mir_pixel_formats] =
+    {
+        {mir_pixel_format_invalid,   GL_INVALID_ENUM, GL_INVALID_ENUM},
+        {mir_pixel_format_abgr_8888, abgr,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_xbgr_8888, abgr,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_argb_8888, argb,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_xrgb_8888, argb,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_bgr_888,   GL_INVALID_ENUM, GL_INVALID_ENUM},
+        {mir_pixel_format_rgb_888,   GL_RGB,          GL_UNSIGNED_BYTE},
+        {mir_pixel_format_rgb_565,   GL_RGB,          GL_UNSIGNED_SHORT_5_6_5},
+        {mir_pixel_format_rgba_5551, GL_RGBA,         GL_UNSIGNED_SHORT_5_5_5_1},
+        {mir_pixel_format_rgba_4444, GL_RGBA,         GL_UNSIGNED_SHORT_4_4_4_4},
+    };
+
+    std::optional<GLPixelFormat> ret;
+
+    if (mir_format > mir_pixel_format_invalid && mir_format < mir_pixel_formats &&
+        mapping[mir_format].mir_format == mir_format) // just a sanity check
+    {
+        ret = {mapping[mir_format].gl_format, mapping[mir_format].gl_type};
+    }
+
+    return ret;
+}
+
 namespace
 {
 struct EGLPlaneAttribs
@@ -1181,7 +1229,7 @@ private:
 
         auto format() const -> MirPixelFormat override
         {
-           return parent.format_.as_mir_format().value_or(mir_pixel_format_invalid);
+            return parent.format_.as_mir_format().value_or(mir_pixel_format_invalid);
         }
 
         auto stride() const -> geom::Stride override
@@ -1479,54 +1527,6 @@ GLuint new_texture()
     return tex;
 }
 
-bool get_gl_pixel_format(MirPixelFormat mir_format,
-                         GLenum& gl_format, GLenum& gl_type)
-{
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-    GLenum const argb = GL_BGRA_EXT;
-    GLenum const abgr = GL_RGBA;
-#elif __BYTE_ORDER == __BIG_ENDIAN
-    // TODO: Big endian support
-    GLenum const argb = GL_INVALID_ENUM;
-    GLenum const abgr = GL_INVALID_ENUM;
-    //GLenum const rgba = GL_RGBA;
-    //GLenum const bgra = GL_BGRA_EXT;
-#endif
-
-    static const struct
-    {
-        MirPixelFormat mir_format;
-        GLenum gl_format, gl_type;
-    } mapping[mir_pixel_formats] =
-    {
-        {mir_pixel_format_invalid,   GL_INVALID_ENUM, GL_INVALID_ENUM},
-        {mir_pixel_format_abgr_8888, abgr,            GL_UNSIGNED_BYTE},
-        {mir_pixel_format_xbgr_8888, abgr,            GL_UNSIGNED_BYTE},
-        {mir_pixel_format_argb_8888, argb,            GL_UNSIGNED_BYTE},
-        {mir_pixel_format_xrgb_8888, argb,            GL_UNSIGNED_BYTE},
-        {mir_pixel_format_bgr_888,   GL_INVALID_ENUM, GL_INVALID_ENUM},
-        {mir_pixel_format_rgb_888,   GL_RGB,          GL_UNSIGNED_BYTE},
-        {mir_pixel_format_rgb_565,   GL_RGB,          GL_UNSIGNED_SHORT_5_6_5},
-        {mir_pixel_format_rgba_5551, GL_RGBA,         GL_UNSIGNED_SHORT_5_5_5_1},
-        {mir_pixel_format_rgba_4444, GL_RGBA,         GL_UNSIGNED_SHORT_4_4_4_4},
-    };
-
-    if (mir_format > mir_pixel_format_invalid &&
-        mir_format < mir_pixel_formats &&
-        mapping[mir_format].mir_format == mir_format) // just a sanity check
-    {
-        gl_format = mapping[mir_format].gl_format;
-        gl_type = mapping[mir_format].gl_type;
-    }
-    else
-    {
-        gl_format = GL_INVALID_ENUM;
-        gl_type = GL_INVALID_ENUM;
-    }
-
-    return gl_format != GL_INVALID_ENUM && gl_type != GL_INVALID_ENUM;
-}
-
 class ShmBufferTexture : public mg::gl::Texture
 {
 public:
@@ -1595,10 +1595,10 @@ public:
             return;
 
         bind();
-        GLenum format, type;
 
-        if (get_gl_pixel_format(pixel_format, format, type))
+        if (auto const gl_pixel_format = get_gl_pixel_format(pixel_format))
         {
+            auto const [format, type] = *gl_pixel_format;
             auto const stride_in_px =
                 stride.as_int() / MIR_BYTES_PER_PIXEL(pixel_format);
             /*

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -1654,84 +1654,6 @@ private:
     mg::BufferID const buffer_id_;
     geom::Size const buffer_size_;
 };
-
-auto export_egl_image(
-    mg::EGLExtensions::MESADmaBufExport const& ext,
-    EGLDisplay dpy,
-    EGLImage image,
-    geom::Size size) -> std::unique_ptr<mg::DMABufBuffer>
-{
-    constexpr int const max_planes = 4;
-
-    int fourcc;
-    int num_planes;
-    std::array<uint64_t, max_planes> modifiers;
-    if (ext.eglExportDMABUFImageQueryMESA(dpy, image, &fourcc, &num_planes, modifiers.data()) != EGL_TRUE)
-    {
-        BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query EGLImage for dma-buf export")));
-    }
-
-    /* There's only a single modifier for a logical buffer. For some reason the EGL interface
-     * decided to return one modifier per plane, but they are always the same.
-     *
-     * We handle DRM_FORMAT_MOD_INVALID as an empty modifier; fix that up here if we get it.
-     */
-    auto modifier =
-        [](uint64_t egl_modifier) -> std::optional<uint64_t>
-        {
-            if (egl_modifier == DRM_FORMAT_MOD_INVALID)
-            {
-                return std::nullopt;
-            }
-            return egl_modifier;
-        }(modifiers[0]);
-
-    std::array<int, max_planes> fds;
-    std::array<EGLint, max_planes> strides;
-    std::array<EGLint, max_planes> offsets;
-
-    if (ext.eglExportDMABUFImageMESA(dpy, image, fds.data(), strides.data(), offsets.data()) != EGL_TRUE)
-    {
-        BOOST_THROW_EXCEPTION((mg::egl_error("Failed to export EGLImage to dma-buf(s)")));
-    }
-
-    std::vector<PlaneInfo> planes;
-    planes.reserve(num_planes);
-    for (int i = 0; i < num_planes; ++i)
-    {
-        mir::Fd fd;
-        // If multiple planes use the same buffer, the fds array will be filled with -1 for subsequent
-        // planes.
-        if (fds[i] == -1)
-        {
-            // Paranoia
-            if (i == 0)
-            {
-                BOOST_THROW_EXCEPTION((std::runtime_error{"Driver has a broken EGL_MESA_image_dma_buf_export extension"}));
-            }
-            fds[i] = fds[i - 1];
-            fd = mir::Fd{mir::IntOwnedFd{fds[i]}};
-        }
-        else
-        {
-            // We own these FDs now.
-            fd = mir::Fd{fds[i]};
-        }
-        planes.push_back(
-            PlaneInfo {
-                .dma_buf = std::move(fd),
-                .stride = static_cast<uint32_t>(strides[i]),
-                .offset = static_cast<uint32_t>(offsets[i])
-            });
-    }
-
-    return std::make_unique<DMABuf>(
-        mg::DRMFormat{static_cast<uint32_t>(fourcc)},
-        modifier,
-        std::move(planes),
-        mg::gl::Texture::Layout::TopRowFirst,
-        size);
-}
 }
 
 auto mg::DMABufEGLProvider::cpu_transfer(std::shared_ptr<DmabufTexBuffer> const& dmabuf_tex) -> std::shared_ptr<mg::gl::Texture>
@@ -1829,21 +1751,18 @@ auto mg::DMABufEGLProvider::dma_transfer(std::shared_ptr<DmabufTexBuffer> const&
     {
         BOOST_THROW_EXCEPTION((std::logic_error{"EGL_ANDROID_native_fence_sync support not implemented yet"}));
     }
-    auto importable_dmabuf = export_egl_image(
-        *importing_provider->dmabuf_export_ext, importing_provider->dpy, importable_image, dmabuf_tex->size());
-
     auto base_extension = importing_provider->egl_extensions->base(importing_provider->dpy);
     base_extension.eglDestroyImageKHR(importing_provider->dpy, src_image);
     base_extension.eglDestroyImageKHR(importing_provider->dpy, importable_image);
 
     if (auto descriptor = descriptor_for_format_and_modifiers(
-            importable_dmabuf->format(), importable_dmabuf->modifier().value_or(DRM_FORMAT_MOD_INVALID), *this))
+            importable_buf->format(), importable_buf->modifier().value_or(DRM_FORMAT_MOD_INVALID), *this))
     {
         /* We're being naughty here and using the fact that `as_texture()` has a side-effect
          * of invoking the buffer's `on_consumed()` callback.
          */
         dmabuf_tex->as_texture();
-        return std::make_shared<DMABufTex>(dpy, *egl_extensions, *importable_dmabuf, *descriptor, egl_delegate);
+        return std::make_shared<DMABufTex>(dpy, *egl_extensions, *importable_buf, *descriptor, egl_delegate);
     }
 
     /* To get here we have to have failed to find the format/modifier descriptor for a

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -357,84 +357,6 @@ private:
     geom::Size const size_;
 };
 
-auto export_egl_image(
-    mg::EGLExtensions::MESADmaBufExport const& ext,
-    EGLDisplay dpy,
-    EGLImage image,
-    geom::Size size) -> std::unique_ptr<mg::DMABufBuffer>
-{
-    constexpr int const max_planes = 4;
-
-    int fourcc;
-    int num_planes;
-    std::array<uint64_t, max_planes> modifiers;
-    if (ext.eglExportDMABUFImageQueryMESA(dpy, image, &fourcc, &num_planes, modifiers.data()) != EGL_TRUE)
-    {
-        BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query EGLImage for dma-buf export")));
-    }
-
-    /* There's only a single modifier for a logical buffer. For some reason the EGL interface
-     * decided to return one modifier per plane, but they are always the same.
-     *
-     * We handle DRM_FORMAT_MOD_INVALID as an empty modifier; fix that up here if we get it.
-     */
-    auto modifier =
-        [](uint64_t egl_modifier) -> std::optional<uint64_t>
-        {
-            if (egl_modifier == DRM_FORMAT_MOD_INVALID)
-            {
-                return std::nullopt;
-            }
-            return egl_modifier;
-        }(modifiers[0]);
-
-    std::array<int, max_planes> fds;
-    std::array<EGLint, max_planes> strides;
-    std::array<EGLint, max_planes> offsets;
-
-    if (ext.eglExportDMABUFImageMESA(dpy, image, fds.data(), strides.data(), offsets.data()) != EGL_TRUE)
-    {
-        BOOST_THROW_EXCEPTION((mg::egl_error("Failed to export EGLImage to dma-buf(s)")));
-    }
-
-    std::vector<PlaneInfo> planes;
-    planes.reserve(num_planes);
-    for (int i = 0; i < num_planes; ++i)
-    {
-        mir::Fd fd;
-        // If multiple planes use the same buffer, the fds array will be filled with -1 for subsequent
-        // planes.
-        if (fds[i] == -1)
-        {
-            // Paranoia
-            if (i == 0)
-            {
-                BOOST_THROW_EXCEPTION((std::runtime_error{"Driver has a broken EGL_MESA_image_dma_buf_export extension"}));
-            }
-            fds[i] = fds[i - 1];
-            fd = mir::Fd{mir::IntOwnedFd{fds[i]}};
-        }
-        else
-        {
-            // We own these FDs now.
-            fd = mir::Fd{fds[i]};
-        }
-        planes.push_back(
-            PlaneInfo {
-                .dma_buf = std::move(fd),
-                .stride = static_cast<uint32_t>(strides[i]),
-                .offset = static_cast<uint32_t>(offsets[i])
-            });
-    }
-
-    return std::make_unique<DMABuf>(
-        mg::DRMFormat{static_cast<uint32_t>(fourcc)},
-        modifier,
-        std::move(planes),
-        mg::gl::Texture::Layout::TopRowFirst,
-        size);
-}
-
 /**
  * Reimport dmabufs into EGL
  *
@@ -1135,12 +1057,14 @@ public:
             format().as_mir_format().has_value())
         {
             // Fastpath; we can just mmap the memory
+            mir::log_debug("LinuxDMABuf::map_readable: %p read using direct mmap", static_cast<void const*>(this));
             return std::unique_ptr<DmaBufMapping>{new DmaBufMapping{*this}};
         }
         else if (auto const info = format().info())
         {
             if (info->components().has_value())
             {
+                mir::log_debug("LinuxDMABuf::map_readable: %p read using GL upload", static_cast<void const*>(this));
                 return std::unique_ptr<GLMapping>(new GLMapping{*this});
             }
         }
@@ -1538,125 +1462,216 @@ void mg::DMABufEGLProvider::validate_import(DMABufBuffer const& dma_buf)
     }
 }
 
+namespace
+{
+GLuint new_texture()
+{
+    GLuint tex;
+    glGenTextures(1, &tex);
+
+    glBindTexture(GL_TEXTURE_2D, tex);
+    // The ShmBuffer *should* be immutable, so we can just set up the properties once
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    return tex;
+}
+
+bool get_gl_pixel_format(MirPixelFormat mir_format,
+                         GLenum& gl_format, GLenum& gl_type)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    GLenum const argb = GL_BGRA_EXT;
+    GLenum const abgr = GL_RGBA;
+#elif __BYTE_ORDER == __BIG_ENDIAN
+    // TODO: Big endian support
+    GLenum const argb = GL_INVALID_ENUM;
+    GLenum const abgr = GL_INVALID_ENUM;
+    //GLenum const rgba = GL_RGBA;
+    //GLenum const bgra = GL_BGRA_EXT;
+#endif
+
+    static const struct
+    {
+        MirPixelFormat mir_format;
+        GLenum gl_format, gl_type;
+    } mapping[mir_pixel_formats] =
+    {
+        {mir_pixel_format_invalid,   GL_INVALID_ENUM, GL_INVALID_ENUM},
+        {mir_pixel_format_abgr_8888, abgr,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_xbgr_8888, abgr,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_argb_8888, argb,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_xrgb_8888, argb,            GL_UNSIGNED_BYTE},
+        {mir_pixel_format_bgr_888,   GL_INVALID_ENUM, GL_INVALID_ENUM},
+        {mir_pixel_format_rgb_888,   GL_RGB,          GL_UNSIGNED_BYTE},
+        {mir_pixel_format_rgb_565,   GL_RGB,          GL_UNSIGNED_SHORT_5_6_5},
+        {mir_pixel_format_rgba_5551, GL_RGBA,         GL_UNSIGNED_SHORT_5_5_5_1},
+        {mir_pixel_format_rgba_4444, GL_RGBA,         GL_UNSIGNED_SHORT_4_4_4_4},
+    };
+
+    if (mir_format > mir_pixel_format_invalid &&
+        mir_format < mir_pixel_formats &&
+        mapping[mir_format].mir_format == mir_format) // just a sanity check
+    {
+        gl_format = mapping[mir_format].gl_format;
+        gl_type = mapping[mir_format].gl_type;
+    }
+    else
+    {
+        gl_format = GL_INVALID_ENUM;
+        gl_type = GL_INVALID_ENUM;
+    }
+
+    return gl_format != GL_INVALID_ENUM && gl_type != GL_INVALID_ENUM;
+}
+
+class ShmBufferTexture : public mg::gl::Texture
+{
+public:
+    ShmBufferTexture(
+        std::shared_ptr<mgc::EGLContextExecutor> const& egl_delegate,
+        mg::BufferID id,
+        void const* pixels,
+        geom::Size const& size,
+        geom::Stride const& stride,
+        MirPixelFormat pixel_format)
+        : egl_delegate(egl_delegate),
+            tex_id_(new_texture()),
+            buffer_id_{id},
+            buffer_size_{size}
+    {
+        try_upload_to_texture(id, pixels, size, stride, pixel_format);
+    }
+
+    ~ShmBufferTexture() override
+    {
+        egl_delegate->spawn(
+            [id=tex_id()]
+            {
+                glDeleteTextures(1, &id);
+            });
+    }
+
+    void bind() override
+    {
+        glBindTexture(GL_TEXTURE_2D, tex_id());
+    }
+
+    auto tex_id() const -> GLuint override
+    {
+        return tex_id_;
+    }
+
+    mg::gl::Program const& shader(mg::gl::ProgramFactory& cache) const override
+    {
+        static int argb_shader{0};
+        return cache.compile_fragment_shader(
+            &argb_shader,
+            "",
+            "uniform sampler2D tex;\n"
+            "vec4 sample_to_rgba(in vec2 texcoord)\n"
+            "{\n"
+            "    return texture2D(tex, texcoord);\n"
+            "}\n");
+    }
+
+    Layout layout() const override
+    {
+        return Layout::GL;
+    }
+
+    void add_syncpoint() override
+    {
+    }
+
+    void try_upload_to_texture(
+        mg::BufferID id, void const* pixels, geom::Size const& size,
+        geom::Stride const& stride, MirPixelFormat pixel_format)
+    {
+        std::lock_guard lock{uploaded_mutex};
+        if (uploaded)
+            return;
+
+        bind();
+        GLenum format, type;
+
+        if (get_gl_pixel_format(pixel_format, format, type))
+        {
+            auto const stride_in_px =
+                stride.as_int() / MIR_BYTES_PER_PIXEL(pixel_format);
+            /*
+                * We assume (as does Weston, AFAICT) that stride is
+                * a multiple of whole pixels, but it need not be.
+                *
+                * TODO: Handle non-pixel-multiple strides.
+                * This should be possible by calculating GL_UNPACK_ALIGNMENT
+                * to match the size of the partial-pixel-stride().
+                */
+
+            glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride_in_px);
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+            glTexImage2D(
+                GL_TEXTURE_2D,
+                0,
+                format,
+                size.width.as_int(), size.height.as_int(),
+                0,
+                format,
+                type,
+                pixels);
+
+            // Be nice to other users of the GL context by reverting our changes to shared state
+            glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0);     // 0 is default, meaning “use width”
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 4);          // 4 is default; word alignment.
+            glFinish();
+        }
+        else
+        {
+            mir::log_error(
+                "Buffer %i has non-GL-compatible pixel format %i; rendering will be incomplete",
+                id.as_value(),
+                pixel_format);
+        }
+
+        uploaded = true;
+    }
+
+    void mark_dirty()
+    {
+        std::lock_guard lock{uploaded_mutex};
+        uploaded = false;
+    }
+
+private:
+    std::mutex uploaded_mutex;
+    bool uploaded = false;
+
+    std::shared_ptr<mgc::EGLContextExecutor> const egl_delegate;
+    GLuint const tex_id_;
+    mg::BufferID const buffer_id_;
+    geom::Size const buffer_size_;
+};
+}
+
 auto mg::DMABufEGLProvider::as_texture(std::shared_ptr<Buffer> buffer)
     -> std::shared_ptr<gl::Texture>
 {
-    if (auto dmabuf_tex = std::dynamic_pointer_cast<DmabufTexBuffer>(buffer))
+    auto native_buf = std::shared_ptr<NativeBufferBase>(buffer, buffer->native_buffer_base());
+
+    if (auto const dmabuf_tex = std::dynamic_pointer_cast<DmabufTexBuffer>(native_buf))
     {
-        if (dmabuf_tex->on_same_egl_display(dpy))
-        {
-            auto tex = dmabuf_tex->as_texture();
-            return std::shared_ptr<gl::Texture>(std::move(dmabuf_tex), tex);
-        }
-        else if (auto descriptor = descriptor_for_format_and_modifiers(
-                    dmabuf_tex->format(),
-                    dmabuf_tex->modifier().value_or(DRM_FORMAT_MOD_INVALID),
-                    *this))
-        {
-            // Cross-GPU import requires explicit modifiers; MOD_INVALID will not work
-            if (dmabuf_tex->modifier().value_or(DRM_FORMAT_MOD_INVALID) != DRM_FORMAT_MOD_INVALID)
-            {
-                /* We're being naughty here and using the fact that `as_texture()` has a side-effect
-                 * of invoking the buffer's `on_consumed()` callback.
-                 */
-                dmabuf_tex->as_texture();
-                return std::make_shared<DMABufTex>(
-                    dpy,
-                    *egl_extensions,
-                    *dmabuf_tex,
-                    *descriptor,
-                    egl_delegate);
-            }
-        }
-        /* Oh, no. We've got a dma-buf in a format that our rendering GPU can't handle.
-         *
-         * In this case we'll need to get the *importing* GPU to blit to a format
-         * we *can* handle.
-         */
-        auto importing_provider = dmabuf_tex->provider();
-
-        if (!importing_provider->dmabuf_export_ext)
-        {
-            mir::log_warning("EGL implementation does not handle cross-GPU buffer export");
-            return nullptr;
-        }
-
-        /* TODO: Be smarter about finding a shared pixel format; everything *should* do
-         * ARGB8888, but if the buffer is in a higher bitdepth this will lose colour information
-         */
-        auto const& supported_formats = *formats;
-        auto const& modifiers =
-            [&supported_formats]() -> std::vector<uint64_t> const&
-            {
-                for (size_t i = 0; i < supported_formats.num_formats(); ++i)
-                {
-                    if (supported_formats[i].format == DRM_FORMAT_ARGB8888)
-                    {
-                        return supported_formats[i].modifiers;
-                    }
-                }
-                BOOST_THROW_EXCEPTION((std::runtime_error{"Platform doesn't support ARGB8888?!"}));
-            }();
-
-        auto importable_buf = importing_provider->allocate_importable_image(
-            mg::DRMFormat{DRM_FORMAT_ARGB8888},
-            std::span<uint64_t const>{modifiers.data(), modifiers.size()},
-            dmabuf_tex->size());
-
-        if (!importable_buf)
-        {
-            mir::log_warning("Failed to allocate common-format buffer for cross-GPU buffer import");
-            return nullptr;
-        }
-
-        auto src_image = import_egl_image(
-            dmabuf_tex->size().width.as_int(), dmabuf_tex->size().height.as_int(),
-            dmabuf_tex->format(),
-            dmabuf_tex->modifier(),
-            dmabuf_tex->planes(),
-            importing_provider->dpy,
-            *importing_provider->egl_extensions);
-        auto importable_image = import_egl_image(
-            importable_buf->size().width.as_int(), importable_buf->size().height.as_int(),
-            importable_buf->format(),
-            importable_buf->modifier(),
-            importable_buf->planes(),
-            importing_provider->dpy,
-            *importing_provider->egl_extensions);
-        auto sync = importing_provider->blitter->blit(src_image, importable_image, dmabuf_tex->size());
-        if (sync)
-        {
-            BOOST_THROW_EXCEPTION((std::logic_error{"EGL_ANDROID_native_fence_sync support not implemented yet"}));
-        }
-        auto importable_dmabuf = export_egl_image(*importing_provider->dmabuf_export_ext, importing_provider->dpy, importable_image, dmabuf_tex->size());
-
-        auto base_extension = importing_provider->egl_extensions->base(importing_provider->dpy);
-        base_extension.eglDestroyImageKHR(importing_provider->dpy, src_image);
-        base_extension.eglDestroyImageKHR(importing_provider->dpy, importable_image);
-
-        if (auto descriptor = descriptor_for_format_and_modifiers(
-                    importable_dmabuf->format(),
-                    importable_dmabuf->modifier().value_or(DRM_FORMAT_MOD_INVALID),
-                    *this))
-        {
-            /* We're being naughty here and using the fact that `as_texture()` has a side-effect
-             * of invoking the buffer's `on_consumed()` callback.
-             */
-            dmabuf_tex->as_texture();
-            return std::make_shared<DMABufTex>(
-                dpy,
-                *egl_extensions,
-                *importable_dmabuf,
-                *descriptor,
-                egl_delegate);
-        }
-
-        /* To get here we have to have failed to find the format/modifier descriptor for a
-         * buffer that we've explicitly allocated to be importable by us.
-         *
-         * This is a logic bug, so go noisily.
-         */
-        BOOST_THROW_EXCEPTION((std::logic_error{"Failed to find import parameterns for buffer we explicitly allocated for import"}));
+        mir::log_debug("Buffer %p on different GPU, uploading via CPU mapping", static_cast<void*>(buffer.get()));
+        auto const pixel_format = mir_pixel_format_argb_8888;
+        return std::make_shared<ShmBufferTexture>(
+            egl_delegate,
+            BufferID{0xfade}, // TODO: BufferID registry to keep track of and generate new buffer IDs?
+            dmabuf_tex->map_readable()->data(),
+            buffer->size(),
+            geom::Stride{buffer->size().width.as<int>() * MIR_BYTES_PER_PIXEL(pixel_format)},
+            pixel_format);
     }
+
     return nullptr;
 }

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -1802,15 +1802,14 @@ auto export_egl_image(
 
 auto mg::DMABufEGLProvider::cpu_transfer(std::shared_ptr<DmabufTexBuffer> const& dmabuf_tex) -> std::shared_ptr<mg::gl::Texture>
 {
-    auto const pixel_format = mir_pixel_format_argb_8888;
-    auto const size = dmabuf_tex->size();
+    auto const map_readable = dmabuf_tex->map_readable();
     return std::make_shared<ShmBufferTexture>(
         egl_delegate,
         mg::BufferID{0xfade}, // TODO: BufferID registry to keep track of and generate new buffer IDs?
-        dmabuf_tex->map_readable()->data(),
-        size,
-        geom::Stride{size.width.as_int() * MIR_BYTES_PER_PIXEL(pixel_format)},
-        pixel_format);
+        map_readable->data(),
+        map_readable->size(),
+        map_readable->stride(),
+        map_readable->format());
 }
 
 auto mg::DMABufEGLProvider::dma_transfer(std::shared_ptr<DmabufTexBuffer> const& dmabuf_tex) -> std::shared_ptr<mg::gl::Texture>

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -1255,7 +1255,11 @@ private:
     {
     public:
         GLMapping(DmabufTexBuffer const& parent)
-            : parent{parent}
+            : parent{parent},
+              readback_format_{
+                  get_gl_pixel_format(parent.pixel_format())
+                      ? parent.pixel_format()
+                      : mir_pixel_format_abgr_8888}
         {
             auto data_promise = std::make_shared<std::promise<std::unique_ptr<std::byte const[]>>>();
             parent.egl_executor->spawn(
@@ -1302,8 +1306,16 @@ private:
 
         auto format() const -> MirPixelFormat override
         {
-            // Because we're reading through GL the underlying format doesn't matter
-            return mir_pixel_format_argb_8888;
+            // Return the MirPixelFormat that matches the byte layout actually written by glReadPixels.
+            // When the buffer's pixel format has a known GL equivalent, glReadPixels uses that format's
+            // GL enumerant, so the bytes in memory correspond to parent.pixel_format() directly.
+            // When falling back to GL_RGBA (unknown format), the output bytes are [R, G, B, A] on
+            // little-endian, which corresponds to mir_pixel_format_abgr_8888.
+            //
+            // Returning the wrong format here causes ShmBufferTexture to choose the wrong GL upload
+            // format (e.g. GL_BGRA_EXT instead of GL_RGBA for an ABGR buffer), swapping the red and
+            // blue channels and producing a colour tint in the rendered output.
+            return readback_format_;
         }
 
         auto stride() const -> geom::Stride override
@@ -1318,6 +1330,7 @@ private:
 
     private:
         DmabufTexBuffer const& parent;
+        MirPixelFormat const readback_format_;
         std::shared_future<std::unique_ptr<std::byte const[]>> data_;
     };
 

--- a/src/platforms/atomic-kms/server/kms/quirks.cpp
+++ b/src/platforms/atomic-kms/server/kms/quirks.cpp
@@ -65,8 +65,15 @@ public:
             std::vector<std::string> tokens;
             boost::split(tokens, option_value, boost::is_any_of(":"));
 
-            auto static const available_options = std::set<std::string>{
-                "skip", "allow", "disable-kms-probe", "gbm-surface-has-free-buffers"};
+            auto static const available_options = std::unordered_map<std::string, mgc::OptionStructure>{
+                // option::{driver,devnode}:<specifier>[:value]
+                {"skip", mgc::OptionStructure{}},
+                {"allow", mgc::OptionStructure{}},
+                {"disable-kms-probe", mgc::OptionStructure{}},
+                {"egl-destroy-surface", mgc::OptionStructure{}},
+                {"gbm-surface-has-free-buffers", mgc::OptionStructure{}},
+            };
+
             auto const structure = mgc::validate_structure(tokens, available_options);
             if(!structure)
                 return false;

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -218,7 +218,7 @@ auto mgg::BufferAllocator::shared_egl_context() -> EGLContext
 auto mgg::GLRenderingProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std::shared_ptr<gl::Texture>
 {
     std::shared_ptr<NativeBufferBase> native_buffer{buffer, buffer->native_buffer_base()};
-    if (auto dmabuf_texture = dmabuf_provider->as_texture(native_buffer))
+    if (auto dmabuf_texture = dmabuf_provider->as_texture(buffer))
     {
         return dmabuf_texture;
     }

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -276,7 +276,7 @@ private:
     mir::geometry::Size size_;
 };
 
-auto gbm_bo_allocate_no_modifiers_linear(auto gbm, auto size, auto format) -> struct gbm_bo*
+auto gbm_bo_allocate_no_modifiers_linear(gbm_device* gbm, mir::geometry::Size size, uint32_t format) -> struct gbm_bo*
 {
 
     auto const gbm_bo = gbm_bo_create(
@@ -291,7 +291,7 @@ auto gbm_bo_allocate_no_modifiers_linear(auto gbm, auto size, auto format) -> st
     return gbm_bo;
 }
 
-auto gbm_bo_allocate_with_modifiers_no_flags(auto gbm, auto modifiers, auto size, auto format)
+auto gbm_bo_allocate_with_modifiers_no_flags(gbm_device* gbm, std::span<uint64_t const> modifiers, mir::geometry::Size size, uint32_t format)
 {
     auto const gbm_bo = gbm_bo_create_with_modifiers2(
         gbm, size.width.as_uint32_t(), size.height.as_uint32_t(), format, modifiers.data(), modifiers.size(), 0);

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -325,7 +325,7 @@ auto gbm_bo_with_modifiers_or_linear(
 
     if (!gbm_bo)
     {
-        switch(errno)
+        switch (errno)
         {
         case ENOSYS:
             // We get ENOSYS if the GBM implementation can't handle modifiers

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -329,7 +329,7 @@ auto gbm_bo_with_modifiers_or_linear(
         {
         case ENOSYS:
             // We get ENOSYS if the GBM implementation can't handle modifiers
-            if (std::ranges::contains(modifiers, DRM_FORMAT_MOD_LINEAR))
+            if (!std::ranges::contains(modifiers, DRM_FORMAT_MOD_LINEAR))
             {
                 // Shouldn't happen, but if LINEAR isn't one of the requested modifiers we can't allocate
                 // something compatible

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -401,6 +401,8 @@ auto maybe_make_dmabuf_provider(
     try
     {
         mg::EGLExtensions::EXTImageDmaBufImportModifiers modifier_ext{dpy};
+        auto strategy_selector = quirks->make_transfer_strategy_selector();
+        
         return std::make_shared<mg::DMABufEGLProvider>(
             dpy,
             std::move(egl_extensions),
@@ -411,7 +413,7 @@ auto maybe_make_dmabuf_provider(
             {
                 return alloc_dma_buf(gbm.get(), format, modifiers, size);
             },
-            quirks->gbm_buffer_transfer_strategy());
+            std::move(strategy_selector));
     }
     catch (std::runtime_error const& error)
     {

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -43,13 +43,6 @@
 #include <system_error>
 #include <xf86drm.h>
 
-#include <boost/throw_exception.hpp>
-#include <drm.h>
-#include <drm_fourcc.h>
-#include <gbm.h>
-#include <system_error>
-#include <xf86drm.h>
-
 #define MIR_LOG_COMPONENT "platform-graphics-gbm-kms"
 #include <mir/log.h>
 

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -402,7 +402,7 @@ auto maybe_make_dmabuf_provider(
     {
         mg::EGLExtensions::EXTImageDmaBufImportModifiers modifier_ext{dpy};
         auto strategy_selector = quirks->make_transfer_strategy_selector();
-        
+
         return std::make_shared<mg::DMABufEGLProvider>(
             dpy,
             std::move(egl_extensions),

--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -109,9 +109,9 @@ public:
                     "Ignoring unexpected value for %s option: %s "
                     "(expects value of the form “{skip, allow}:{driver,devnode}:<driver or devnode>”"
                     ", “disable-kms-probe:{driver,devnode}:<driver or devnode>”, "
-                    "“egl-destroy-surface:{driver,devnode}:{default:leak}”), "
-                    "or “gbm-surface-has-free-buffers:{driver,devnode}:<driver or devnode>:{default,skip}”)"
-                    "or “gbm-buffer-transfer-strategy:{driver,devnode}:<driver or devnode>:{default,cpu}”",
+                    "“egl-destroy-surface:{driver,devnode}:{default:leak}”, "
+                    "or “gbm-surface-has-free-buffers:{driver,devnode}:<driver or devnode>:{default,skip}”"
+                    "or “gbm-buffer-transfer-strategy:{driver,devnode}:<driver or devnode>:{default,cpu}”)",
                     quirks_option_name,
                     quirk.c_str());
             }

--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -25,8 +25,11 @@
 
 #include <gbm.h>
 
-#include <vector>
+#include <algorithm>
+#include <cctype>
+#include <string_view>
 #include <unordered_set>
+#include <vector>
 
 namespace mgg = mir::graphics::gbm;
 namespace mo = mir::options;
@@ -35,6 +38,107 @@ namespace mgc = mir::graphics::common;
 namespace
 {
 char const* quirks_option_name = "driver-quirks";
+
+auto contains_case_insensitive(std::string_view haystack, std::string_view needle) -> bool
+{
+    auto it = std::search(
+        haystack.begin(),
+        haystack.end(),
+        needle.begin(),
+        needle.end(),
+        [](char ch1, char ch2) { return std::tolower(ch1) == std::tolower(ch2); });
+    return it != haystack.end();
+}
+
+auto is_nvidia(std::string_view vendor) -> bool
+{
+    return contains_case_insensitive(vendor, "nvidia");
+}
+
+auto is_intel(std::string_view vendor) -> bool
+{
+    return contains_case_insensitive(vendor, "intel") || contains_case_insensitive(vendor, "i915");
+}
+
+struct VendorPairTransferStrategy
+{
+    void add(std::string_view source_vendor, std::string_view dest_vendor, std::string_view strategy);
+    auto get_strategy(std::string_view source_vendor, std::string_view dest_vendor) const
+        -> std::optional<mgg::GbmQuirks::BufferTransferStrategy>;
+
+    // Map from "source:dest" to strategy
+    std::unordered_map<std::string, mgg::GbmQuirks::BufferTransferStrategy> vendor_pairs;
+};
+
+void VendorPairTransferStrategy::add(
+    std::string_view source_vendor, std::string_view dest_vendor, std::string_view strategy)
+{
+    auto key = std::string{source_vendor} + ":" + std::string{dest_vendor};
+
+    if (strategy == "cpu")
+    {
+        vendor_pairs[key] = mgg::GbmQuirks::BufferTransferStrategy::cpu;
+        mir::log_info(
+            "Quirks: Configured %s -> %s to use CPU transfer strategy",
+            std::string{source_vendor}.c_str(),
+            std::string{dest_vendor}.c_str());
+    }
+    else if (strategy == "dma")
+    {
+        vendor_pairs[key] = mgg::GbmQuirks::BufferTransferStrategy::dma;
+        mir::log_info(
+            "Quirks: Configured %s -> %s to use DMA transfer strategy",
+            std::string{source_vendor}.c_str(),
+            std::string{dest_vendor}.c_str());
+    }
+    else
+    {
+        mir::log_warning(
+            "Quirks: Unknown strategy '%s' for %s -> %s, ignoring",
+            std::string{strategy}.c_str(),
+            std::string{source_vendor}.c_str(),
+            std::string{dest_vendor}.c_str());
+    }
+}
+
+auto VendorPairTransferStrategy::get_strategy(std::string_view source_vendor, std::string_view dest_vendor) const
+    -> std::optional<mgg::GbmQuirks::BufferTransferStrategy>
+{
+    auto key = std::string{source_vendor} + ":" + std::string{dest_vendor};
+    auto it = vendor_pairs.find(key);
+    if (it != vendor_pairs.end())
+    {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+auto parse_vendor_pair_quirk(
+    std::vector<std::string> const& tokens, VendorPairTransferStrategy& vendor_pair_transfer_strategy) -> bool
+{
+    if (tokens.size() != 4)
+    {
+        mir::log_debug(
+            "Invalid number of tokens (%zu) for gbm-buffer-transfer-strategy quirk (expected 4)", tokens.size());
+        return false;
+    }
+
+    auto const& source_vendor = tokens[1];
+    auto const& dest_vendor = tokens[2];
+    auto const& strategy = tokens[3];
+
+    if (strategy == "cpu" || strategy == "dma")
+    {
+        vendor_pair_transfer_strategy.add(source_vendor, dest_vendor, strategy);
+        return true;
+    }
+    else
+    {
+        mir::log_warning(
+            "Invalid strategy '%s' for gbm-buffer-transfer-strategy (expected 'cpu' or 'dma')", strategy.c_str());
+        return false;
+    }
+}
 }
 
 class mgg::Quirks::Impl
@@ -52,15 +156,20 @@ public:
             std::vector<std::string> tokens;
             boost::split(tokens, option_value, boost::is_any_of(":"));
 
-            auto static const available_options = std::set<std::string>{
-                "skip",
-                "allow",
-                "disable-kms-probe",
-                "egl-destroy-surface",
-                "gbm-surface-has-free-buffers",
-                "gbm-buffer-transfer-strategy"};
+            auto static const available_options = std::unordered_map<std::string, mgc::OptionStructure>{
+                // option::{driver,devnode}:<specifier>[:value]
+                {"skip", mgc::OptionStructure{}},
+                {"allow", mgc::OptionStructure{}},
+                {"disable-kms-probe", mgc::OptionStructure{}},
+                {"egl-destroy-surface", mgc::OptionStructure{}},
+                {"gbm-surface-has-free-buffers", mgc::OptionStructure{}},
+
+                // option:source_vendor:dest_vendor:strategy
+                {"gbm-buffer-transfer-strategy", mgc::OptionStructure::freeform(4)},
+            };
+
             auto const structure = mgc::validate_structure(tokens, available_options);
-            if(!structure)
+            if (!structure)
                 return false;
 
             auto const [option, specifier, specifier_value] = *structure;
@@ -90,10 +199,9 @@ public:
                 gbm_surface_has_free_buffers.add(specifier, specifier_value, tokens[3]);
                 return true;
             }
-            else if (mgc::matches(tokens, "gbm-buffer-transfer-strategy", {"default", "cpu"}))
+            else if (option == "gbm-buffer-transfer-strategy")
             {
-                gbm_buffer_transfer_strategy.add(specifier, specifier_value, tokens[3]);
-                return true;
+                return parse_vendor_pair_quirk(tokens, vendor_pair_transfer_strategy);
             }
 
             return false;
@@ -107,11 +215,12 @@ public:
                 // clangd really can't format this...
                 mir::log_warning(
                     "Ignoring unexpected value for %s option: %s "
-                    "(expects value of the form “{skip, allow}:{driver,devnode}:<driver or devnode>”"
-                    ", “disable-kms-probe:{driver,devnode}:<driver or devnode>”, "
-                    "“egl-destroy-surface:{driver,devnode}:{default:leak}”, "
-                    "or “gbm-surface-has-free-buffers:{driver,devnode}:<driver or devnode>:{default,skip}”"
-                    "or “gbm-buffer-transfer-strategy:{driver,devnode}:<driver or devnode>:{default,cpu}”)",
+                    "(expects value of the form "
+                    "\"{skip, allow}:{driver,devnode}:<driver or devnode>\", "
+                    "\"disable-kms-probe:{driver,devnode}:<driver or devnode>\", "
+                    "\"egl-destroy-surface:{driver,devnode}:{default:leak}\", "
+                    "\"gbm-surface-has-free-buffers:{driver,devnode}:<driver or devnode>:{default,skip}\", "
+                    "or \"gbm-buffer-transfer-strategy:<source_vendor>:<dest_vendor>:{cpu,dma}\")",
                     quirks_option_name,
                     quirk.c_str());
             }
@@ -214,7 +323,8 @@ public:
             }
         };
 
-        mir::log_debug("Quirks(gbm-surface-has-free-buffers): checking device with devnode: %s, driver %s", devnode, driver);
+        mir::log_debug(
+            "Quirks(gbm-surface-has-free-buffers): checking device with devnode: %s, driver %s", devnode, driver);
 
         auto surface_has_free_buffers_impl_name = mgc::apply_quirk(
             devnode,
@@ -230,30 +340,16 @@ public:
             return std::make_unique<DefaultGbmSurfaceHasFreeBuffers>();
         }();
 
-        mir::log_debug("Quirks(gbm-buffer-transfer-strategy): checking device with devnode: %s, driver %s", devnode, driver);
-
-        auto gbm_buffer_transfer_strategy_name = mgc::apply_quirk(
-            devnode,
-            driver,
-            gbm_buffer_transfer_strategy.devnodes,
-            gbm_buffer_transfer_strategy.drivers,
-            "gbm-buffer-transfer-strategy");
-
-        auto gbm_buffer_transfer_strategy = [&]() -> GbmQuirks::BufferTransferStrategy
-        {
-            if (gbm_buffer_transfer_strategy_options.contains(gbm_buffer_transfer_strategy_name))
-                return GbmQuirks::BufferTransferStrategy::cpu;
-            return GbmQuirks::BufferTransferStrategy::dma;
-        }();
-
         return std::make_shared<GbmQuirks>(
             std::move(egl_destroy_surface_impl),
             std::move(surface_has_free_buffers_impl),
-            gbm_buffer_transfer_strategy);
+            GbmQuirks::VendorPairConfig{vendor_pair_transfer_strategy.vendor_pairs});
     }
+
 private:
     /* AST is a simple 2D output device, built into some motherboards.
-     * They do not have any 3D engine associated, so were quirked off to avoid https://github.com/canonical/mir/issues/2678
+     * They do not have any 3D engine associated, so were quirked off to avoid
+     * https://github.com/canonical/mir/issues/2678
      *
      * At least as of drivers ≤ version 550, the NVIDIA gbm implementation is buggy in a way that prevents
      * Mir from working. Quirk off gbm-kms on NVIDIA.
@@ -272,12 +368,11 @@ private:
     inline static std::set<std::string_view> const gbm_surface_has_free_buffers_always_true_options{"skip", "nvidia"};
     mgc::ValuedOption gbm_surface_has_free_buffers;
 
-    inline static std::set<std::string_view> const gbm_buffer_transfer_strategy_options{"cpu", "nvidia"};
-    mgc::ValuedOption gbm_buffer_transfer_strategy;
+    VendorPairTransferStrategy vendor_pair_transfer_strategy;
 };
 
-mgg::Quirks::Quirks(const options::Option& options)
-    : impl{std::make_unique<Impl>(options)}
+mgg::Quirks::Quirks(options::Option const& options) :
+    impl{std::make_unique<Impl>(options)}
 {
 }
 
@@ -290,11 +385,11 @@ auto mgg::Quirks::should_skip(udev::Device const& device) const -> bool
 
 void mgg::Quirks::add_quirks_option(boost::program_options::options_description& config)
 {
-    config.add_options()
-        (quirks_option_name,
-         boost::program_options::value<std::vector<std::string>>(),
-         "Driver quirks to apply. "
-         "May be specified multiple times; multiple quirks are combined.");
+    config.add_options()(
+        quirks_option_name,
+        boost::program_options::value<std::vector<std::string>>(),
+        "Driver quirks to apply. "
+        "May be specified multiple times; multiple quirks are combined.");
 }
 
 auto mir::graphics::gbm::Quirks::require_modesetting_support(mir::udev::Device const& device) const -> bool
@@ -304,7 +399,7 @@ auto mir::graphics::gbm::Quirks::require_modesetting_support(mir::udev::Device c
         mir::log_debug("MIR_MESA_KMS_DISABLE_MODESET_PROBE is set");
         return false;
     }
-    else if (getenv("MIR_GBM_KMS_DISABLE_MODESET_PROBE")  != nullptr)
+    else if (getenv("MIR_GBM_KMS_DISABLE_MODESET_PROBE") != nullptr)
     {
         mir::log_debug("MIR_GBM_KMS_DISABLE_MODESET_PROBE is set");
         return false;
@@ -320,12 +415,13 @@ auto mir::graphics::gbm::Quirks::gbm_quirks_for(udev::Device const& device) -> s
     return impl->gbm_quirks_for(device);
 }
 
-mir::graphics::gbm::GbmQuirks::GbmQuirks(std::unique_ptr<EglDestroySurfaceQuirk> egl_destroy_surface,
-                                         std::unique_ptr<SurfaceHasFreeBuffersQuirk> surface_has_free_buffers,
-                                         BufferTransferStrategy buffer_transfer_strategy) :
+mir::graphics::gbm::GbmQuirks::GbmQuirks(
+    std::unique_ptr<EglDestroySurfaceQuirk> egl_destroy_surface,
+    std::unique_ptr<SurfaceHasFreeBuffersQuirk> surface_has_free_buffers,
+    VendorPairConfig vendor_pair_config) :
     egl_destroy_surface_{std::move(egl_destroy_surface)},
     surface_has_free_buffers_{std::move(surface_has_free_buffers)},
-    buffer_transfer_strategy_{buffer_transfer_strategy}
+    vendor_pair_config_{std::move(vendor_pair_config)}
 {
 }
 
@@ -339,7 +435,53 @@ auto mir::graphics::gbm::GbmQuirks::gbm_surface_has_free_buffers(gbm_surface* gb
     return surface_has_free_buffers_->gbm_surface_has_free_buffers(gbm_surface);
 }
 
-auto mir::graphics::gbm::GbmQuirks::gbm_buffer_transfer_strategy() const -> BufferTransferStrategy
+auto mir::graphics::gbm::GbmQuirks::make_transfer_strategy_selector() const
+    -> DMABufEGLProvider::TransferStrategySelector
 {
-    return buffer_transfer_strategy_;
+    // Capture vendor pair config and default strategy
+    auto config = vendor_pair_config_;
+
+    return [config](std::string_view source_vendor, std::string_view dest_vendor) -> DMABufEGLProvider::BufferTransferStrategy
+    {
+        auto constexpr default_strategy = DMABufEGLProvider::BufferTransferStrategy::dma;
+
+        // If either vendor is unknown, use default
+        if (source_vendor.empty() || dest_vendor.empty())
+        {
+            return default_strategy;
+        }
+
+        std::string_view source_view{source_vendor};
+        std::string_view dest_view{dest_vendor};
+
+        // Check if user configured this specific vendor pair
+        auto key = std::string{source_view} + ":" + std::string{dest_view};
+        auto it = config.vendor_pairs.find(key);
+        if (it != config.vendor_pairs.end())
+        {
+            mir::log_debug(
+                "Using configured %s transfer for %s -> %s import",
+                it->second == DMABufEGLProvider::BufferTransferStrategy::cpu ? "CPU" : "DMA",
+                source_vendor.data(),
+                dest_vendor.data());
+            return it->second;
+        }
+
+        // If vendors are the same, use default
+        if (source_view == dest_view)
+        {
+            return default_strategy;
+        }
+
+
+        // Fallback: Intel -> NVIDIA: Use CPU transfer (known bug)
+        if (is_intel(source_view) && is_nvidia(dest_view))
+        {
+            mir::log_info("Using CPU transfer for Intel -> NVIDIA import (workaround for known issue)");
+            return DMABufEGLProvider::BufferTransferStrategy::cpu;
+        }
+
+        // All other combinations: use default
+        return default_strategy;
+    };
 }

--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -63,8 +63,6 @@ auto is_intel(std::string_view vendor) -> bool
 struct VendorPairTransferStrategy
 {
     void add(std::string_view source_vendor, std::string_view dest_vendor, std::string_view strategy);
-    auto get_strategy(std::string_view source_vendor, std::string_view dest_vendor) const
-        -> std::optional<mgg::GbmQuirks::BufferTransferStrategy>;
 
     // Map from "source:dest" to strategy
     std::unordered_map<std::string, mgg::GbmQuirks::BufferTransferStrategy> vendor_pairs;
@@ -99,18 +97,6 @@ void VendorPairTransferStrategy::add(
             std::string{source_vendor}.c_str(),
             std::string{dest_vendor}.c_str());
     }
-}
-
-auto VendorPairTransferStrategy::get_strategy(std::string_view source_vendor, std::string_view dest_vendor) const
-    -> std::optional<mgg::GbmQuirks::BufferTransferStrategy>
-{
-    auto key = std::string{source_vendor} + ":" + std::string{dest_vendor};
-    auto it = vendor_pairs.find(key);
-    if (it != vendor_pairs.end())
-    {
-        return it->second;
-    }
-    return std::nullopt;
 }
 
 auto parse_vendor_pair_quirk(

--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -55,10 +55,6 @@ auto is_nvidia(std::string_view vendor) -> bool
     return contains_case_insensitive(vendor, "nvidia");
 }
 
-auto is_intel(std::string_view vendor) -> bool
-{
-    return contains_case_insensitive(vendor, "intel") || contains_case_insensitive(vendor, "i915");
-}
 
 struct VendorPairTransferStrategy
 {
@@ -453,18 +449,17 @@ auto mir::graphics::gbm::GbmQuirks::make_transfer_strategy_selector() const
             return it->second;
         }
 
+        // Fallback: * -> NVIDIA: Use CPU transfer (known bug)
+        if (is_nvidia(dest_view))
+        {
+            mir::log_info("Using CPU transfer for Intel -> NVIDIA import (workaround for known issue)");
+            return DMABufEGLProvider::BufferTransferStrategy::cpu;
+        }
+
         // If vendors are the same, use default
         if (source_view == dest_view)
         {
             return default_strategy;
-        }
-
-
-        // Fallback: Intel -> NVIDIA: Use CPU transfer (known bug)
-        if (is_intel(source_view) && is_nvidia(dest_view))
-        {
-            mir::log_info("Using CPU transfer for Intel -> NVIDIA import (workaround for known issue)");
-            return DMABufEGLProvider::BufferTransferStrategy::cpu;
         }
 
         // All other combinations: use default

--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -449,10 +449,13 @@ auto mir::graphics::gbm::GbmQuirks::make_transfer_strategy_selector() const
             return it->second;
         }
 
-        // Fallback: * -> NVIDIA: Use CPU transfer (known bug)
-        if (is_nvidia(dest_view))
+        // Fallback: * -> NVIDIA or NVIDIA -> *: Use CPU transfer (known bug)
+        if (is_nvidia(source_view) || is_nvidia(dest_view))
         {
-            mir::log_info("Using CPU transfer for Intel -> NVIDIA import (workaround for known issue)");
+            mir::log_info(
+                "Using CPU transfer for %s -> %s import (workaround for known issue)",
+                source_vendor.data(),
+                dest_vendor.data());
             return DMABufEGLProvider::BufferTransferStrategy::cpu;
         }
 

--- a/src/platforms/gbm-kms/server/kms/quirks.h
+++ b/src/platforms/gbm-kms/server/kms/quirks.h
@@ -17,6 +17,8 @@
 #ifndef MIR_GRAPHICS_GBM_KMS_QUIRKS_H_
 #define MIR_GRAPHICS_GBM_KMS_QUIRKS_H_
 
+#include "mir/graphics/linux_dmabuf.h"
+
 #include <EGL/egl.h>
 
 #include <memory>
@@ -37,8 +39,6 @@ class Device;
 
 namespace graphics::gbm
 {
-// Maybe overkill for just one quirk, but we'll be really glad if we decide to
-// add another..
 class GbmQuirks
 {
 public:
@@ -66,17 +66,21 @@ public:
         virtual auto gbm_surface_has_free_buffers(gbm_surface* gbm_surface) const -> int = 0;
     };
 
+    using BufferTransferStrategy = DMABufEGLProvider::BufferTransferStrategy;
     GbmQuirks(
         std::unique_ptr<EglDestroySurfaceQuirk> create_surface_flags,
-        std::unique_ptr<SurfaceHasFreeBuffersQuirk> surface_has_free_buffers
+        std::unique_ptr<SurfaceHasFreeBuffersQuirk> surface_has_free_buffers,
+        BufferTransferStrategy gbm_buffer_transfer_strategy
     );
 
     void egl_destroy_surface(EGLDisplay dpy, EGLSurface surf) const;
     auto gbm_surface_has_free_buffers(gbm_surface* gbm_surface) const -> int;
+    auto gbm_buffer_transfer_strategy() const -> BufferTransferStrategy;
 
 private:
     std::unique_ptr<EglDestroySurfaceQuirk> const egl_destroy_surface_;
     std::unique_ptr<SurfaceHasFreeBuffersQuirk> const surface_has_free_buffers_;
+    BufferTransferStrategy const buffer_transfer_strategy_;
 };
 
 /**

--- a/src/platforms/gbm-kms/server/kms/quirks.h
+++ b/src/platforms/gbm-kms/server/kms/quirks.h
@@ -67,20 +67,28 @@ public:
     };
 
     using BufferTransferStrategy = DMABufEGLProvider::BufferTransferStrategy;
+
+    struct VendorPairConfig
+    {
+        std::unordered_map<std::string, BufferTransferStrategy> vendor_pairs;
+    };
+
     GbmQuirks(
         std::unique_ptr<EglDestroySurfaceQuirk> create_surface_flags,
         std::unique_ptr<SurfaceHasFreeBuffersQuirk> surface_has_free_buffers,
-        BufferTransferStrategy gbm_buffer_transfer_strategy
+        VendorPairConfig vendor_pair_config
     );
 
     void egl_destroy_surface(EGLDisplay dpy, EGLSurface surf) const;
     auto gbm_surface_has_free_buffers(gbm_surface* gbm_surface) const -> int;
-    auto gbm_buffer_transfer_strategy() const -> BufferTransferStrategy;
+
+    auto make_transfer_strategy_selector() const
+        -> DMABufEGLProvider::TransferStrategySelector;
 
 private:
     std::unique_ptr<EglDestroySurfaceQuirk> const egl_destroy_surface_;
     std::unique_ptr<SurfaceHasFreeBuffersQuirk> const surface_has_free_buffers_;
-    BufferTransferStrategy const buffer_transfer_strategy_;
+    VendorPairConfig const vendor_pair_config_;
 };
 
 /**

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -312,7 +312,7 @@ auto mge::GLRenderingProvider::as_texture(std::shared_ptr<Buffer> buffer) -> std
     std::shared_ptr<NativeBufferBase> native_buffer{buffer, buffer->native_buffer_base()};
     if (dmabuf_provider)
     {
-        if (auto tex = dmabuf_provider->as_texture(native_buffer))
+        if (auto tex = dmabuf_provider->as_texture(buffer))
         {
             return tex;
         }

--- a/src/platforms/renderer-generic-egl/rendering_platform.cpp
+++ b/src/platforms/renderer-generic-egl/rendering_platform.cpp
@@ -16,6 +16,7 @@
 
 #include "rendering_platform.h"
 #include "buffer_allocator.h"
+#include "mir/graphics/linux_dmabuf.h"
 #include <mir/graphics/egl_extensions.h>
 #include <mir/graphics/platform.h>
 #include <mir/graphics/egl_error.h>
@@ -180,7 +181,8 @@ auto maybe_make_dmabuf_provider(
             [](mg::DRMFormat, std::span<uint64_t const>, geom::Size) -> std::shared_ptr<mg::DMABufBuffer>
             {
                 return nullptr;    // We can't (portably) allocate dmabufs, but we also shouldn't need to
-            });
+            },
+            mg::DMABufEGLProvider::BufferTransferStrategy::cpu);
     }
     catch (std::runtime_error const& error)
     {

--- a/src/platforms/renderer-generic-egl/rendering_platform.cpp
+++ b/src/platforms/renderer-generic-egl/rendering_platform.cpp
@@ -182,7 +182,7 @@ auto maybe_make_dmabuf_provider(
             {
                 return nullptr;    // We can't (portably) allocate dmabufs, but we also shouldn't need to
             },
-            mg::DMABufEGLProvider::BufferTransferStrategy::cpu);
+            nullptr);  // No strategy selector for generic EGL platform
     }
     catch (std::runtime_error const& error)
     {


### PR DESCRIPTION
Closes #4035 

## What's new?
- Adds a fallback path in `gbm_bo_with_modifiers_or_linear`  to account for nvidia non-compliance 
- Adds a codepath in `DMABufEGLProvider` to copy buffers via the CPU
- Adds a quirk to detect to determine which codepath to use for buffer transfers, and passes that down to `DMABufEGLProvider`
- Any transfer involving nvidia goes through the CPU for now until we get to the bottom of the bug.

## How to test
On a machine with an intel iGPU and an nvidia dGPU, with one output connected to each:
1. Launch mir as follows:
```
miral-app --platform-display-libs=mir:atomic-kms --platform-rendering-libs=mir:gbm-kms --display-config=sidebyside --driver-quirks=gbm-buffer-transfer-strategy:nvidia:nvidia:dma
```
2. Launch one of `firefox`, `ghostty`, `gtk4-demo` as follows 
```
__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json  DRI_PRIME=1 <command>
```
3. Drag the window onto the screen connected to the nvidia card
4. If the app still renders correctly, resize the *width* using the mouse 
5. Observe as the window warps in a sawtooth pattern as you change the width
6. Repeat steps 1-4, but remove the last flag or change it  to `--driver-quirks=gbm-buffer-transfer-strategy:nvidia:nvidia:cpu`
7. Observe as the window renders correctly.

## Checklist
- [ ] Adequate documentation added (How should we document this?)
