### PR TITLE
Allowing override of the associate method and passing boxes from C++ -> Rust as references

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -472,7 +472,7 @@ fn cpp_arg_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) ->
         (CppType::CppU32, _) => "uint32_t".into(),
         (CppType::CppF64, _) => "double".into(),
         (CppType::Fd, _) => "int32_t".into(),
-        (CppType::Object(name), _) => format!("std::shared_ptr<{}> const&", name),
+        (CppType::Object(name), _) => format!("std::unique_ptr<{}> const&", name),
         (CppType::Box(name), _) => {
             if originates_from_rust {
                 format!("rust::Box<{}>", name)

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -472,8 +472,14 @@ fn cpp_arg_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) ->
         (CppType::CppU32, _) => "uint32_t".into(),
         (CppType::CppF64, _) => "double".into(),
         (CppType::Fd, _) => "int32_t".into(),
-        (CppType::Object(name), _) => format!("std::unique_ptr<{}> const&", name),
-        (CppType::Box(name), _) => format!("rust::Box<{}>", name),
+        (CppType::Object(name), _) => format!("std::shared_ptr<{}> const&", name),
+        (CppType::Box(name), _) => {
+            if originates_from_rust {
+                format!("rust::Box<{}>", name)
+            } else {
+                format!("rust::Box<{}> const&", name)
+            }
+        }
         (CppType::String, true) => "rust::String".into(),
         (CppType::String, false) => "std::string const&".into(),
         (CppType::Array, true) => "rust::Vec<uint8_t>".into(),
@@ -533,7 +539,11 @@ fn cpp_arg_type_to_rust_source(cpp_type: &CppType, originates_from_rust: bool) -
         CppType::Fd => quote! { i32 },
         CppType::Box(name) => {
             let type_name = format_ident!("{}", name);
-            quote! { Box<#type_name> }
+            if originates_from_rust {
+                quote! { Box<#type_name> }
+            } else {
+                quote! { &Box<#type_name> }
+            }
         }
     }
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -706,7 +706,7 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     }
 
     // Add the method that associates the boxed rust interface with the C++ class.
-    let mut associate_method = CppMethod::new("associate", None, false);
+    let mut associate_method = CppMethod::new("associate", None, true);
     associate_method.add_arg(CppArg::new(
         CppType::Box(snake_to_pascal(
             &format_wayland_interface_to_rust_extension_struct(&interface.name),


### PR DESCRIPTION
## What's new?

- The `associate` method should be overridable
- Also, the `Box` parameters (coupled with associate) should be `const&` when going from C++ to Rust so as not to transfer ownership

## How to test

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
