### PR TITLE
std::format instead of snprintf in logger.cpp

### DIFF
--- a/src/core/logging/logger.cpp
+++ b/src/core/logging/logger.cpp
@@ -98,8 +98,7 @@ void ml::format_message(std::ostream& out, Severity severity, std::string const&
         auto now = system_clock::now();
         auto now_us = time_point_cast<microseconds>(now);
         auto local = zoned_time{current_zone(), now_us};
-        std::format_to(std::ostreambuf_iterator<char>(out),
-            "[{:%F %T}] {}{}: {}\n",
+        std::format_to(std::ostreambuf_iterator{out}, "[{:%F %T}] {}{}: {}\n",
             local, lut[static_cast<int>(severity)], component, message);
         out.flush();
     }


### PR DESCRIPTION
Closes nothing

<!-- Mention the issue this closes if applicable -->

Related: #4660 

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

Related to #4736

## What's new?

std::format instead of snprintf in logger.cpp

<!-- List the major changes of this PR -->

## How to test

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
