### PR TITLE
sbuild: move wlcs run to autopkgtest

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -253,6 +253,8 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          mir-platform-graphics-stub23,
          mir-platform-input-stub10,
+# FIXME: canonical/mir#4772
+         mir-platform-rendering-egl-generic,
 Description: Display Server for Ubuntu - wlcs integration
  Mir is a display server running on linux systems, with a focus on efficiency,
  robust operation and a well-defined driver model.

--- a/debian/rules
+++ b/debian/rules
@@ -30,6 +30,7 @@ COMMON_CONFIGURE_OPTIONS = \
   -DMIR_ENABLE_RUST=OFF\
   -DCMAKE_INSTALL_LIBEXECDIR="lib/$(DEB_HOST_MULTIARCH)/mir"\
   -DMIR_BUILD_INTERPROCESS_TESTS=OFF\
+  -DMIR_RUN_WLCS_TESTS=OFF\
 
 # Disable LTO on broken binutils
 # https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/2070302
@@ -39,17 +40,10 @@ ifeq ($(filter arm64,$(DEB_HOST_ARCH)),arm64)
 	endif
 endif
 
-# We can't guarantee non-Ubuntu builds will build against WLCS packages we
-# control, so disable it on non-Ubuntu builds
-ifeq ($(filter Ubuntu,$(DEB_VENDOR)),)
-	COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_WLCS_TESTS=OFF
-endif
-
 # Disable tests on Launchpad riscv64 (canonical/mir#3443, canonical/mir#3470)
 ifeq ($(USER) $(DEB_HOST_ARCH),buildd riscv64)
   COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_MIRAL_TESTS=OFF
   COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_WINDOW_MANAGEMENT_TESTS=OFF
-  COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_WLCS_TESTS=OFF
 endif
 
 # Disable pre-compiled headers on GCC>=12

--- a/debian/tests/PrintExcludedTests.cmake
+++ b/debian/tests/PrintExcludedTests.cmake
@@ -15,6 +15,9 @@ endfunction()
 function(target_link_libraries)
   # Dummy
 endfunction()
+function(target_include_directories)
+  # Dummy
+endfunction()
 function(set_target_properties)
   # Dummy
 endfunction()

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
 Tests: wlcs
 Restrictions: allow-stderr, skippable
-Depends: wlcs, pkg-config, dpkg, mir-wlcs-integration, cmake, build-essential
+Depends: wlcs (>= 1.8~), pkg-config, dpkg, mir-wlcs-integration, cmake, build-essential

--- a/spread/sbuild/task.yaml
+++ b/spread/sbuild/task.yaml
@@ -18,6 +18,7 @@ execute: |
     apt-get install \
         --yes \
         --no-install-recommends \
+        autopkgtest \
         binfmt-support \
         debootstrap \
         debhelper \
@@ -70,8 +71,15 @@ execute: |
       SBUILD_OPTS+=(
         --extra-repository="deb http://ppa.launchpad.net/mir-team/dev/ubuntu ${RELEASE} main"
         --extra-repository-key=${SPREAD_PATH}/${SPREAD_TASK}/mir-team.asc
+        --autopkgtest-opt="--add-apt-source=ppa:mir-team/dev"
       )
     fi
+
+    # Run autopkgtests
+    SBUILD_OPTS+=(
+      --run-autopkgtest
+      --autopkgtest-opts="-- schroot %r-%a"
+    )
 
     # Cross building
     if [ "${DEB_BUILD_ARCH}" != "${DEB_HOST_ARCH}" ]; then


### PR DESCRIPTION
## What's new?

Rather than running WLCS during the build, run it in autopkgtest, testing the stack, rather than the built artifacts.

## How to test

CI

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
