### PR TITLE
ci: improve renovate config and fix zizmor suppression

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,4 +10,4 @@ rules:
     - tics.yml
   cache-poisoning:
     ignore:
-    - spread.yml:127:7  # Not a release-producing workflow
+    - spread.yml:132:7  # Not a release-producing workflow

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver",
+    "helpers:githubDigestChangelogs",
+    "group:all",
     ":enablePreCommit"
   ]
 }


### PR DESCRIPTION
## What's new?

This will improve how Renovate works:
- pin actions to digests (our pre-commit already does, but this makes it explicit for Renovate, too)
- include a link to the diff for GitHub Actions updates
- group updates together 

## How to test

Needs merging for Renovate to act

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
