### PR TITLE
Update `ext-input-trigger-action-v1.xml` to add more details about token validity and availability

### DIFF
--- a/wayland-protocols/ext-input-trigger-action-v1.xml
+++ b/wayland-protocols/ext-input-trigger-action-v1.xml
@@ -55,12 +55,12 @@
         This request creates an input trigger action object.
 
         The token should be one issued by the compositor. If the token was not
-        issued by the compositor, the compositor must raise an invalid_token
-        protocol error.
+        issued by the compositor, or is no longer valid, the compositor must
+        raise an invalid_token protocol error.
 
-        If the token has been issued by the compositor, but is no longer
-        available, then an ext_input_trigger_action_v1.unavailable event
-        should be sent immediately.
+        If the token has been issued by the compositor, is still valid, but is
+        no longer available, then an ext_input_trigger_action_v1.unavailable
+        event should be sent immediately.
       </description>
       <arg name="token" type="string" summary="the exported action token"/>
       <arg name="id" type="new_id" interface="ext_input_trigger_action_v1"/>


### PR DESCRIPTION
Related: https://github.com/canonical/mir/pull/4410#discussion_r2925416331

## What's new?

- Updates the description of `get_input_trigger_action` to detail token lifetime validity and availability