### PR TITLE
Use `SurfaceStateTracker` to hide/restore windows to the proper state

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -350,13 +350,14 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     {
         bool const is_mapped = scene_surface->visible();
         bool const should_be_mapped = static_cast<bool>(surface.value().buffer_size());
-        if (!is_mapped && should_be_mapped && scene_surface->state() == mir_window_state_hidden)
+        auto const state_tracker = scene_surface->state_tracker();
+        if (!is_mapped && should_be_mapped && state_tracker.has(mir_window_state_hidden))
         {
-            spec().state = mir_window_state_restored;
+            spec().state = state_tracker.without(mir_window_state_hidden).active_state();
         }
         else if (is_mapped && !should_be_mapped)
         {
-            spec().state = mir_window_state_hidden;
+            spec().state = state_tracker.with(mir_window_state_hidden).active_state();
         }
 
         apply_client_size(spec());

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -135,13 +135,14 @@ void mf::XWaylandSurfaceRole::commit(WlSurfaceState const& state)
 
         bool const is_mapped = surface.value()->visible();
         bool const should_be_mapped = static_cast<bool>(wl_surface->buffer_size());
-        if (!is_mapped && should_be_mapped && surface.value()->state() == mir_window_state_hidden)
+        auto const state_tracker = surface.value()->state_tracker();
+        if (!is_mapped && should_be_mapped && state_tracker.has(mir_window_state_hidden))
         {
-            spec.state = mir_window_state_restored;
+            spec.state = state_tracker.without(mir_window_state_hidden).active_state();
         }
         else if (is_mapped && !should_be_mapped)
         {
-            spec.state = mir_window_state_hidden;
+            spec.state = state_tracker.with(mir_window_state_hidden).active_state();
         }
 
         std::vector<std::shared_ptr<void>> keep_alive_until_spec_is_used;


### PR DESCRIPTION
Spawned off https://github.com/canonical/mir/pull/4664#discussion_r2815946423

## What's new?

- Instead of forcing `mir_window_state_restored` or `mir_window_state_hidden` when mapping/unmapping windows, the code now uses `SurfaceStateTracker` which manages state precedence. 

## How to test

- A separate PR for WLCS tests will be opened shortly.

## Checklist

- [x] Tests added and pass
