### PR TITLE
std::format instead of snprintf in input_timestamp.cpp

### DIFF
--- a/src/common/logging/input_timestamp.cpp
+++ b/src/common/logging/input_timestamp.cpp
@@ -15,8 +15,8 @@
  */
 
 #include <mir/logging/input_timestamp.h>
-#include <cstdio>
 #include <cstdlib>
+#include <format>
 
 using namespace std::chrono;
 
@@ -33,9 +33,6 @@ std::string mir::logging::input_timestamp(mir::time::Clock const& clock, std::ch
 
     char const* sign_suffix = (age_ns < 0) ? "in the future" : "ago";
 
-    char str[64];
-    snprintf(str, sizeof str, "%lld (%lld.%06lldms %s)",
-             when_ns, milliseconds, sub_milliseconds, sign_suffix);
-
-    return std::string(str);
+    return std::format("{} ({}.{:06}ms {})",
+        when_ns, milliseconds, sub_milliseconds, sign_suffix);
 }


### PR DESCRIPTION
Closes nothing

<!-- Mention the issue this closes if applicable -->

Related: #4660 

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

Related to PR #4736

## What's new?

std::format instead of snprintf in input_timestamp.cpp

<!-- List the major changes of this PR -->

## How to test

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
