### PR TITLE
If a surface has an opaque region BUT the alpha is not 1.0, then we shouldn't use it as an occlusion

### DIFF
--- a/src/server/compositor/occlusion.cpp
+++ b/src/server/compositor/occlusion.cpp
@@ -54,7 +54,7 @@ bool renderable_is_occluded(
         }
     }
 
-    if (!occluded)
+    if (!occluded && renderable.alpha() == 1.0f)
     {
         if (renderable.shaped())
         {
@@ -68,7 +68,7 @@ bool renderable_is_occluded(
             }
             // Client didn't send an opaque region
         }
-        else if (renderable.alpha() == 1.0f)
+        else
         {
             coverage.push_back(clipped_window);
         }

--- a/tests/unit-tests/compositor/test_occlusion.cpp
+++ b/tests/unit-tests/compositor/test_occlusion.cpp
@@ -131,6 +131,19 @@ TEST_F(OcclusionFilterTest, shaped_window_with_opaque_region_occludes_something)
     EXPECT_THAT(renderables_from(elements), ElementsAre(top));
 }
 
+TEST_F(OcclusionFilterTest, shaped_translucent_window_with_opaque_region_occludes_nothing)
+{
+    // A window with opaque_region but uniform alpha < 1.0 should NOT occlude
+    auto top = std::make_shared<mtd::FakeRenderable>(
+        Rectangle{{10, 10}, {10, 10}}, 0.5f, false, Rectangles{Rectangle{{11, 11}, {9, 9}}});
+    auto bottom = std::make_shared<mtd::FakeRenderable>(12, 12, 5, 5);
+
+    auto const& [occlusions, elements] = split_occluded_and_visible(scene_elements_from({bottom, top}), monitor_rect);
+
+    EXPECT_THAT(renderables_from(occlusions), IsEmpty());
+    EXPECT_THAT(renderables_from(elements), ElementsAre(bottom, top));
+}
+
 TEST_F(OcclusionFilterTest, identical_window_occluded)
 {
     auto top = std::make_shared<mtd::FakeRenderable>(10, 10, 10, 10);


### PR DESCRIPTION
Related:
https://github.com/miracle-wm-org/miracle-wm/issues/770

## What's new?
This has been breaking me in a funky way. In miracle, if I have Firefox on workspace 1 and some terminals on workspace 2, running the fade animation between the two screens was the fade to not happen on the terminals in workspace 2 because they believed themselves to be occluded by Firefox, even though it was fading away. The solution is to only use the occlusion zone if alpha is not 1.0, or else you can see through the surface.

## How to test
1. Build miracle with this version of Mir and this version of miracle: https://github.com/miracle-wm-org/miracle-wm/pull/785
2. Have fade animations configured in Miracle
3. Open up Firefox on workspace 1
4. Open up 5 terminals on workspace 2
5. Switch between the workspaces and note that the fade and transform animations work again

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
