### PR TITLE
Use `uint32_t` for `scancode_is_pressed` instead of `int32_t`

### DIFF
--- a/src/server/frontend_wayland/keyboard_state_tracker.cpp
+++ b/src/server/frontend_wayland/keyboard_state_tracker.cpp
@@ -135,7 +135,7 @@ auto mf::KeyboardStateTracker::keysym_is_pressed(MirInputDeviceId device, xkb_ke
         device_states.at(device).scancode_to_keysym, [keysym](auto const& pair) { return pair.second == keysym; });
 }
 
-auto mf::KeyboardStateTracker::scancode_is_pressed(MirInputDeviceId device, int32_t scancode) const -> bool
+auto mf::KeyboardStateTracker::scancode_is_pressed(MirInputDeviceId device, uint32_t scancode) const -> bool
 {
     if (!device_states.contains(device))
         return false;

--- a/src/server/frontend_wayland/keyboard_state_tracker.h
+++ b/src/server/frontend_wayland/keyboard_state_tracker.h
@@ -58,7 +58,7 @@ public:
 
     auto keysym_is_pressed(MirInputDeviceId device, xkb_keysym_t keysym) const -> bool;
 
-    auto scancode_is_pressed(MirInputDeviceId device, int32_t scancode) const -> bool;
+    auto scancode_is_pressed(MirInputDeviceId device, uint32_t scancode) const -> bool;
 
 private:
     /// Owns the per-device XKB keymap and state used to resolve keysyms from


### PR DESCRIPTION
Related: #4410


## What's new?

- What it says on the tin

## How to test

- Code should still compile.
- `KeyboardStateTrackerTest`s should still pass.
