### PR TITLE
Access `key_mapper->xkb_modifiers()` with `device_state_mutex` locked

### DIFF
--- a/src/server/input/seat_input_device_tracker.cpp
+++ b/src/server/input/seat_input_device_tracker.cpp
@@ -319,6 +319,7 @@ mir::EventUPtr mi::SeatInputDeviceTracker::create_device_state() const
 
 auto mi::SeatInputDeviceTracker::xkb_modifiers() const -> MirXkbModifiers
 {
+    std::lock_guard lock(device_state_mutex);
     return key_mapper->xkb_modifiers();
 }
 


### PR DESCRIPTION
Fixes: #4673
