### PR TITLE
ci,doc: `plucky` is no more

### DIFF
--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         release:
         - "24.04"
-        - "25.04"
         - "25.10"
         - "devel"
 

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -49,7 +49,6 @@ jobs:
                 "lxd:...:ubuntu_arm64"
                 "lxd:...:ubuntu_armhf"
                 "lxd:...:ubuntu_devel"
-                "lxd:...:ubuntu_plucky"
                 "lxd:...:ubuntu_proposed"
                 "lxd:...:ubuntu_questing"
                 "lxd:alpine-3.20:...:amd64"

--- a/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
+++ b/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
@@ -70,7 +70,7 @@ Each test must be performed across a combination of different display
 platforms and Ubuntu releases. The following matrix provides the environments
 in which we need to test:
 
-|                                | 24.04 | 25.04 |
+|                                | 24.04 | 25.10 |
 | ------------------------------ | ----- | ----- |
 | gbm-kms                        |       |       |
 | eglstream-kms                  |       |       |
@@ -194,7 +194,7 @@ For each empty box in the matrix above, ensure that the following applications c
 
 For each Ubuntu release ensure that the compositor can start with each of the console providers:
 
-|         | 24.04 | 25.04 |
+|         | 24.04 | 25.10 |
 | ------- | ----- | ----- |
 | vt      |       |       |
 | logind  |       |       |

--- a/spread.yaml
+++ b/spread.yaml
@@ -20,7 +20,6 @@ environment:
     DISTRO/debian_sid: debian
     RELEASE: noble
     RELEASE/ubuntu: noble
-    RELEASE/ubuntu_plucky: plucky
     RELEASE/ubuntu_questing: questing
     RELEASE/ubuntu_devel: resolute
     RELEASE/debian_sid: sid


### PR DESCRIPTION
## What's old?

Plucky is.

## How to test

PPA upload after.

## Checklist

- [ ] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
