### PR TITLE
In tics, fprofile update needs to be atomic to avoid negative counters causes by concurrent test execution

### DIFF
--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -87,6 +87,9 @@
 #     - fix append_coverage_compiler_flags_to_target to correctly add flags
 #     - replace "-fprofile-arcs -ftest-coverage" with "--coverage" (equivalent)
 #
+# 2026-01-20, Michał Sawicz
+#     - add `-fprofile-update=atomic` flag, if supported, for concurrent test runs
+#
 # USAGE:
 #
 # 1. Copy this file into your cmake modules path.
@@ -185,6 +188,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     if(HAVE_cxx_fprofile_abs_path)
         set(COVERAGE_CXX_COMPILER_FLAGS "${COVERAGE_CXX_COMPILER_FLAGS} -fprofile-abs-path")
     endif()
+    check_cxx_compiler_flag(-fprofile-update=atomic HAVE_cxx_fprofile_update_atomic)
+    if(HAVE_cxx_fprofile_update_atomic)
+        set(COVERAGE_CXX_COMPILER_FLAGS "${COVERAGE_CXX_COMPILER_FLAGS} -fprofile-update=atomic")
+    endif()
 endif()
 
 set(COVERAGE_C_COMPILER_FLAGS ${COVERAGE_COMPILER_FLAGS})
@@ -194,6 +201,10 @@ if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)")
     if(HAVE_c_fprofile_abs_path)
         set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_C_COMPILER_FLAGS} -fprofile-abs-path")
     endif()
+    check_c_compiler_flag(-fprofile-update=atomic HAVE_c_fprofile_update_atomic)
+    if(HAVE_c_fprofile_update_atomic)
+        set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_C_COMPILER_FLAGS} -fprofile-update=atomic")
+    endif()
 endif()
 
 set(COVERAGE_Fortran_COMPILER_FLAGS ${COVERAGE_COMPILER_FLAGS})
@@ -202,6 +213,10 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "(GNU|Clang)")
     check_fortran_compiler_flag(-fprofile-abs-path HAVE_fortran_fprofile_abs_path)
     if(HAVE_fortran_fprofile_abs_path)
         set(COVERAGE_Fortran_COMPILER_FLAGS "${COVERAGE_Fortran_COMPILER_FLAGS} -fprofile-abs-path")
+    endif()
+    check_fortran_compiler_flag(-fprofile-update=atomic HAVE_fortran_fprofile_update_atomic)
+    if(HAVE_fortran_fprofile_update_atomic)
+        set(COVERAGE_Fortran_COMPILER_FLAGS "${COVERAGE_Fortran_COMPILER_FLAGS} -fprofile-update=atomic")
     endif()
 endif()
 


### PR DESCRIPTION
Seen here: https://github.com/canonical/mir/pull/4701

## What's new?
Fixes this error that I keep seeing:

```
[014](https://github.com/canonical/mir/actions/runs/22195820775/job/64195700617?pr=4701#step:11:2015)
Processing /home/ubuntu/actions-runner/_work/mir/mir/build/src/core/CMakeFiles/mircore.dir/anonymous_shm_file.cpp.gcda
geninfo: ERROR: Unexpected negative count '-2' for /usr/include/c++/13/bits/char_traits.h:433.
	Perhaps you need to compile with '-fprofile-update=atomic
	(use "geninfo --ignore-errors negative ..." to bypass this error)
ninja: build stopped: subcommand failed.
Error: Process completed with exit code 1.
```

## How to test
CI is no longer borked.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
