### PR TITLE
Generating implementations for Wayland events so that they can be sent from C++ to Rust to Wayland clients

### DIFF
--- a/cmake/RustLibrary.cmake
+++ b/cmake/RustLibrary.cmake
@@ -34,12 +34,18 @@ function(add_rust_cxx_library target)
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     COMMENT "Building Rust crate ${arg_CRATE}")
 
+  # We build the Rust target first as it could potentially output C++ code
+  # during its build script that other targets depend on.
+  add_custom_target(${target}-rust-build
+    DEPENDS ${cxxbridge_header} ${cxxbridge_source} ${crate_staticlib})
+
   add_library(${target}-rust STATIC IMPORTED)
   set_target_properties(${target}-rust PROPERTIES
     IMPORTED_LOCATION ${crate_staticlib})
 
   add_library(${target}-cxxbridge STATIC
     ${cxxbridge_source} ${cxxbridge_header})
+  add_dependencies(${target}-cxxbridge ${target}-rust-build)
   target_include_directories(${target}-cxxbridge PRIVATE ${cxxbridge_include_dir})
 
   if(arg_INCLUDES)

--- a/src/wayland/wayland_rs/.gitignore
+++ b/src/wayland/wayland_rs/.gitignore
@@ -2,4 +2,5 @@ src/protocols.rs
 src/dispatch.rs
 src/ffi.rs
 src/middleware.rs
-include/*
+wayland_rs_cpp/include
+wayland_rs_cpp/src

--- a/src/wayland/wayland_rs/CMakeLists.txt
+++ b/src/wayland/wayland_rs/CMakeLists.txt
@@ -2,7 +2,53 @@ add_rust_cxx_library(mirwayland_rs
   CRATE wayland_rs
   CXX_BRIDGE_SOURCE_FILE src/ffi.rs
   DEPENDS Cargo.toml build_script/main.rs build_script/protocol_parser.rs src/lib.rs src/wayland_server.rs
-  INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
+  INCLUDES
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/include
+)
+
+set(wayland_rs_generated_sources
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/ext_data_control_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/ext_foreign_toplevel_list_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/ext_image_capture_source_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/ext_image_copy_capture_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/ext_input_trigger_action_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/ext_input_trigger_registration_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/ext_session_lock_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/fractional_scale_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/global_factory.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/idle_inhibit_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/input_method_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/input_method_unstable_v2.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/linux_dmabuf_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/linux_drm_syncobj_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/mir_shell_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/pointer_constraints_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/relative_pointer_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/server_decoration.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/text_input_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/text_input_unstable_v2.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/text_input_unstable_v3.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/viewporter.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/virtual_keyboard_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/wayland.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/wlr_foreign_toplevel_management_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/wlr_layer_shell_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/wlr_screencopy_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/wlr_virtual_pointer_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/wp_primary_selection_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/xdg_activation_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/xdg_decoration_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/xdg_output_unstable_v1.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/xdg_shell.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wayland_rs_cpp/src/xdg_shell_unstable_v6.cpp
+)
+
+set_source_files_properties(${wayland_rs_generated_sources} PROPERTIES GENERATED TRUE)
+
+target_sources(mirwayland_rs-cxxbridge
+  PRIVATE
+    ${wayland_rs_generated_sources}
 )
 
 add_executable(

--- a/src/wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/wayland/wayland_rs/build_script/cpp_builder.rs
@@ -2,20 +2,28 @@ use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
 use syn::Ident;
 
+use crate::helpers::format_has_arg;
+
 pub struct CppBuilder {
     guard_name: String,
     pub filename: String,
     namespaces: Vec<CppNamespace>,
-    includes: Vec<String>,
+
+    /// Includes in the generated .h file.
+    header_includes: Vec<String>,
+
+    /// Includes in the generated .cpp file.
+    cpp_includes: Vec<String>,
 }
 
 impl CppBuilder {
-    pub fn new(guard_name: String, filename: String) -> CppBuilder {
+    pub fn new(guard_name: impl Into<String>, filename: impl Into<String>) -> CppBuilder {
         CppBuilder {
-            guard_name,
-            filename,
+            guard_name: guard_name.into(),
+            filename: filename.into(),
             namespaces: vec![],
-            includes: vec![],
+            header_includes: vec![],
+            cpp_includes: vec![],
         }
     }
 
@@ -29,30 +37,40 @@ impl CppBuilder {
             .expect("namespaces cannot be empty after push")
     }
 
-    pub fn add_include(&mut self, include: String) {
-        self.includes.push(include);
+    pub fn add_header_include(&mut self, include: impl Into<String>) {
+        self.header_includes.push(include.into());
     }
 
-    fn build_ret_string(method: &CppMethod) -> String {
+    pub fn add_cpp_include(&mut self, include: impl Into<String>) {
+        self.cpp_includes.push(include.into());
+    }
+
+    fn build_ret_string_for_cpp(method: &CppMethod) -> String {
         method
             .retval
             .as_ref()
-            .map(|retval| cpp_type_to_string(retval, true))
+            .map(cpp_return_type_to_cpp_source)
             .unwrap_or("void".to_string())
     }
 
-    fn build_arg_str(method: &CppMethod) -> String {
-        let args: Vec<String> = method
+    fn build_arg_str_for_cpp(method: &CppMethod) -> String {
+        let cpp_method_num_args = method
             .args
             .iter()
-            .map(|arg| {
-                format!(
-                    "{} {}",
-                    cpp_type_to_string(&arg.cpp_type, false),
-                    sanitize_identifier(&arg.name)
-                )
-            })
-            .collect();
+            .map(|arg| if arg.has_name.is_some() { 2 } else { 1 })
+            .sum();
+        let mut args: Vec<String> = Vec::with_capacity(cpp_method_num_args);
+        for arg in &method.args {
+            args.push(format!(
+                "{} {}",
+                cpp_arg_type_to_cpp_source(&arg.cpp_type, method.originates_from_rust()),
+                arg.name
+            ));
+
+            if let Some(has_name) = &arg.has_name {
+                args.push(format!("bool {}", has_name));
+            }
+        }
         args.join(", ")
     }
 
@@ -65,7 +83,7 @@ impl CppBuilder {
         result.push_str(&format!("#define {}\n\n", self.guard_name));
 
         // Add includes
-        for include in &self.includes {
+        for include in &self.header_includes {
             result.push_str(&format!("#include {}\n", include));
         }
 
@@ -92,11 +110,7 @@ impl CppBuilder {
                     result.push_str("    {\n");
 
                     for option in &enum_.options {
-                        result.push_str(&format!(
-                            "        {} = {},\n",
-                            sanitize_identifier(&option.name),
-                            option.value.to_string(),
-                        ));
+                        result.push_str(&format!("        {} = {},\n", option.name, option.value,));
                     }
                     result.push_str("    };\n");
                     result.push_str("\n");
@@ -107,20 +121,28 @@ impl CppBuilder {
 
                 // Generate methods
                 for method in &class.methods {
-                    let args_str = Self::build_arg_str(method);
-                    let retstring = Self::build_ret_string(method);
-                    let method_name = sanitize_identifier(&method.name);
-                    if method.is_virtual {
+                    let args_str = Self::build_arg_str_for_cpp(method);
+                    let retstring = Self::build_ret_string_for_cpp(method);
+                    if method.originates_from_rust() {
                         result.push_str(&format!(
                             "    virtual auto {}({}) -> {} = 0;\n",
-                            method_name, args_str, retstring
+                            method.name, args_str, retstring
                         ));
                     } else {
                         result.push_str(&format!(
                             "    auto {}({}) -> {};\n",
-                            method_name, args_str, retstring
+                            method.name, args_str, retstring
                         ));
                     }
+                }
+
+                result.push_str("private:\n");
+                for member in &class.private_members {
+                    result.push_str(&format!(
+                        "    {} {};\n",
+                        cpp_arg_type_to_cpp_source(&member.cpp_type, true),
+                        member.name
+                    ));
                 }
 
                 result.push_str("};\n\n");
@@ -139,9 +161,13 @@ impl CppBuilder {
     }
 
     /// Generates the .cpp file contents corresponding to the information in this builder.
-    pub fn to_cpp_source(&self, header_path: String) -> String {
+    pub fn to_cpp_source(&self, header_path: &str) -> String {
         let mut result = String::new();
-        result.push_str(&format!("#include \"{}\"\n\n", header_path));
+        result.push_str(&format!("#include \"{}\"\n", header_path));
+
+        for include in &self.cpp_includes {
+            result.push_str(&format!("#include {}\n", include));
+        }
 
         for namespace in &self.namespaces {
             let namespace_str = namespace.name.join("::");
@@ -151,16 +177,19 @@ impl CppBuilder {
                         continue;
                     }
 
-                    let args_str = Self::build_arg_str(method);
-                    let retstring = Self::build_ret_string(method);
+                    let args_str = Self::build_arg_str_for_cpp(method);
+                    let retstring = Self::build_ret_string_for_cpp(method);
 
                     result.push_str(&format!(
                         "auto {}::{}::{}({}) -> {}\n",
                         namespace_str, class.name, method.name, args_str, retstring
                     ));
                     result.push_str("{\n");
-                    result.push_str("  // TODO: Call out to Rust code here.\n");
-
+                    let body = method
+                        .body
+                        .as_deref()
+                        .unwrap_or("// TODO: Call out to Rust code here.");
+                    result.push_str(&format!("    {}\n", body));
                     result.push_str("}\n\n");
                 }
             }
@@ -178,7 +207,8 @@ impl CppBuilder {
     /// an `unsafe extern "C++"` block. This method does NOT add the surrounding `mod ffi`
     /// or `unsafe extern "C++"` blocks; callers are responsible for adding those themselves.
     pub fn to_rust_cpp_bindings(&self) -> Vec<TokenStream> {
-        let header_name = Literal::string(format!("include/{}.h", self.filename).as_str());
+        let header_name =
+            Literal::string(format!("wayland_rs_cpp/include/{}.h", self.filename).as_str());
         // Include the corresponding C++ header once per protocol/header.
         let mut tokens: Vec<TokenStream> = Vec::new();
         tokens.push(quote! {
@@ -190,17 +220,29 @@ impl CppBuilder {
                 let class_name = format_ident!("{}", class.name);
                 // Generate methods for this class
                 let methods = class.methods.iter().map(|method| {
-                    let method_name = format_ident!("{}", sanitize_identifier(&method.name));
-                    let args = method.args.iter().map(|arg| {
-                        let arg_name = format_ident!("{}", sanitize_identifier(&arg.name));
-                        let arg_type = cpp_type_to_rust_type(&arg.cpp_type, false);
-                        quote! { #arg_name: #arg_type }
+                    let method_name = format_ident!("{}", method.name);
+                    let args = method.args.iter().flat_map(|arg| {
+                        let arg_name = format_ident!("{}", arg.name);
+
+                        // If the argument is optional, we provide a boolean describing if it is set
+                        // or not, since `std::optional` cannot be ferried over the C++/Rust boundary.
+                        let arg_type = cpp_arg_type_to_rust_source(
+                            &arg.cpp_type,
+                            method.originates_from_rust(),
+                        );
+                        let main_arg = quote! { #arg_name: #arg_type };
+                        if let Some(has_name) = &arg.has_name {
+                            let has_arg_name = format_ident!("{}", has_name);
+                            vec![main_arg, quote! { #has_arg_name: bool }]
+                        } else {
+                            vec![main_arg]
+                        }
                     });
 
                     // Note: When generating Rust bindings for C++ methods that will mutate the underlying
                     // C++ class, cxx.rs enforces that we `Pin` them.
                     if let Some(retval) = &method.retval {
-                        let retval = cpp_type_to_rust_type(retval, true);
+                        let retval = cpp_return_type_to_rust_source(retval);
                         quote! {
                             pub fn #method_name(self: Pin<&mut #class_name>, #(#args),*) -> #retval;
                         }
@@ -228,9 +270,13 @@ pub struct CppNamespace {
 }
 
 impl CppNamespace {
-    pub fn new(name: Vec<String>) -> CppNamespace {
+    pub fn new<I, S>(name: I) -> CppNamespace
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
         CppNamespace {
-            name: name,
+            name: name.into_iter().map(Into::into).collect(),
             classes: vec![],
             forward_declarations: vec![],
         }
@@ -256,14 +302,16 @@ pub struct CppClass {
     pub name: String,
     pub methods: Vec<CppMethod>,
     pub enums: Vec<CppEnum>,
+    pub private_members: Vec<CppArg>,
 }
 
 impl CppClass {
-    pub fn new(name: String) -> CppClass {
+    pub fn new(name: impl Into<String>) -> CppClass {
         CppClass {
-            name,
+            name: sanitize_identifier(&name.into()),
             methods: vec![],
             enums: vec![],
+            private_members: vec![],
         }
     }
 
@@ -280,6 +328,13 @@ impl CppClass {
             .last_mut()
             .expect("enums cannot be empty after push")
     }
+
+    pub fn add_private_member(&mut self, member: CppArg) -> &mut CppArg {
+        self.private_members.push(member);
+        self.private_members
+            .last_mut()
+            .expect("members cannot be empty after push")
+    }
 }
 
 pub struct CppEnum {
@@ -288,9 +343,9 @@ pub struct CppEnum {
 }
 
 impl CppEnum {
-    pub fn new(name: String) -> CppEnum {
+    pub fn new(name: impl Into<String>) -> CppEnum {
         CppEnum {
-            name,
+            name: sanitize_identifier(&name.into()),
             options: vec![],
         }
     }
@@ -308,20 +363,31 @@ pub struct CppEnumOption {
     pub value: u32,
 }
 
+impl CppEnumOption {
+    pub fn new(name: impl Into<String>, value: u32) -> CppEnumOption {
+        CppEnumOption {
+            name: sanitize_identifier(&name.into()),
+            value: value,
+        }
+    }
+}
+
 pub struct CppMethod {
     pub name: String,
     pub args: Vec<CppArg>,
     pub retval: Option<CppType>,
     pub is_virtual: bool,
+    pub body: Option<String>,
 }
 
 impl CppMethod {
-    pub fn new(name: String, retval: Option<CppType>, is_virtual: bool) -> CppMethod {
+    pub fn new(name: impl Into<String>, retval: Option<CppType>, is_virtual: bool) -> CppMethod {
         CppMethod {
-            name,
+            name: sanitize_identifier(&name.into()),
             args: vec![],
             retval,
             is_virtual,
+            body: None,
         }
     }
 
@@ -330,6 +396,23 @@ impl CppMethod {
         self.args
             .last_mut()
             .expect("args cannot be empty after push")
+    }
+
+    // Set the body of the method.
+    // This may be a more complicated "builder" some day, but we are doing such
+    // simple stuff for now that we might as well make it a string
+    pub fn set_body(&mut self, body: impl Into<String>) {
+        self.body = Some(body.into());
+    }
+
+    // Return whether or not this method is called from Rust code.
+    pub fn originates_from_rust(&self) -> bool {
+        // If a method is virtual, we assume that it is a request method that
+        // is called from the Rust Wayland layer rather than an event method
+        // which is called from the C++ business logic layer.
+        // This is an assumption for now, but it is one that serves our needs.
+        // We may revisit this in the future.
+        self.is_virtual
     }
 }
 
@@ -344,40 +427,94 @@ pub enum CppType {
     Box(String),
 }
 
-fn cpp_type_to_string(cpp_type: &CppType, is_retval: bool) -> String {
+/// Convert a CppType intended as a return value to its corresponding
+/// C++ source code string in the function signature.
+fn cpp_return_type_to_cpp_source(cpp_type: &CppType) -> String {
     match cpp_type {
         CppType::CppI32 => "int32_t".to_string(),
         CppType::CppU32 => "uint32_t".to_string(),
         CppType::CppF64 => "double".to_string(),
-        CppType::String => "rust::String".to_string(),
+        CppType::String => "std::string".to_string(),
         CppType::Object(name) => {
-            if is_retval {
-                format!("std::unique_ptr<{}>", name)
-            } else {
-                format!("std::unique_ptr<{}> const&", name)
-            }
+            format!("std::unique_ptr<{}>", name)
         }
-        CppType::Array => "rust::Vec<uint8_t>".to_string(),
+        CppType::Array => "std::vector<uint8_t>".to_string(),
         CppType::Fd => "int32_t".to_string(),
-        CppType::Box(name) => format!("rust::Box<{}>", name),
+        CppType::Box(name) => {
+            format!("rust::Box<{}> const&", name)
+        }
     }
 }
 
-fn cpp_type_to_rust_type(cpp_type: &CppType, is_retval: bool) -> TokenStream {
+/// Convert a CppType for an argument to its corresponding C++ source
+/// code string.
+///
+/// If the method is called from Rust, we will use the cxx.rs C++ wrapper
+/// for the type instead of the standard library type.
+fn cpp_arg_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) -> String {
+    match (cpp_type, originates_from_rust) {
+        (CppType::CppI32, _) => "int32_t".into(),
+        (CppType::CppU32, _) => "uint32_t".into(),
+        (CppType::CppF64, _) => "double".into(),
+        (CppType::Fd, _) => "int32_t".into(),
+        (CppType::Object(name), _) => format!("std::unique_ptr<{}> const&", name),
+        (CppType::Box(name), _) => format!("rust::Box<{}>", name),
+        (CppType::String, true) => "rust::String".into(),
+        (CppType::String, false) => "std::string const&".into(),
+        (CppType::Array, true) => "rust::Vec<uint8_t>".into(),
+        (CppType::Array, false) => "std::vector<uint8_t> const&".into(),
+    }
+}
+
+/// Convert a CppType intended as a return value to its corresponding
+/// Rust source code token in the function signature.
+fn cpp_return_type_to_rust_source(cpp_type: &CppType) -> TokenStream {
     match cpp_type {
         CppType::CppI32 => quote! { i32 },
         CppType::CppU32 => quote! { u32 },
         CppType::CppF64 => quote! { f64 },
-        CppType::String => quote! { String },
+        CppType::String => quote! { &CxxString },
         CppType::Object(name) => {
             let type_name = format_ident!("{}", name);
-            if is_retval {
-                quote! { UniquePtr<#type_name> }
+            quote! { UniquePtr<#type_name> }
+        }
+        CppType::Array => quote! { &CxxVector<u8> },
+        CppType::Fd => quote! { i32 },
+        CppType::Box(name) => {
+            let type_name = format_ident!("{}", name);
+            quote! { &Box<#type_name> }
+        }
+    }
+}
+
+/// Convert a CppType for an argument to its corresponding Rust source
+/// code block.
+///
+/// If the method is called from Rust, we will use the cxx.rs C++ wrapper
+/// for the type instead of the standard library type.
+fn cpp_arg_type_to_rust_source(cpp_type: &CppType, originates_from_rust: bool) -> TokenStream {
+    match cpp_type {
+        CppType::CppI32 => quote! { i32 },
+        CppType::CppU32 => quote! { u32 },
+        CppType::CppF64 => quote! { f64 },
+        CppType::String => {
+            if originates_from_rust {
+                quote! { String }
             } else {
-                quote! { &UniquePtr<#type_name> }
+                quote! { &CxxString }
             }
         }
-        CppType::Array => quote! { Vec<u8> },
+        CppType::Object(name) => {
+            let type_name = format_ident!("{}", name);
+            quote! { &UniquePtr<#type_name> }
+        }
+        CppType::Array => {
+            if originates_from_rust {
+                quote! { Vec<u8> }
+            } else {
+                quote! { &CxxVector<u8> }
+            }
+        }
         CppType::Fd => quote! { i32 },
         CppType::Box(name) => {
             let type_name = format_ident!("{}", name);
@@ -411,10 +548,20 @@ pub fn sanitize_identifier(name: &str) -> String {
 pub struct CppArg {
     pub cpp_type: CppType,
     pub name: String,
+    pub has_name: Option<String>,
 }
 
 impl CppArg {
-    pub fn new(cpp_type: CppType, name: String) -> CppArg {
-        CppArg { cpp_type, name }
+    pub fn new(cpp_type: CppType, name: impl Into<String>, optional: bool) -> CppArg {
+        let name = name.into();
+        CppArg {
+            cpp_type,
+            name: sanitize_identifier(name.as_str()),
+            has_name: if optional {
+                Some(sanitize_identifier(&format_has_arg(&name.clone())))
+            } else {
+                None
+            },
+        }
     }
 }

--- a/src/wayland/wayland_rs/build_script/helpers.rs
+++ b/src/wayland/wayland_rs/build_script/helpers.rs
@@ -8,9 +8,10 @@ pub fn write_generated_rust_file(tokens: TokenStream, filename: &str) {
     let out_dir = "src";
     let dest_path = std::path::Path::new(&out_dir).join(filename);
 
-    let syntax_tree: syn::File = syn::parse2(tokens.clone()).unwrap_or_else(|e| {
+    let tokens_for_error = tokens.to_string();
+    let syntax_tree: syn::File = syn::parse2(tokens).unwrap_or_else(|e| {
         panic!(
-            "syn::parse2 failed while generating '{filename}': {e}\n\nGenerated tokens:\n{tokens}"
+            "syn::parse2 failed while generating '{filename}': {e}\n\nGenerated tokens:\n{tokens_for_error}"
         )
     });
     let formatted_code = prettyplease::unparse(&syntax_tree);
@@ -19,8 +20,7 @@ pub fn write_generated_rust_file(tokens: TokenStream, filename: &str) {
 }
 
 /// Write the generated C++ code to the correct directory.
-pub fn write_generated_cpp_file(content: &str, filename: &str) {
-    let out_dir = "include";
+pub fn write_generated_cpp_file(content: &str, out_dir: &str, filename: &str) {
     let dest_path = std::path::Path::new(&out_dir).join(filename);
 
     fs::create_dir_all(&out_dir).unwrap();
@@ -49,12 +49,20 @@ pub fn snake_to_pascal(s: &str) -> String {
 
 /// Formats the Wayland interface name to the name of the class that
 /// provides its C++ implementation.
-pub fn format_wayland_interface_to_cpp_class(s: &String) -> String {
+pub fn format_wayland_interface_to_cpp_class(s: &str) -> String {
     format!("{}Impl", snake_to_pascal(s))
 }
 
 /// Formats the Wayland interface name to the name of the struct that
 /// provides its Rust extension implementation.
-pub fn format_wayland_interface_to_rust_extension_struct(s: &String) -> String {
+pub fn format_wayland_interface_to_rust_extension_struct(s: &str) -> String {
     format!("{}Ext", snake_to_pascal(s))
+}
+
+pub fn format_has_arg(s: &str) -> String {
+    format!("has_{}", dash_to_snake(s))
+}
+
+pub fn format_has_arg_ident(s: &str) -> Ident {
+    format_ident!("has_{}", dash_to_snake(s))
 }

--- a/src/wayland/wayland_rs/build_script/main.rs
+++ b/src/wayland/wayland_rs/build_script/main.rs
@@ -186,7 +186,7 @@ fn generate_global_dispatch_impl(
     interface: &protocol_parser::WaylandInterface,
     namespace_name: &TokenStream,
 ) -> TokenStream {
-    let interface_name = dash_to_snake_ident(&interface.name.to_string());
+    let interface_name = dash_to_snake_ident(&interface.name);
 
     if interface_name == "wl_display" {
         // wl_display is handled specially in wayland_server crate via the 'Display' struct.
@@ -257,15 +257,17 @@ fn transform_argument_for_cpp(arg: &WaylandArg) -> Option<TokenStream> {
         WaylandArgType::Object => {
             let arg_type = format_ident!(
                 "{}",
-                format_wayland_interface_to_cpp_class(&arg.interface.clone().unwrap())
+                format_wayland_interface_to_cpp_class(
+                    arg.interface.as_ref().expect("Object is missing interface"),
+                )
             );
             if arg.allow_null.unwrap_or(false) {
-                let null_ptr_name = format_ident!("__{}_null_ptr", arg.name.replace('-', "_"));
+                let has_arg_name = format_has_arg_ident(&arg.name);
                 Some(quote! {
-                    let #null_ptr_name = cxx::UniquePtr::<ffi::#arg_type>::null();
+                    let #has_arg_name = #arg_name.is_some();
                     let #arg_name: &cxx::UniquePtr<ffi::#arg_type> = match #arg_name.as_ref() {
                         Some(o) => o.data().unwrap(),
-                        None => &#null_ptr_name
+                        None => &cxx::UniquePtr::<ffi::#arg_type>::null()
                     };
                 })
             } else {
@@ -277,12 +279,16 @@ fn transform_argument_for_cpp(arg: &WaylandArg) -> Option<TokenStream> {
         WaylandArgType::Fd => Some(quote! {
             let #arg_name = #arg_name.as_raw_fd();
         }),
-        WaylandArgType::String if arg.allow_null.unwrap_or(false) => Some(quote! {
-            let #arg_name = match #arg_name {
-                Some(o) => o,
-                None => String::new()
-            };
-        }),
+        WaylandArgType::String if arg.allow_null.unwrap_or(false) => {
+            let has_arg_name = format_has_arg_ident(&arg.name);
+            Some(quote! {
+                let #has_arg_name = #arg_name.is_some();
+                let #arg_name = match #arg_name {
+                    Some(o) => o,
+                    None => String::new()
+                };
+            })
+        }
         _ => None,
     }
 }
@@ -301,32 +307,53 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
         .iter()
         .find(|arg| arg.type_ == WaylandArgType::NewId);
 
+    let arg_to_tokens = |arg: &WaylandArg| {
+        let arg_name = format_ident!("{}", arg.name.as_str());
+        if arg.allow_null.unwrap_or(false)
+            && matches!(arg.type_, WaylandArgType::Object | WaylandArgType::String)
+        {
+            let has_arg_name = format_has_arg_ident(&arg.name);
+            vec![quote! { #arg_name }, quote! { #has_arg_name }]
+        } else {
+            vec![quote! { #arg_name }]
+        }
+    };
+
     if let Some(new_id_arg) = new_id_arg {
         let new_id_name = format_ident!("{}", new_id_arg.name);
+        let ext_interface_struct_name = format_ident!(
+            "{}",
+            format_wayland_interface_to_rust_extension_struct(
+                new_id_arg
+                    .interface
+                    .as_ref()
+                    .expect("NewId is missing interface")
+            )
+        );
         let call_arg_names: Vec<TokenStream> = request
             .args
             .iter()
             .filter(|arg| arg.type_ != WaylandArgType::NewId)
-            .map(|arg| {
-                let arg_name = format_ident!("{}", arg.name.as_str());
-                quote! { #arg_name }
-            })
+            .flat_map(arg_to_tokens)
             .collect();
 
         quote! {
             let mut guard = data.lock().unwrap();
             let child = (&mut *guard).pin_mut().#snake_request_name(#( #call_arg_names ),*);
-            data_init.init(#new_id_name, Arc::new(Mutex::new(child)));
+            let arc = Arc::new(Mutex::new(child));
+
+            // The initialization strategy here mirrors the global bind flow: First,
+            // we associate the C++ implementation with the Rust data. Afterwards, we wrap
+            // the Rust resource in an "extension" object that ferries the data from C++ -> Rust.
+            // Finally, we associate this "extension" object with our C++ object.
+            let instance = data_init.init(#new_id_name, arc.clone());
+            let boxed = Box::new(crate::middleware::#ext_interface_struct_name{ wrapped: instance });
+            let mut guard = arc.lock().unwrap();
+            guard.pin_mut().associate(boxed);
         }
     } else {
-        let call_arg_names: Vec<TokenStream> = request
-            .args
-            .iter()
-            .map(|arg| {
-                let arg_name = format_ident!("{}", arg.name.as_str());
-                quote! { #arg_name }
-            })
-            .collect();
+        let call_arg_names: Vec<TokenStream> =
+            request.args.iter().flat_map(arg_to_tokens).collect();
 
         quote! {
             let mut guard = data.lock().unwrap();
@@ -514,14 +541,11 @@ fn write_dispatch_rs(protocols: &Vec<WaylandProtocol>) {
 }
 
 fn create_global_factory(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
-    let mut builder: CppBuilder = CppBuilder::new(
-        "MIR_WAYLANDRS_GLOBALS".to_string(),
-        "global_factory".to_string(),
-    );
-    builder.add_include("<memory>".to_string());
-    builder.add_include("<rust/cxx.h>".to_string());
-    let mut namespace = CppNamespace::new(vec!["mir".to_string(), "wayland_rs".to_string()]);
-    let mut class = CppClass::new("GlobalFactory".to_string());
+    let mut builder: CppBuilder = CppBuilder::new("MIR_WAYLANDRS_GLOBALS", "global_factory");
+    builder.add_header_include("<memory>");
+    builder.add_header_include("<rust/cxx.h>");
+    let mut namespace = CppNamespace::new(vec!["mir", "wayland_rs"]);
+    let mut class = CppClass::new("GlobalFactory");
     protocols.iter().for_each(|protocol| {
         protocol
             .interfaces
@@ -587,11 +611,11 @@ fn write_cpp_protocol_implementations(protocols: &Vec<WaylandProtocol>) {
 /// only stores a T* internally and does not require T to be a complete type at
 /// the point of a virtual function declaration.
 fn create_ffi_fwd_builder(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
-    let mut builder = CppBuilder::new("MIR_WAYLANDRS_FFI_FWD".to_string(), "ffi_fwd".to_string());
+    let mut builder = CppBuilder::new("MIR_WAYLANDRS_FFI_FWD", "ffi_fwd");
     // <rust/cxx.h> is included here so that protocol headers pulling in ffi_fwd.h
     // have access to rust::Box, rust::String, etc. without a direct dependency on ffi.rs.h.
-    builder.add_include("<rust/cxx.h>".to_string());
-    let mut namespace = CppNamespace::new(vec!["mir".to_string(), "wayland_rs".to_string()]);
+    builder.add_header_include("<rust/cxx.h>");
+    let mut namespace = CppNamespace::new(vec!["mir", "wayland_rs"]);
 
     // WaylandServer is declared in ffi.rs but used nowhere in the protocol headers;
     // include it for completeness so all Rust types are forward-declared.
@@ -614,8 +638,8 @@ fn create_ffi_fwd_builder(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
 
 fn create_cpp_builder(protocol: &WaylandProtocol) -> CppBuilder {
     let guard = format!("MIR_WAYLANDRS_{}", protocol.name.to_uppercase());
-    let mut builder = CppBuilder::new(guard, protocol.name.clone());
-    let mut namespace = CppNamespace::new(vec!["mir".to_string(), "wayland_rs".to_string()]);
+    let mut builder = CppBuilder::new(guard, protocol.name.as_str());
+    let mut namespace = CppNamespace::new(vec!["mir", "wayland_rs"]);
 
     let classes = protocol
         .interfaces
@@ -634,24 +658,34 @@ fn create_cpp_builder(protocol: &WaylandProtocol) -> CppBuilder {
     // Use ffi_fwd.h (generated alongside the protocol headers) instead of the
     // CXX-generated ffi.rs.h to avoid a circular include dependency:
     //   ffi.rs.h  →  include/*.h  →  ffi.rs.h
-    builder.add_include("\"ffi_fwd.h\"".to_string());
-    builder.add_include("<memory>".to_string());
-    builder.add_include("<cstdint>".to_string());
-    builder.add_include("<rust/cxx.h>".to_string());
+    builder.add_header_include("\"ffi_fwd.h\"");
+    builder.add_header_include("<memory>");
+    builder.add_header_include("<cstdint>");
+    builder.add_header_include("<rust/cxx.h>");
+
+    builder.add_cpp_include("\"wayland_rs/src/ffi.rs.h\"");
 
     builder
 }
 
 fn write_cpp_header(builder: &CppBuilder) {
     let filename = format!("{}.h", builder.filename);
-    write_generated_cpp_file(&builder.to_cpp_header(), filename.as_str());
+    write_generated_cpp_file(
+        &builder.to_cpp_header(),
+        "wayland_rs_cpp/include",
+        filename.as_str(),
+    );
 }
 
 fn write_cpp_source(builder: &CppBuilder) {
     let header_filename = format!("{}.h", builder.filename);
 
     let filename = format!("{}.cpp", builder.filename);
-    write_generated_cpp_file(&builder.to_cpp_source(header_filename), filename.as_str());
+    write_generated_cpp_file(
+        &builder.to_cpp_source(&header_filename),
+        "wayland_rs_cpp/src",
+        filename.as_str(),
+    );
 }
 
 fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
@@ -672,14 +706,35 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     }
 
     // Add the method that associates the boxed rust interface with the C++ class.
-    let mut associate_method = CppMethod::new("associate".to_string(), None, true);
-    associate_method.add_arg(CppArg {
-        cpp_type: CppType::Box(snake_to_pascal(
+    let mut associate_method = CppMethod::new("associate", None, false);
+    associate_method.add_arg(CppArg::new(
+        CppType::Box(snake_to_pascal(
             &format_wayland_interface_to_rust_extension_struct(&interface.name),
         )),
-        name: "instance".to_string(),
-    });
+        "instance",
+        false,
+    ));
+    associate_method.set_body("instance_ = std::move(instance);");
     class.add_method(associate_method);
+    class.add_private_member(CppArg::new(
+        CppType::Box(snake_to_pascal(
+            &format_wayland_interface_to_rust_extension_struct(&interface.name),
+        )),
+        "instance_",
+        false,
+    ));
+
+    // Add the "get_box" method that will return the boxes rust interface. This is used
+    // when sending a Box from C++ to Rust.
+    let mut get_box_method = CppMethod::new(
+        "get_box",
+        Some(CppType::Box(snake_to_pascal(
+            &format_wayland_interface_to_rust_extension_struct(&interface.name),
+        ))),
+        false,
+    );
+    get_box_method.set_body("return instance_;");
+    class.add_method(get_box_method);
 
     for method in methods {
         class.add_method(method);
@@ -702,10 +757,10 @@ fn wayland_enum_to_cpp_enum(enum_: &WaylandEnum) -> CppEnum {
     let mut result = CppEnum::new(snake_to_pascal(enum_.name.as_str()));
 
     for option in &enum_.entries {
-        result.add_option(CppEnumOption {
-            name: snake_to_pascal(option.name.as_str()),
-            value: option.value as u32,
-        });
+        result.add_option(CppEnumOption::new(
+            snake_to_pascal(option.name.as_str()),
+            option.value as u32,
+        ));
     }
 
     result
@@ -718,14 +773,16 @@ fn wayland_arg_to_cpp_arg(arg: &WaylandArg) -> CppArg {
         WaylandArgType::Fixed => CppType::CppF64,
         WaylandArgType::String => CppType::String,
         WaylandArgType::Object => CppType::Object(format_wayland_interface_to_cpp_class(
-            &arg.interface.clone().expect("Object is missing interface"),
+            arg.interface.as_ref().expect("Object is missing interface"),
         )),
         WaylandArgType::Array => CppType::Array,
         WaylandArgType::Fd => CppType::Fd,
-        _ => panic!("Unhandled argument type"),
+        WaylandArgType::NewId => CppType::Box(format_wayland_interface_to_rust_extension_struct(
+            arg.interface.as_ref().expect("NewId is missing interface"),
+        )),
     };
 
-    CppArg::new(type_, arg.name.clone())
+    CppArg::new(type_, arg.name.as_str(), arg.allow_null.unwrap_or(false))
 }
 
 fn wayland_request_to_cpp_method(method: &WaylandRequest) -> CppMethod {
@@ -737,14 +794,18 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> CppMethod {
         .find(|arg| arg.type_ == WaylandArgType::NewId)
     {
         Some(new_id_arg) => {
-            let name =
-                format_wayland_interface_to_cpp_class(&new_id_arg.interface.clone().unwrap());
+            let name = format_wayland_interface_to_cpp_class(
+                new_id_arg
+                    .interface
+                    .as_ref()
+                    .expect("NewId is missing interface"),
+            );
             Some(CppType::Object(name))
         }
         None => None,
     };
 
-    let mut cpp_method = CppMethod::new(method.name.clone(), retval, true);
+    let mut cpp_method = CppMethod::new(method.name.as_str(), retval, true);
     let args = method
         .args
         .iter()
@@ -759,16 +820,32 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> CppMethod {
 }
 
 fn wayland_event_to_cpp_method(event: &WaylandEvent) -> CppMethod {
-    let mut cpp_method = CppMethod::new(format!("send_{}", event.name), None, true);
-    let args = event
-        .args
-        .iter()
-        .filter(|arg| arg.type_ != WaylandArgType::NewId)
-        .map(wayland_arg_to_cpp_arg);
+    let mut cpp_method = CppMethod::new(format!("send_{}", event.name), None, false);
+    let args = event.args.iter().map(wayland_arg_to_cpp_arg);
+
+    let sanitized_args: Vec<String> = args
+        .clone()
+        .flat_map(|arg| {
+            let arg_name = match arg.cpp_type {
+                CppType::Object(_) => format!("{}->get_box()", sanitize_identifier(&arg.name)),
+                _ => sanitize_identifier(&arg.name),
+            };
+            if let Some(has_name) = arg.has_name {
+                vec![arg_name, has_name]
+            } else {
+                vec![arg_name]
+            }
+        })
+        .collect();
 
     for arg in args {
         cpp_method.add_arg(arg);
     }
 
+    cpp_method.set_body(format!(
+        "instance_->{}({});",
+        event.name,
+        sanitized_args.join(", ")
+    ));
     cpp_method
 }

--- a/src/wayland/wayland_rs/build_script/protocol_middleware_generation.rs
+++ b/src/wayland/wayland_rs/build_script/protocol_middleware_generation.rs
@@ -170,18 +170,11 @@ pub fn wayland_arg_to_ffi_rust_str(arg: &WaylandArg) -> String {
         WaylandArgType::Uint => format!("{}: {}", name, "u32"),
         WaylandArgType::Fixed => format!("{}: {}", name, "f64"),
         WaylandArgType::String => format!("{}: {}", name, "&CxxString"),
-        WaylandArgType::Object => format!(
+        WaylandArgType::Object | WaylandArgType::NewId => format!(
             "{}: &Box<{}>",
             name,
             format_wayland_interface_to_rust_extension_struct(
-                &arg.interface.clone().expect("Object is missing interface")
-            )
-        ),
-        WaylandArgType::NewId => format!(
-            "{}: &Box<{}>",
-            name,
-            format_wayland_interface_to_rust_extension_struct(
-                &arg.interface.clone().expect("Object is missing interface")
+                arg.interface.as_ref().expect("Object is missing interface")
             )
         ),
         WaylandArgType::Array => format!("{}: {}", name, "&CxxVector<u8>"),
@@ -189,7 +182,7 @@ pub fn wayland_arg_to_ffi_rust_str(arg: &WaylandArg) -> String {
     };
 
     if arg.allow_null.unwrap_or(false) {
-        arg_str += format!(", has_{}: bool", arg.name).as_str();
+        arg_str.push_str(&format!(", has_{}: bool", arg.name));
     }
 
     arg_str
@@ -198,12 +191,9 @@ pub fn wayland_arg_to_ffi_rust_str(arg: &WaylandArg) -> String {
 fn wayland_arg_to_rust_param_str(arg: &WaylandArg, interface_name: &str) -> String {
     let name = sanitize_identifier(&arg.name);
     let mut param = match arg.type_ {
-        WaylandArgType::Int => name.clone(),
-        WaylandArgType::Uint => name.clone(),
-        WaylandArgType::Fixed => name.clone(),
+        WaylandArgType::Int | WaylandArgType::Uint | WaylandArgType::Fixed => name,
         WaylandArgType::String => format!("{}.to_string()", name),
-        WaylandArgType::Object => format!("&{}.wrapped", name),
-        WaylandArgType::NewId => format!("&{}.wrapped", name),
+        WaylandArgType::Object | WaylandArgType::NewId => format!("&{}.wrapped", name),
         WaylandArgType::Array => format!("{}.iter().cloned().collect()", name),
         WaylandArgType::Fd => format!("unsafe {{ BorrowedFd::borrow_raw({}) }}", name),
     };

--- a/src/wayland/wayland_rs/build_script/protocol_parser.rs
+++ b/src/wayland/wayland_rs/build_script/protocol_parser.rs
@@ -245,9 +245,7 @@ pub fn parse_protocols() -> Vec<WaylandProtocol> {
                 dependencies.push(interface_name.clone());
             }
             if let Some(enm) = &arg.enum_ {
-                let split = enm.split(".").collect::<Vec<&str>>();
-                if split.len() == 2 {
-                    let interface_name = split[0];
+                if let Some((interface_name, _)) = enm.split_once('.') {
                     dependencies.push(interface_name.to_string());
                 }
             }


### PR DESCRIPTION

<img width="1517" height="692" alt="image" src="https://github.com/user-attachments/assets/eeaa5e50-28de-42e2-8eb2-932eb23a0277" />


## What's new?
- Generating C++ implementations for each Wayland protocol
- Fixing some minor things for proper method signatures for the FFI boundary, for both C++ to call into Rust and vice versa
  - Particularly, I needed to handle optional arguments over the boundary, but we don't have `std::optional`, so I had to settle for a new `has_X` argument
- Updating `mirwayland_rs-demo` so that it compiles against the generated C++ implementations
- Minor fixes to some method signatures to take any type of string in the Rust code

## How to test
1. Run the build
2. See that the relevant `.cpp` files are outputted to `wayland_rs_cpp` and that `mirwayland_rs-demo` compiles and runs properly

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
