### PR TITLE
tics: install clang-tools, too

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -94,6 +94,7 @@ jobs:
         sudo --preserve-env apt-get install --yes --no-install-recommends \
           cargo-1.82 \
           clang \
+          clang-tools \
           dmz-cursor-theme \
           flake8 \
           gcovr \


### PR DESCRIPTION
## What's new?

`clang-scan-deps` is required to build.

## How to test

This TICS run doesn't fail with a 5000 error: https://github.com/canonical/mir/actions/runs/22314828294/job/64556630946

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos