### PR TITLE
Fixes TICS violations in wayland_connector.cpp

### DIFF
--- a/include/wayland/mir/wayland/client.h
+++ b/include/wayland/mir/wayland/client.h
@@ -42,7 +42,6 @@ class Client : public wayland::LifetimeTracker
 {
 public:
     /// Returns the Client object for the given libwayland client
-    static auto from(wl_client* client) -> Client&;
     static auto from(wl_client const* client) -> Client&;
 
     /// The underlying Wayland client
@@ -75,12 +74,11 @@ public:
     /// @}
 
 protected:
-    static void register_client(wl_client* raw, std::shared_ptr<Client> const& shared);
-    static void unregister_client(wl_client* raw);
+    static void register_client(wl_client const* raw, std::shared_ptr<Client> const& shared);
+    static void unregister_client(wl_client const* raw);
 
 private:
     friend Resource;
-    static auto shared_from(wl_client* client) -> std::shared_ptr<Client>;
     static auto shared_from(wl_client const* client) -> std::shared_ptr<Client>;
 };
 }

--- a/src/include/server/mir/frontend/wayland.h
+++ b/src/include/server/mir/frontend/wayland.h
@@ -38,7 +38,6 @@ namespace frontend
 {
 
 /// Utility function to recover the session associated with a wl_client
-auto get_session(wl_client* client) -> std::shared_ptr<scene::Session>;
 auto get_session(wl_client const* client) -> std::shared_ptr<scene::Session>;
 
 /// Utility function to recover the session associated with a wl_resource

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -616,11 +616,6 @@ bool mf::WaylandConnector::wl_display_global_filter_func(wl_client const* client
     return extension_filter(session, interface->name);
 }
 
-auto mir::frontend::get_session(wl_client* wl_client) -> std::shared_ptr<scene::Session>
-{
-    return WlClient::from(wl_client).client_session();
-}
-
 auto mir::frontend::get_session(wl_client const* wl_client) -> std::shared_ptr<scene::Session>
 {
     return WlClient::from(wl_client).client_session();

--- a/src/wayland/client.cpp
+++ b/src/wayland/client.cpp
@@ -27,12 +27,7 @@ namespace
 {
 /// All operations for the same display should happen on the same thread, but since in theory a single process could
 /// manage multiple Wayland displays, best to keep global state threadsafe.
-mir::Synchronised<std::vector<std::pair<wl_client*, std::weak_ptr<mw::Client>>>> client_map;
-}
-
-auto mw::Client::from(wl_client* client) -> Client&
-{
-    return *shared_from(client);
+mir::Synchronised<std::vector<std::pair<wl_client const*, std::weak_ptr<mw::Client>>>> client_map;
 }
 
 auto mw::Client::from(wl_client const* client) -> Client&
@@ -40,18 +35,18 @@ auto mw::Client::from(wl_client const* client) -> Client&
     return *shared_from(client);
 }
 
-void mw::Client::register_client(wl_client* raw, std::shared_ptr<Client> const& shared)
+void mw::Client::register_client(wl_client const* raw, std::shared_ptr<Client> const& shared)
 {
     client_map.lock()->push_back({raw, shared});
 }
 
-void mw::Client::unregister_client(wl_client* raw)
+void mw::Client::unregister_client(wl_client const* raw)
 {
     auto const map = client_map.lock();
     std::erase_if(*map, [&](auto const& item){ return item.first == raw; });
 }
 
-auto mw::Client::shared_from(wl_client* client) -> std::shared_ptr<Client>
+auto mw::Client::shared_from(wl_client const* client) -> std::shared_ptr<Client>
 {
     auto const locked = client_map.lock();
     for (auto& [wlc, wmc] : *locked)
@@ -66,16 +61,10 @@ auto mw::Client::shared_from(wl_client* client) -> std::shared_ptr<Client>
             {
                 // The client should remove itself from the map in it's destructor and should be destroyed/accessed on a
                 // single thread, so this should never happen
-                mir::fatal_error("client_map has stale entry for wl_client %p", static_cast<void*>(client));
+                mir::fatal_error("client_map has stale entry for wl_client %p", static_cast<void const*>(client));
             }
         }
     }
-    mir::fatal_error("wl_client %p is %s", static_cast<void*>(client), client ? "unknown" : "null");
+    mir::fatal_error("wl_client %p is %s", static_cast<void const*>(client), client ? "unknown" : "null");
     abort(); // Make compiler happy
-}
-
-auto mw::Client::shared_from(wl_client const* client) -> std::shared_ptr<Client>
-{
-    // The lookup only does pointer comparison, so const_cast is safe here
-    return shared_from(const_cast<wl_client*>(client));
 }


### PR DESCRIPTION
Closes #4711

## What's new?

Resolved TICS violations in mentioned file.
1. `reinterpret_cast `-> `static_cast`
2. initialized earlier uninitalized variable `eventfd_t ignored{};`
3. added overload for `WlClient::from `to accept const client.