### PR TITLE
tests/mirtest*.pc.in: Drop remaining references to boost_system

### DIFF
--- a/tests/mirtest-internal.pc.in
+++ b/tests/mirtest-internal.pc.in
@@ -6,5 +6,5 @@ Name: mirtest-internal
 Description: Mir test assist internal library
 Version: @PROJECT_VERSION@
 Requires: mirtest mirserver mirserver-internal
-Libs: -L${libdir} -lmir-test-assist -lmir-test-assist-internal -ldl -lboost_filesystem -lboost_system
+Libs: -L${libdir} -lmir-test-assist -lmir-test-assist-internal -ldl -lboost_filesystem
 Cflags: -I${includedir}

--- a/tests/mirtest.pc.in
+++ b/tests/mirtest.pc.in
@@ -6,5 +6,5 @@ Name: mirtest
 Description: Mir test assist library
 Version: @PROJECT_VERSION@
 Requires: miral mirserver mirplatform mircommon
-Libs: -L${libdir} -lmir-test-assist -ldl -lboost_filesystem -lboost_system
+Libs: -L${libdir} -lmir-test-assist -ldl -lboost_filesystem
 Cflags: -I${includedir}


### PR DESCRIPTION
Closes https://github.com/miracle-wm-org/miracle-wm/issues/728

Related: #4329

## What's new?

Drop leftover linking references to `boost_system` (stub library since Boost 1.69, dropped in Boost 1.89)

## How to test

Build https://github.com/miracle-wm-org/miracle-wm with Boost 1.89.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
