### PR TITLE
Allow destructor methods (like destroy) to be overridable with a default passthrough destructor to match the existing implementation

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -124,10 +124,17 @@ impl CppBuilder {
                     let args_str = Self::build_arg_str_for_cpp(method);
                     let retstring = Self::build_ret_string_for_cpp(method);
                     if method.originates_from_rust() {
-                        result.push_str(&format!(
-                            "    virtual auto {}({}) -> {} = 0;\n",
-                            method.name, args_str, retstring
-                        ));
+                        if method.body.is_some() {
+                            result.push_str(&format!(
+                                "    virtual auto {}({}) -> {};\n",
+                                method.name, args_str, retstring
+                            ));
+                        } else {
+                            result.push_str(&format!(
+                                "    virtual auto {}({}) -> {} = 0;\n",
+                                method.name, args_str, retstring
+                            ));
+                        }
                     } else {
                         result.push_str(&format!(
                             "    auto {}({}) -> {};\n",
@@ -181,7 +188,7 @@ impl CppBuilder {
             let namespace_str = namespace.name.join("::");
             for class in &namespace.classes {
                 for method in &class.methods {
-                    if method.is_virtual {
+                    if method.body.is_none() {
                         continue;
                     }
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -818,6 +818,12 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> CppMethod {
         cpp_method.add_arg(arg);
     }
 
+    if let Some(type_) = &method.type_ {
+        if type_ == "destructor" {
+            cpp_method.set_body("");
+        }
+    }
+
     cpp_method
 }
 


### PR DESCRIPTION
## What's new?
- Destructor methods in wayland_rs now have a default empty body which matches the existing C++ implementation

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
