### PR TITLE
bugfix: prepend the Rust path in tics.yml

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -103,7 +103,7 @@ jobs:
 
         sudo --preserve-env apt-get build-dep --yes ./
 
-        echo PATH=${PATH}:/usr/lib/rust-1.82/bin >> $GITHUB_ENV
+        echo PATH=/usr/lib/rust-1.82/bin:${PATH} >> $GITHUB_ENV
 
     - name: Configure
       run: >


### PR DESCRIPTION
Found while trying to merge https://github.com/canonical/mir/pull/4646

## What's new?
TICS was finding rust version 1.75, which was the system default. We should prepend to the path instead so that the installed version has priority 
