### PR TITLE
Introduce safe mode when there is a problem with configuration

### DIFF
--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -131,6 +131,7 @@ try
 
     miral::live_config::IniFile config_store;
     runner.set_exception_handler(exception_handler);
+    runner.enable_safe_mode();
 
     miral::CursorScale cursor_scale{config_store};
     miral::OutputFilter output_filter{config_store};

--- a/include/miral/miral/runner.h
+++ b/include/miral/miral/runner.h
@@ -161,6 +161,15 @@ public:
     /// \sa miral::X11Support - provides X11 support to a Mir server
     auto x11_display() const -> mir::optional_value<std::string>;
 
+    /// Enable safe mode for this compositor.
+    ///
+    /// This is intended for use in embedded compositors (e.g. Ubuntu Frame)
+    /// where there is no terminal to display errors and the compositor must
+    /// start in order to show the error to the user.
+    ///
+    /// Safe mode is disabled by default.
+    void enable_safe_mode();
+
 private:
     MirRunner(MirRunner const&) = delete;
     MirRunner& operator=(MirRunner const&) = delete;

--- a/src/miral/runner.cpp
+++ b/src/miral/runner.cpp
@@ -26,6 +26,7 @@
 #include <mir/main_loop.h>
 #include <mir/report_exception.h>
 #include <mir/options/option.h>
+#include <boost/program_options/errors.hpp>
 
 #include <algorithm>
 #include <mutex>
@@ -60,6 +61,7 @@ struct miral::MirRunner::Self
     std::string const config_file;
     std::string const display_config_file;
     bool const safe_mode{getenv("MIR_SAFE_MODE") != nullptr};
+    bool safe_mode_enabled{false};
 
     std::mutex mutex;
     std::function<void()> start_callback{[]{}};
@@ -208,13 +210,24 @@ catch (mir::ExitWithOutput const&)
 }
 catch (mir::AbnormalExit const& e)
 {
-    if(!safe_mode)
+    if(safe_mode_enabled && !safe_mode)
     {
         reexec_in_safe_mode(e.what());
     }
     else
     {
-        fprintf(stderr, "[MIR SAFE MODE] Failed even in safe mide: %s\n", e.what());
+        exception_handler();
+    }
+    return EXIT_FAILURE;
+}
+catch (boost::program_options::error const& e)
+{
+    if (safe_mode_enabled && !safe_mode)
+    {
+        reexec_in_safe_mode(e.what());
+    }
+    else
+    {
         exception_handler();
     }
     return EXIT_FAILURE;
@@ -223,6 +236,11 @@ catch (...)
 {
     exception_handler();
     return EXIT_FAILURE;
+}
+
+void miral::MirRunner::enable_safe_mode()
+{
+    self->safe_mode_enabled = true;
 }
 
 void miral::MirRunner::add_start_callback(std::function<void()> const& start_callback)

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -98,6 +98,7 @@ global:
     miral::MirRunner::add_stop_callback*;
     miral::MirRunner::config_file*;
     miral::MirRunner::display_config_file*;
+    miral::MirRunner::enable_safe_mode*;
     miral::MirRunner::register_fd_handler*;
     miral::MirRunner::register_signal_handler*;
     miral::MirRunner::run_with*;

--- a/src/platform/options/program_option.cpp
+++ b/src/platform/options/program_option.cpp
@@ -16,6 +16,7 @@
 
 #include <mir/options/program_option.h>
 #include <mir/log.h>
+#include <mir/abnormal_exit.h>
 
 #include <boost/program_options/parsers.hpp>
 
@@ -91,11 +92,34 @@ void mo::ProgramOption::parse_file(
         try
         {
             std::ifstream file(filename);
-            po::store(po::parse_config_file(file, config_file_desc, true), options);
+            if (!file)
+            {
+                continue;
+            }
+            auto parsed = po::parse_config_file(file, config_file_desc, true);
+
+            auto const unrecognised = po::collect_unrecognized(parsed.options, po::exclude_positional);
+
+            if(!unrecognised.empty())
+            {
+                std::ostringstream error;
+                error << "Unrecognised options in " << filename << ": ";
+                for(auto const& opt : unrecognised)
+                {
+                    error << " " << opt;
+                }
+                BOOST_THROW_EXCEPTION(mir::AbnormalExit(error.str()));
+            }
+
+            po::store(parsed, options);
+        }
+        catch(mir::AbnormalExit const&)
+        {
+            throw;
         }
         catch (const po::error& error)
         {
-            log_warning("Error in %s: %s", filename.c_str(), error.what());
+            BOOST_THROW_EXCEPTION(mir::AbnormalExit(std::string{"Error in config file "} + filename + ": " + error.what()));
         }
     }
 


### PR DESCRIPTION
Closes #3637 


<!-- Mention the issue this closes if applicable -->

Related #3628 

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

## What's new?
When Mir encounters a configuration error (mir::AbnormalExit) during startup, instead of exiting with failure, it now re-execs itself with minimal configuration (safe mode)

<!-- List the major changes of this PR -->

## How to test

Run mir_demo_server with an invalid option and observe it re-execs into safe mode instead of dying:

`./bin/mir_demo_server --invalid-option=garbage`

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
