### PR TITLE
fix: preserve errno when close() follows a failed unlink() (#4557)

### DIFF
--- a/src/core/anonymous_shm_file.cpp
+++ b/src/core/anonymous_shm_file.cpp
@@ -54,8 +54,11 @@ mir::Fd create_anonymous_file(off_t size)
             {
                 if (unlink(template_filename) < 0)
                 {
+                    // Save errno before close() can overwrite it with an unrelated error
+                    int const original_errno = errno;
                     close(raw_fd);
                     raw_fd = -1;
+                    errno = original_errno;
                 }
             }
         }


### PR DESCRIPTION
Closes #4557                                                                                                                                                                                                                                                                                   
   
## What's new?                                                                                                                                                                                                                                                                                 

When `unlink()` fails and `close()` is called for cleanup, `close()` can overwrite `errno` with an unrelated error. The subsequent error message then reports the wrong reason for the failure.

This fix saves `errno` immediately after the failing call, before `close()` can clobber it.

## How to test

I don't think unit tests are warranted here given the simplicity of the fix, a review should be enough, but let me know if I'm being naive.

## Checklist

- [x] Tests ~~added~~ and pass (unit tests not included in the PR to keep things simple, see [that separate branch](https://github.com/pierre-l/mir/commit/e19160554fdfedaa2c465bbd2b53de65ddfde034))
- [x] Adequate documentation added
- [x] ~~(optional) Added Screenshots or videos~~
