### PR TITLE
fix(mousekeys): improve Ctrl+Shift+Numlock toggle shortcut

### DIFF
--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -155,7 +155,7 @@ int main(int argc, char const* argv[])
         auto const keysym = mir_keyboard_event_keysym(key_event);
         auto const action = mir_keyboard_event_action(key_event);
 
-        if ((modifiers & mir_input_event_modifier_ctrl) && (modifiers & mir_input_event_modifier_shift) && (keysym == XKB_KEY_F12)) 
+        if ((modifiers & mir_input_event_modifier_ctrl) && (modifiers & mir_input_event_modifier_shift) && (keysym == XKB_KEY_F12))
         {
             if (action != mir_keyboard_action_down)
                 return true;


### PR DESCRIPTION
Closes #3902 

<!-- Mention the issue this closes if applicable -->

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

## What's new?

Changed mousekeys toggle shortcut from Ctrl+Shift+Numlock to Ctrl+Shift+F12 to avoid Numlock state conflicts
Simplified toggle logic using a clean boolean flag Use initial_mousekeys_state to initialize mousekeys_on

## How to test

1. Run miral-shell
2. Press Ctrl+Shift+F12 to enable mousekeys (on laptops: Ctrl+Shift+Fn+F12)
3. Press numpad 2 4 6 8 — pointer should move
4. Press Ctrl+Shift+F12 again to disable mousekeys
5. Press numpad keys — pointer should no longer move

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
