### PR TITLE
Send the cursor image via ext_image_copy_capture_v1

### DIFF
--- a/src/server/frontend_wayland/ext_image_capture_v1.cpp
+++ b/src/server/frontend_wayland/ext_image_capture_v1.cpp
@@ -936,7 +936,7 @@ void mf::ExtImageCopyCaptureCursorSessionV1::ImageCopyBackend::begin_capture(
     if (cursor_image)
     {
         auto const dest_stride = mapping->stride();
-        auto const cursor_data = reinterpret_cast<char const*>(cursor_image->as_argb_8888());
+        auto const cursor_data = static_cast<char const*>(cursor_image->as_argb_8888());
         if (dest_stride == cursor_stride)
         {
             memcpy(mapping->data(), cursor_data, mapping->len());
@@ -944,7 +944,7 @@ void mf::ExtImageCopyCaptureCursorSessionV1::ImageCopyBackend::begin_capture(
         else
         {
             // strides don't match: copy data in rows
-            for (auto y = 0u; y < cursor_size.height.as_uint32_t(); ++y)
+            for (size_t y = 0u; y < cursor_size.height.as_uint32_t(); ++y)
             {
                 memcpy(mapping->data() + (dest_stride.as_uint32_t() * y),
                        cursor_data + (cursor_stride.as_uint32_t() * y),


### PR DESCRIPTION
Closes #3659

## What's new?

This adds support for sending the cursor image via the `ext_image_copy_capture_v1` protocol. This makes the `ImageCopyBackend` used by the cursor session into a `CursorObserver` so it can receive `image_set_to` notifications.

If the cursor is hidden, we send a 1x1 transparent cursor. Sending 0x0 caused problems with wayvnc.

## How to test

Run miral with appropriate extensions enabled:

```
./bin/miral-app --add-wayland-extensions ext_output_image_capture_source_manager_v1:ext_image_copy_capture_manager_v1:zwlr_virtual_pointer_manager_v1:zwp_virtual_keyboard_manager_v1
```

Run wayvnc connecting to the this compositor:

```
WAYLAND_DISPLAY=wayland-1 wayvnc
```

Connect to the VNC session with a client that supports client cursor display like Remmina (GNOME Connections [does not work](https://gitlab.gnome.org/GNOME/gnome-connections/-/issues/140#note_2679520)).

Verify that the cursor changes as expected when resizing windows, or changes to a text insertion point in text entry fields. Try playing a video in Totem and note that the cursor is hidden when not in motion.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
