### PR TITLE
Add missing alpha and tiled_edges checks to SurfaceSpecification BasicWindowManager

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1235,6 +1235,9 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
 
     if (modifications.confine_pointer().is_set())
         std::shared_ptr<scene::Surface>(window)->set_confine_pointer_state(modifications.confine_pointer().value());
+
+    if (modifications.alpha().is_set())
+        std::shared_ptr<scene::Surface>(window)->set_alpha(modifications.alpha().value());
 }
 
 auto miral::BasicWindowManager::info_for_window_id(std::string const& id) const -> WindowInfo&

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -57,7 +57,8 @@ miral::WindowSpecification::Self::Self(mir::shell::SurfaceSpecification const& s
     server_side_decorated(spec.server_side_decorated),
     focus_mode(spec.focus_mode),
     visible_on_lock_screen(spec.visible_on_lock_screen),
-    tiled_edges(spec.tiled_edges)
+    tiled_edges(spec.tiled_edges),
+    opacity(spec.alpha)
 {
     if (spec.aux_rect_placement_offset_x.is_set() && spec.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{spec.aux_rect_placement_offset_x.value(), spec.aux_rect_placement_offset_y.value()};

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -68,7 +68,9 @@ bool msh::SurfaceSpecification::is_empty() const
         !application_id.is_set() &&
         !server_side_decorated.is_set() &&
         !focus_mode.is_set() &&
-        !visible_on_lock_screen.is_set();
+        !visible_on_lock_screen.is_set() &&
+        !tiled_edges.is_set() &&
+        !alpha.is_set();
 }
 
 void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)


### PR DESCRIPTION
## What's new?
We forgot to set_alpha in modify_window and check if `SurfaceSpecification::is_empty` properly

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
