### PR TITLE
server: Fix re-raising original signal in `fatal_signal_cleanup`

### DIFF
--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -184,6 +184,12 @@ extern "C" [[noreturn]] void fatal_signal_cleanup(int sig, siginfo_t* info, void
 
     perform_emergency_cleanup();
 
+    // Unblock the signal that we're handling, so that if the handler tries to re-raise it (e.g. to dump core) then it will succeed.
+    sigset_t current_signal_mask;
+    sigemptyset(&current_signal_mask);
+    sigaddset(&current_signal_mask, sig);
+    sigprocmask(SIG_UNBLOCK, &current_signal_mask, nullptr);
+
     auto const old_handler = old_handlers.at(sig);
     sigaction(sig, old_handler, nullptr);
     if (old_handler->sa_flags & SA_SIGINFO)


### PR DESCRIPTION
After we do our cleanup we restore whatever signal handler was present prior to `run_mir` executing, and re-raise the signal to pass execution to the original handler.

At least, that was the plan. In actuality, when registering our signal handler we (correctly!) blocked all signal dispatch while the handler is being executed. That's the right thing to do, but in this case it meant that when we re-raised the signal it was blocked. Ooops!

Remove the handled signal from the process' blocked signal mask before invoking the old handler, so it actually gets run.

(Last part of) Fixes: #2658

## How to test

Run a Mir server, and kill it with `SIGABRT`. You should *not* see “Unsupported attempt to continue after a fatal signal: SIGABRT” logged. (This should be visible with Mir from main)

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
