### PR TITLE
Perform DRM client cap check with proper ioctl call

### DIFF
--- a/src/platforms/atomic-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/atomic-kms/server/kms/platform_symbols.cpp
@@ -205,7 +205,7 @@ auto probe_display_platform(
                         std::string{"Failed to set DRM interface version on device "} + device.devnode()}));
                 }
 
-                if (!mgk::get_cap_checked(tmp_fd, DRM_CLIENT_CAP_ATOMIC))
+                if (drmSetClientCap(tmp_fd, DRM_CLIENT_CAP_ATOMIC, 1) != 0)
                 {
                     mir::log_info("KMS device %s does not support Atomic KMS", device.devnode());
                     continue;


### PR DESCRIPTION
Closes #4774

## What's new?

The DRM_CLIENT_CAP_ATOMIC is now checked via drmSetClientCap, not mgk::get_cap_checked (which evaluates to drmGetCap). Previous call was not reliable as drmGetCap is not able to validate client caps.

## How to test

- Code compiles.
- Platform with Atomic KMS support reports it successfully.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
