### PR TITLE
Protocol implementations should be shared_ptr instead of unique_ptr

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -451,7 +451,7 @@ fn cpp_return_type_to_cpp_source(cpp_type: &CppType) -> String {
         CppType::CppF64 => "double".to_string(),
         CppType::String => "std::string".to_string(),
         CppType::Object(name) => {
-            format!("std::unique_ptr<{}>", name)
+            format!("std::shared_ptr<{}>", name)
         }
         CppType::Array => "std::vector<uint8_t>".to_string(),
         CppType::Fd => "int32_t".to_string(),
@@ -472,7 +472,7 @@ fn cpp_arg_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) ->
         (CppType::CppU32, _) => "uint32_t".into(),
         (CppType::CppF64, _) => "double".into(),
         (CppType::Fd, _) => "int32_t".into(),
-        (CppType::Object(name), _) => format!("std::unique_ptr<{}> const&", name),
+        (CppType::Object(name), _) => format!("std::shared_ptr<{}> const&", name),
         (CppType::Box(name), _) => format!("rust::Box<{}>", name),
         (CppType::String, true) => "rust::String".into(),
         (CppType::String, false) => "std::string const&".into(),
@@ -491,7 +491,7 @@ fn cpp_return_type_to_rust_source(cpp_type: &CppType) -> TokenStream {
         CppType::String => quote! { &CxxString },
         CppType::Object(name) => {
             let type_name = format_ident!("{}", name);
-            quote! { UniquePtr<#type_name> }
+            quote! { SharedPtr<#type_name> }
         }
         CppType::Array => quote! { &CxxVector<u8> },
         CppType::Fd => quote! { i32 },
@@ -521,7 +521,7 @@ fn cpp_arg_type_to_rust_source(cpp_type: &CppType, originates_from_rust: bool) -
         }
         CppType::Object(name) => {
             let type_name = format_ident!("{}", name);
-            quote! { &UniquePtr<#type_name> }
+            quote! { &SharedPtr<#type_name> }
         }
         CppType::Array => {
             if originates_from_rust {

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -345,6 +345,10 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
 
         quote! {
             let mut guard = data.lock().unwrap();
+            // SAFETY: The mutex guard provides the only mutable access to this child while
+            // the call is in progress, so this cannot introduce aliased mutable access across
+            // FFI. The unchecked pin is used only for the duration of the `associate()` call,
+            // and the guarded value is not moved while that temporary `Pin<&mut _>` exists.
             let child = unsafe { (&mut *guard).pin_mut_unchecked().#snake_request_name(#( #call_arg_names ),*) };
             let arc = Arc::new(Mutex::new(child));
 
@@ -367,6 +371,10 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
 
         quote! {
             let mut guard = data.lock().unwrap();
+            // SAFETY: The mutex guard provides the only mutable access to this child while
+            // the call is in progress, so this cannot introduce aliased mutable access across
+            // FFI. The unchecked pin is used only for the duration of the `associate()` call,
+            // and the guarded value is not moved while that temporary `Pin<&mut _>` exists.
             unsafe { (&mut *guard).pin_mut_unchecked().#snake_request_name(#( #call_arg_names ),*); }
         }
     }

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -228,7 +228,14 @@ fn generate_global_dispatch_impl(
                 let instance = data_init.init(resource, arc.clone());
                 let boxed = Box::new(crate::middleware::#ext_interface_struct_name{ wrapped: instance });
                 let mut guard = arc.lock().unwrap();
-                unsafe { guard.pin_mut_unchecked().associate(boxed); }
+                // SAFETY: `guard` is a `MutexGuard`, so we have exclusive access to the
+                // underlying C++ object for the duration of this call and cannot concurrently
+                // create any aliasing references to it. The pointee is owned by `UniquePtr`,
+                // so taking a pinned mutable reference here does not move it, and the pinned
+                // reference is used only for this immediate FFI call and does not escape.
+                unsafe {
+                    guard.pin_mut_unchecked().associate(boxed);
+                }
             }
         }
     }

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -355,6 +355,10 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
             let instance = data_init.init(#new_id_name, arc.clone());
             let boxed = Box::new(crate::middleware::#ext_interface_struct_name{ wrapped: instance });
             let mut guard = arc.lock().unwrap();
+            // SAFETY: The mutex guard provides the only mutable access to this child while
+            // the call is in progress, so this cannot introduce aliased mutable access across
+            // FFI. The unchecked pin is used only for the duration of the `associate()` call,
+            // and the guarded value is not moved while that temporary `Pin<&mut _>` exists.
             unsafe { guard.pin_mut_unchecked().associate(boxed); }
         }
     } else {

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -228,7 +228,7 @@ fn generate_global_dispatch_impl(
                 let instance = data_init.init(resource, arc.clone());
                 let boxed = Box::new(crate::middleware::#ext_interface_struct_name{ wrapped: instance });
                 let mut guard = arc.lock().unwrap();
-                guard.pin_mut().associate(boxed);
+                unsafe { guard.pin_mut_unchecked().associate(boxed); }
             }
         }
     }
@@ -264,14 +264,14 @@ fn transform_argument_for_cpp(arg: &WaylandArg) -> Option<TokenStream> {
                 let has_arg_name = format_has_arg_ident(&arg.name);
                 Some(quote! {
                     let #has_arg_name = #arg_name.is_some();
-                    let #arg_name: &cxx::UniquePtr<ffi::#arg_type> = match #arg_name.as_ref() {
+                    let #arg_name: &cxx::SharedPtr<ffi::#arg_type> = match #arg_name.as_ref() {
                         Some(o) => o.data().unwrap(),
-                        None => &cxx::UniquePtr::<ffi::#arg_type>::null()
+                        None => &cxx::SharedPtr::<ffi::#arg_type>::null()
                     };
                 })
             } else {
                 Some(quote! {
-                    let #arg_name: &cxx::UniquePtr<ffi::#arg_type> = #arg_name.data().unwrap();
+                    let #arg_name: &cxx::SharedPtr<ffi::#arg_type> = #arg_name.data().unwrap();
                 })
             }
         }
@@ -338,7 +338,7 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
 
         quote! {
             let mut guard = data.lock().unwrap();
-            let child = (&mut *guard).pin_mut().#snake_request_name(#( #call_arg_names ),*);
+            let child = unsafe { (&mut *guard).pin_mut_unchecked().#snake_request_name(#( #call_arg_names ),*) };
             let arc = Arc::new(Mutex::new(child));
 
             // The initialization strategy here mirrors the global bind flow: First,
@@ -348,7 +348,7 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
             let instance = data_init.init(#new_id_name, arc.clone());
             let boxed = Box::new(crate::middleware::#ext_interface_struct_name{ wrapped: instance });
             let mut guard = arc.lock().unwrap();
-            guard.pin_mut().associate(boxed);
+            unsafe { guard.pin_mut_unchecked().associate(boxed); }
         }
     } else {
         let call_arg_names: Vec<TokenStream> =
@@ -356,7 +356,7 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
 
         quote! {
             let mut guard = data.lock().unwrap();
-            (&mut *guard).pin_mut().#snake_request_name(#( #call_arg_names ),*);
+            unsafe { (&mut *guard).pin_mut_unchecked().#snake_request_name(#( #call_arg_names ),*); }
         }
     }
 }
@@ -471,7 +471,7 @@ fn generate_dispatch_impl(
         unsafe impl Send for ffi::#ext_struct_name {}
         unsafe impl Sync for ffi::#ext_struct_name {}
 
-        impl Dispatch<#namespace_name::#interface_name::#protocol_struct_name, Arc<Mutex<cxx::UniquePtr<ffi::#ext_struct_name>>>>
+        impl Dispatch<#namespace_name::#interface_name::#protocol_struct_name, Arc<Mutex<cxx::SharedPtr<ffi::#ext_struct_name>>>>
             for ServerState
         {
             fn request(
@@ -479,7 +479,7 @@ fn generate_dispatch_impl(
                 _client: &Client,
                 _resource: &#namespace_name::#interface_name::#protocol_struct_name,
                 request: <#namespace_name::#interface_name::#protocol_struct_name as wayland_server::Resource>::Request,
-                #data_name: &Arc<Mutex<cxx::UniquePtr<ffi::#ext_struct_name>>>,
+                #data_name: &Arc<Mutex<cxx::SharedPtr<ffi::#ext_struct_name>>>,
                 _dhandle: &DisplayHandle,
                 #data_init_name: &mut DataInit<'_, Self>,
             ) {


### PR DESCRIPTION
## What's new?
- Protocol implementation classes are now held as `shared_ptr` in Rust instead of `unique_ptr` so that they can be referenced as `weak_ptr` by other protocols

## How to test

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
