### PR TITLE
ci: only cache from `main` builds

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -110,13 +110,19 @@ jobs:
         echo "merge-base=$( git merge-base origin/main ${{ github.sha }} )" >> $GITHUB_OUTPUT
 
     - name: CCache
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: actions/cache@v5
-      with:
+      with: &ccache_with
         key: ccache-${{ matrix.spread-task }}-${{ steps.setup-ccache.outputs.merge-base }}
         # if exact match isn't found, use the most recent entry for the task
         restore-keys: |
           ccache-${{ matrix.spread-task }}-
         path: ${{ env.CCACHE_DIR }}
+
+    - name: Restore CCache
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+      uses: actions/cache/restore@v5
+      with: *ccache_with
 
     - name: Ensure ccache size
       run: |

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -69,13 +69,19 @@ jobs:
         echo "merge-base=$( git merge-base origin/main ${{ github.sha }} )" >> $GITHUB_OUTPUT
 
     - name: CCache
+      if: ${{ github.event_name == 'push' }}
       uses: actions/cache@v5
-      with:
+      with: &ccache_with
         key: ccache-coverage-${{ steps.setup-ccache.outputs.merge-base }}
         # if exact match isn't found, use the most recent entry for the task
         restore-keys: |
           ccache-coverage-
         path: ${{ env.CCACHE_DIR }}
+
+    - name: Restore CCache
+      if: ${{ github.event_name != 'push' }}
+      uses: actions/cache/restore@v5
+      with: *ccache_with
 
     - name: Ensure ccache size
       run: |


### PR DESCRIPTION
## What's new?

We only _store_ ccache on `main` builds, otherwise they often fall off the storage allowed and we get cache misses across the board.

## How to test

PR CI _doesn't_ store cache for spread and tics jobs.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos