### PR TITLE
ci: better "Start release" workflow

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -161,6 +161,10 @@ jobs:
             -v name='${{ steps.gpg.outputs.name }}' \
             -v email='${{ steps.gpg.outputs.email }}' \
             -v date="$(date "+%a, %b %d %Y")" '
+            /^Version:/ {
+              print "Version: " next_version "~dev"
+              next
+            }
             /^%changelog/ {
               print
               print "* " date " " name " <" email "> - " next_version "~dev-1"


### PR DESCRIPTION
## What's new?

"Start release" will now begin development on `main`.

## How to test

Check out the [test run on my fork]https://github.com/Saviq/mir/actions/runs/23241488889), and the result in:
- [RC tag](https://github.com/Saviq/mir/tags/v2.26.0~rc) and [symbols release](https://github.com/Saviq/mir/commit/b77d9ad70d447170cbaa054bf42b3ae19c8c36e1)
- [release branch](https://github.com/Saviq/mir/branches/)
- [main bump](https://github.com/Saviq/mir/commit/81ab5460e72626311458c51df0a658552daf1ee8)

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos