### PR TITLE
When a window has a size send that size in configure

### DIFF
--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -681,7 +681,7 @@ void mf::XdgToplevelStable::send_toplevel_configure()
     }
 
     // 0 sizes means default for toplevel configure
-    auto size= opt_window_size.value_or(geom::Size{0, 0});
+    auto size = opt_window_size.value_or(geom::Size{0, 0});
 
     send_configure_event(size.width.as_int(), size.height.as_int(), &states);
     wl_array_release(&states);


### PR DESCRIPTION
Closes #4688

## What's new?

We can call send_toplevel_configure() without fully updating the frontend state.

This improves our behaviour by identifying cases where we know window management has set a size and grabbing that size (bypassing `requested_size`).

This works for more cases than the previous logic but there' is a wider underlying issue here: ensuring that updates to the frontend are atomic and that size, state and active status are sent together and not piecemeal.

## How to test

See linked issue