### PR TITLE
all: rebase on newest distro releases

### DIFF
--- a/.github/skills/update-ci-distro-releases/SKILL.md
+++ b/.github/skills/update-ci-distro-releases/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: update-ci-distro-releases
+description: Update spread and GitHub Actions distro/runner versions to current supported Ubuntu, Fedora, and Alpine releases; remove EOL stable releases by default, preserve existing development tracks, optionally keep only latest stable per distro, and refresh GitHub runner images.
+---
+
+# Update CI Distro Releases
+
+Use this workflow when asked to refresh distro versions in spread and GitHub Actions configuration.
+
+Authoritative sources:
+
+- Ubuntu release support and lifecycle: https://ubuntu.com/about/release-cycle
+- Fedora release history (for current and EOL): https://en.wikipedia.org/wiki/Fedora_Linux_release_history
+- Alpine releases and support windows: https://alpinelinux.org/releases/
+- GitHub Actions runner images and deprecations: https://github.com/actions/runner-images
+
+## Behavior
+
+Default behavior:
+
+1. Remove unsupported/EOL distro releases.
+1. Keep all still-supported releases.
+1. Add newly supported releases to the version lists/matrices.
+1. Preserve existing development images/tracks (for example `edge`, `rawhide`, `devel`)
+
+Optional behavior when explicitly requested:
+
+1. Keep only the latest supported stable release for each distro.
+1. Where applicable, replace the default release with the latest supported stable release.
+
+## Files to inspect and update
+
+- `spread.yaml`
+- `.github/workflows/spread.yml`
+- Any workflow under `.github/workflows/*.yml` with distro version literals or explicit runner image pins.
+
+Typical fields:
+
+- spread backend systems list (`backends.lxd.systems`)
+- spread environment release aliases (`RELEASE/...`)
+- unversioned spread release aliases (for example `RELEASE/fedora_clang`) aligned to the latest supported stable release for their distro track
+- `RELEASE` and `RELEASE/ubuntu` are special-case Ubuntu aliases: update only in latest-only mode, and only to the latest supported Ubuntu LTS codename
+- spread GitHub Actions matrix entries (for example `lxd:alpine-...`, `lxd:fedora_...`)
+- workflow `runs-on` image pins (for example `ubuntu-24.04`, `ubuntu-22.04`, `ubuntu-latest`)
+
+Ubuntu-specific (especially in latest-only mode):
+
+- stable Ubuntu system image in `backends.lxd.systems` (for example `ubuntu-24.04` -> `ubuntu-26.04`)
+- default Ubuntu release aliases (`RELEASE` and `RELEASE/ubuntu`) to the latest supported Ubuntu LTS codename
+- remove superseded interim aliases from `RELEASE/...` when latest-only is requested (for example remove `RELEASE/ubuntu_questing` once `RELEASE/ubuntu_resolute` is the selected stable baseline)
+- remove matching superseded spread matrix tasks under `.github/workflows/spread.yml` (for example `lxd:...:ubuntu_questing`)
+
+## Update procedure
+
+1. Determine current supported stable releases for Ubuntu, Fedora, and Alpine from the sources above.
+1. Choose target versions per distro:
+   - Default mode: keep all supported stable releases.
+   - Latest-only mode: keep only the newest supported stable release.
+1. Update the fields listed above:
+   - Add newly supported versions and remove EOL versions.
+   - Preserve existing development tracks (`edge`, `rawhide`, `devel`).
+   - Keep naming conventions consistent with the existing config.
+   - Update unversioned stable release aliases to match the newest supported stable release for their distro track (for example keep `RELEASE/fedora_clang` aligned with the newest supported stable Fedora release kept in `RELEASE/fedora_<version>`).
+   - Do not update `RELEASE` or `RELEASE/ubuntu` in default mode.
+   - In Ubuntu latest-only mode, set `RELEASE` and `RELEASE/ubuntu` to the latest supported Ubuntu LTS codename, keep only the latest stable Ubuntu image in `backends.lxd.systems`, and remove superseded interim aliases/tasks.
+1. If runner images are in scope:
+   - Update explicit pinned `runs-on` images only when repo policy or prompt requires it.
+   - Only change `runs-on` to labels that are documented as available GitHub-hosted runner images in `actions/runner-images`.
+   - Do not infer a new `runs-on` label from distro upgrades in spread config; if no matching GitHub-hosted image exists, keep the current pin (or `ubuntu-latest`) and note the constraint.
+   - Leave `ubuntu-latest` unchanged unless explicitly requested.
+1. When runner updates are touched, include this user prompt verbatim:
+   - `Please verify whether any self-hosted runners also need OS/image updates to match these CI changes.`
+
+## Validation checklist
+
+- No remaining references to removed/EOL distro versions in `spread.yaml` or `.github/workflows/*.yml`.
+- Spread matrix entries align with `backends.lxd.systems` and `RELEASE/...` aliases.
+- Unversioned stable release aliases (excluding `RELEASE` and `RELEASE/ubuntu`) match the selected latest supported stable release for their distro track.
+- Existing development images/tracks are preserved.
+- If latest-only mode was requested, exactly one stable version remains per distro.
+- If latest-only mode was requested for Ubuntu, `RELEASE` and `RELEASE/ubuntu` match the latest supported Ubuntu LTS codename and superseded interim aliases/tasks are removed.
+- YAML syntax remains valid (validate with `yq`).
+
+Recommended validation command:
+
+```bash
+yq '.' spread.yaml >/dev/null && yq '.' .github/workflows/spread.yml >/dev/null
+```
+
+## Suggested search commands
+
+```bash
+rg -n "alpine-|fedora-|ubuntu-|rawhide|edge|devel|runs-on:" spread.yaml .github/workflows/*.yml
+```
+
+## Rules
+
+- Prefer minimal, targeted edits.
+- Do not silently change release-policy intent; follow default mode unless the prompt explicitly requests latest-only mode.
+- Never update workflow `runs-on` to an unverified or unavailable image label.
+- If upstream support status is ambiguous, state assumptions explicitly before finalizing.

--- a/.github/workflows/close-snap.yml
+++ b/.github/workflows/close-snap.yml
@@ -29,10 +29,10 @@ jobs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
       run: |
-        snapcraft close mir-libs "22/edge/pr${{ github.event.number }}" || true
+        snapcraft close mir-libs "26/edge/pr${{ github.event.number }}" || true
         for snap in confined-shell miriway; do
           snapcraft close "$snap" "edge/mir-pr${{ github.event.number }}" || true
         done
         for snap in mir-test-tools ubuntu-frame; do
-          snapcraft close "$snap" "24/edge/mir-pr${{ github.event.number }}" || true
+          snapcraft close "$snap" "26/edge/mir-pr${{ github.event.number }}" || true
         done

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -73,7 +73,7 @@ jobs:
         launchpad-credentials: ${{ secrets.LAUNCHPAD_CREDENTIALS }}
         launchpad-accept-public-upload: true
         publish: ${{ github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name }}
-        publish-channel: 24/edge/pr${{ github.event.number }}
+        publish-channel: 26/edge/pr${{ github.event.number }}
 
   snap:
     # Only run if we have access to secrets.
@@ -100,11 +100,11 @@ jobs:
         architecture: ${{ fromJSON(needs.arches.outputs.arches) }}
         include:
         - snap: canonical/mir-test-tools
-          track: 24
+          track: 26
         - snap: canonical/confined-shell-wip
           track: latest
         - snap: canonical/ubuntu-frame
-          track: 24
+          track: 26
         - snap: Miriway/Miriway
           track: latest
           review-opts: --allow-classic

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -118,7 +118,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ matrix.snap }}
-        ref: mir-libs-build
+        ref: 26/mir-libs-build
         fetch-depth: 0  # needed for version determination
         persist-credentials: false
 

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -65,6 +65,10 @@ jobs:
         git config --global --add safe.directory "$(pwd)"
         sed -i "s@version: testing@version: $(git describe)@" snap/snapcraft.yaml
 
+    - name: Strip git tags to speed up Launchpad remote build indexing
+      if: matrix.architecture != 'amd64'
+      run: git tag -l | xargs -r git tag -d
+
     - name: Build and publish the snap
       uses: canonical/actions/build-snap@78e8dd5f693653767f2c60c4a6a421a1ebed35af # release @ 2025.06.05
       with:

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -47,7 +47,7 @@ jobs:
 
         TASKS+=(
           "lxd:...:debian_sid"
-          "lxd:...:fedora_43"
+          "lxd:...:fedora_44"
           "lxd:...:fedora_clang"
           "lxd:...:fedora_rawhide"
           "lxd:...:spread/ubuntu:asan"
@@ -61,11 +61,8 @@ jobs:
           "lxd:...:ubuntu_armhf"
           "lxd:...:ubuntu_devel"
           "lxd:...:ubuntu_proposed"
-          "lxd:...:ubuntu_questing"
           "lxd:...:ubuntu_resolute"
-          "lxd:alpine-3.21:...:amd64"
-          "lxd:alpine-3.22:...:amd64"
-          "lxd:alpine-3.23:...:amd64"
+          "lxd:alpine-3.24:...:amd64"
           "lxd:alpine-edge:...:amd64"
         )
 
@@ -116,7 +113,7 @@ jobs:
           sources_list: |
             Types: deb
             URIs: http://azure.archive.ubuntu.com/ubuntu/
-            Suites: noble noble-updates noble-security
+            Suites: resolute resolute-updates resolute-security
             Components: main universe
         EOF
 

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -118,7 +118,7 @@ jobs:
         EOF
 
         sudo apt-get update
-        sudo apt-get install --yes binfmt-support qemu-user-static
+        sudo apt-get install --yes binfmt-support qemu-user-binfmt
         echo "LXD_DIR=/var/snap/lxd/common/lxd" >> "$GITHUB_ENV"
 
     - name: Check out code

--- a/.workshop/mir/hooks/setup-base
+++ b/.workshop/mir/hooks/setup-base
@@ -8,7 +8,9 @@ apt-get --yes --no-install-recommends install \
   clang \
   mold \
   ninja-build \
-  python3-venv
+  python3-venv \
+  ripgrep \
+  yq
 apt-get --no-install-recommends build-dep mir
 
 cat <<'EOF' > /etc/profile.d/mir.sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mir-libs
-base: core24
+base: core26
 summary: The fast, open and secure display server for any device - build environment
 description: |
   Mir is a display server running on linux systems, with a focus on efficiency,
@@ -19,11 +19,9 @@ parts:
     - -DCMAKE_INSTALL_PREFIX=/usr
     - -DMIR_ENABLE_WLCS_TESTS=OFF
     - -DMIR_PLATFORM='atomic-kms;gbm-kms;eglstream-kms;x11;wayland'
-    build-environment:
-    - PATH: $PATH:/usr/lib/rust-1.82/bin
     build-packages:
     - build-essential
-    - cargo-1.82
+    - cargo
     - eglexternalplatform-dev
     - git
     - libboost-date-time-dev
@@ -61,10 +59,10 @@ parts:
     - libpixman-1-dev
     - xwayland
     stage-packages:
-    - libboost-iostreams1.83.0
-    - libboost-program-options1.83.0
+    - libboost-iostreams1.90.0
+    - libboost-program-options1.90.0
     - libdrm2
-    - libdisplay-info1
+    - libdisplay-info3
     - libegl1
     - libepoxy0
     - libevdev2
@@ -75,7 +73,7 @@ parts:
     - libglibmm-2.4-1t64
     - libglvnd0
     - libgudev-1.0-0
-    - libicu74
+    - libicu78
     - libinput10
     - liblttng-ust1t64
     - libmtdev1t64
@@ -103,7 +101,7 @@ parts:
     - libxkbcommon0
     - libxkbcommon-x11-0
     - libxml++2.6-2v5
-    - libxml2
+    - libxml2-16
     - libxrender1
     - libyaml-cpp0.8
     - libapparmor1

--- a/spread.yaml
+++ b/spread.yaml
@@ -5,12 +5,10 @@ kill-timeout: 45m
 backends:
     lxd:
         systems:
-            - alpine-3.21
-            - alpine-3.22
-            - alpine-3.23
+            - alpine-3.24
             - alpine-edge
-            - ubuntu-24.04
-            - fedora-43
+            - ubuntu-26.04
+            - fedora-44
 
 environment:
     ARCH: amd64
@@ -18,15 +16,14 @@ environment:
     ARCH/ubuntu_armhf: armhf
     DISTRO: ubuntu
     DISTRO/debian_sid: debian
-    RELEASE: noble
-    RELEASE/ubuntu: noble
-    RELEASE/ubuntu_questing: questing
+    RELEASE: resolute
+    RELEASE/ubuntu: resolute
     RELEASE/ubuntu_resolute: resolute
     RELEASE/ubuntu_devel: stonking
     RELEASE/debian_sid: sid
-    RELEASE/fedora_43: 43
+    RELEASE/fedora_44: 44
     RELEASE/fedora_rawhide: rawhide
-    RELEASE/fedora_clang: 43
+    RELEASE/fedora_clang: 44
     PROPOSED: false
     PROPOSED/ubuntu_proposed: true
     CLANG: 0

--- a/spread/sbuild/task.yaml
+++ b/spread/sbuild/task.yaml
@@ -19,13 +19,11 @@ execute: |
         --yes \
         --no-install-recommends \
         autopkgtest \
-        binfmt-support \
         debootstrap \
         debhelper \
         dh-python \
         fakeroot \
         nullmailer \
-        qemu-user-binfmt \
         sbuild \
         schroot \
         ubuntu-dev-tools
@@ -55,7 +53,7 @@ execute: |
     MKSBUILD_OPTS=(
       mk-sbuild
       --distro ${DISTRO}
-      --debootstrap-include=ccache,passwd
+      --debootstrap-include=ccache,passwd,qemu-user
       ${RELEASE}
     )
 
@@ -115,6 +113,13 @@ execute: |
 
     # Build the schroot, if it doesn't already exist
     [ -f /etc/schroot/chroot.d/sbuild-${SCHROOT_NAME} ] || sg sbuild -c "${MKSBUILD_OPTS[*]}"
+
+    # TODO: drop once we move from 24.04 on the host
+    # Newer guest releases may register a different qemu-binfmt interpreter path than older hosts.
+    mkdir --parents /var/lib/schroot/chroots/${SCHROOT_NAME}/usr/libexec/qemu-binfmt
+    for q in /var/lib/schroot/chroots/${SCHROOT_NAME}/usr/bin/qemu-*; do
+      ln --verbose --symbolic --force "../../bin/qemu-${q##*-}" "/var/lib/schroot/chroots/${SCHROOT_NAME}/usr/libexec/qemu-binfmt/${q##*-}-binfmt-P"
+    done
 
     echo "export XDG_RUNTIME_DIR=/tmp" >> debian/opts.mk
 

--- a/spread/sbuild/task.yaml
+++ b/spread/sbuild/task.yaml
@@ -41,7 +41,12 @@ execute: |
     EOF
     apparmor_parser -r /etc/apparmor.d/sbuild
 
+    # trick mk-sbuild into making the chroot for us
+    addgroup --system sbuild
     adduser $USER sbuild
+    mkdir --parents /var/lib/sbuild/build
+    chown --recursive :sbuild /var/lib/sbuild
+    chmod --recursive g+w /var/lib/sbuild
     # set host and build environment up
     source <( dpkg-architecture --print-set --host-arch ${ARCH} )
 
@@ -50,7 +55,7 @@ execute: |
     MKSBUILD_OPTS=(
       mk-sbuild
       --distro ${DISTRO}
-      --debootstrap-include=ccache
+      --debootstrap-include=ccache,passwd
       ${RELEASE}
     )
 
@@ -60,6 +65,8 @@ execute: |
     fi
 
     SBUILD_OPTS=(
+      --chroot-mode schroot
+      --no-clean-source
       --jobs=$(nproc)
       --verbose
       --dist=${RELEASE}

--- a/spread/sbuild/task.yaml
+++ b/spread/sbuild/task.yaml
@@ -25,7 +25,7 @@ execute: |
         dh-python \
         fakeroot \
         nullmailer \
-        qemu-user-static \
+        qemu-user-binfmt \
         sbuild \
         schroot \
         ubuntu-dev-tools


### PR DESCRIPTION
Rebase on newest Ubuntu, Fedora, Alpine, along with CI.

Related: https://github.com/canonical/mir/actions/runs/27554193823/job/81448621493

## What's new?

- Upgrade snap to `base: core26` and update stage package names for Ubuntu 26.04
- Update CI snap channels from track 24 to track 26
- Update spread config to Fedora 44, Alpine 3.24, Ubuntu 26.04 (resolute)
- Remove EOL spread targets (alpine-3.21, alpine-3.22, alpine-3.23, ubuntu_questing)
- Fix sbuild cross-chroot setup for 26.04
- Strip git tags before `snapcraft remote-build` to avoid Launchpad git indexing delays that caused intermittent `mir-libs (armhf)` failures

## How to test

Test out the downstream snaps built in `edge/mir-pr…`

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos