### PR TITLE
Converting shared_ptr references to wayland_rs::Weak for a more idiomatic API

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/.gitignore
+++ b/src/server/frontend_wayland/wayland_rs/.gitignore
@@ -7,4 +7,5 @@ wayland_rs_cpp/include/*
 wayland_rs_cpp/src/*
 
 !wayland_rs_cpp/include/protocol_error.h
+!wayland_rs_cpp/include/weak.h
 !wayland_rs_cpp/src/protocol_error.cpp

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -63,7 +63,7 @@ impl CppBuilder {
         for arg in &method.args {
             args.push(format!(
                 "{} {}",
-                cpp_arg_type_to_cpp_source(&arg.cpp_type, method.originates_from_rust()),
+                cpp_arg_type_to_cpp_source(&arg.cpp_type, method.originates_from_rust),
                 arg.name
             ));
 
@@ -129,7 +129,7 @@ impl CppBuilder {
                 for method in &class.methods {
                     let args_str = Self::build_arg_str_for_cpp(method);
                     let retstring = Self::build_ret_string_for_cpp(method);
-                    if method.originates_from_rust() {
+                    if method.is_virtual {
                         if method.body.is_some() {
                             result.push_str(&format!(
                                 "    virtual auto {}({}) -> {};\n",
@@ -240,7 +240,11 @@ impl CppBuilder {
             for class in &namespace.classes {
                 let class_name = format_ident!("{}", class.name);
                 // Generate methods for this class
-                let methods = class.methods.iter().map(|method| {
+                let methods = class.methods.iter().flat_map(|method| {
+                    if !method.generates_rust_code {
+                        return None;
+                    }
+
                     let method_name = format_ident!("{}", method.name);
                     let args = method.args.iter().flat_map(|arg| {
                         let arg_name = format_ident!("{}", arg.name);
@@ -249,7 +253,7 @@ impl CppBuilder {
                         // or not, since `std::optional` cannot be ferried over the C++/Rust boundary.
                         let arg_type = cpp_arg_type_to_rust_source(
                             &arg.cpp_type,
-                            method.originates_from_rust(),
+                            method.originates_from_rust,
                         );
                         let main_arg = quote! { #arg_name: #arg_type };
                         if let Some(has_name) = &arg.has_name {
@@ -268,19 +272,19 @@ impl CppBuilder {
                     if let Some(retval) = &method.retval {
                         let retval = cpp_return_type_to_rust_source(retval);
                         let retval = if method.throws { quote!{ Result<#retval> } } else { retval };
-                        quote! {
+                        Some(quote! {
                             pub fn #method_name(self: Pin<&mut #class_name>, #(#args),*) -> #retval;
-                        }
+                        })
                     } else {
                         if method.throws {
-                            quote! {
+                            Some(quote! {
                                 pub fn #method_name(self: Pin<&mut #class_name>, #(#args),*) -> Result<()>;
-                            }
+                            })
                         }
                         else {
-                            quote! {
+                            Some(quote! {
                                 pub fn #method_name(self: Pin<&mut #class_name>, #(#args),*);
-                            }
+                            })
                         }
                     }
                 });
@@ -405,12 +409,14 @@ impl CppEnumOption {
 }
 
 pub struct CppMethod {
-    pub name: String,
-    pub args: Vec<CppArg>,
-    pub retval: Option<CppType>,
-    pub is_virtual: bool,
-    pub body: Option<String>,
-    pub throws: bool,
+    name: String,
+    args: Vec<CppArg>,
+    retval: Option<CppType>,
+    is_virtual: bool,
+    body: Option<String>,
+    throws: bool,
+    originates_from_rust: bool,
+    generates_rust_code: bool,
 }
 
 impl CppMethod {
@@ -419,6 +425,8 @@ impl CppMethod {
         retval: Option<CppType>,
         is_virtual: bool,
         throws: bool,
+        originates_from_rust: bool,
+        generates_rust_code: bool,
     ) -> CppMethod {
         CppMethod {
             name: sanitize_identifier(&name.into()),
@@ -427,6 +435,8 @@ impl CppMethod {
             is_virtual,
             body: None,
             throws,
+            originates_from_rust,
+            generates_rust_code,
         }
     }
 
@@ -443,16 +453,6 @@ impl CppMethod {
     pub fn set_body(&mut self, body: impl Into<String>) {
         self.body = Some(body.into());
     }
-
-    // Return whether or not this method is called from Rust code.
-    pub fn originates_from_rust(&self) -> bool {
-        // If a method is virtual, we assume that it is a request method that
-        // is called from the Rust Wayland layer rather than an event method
-        // which is called from the C++ business logic layer.
-        // This is an assumption for now, but it is one that serves our needs.
-        // We may revisit this in the future.
-        self.is_virtual
-    }
 }
 
 pub enum CppType {
@@ -461,6 +461,7 @@ pub enum CppType {
     CppF64,
     String,
     Object(String),
+    Weak(String),
     Array,
     Fd,
     Box(String),
@@ -476,6 +477,9 @@ fn cpp_return_type_to_cpp_source(cpp_type: &CppType) -> String {
         CppType::String => "std::string".to_string(),
         CppType::Object(name) => {
             format!("std::shared_ptr<{}>", name)
+        }
+        CppType::Weak(name) => {
+            format!("wayland_rs::Weak<{}>", name)
         }
         CppType::Array => "std::vector<uint8_t>".to_string(),
         CppType::Fd => "int32_t".to_string(),
@@ -497,6 +501,7 @@ fn cpp_arg_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) ->
         (CppType::CppF64, _) => "double".into(),
         (CppType::Fd, _) => "int32_t".into(),
         (CppType::Object(name), _) => format!("std::shared_ptr<{}> const&", name),
+        (CppType::Weak(name), _) => format!("wayland_rs::Weak<{}> const&", name),
         (CppType::Box(name), _) => {
             if originates_from_rust {
                 format!("rust::Box<{}>", name)
@@ -525,6 +530,7 @@ fn cpp_return_type_to_rust_source(cpp_type: &CppType) -> TokenStream {
         }
         CppType::Array => quote! { &CxxVector<u8> },
         CppType::Fd => quote! { i32 },
+        CppType::Weak(_) => unreachable!("Weak type should not generate Rust code"),
         CppType::Box(name) => {
             let type_name = format_ident!("{}", name);
             quote! { &Box<#type_name> }
@@ -561,6 +567,7 @@ fn cpp_arg_type_to_rust_source(cpp_type: &CppType, originates_from_rust: bool) -
             }
         }
         CppType::Fd => quote! { i32 },
+        CppType::Weak(_) => unreachable!("Weak type should not generate Rust code"),
         CppType::Box(name) => {
             let type_name = format_ident!("{}", name);
             if originates_from_rust {
@@ -683,10 +690,10 @@ pub fn sanitize_identifier(name: &str) -> String {
 }
 
 pub struct CppArg {
-    pub cpp_type: CppType,
-    pub name: String,
-    pub has_name: Option<String>,
-    pub optional: bool,
+    cpp_type: CppType,
+    name: String,
+    has_name: Option<String>,
+    optional: bool,
 }
 
 impl CppArg {
@@ -702,5 +709,17 @@ impl CppArg {
             },
             optional,
         }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn has_name(&self) -> Option<String> {
+        self.has_name.clone()
+    }
+
+    pub fn cpp_type(&self) -> &CppType {
+        &self.cpp_type
     }
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -826,7 +826,14 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
 
     // Add a public accessor for the object ID so that C++ implementations
     // can pass it to ProtocolError.
-    let mut object_id_method = CppMethod::new("object_id", Some(CppType::CppU32), false, false);
+    let mut object_id_method = CppMethod::new(
+        "object_id",
+        Some(CppType::CppU32),
+        false,
+        false,
+        false,
+        false,
+    );
     object_id_method.set_body("return object_id_;");
     class.add_method(object_id_method);
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -939,7 +939,7 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
     // If this is the case, we need to do the following:
     // 1. Generate a different virtual method that is NOT called from Rust which will handle
     //    the logic using the weak value.
-    // 2. Make th eoriginal handler NOT be virtual, as the overridable logic will be delegated
+    // 2. Make the original handler NOT be virtual, as the overridable logic will be delegated
     //    to the new method from #1.
     let wayland_weak_transformers: Vec<String> = args
         .clone()

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -609,6 +609,8 @@ fn create_global_factory(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
                     Some(CppType::Object(class_name)),
                     true,
                     false,
+                    true,
+                    true,
                 );
                 class.add_method(method);
             })
@@ -708,6 +710,7 @@ fn create_cpp_builder(protocol: &WaylandProtocol) -> CppBuilder {
     // CXX-generated ffi.rs.h to avoid a circular include dependency:
     //   ffi.rs.h  →  include/*.h  →  ffi.rs.h
     builder.add_header_include("\"ffi_fwd.h\"");
+    builder.add_header_include("\"weak.h\"");
     builder.add_header_include("<memory>");
     builder.add_header_include("<optional>");
     builder.add_header_include("<cstdint>");
@@ -741,22 +744,26 @@ fn write_cpp_source(builder: &CppBuilder) {
 fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     let class_name = format_wayland_interface_to_cpp_class(&interface.name);
     let mut class = CppClass::new(class_name);
-    let methods = interface.items.iter().filter_map(|item| {
-        if let protocol_parser::InterfaceItem::Request(request) = item {
-            Some(wayland_request_to_cpp_method(request))
-        } else if let protocol_parser::InterfaceItem::Event(event) = item {
-            Some(wayland_event_to_cpp_method(event))
-        } else {
-            None
-        }
-    });
+    let methods = interface
+        .items
+        .iter()
+        .filter_map(|item| {
+            if let protocol_parser::InterfaceItem::Request(request) = item {
+                Some(wayland_request_to_cpp_method(request))
+            } else if let protocol_parser::InterfaceItem::Event(event) = item {
+                Some(vec![wayland_event_to_cpp_method(event)])
+            } else {
+                None
+            }
+        })
+        .flatten();
 
     for enum_ in wayland_interface_to_enums(interface) {
         class.add_enum(enum_);
     }
 
     // Add the method that associates the boxed rust interface with the C++ class.
-    let mut associate_method = CppMethod::new("associate", None, true, false);
+    let mut associate_method = CppMethod::new("associate", None, true, false, true, true);
     associate_method.add_arg(CppArg::new(
         CppType::Box(snake_to_pascal(
             &format_wayland_interface_to_rust_extension_struct(&interface.name),
@@ -783,6 +790,8 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
         ))),
         false,
         false,
+        true,
+        true,
     );
     get_box_method.set_body(
         "if (!instance_) { throw \"get_box() called before associate()\"; }\nreturn instance_.value();",
@@ -838,7 +847,7 @@ fn wayland_arg_to_cpp_arg(arg: &WaylandArg) -> CppArg {
     CppArg::new(type_, arg.name.as_str(), arg.allow_null.unwrap_or(false))
 }
 
-fn wayland_request_to_cpp_method(method: &WaylandRequest) -> CppMethod {
+fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
     // Methods will have a return value in C++ if they are creating a new Wayland object.
     // Otherwise they always return void.
     let retval = match method
@@ -858,38 +867,151 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> CppMethod {
         None => None,
     };
 
-    let mut cpp_method = CppMethod::new(method.name.as_str(), retval, true, true);
     let args = method
         .args
         .iter()
         .filter(|arg| arg.type_ != WaylandArgType::NewId)
         .map(wayland_arg_to_cpp_arg);
 
+    // If a C++ argument is being sent from Rust to C++ as a shared_ptr, we do NOT want
+    // to encourage the protocol implementer to hold a shared reference to the object, as
+    // that muddies up the lifetimes significantly. Only the Rust Wayland frontend should
+    // have access to the lifetime. However, it is important for the protocol business logic
+    // to be able to interact with other protocol implementations. Hence, we wrap the shared_ptr
+    // in our own "Weak" construct.
+    //
+    // If this is the case, we need to do the following:
+    // 1. Generate a different virtual method that is NOT called from Rust which will handle
+    //    the logic using the weak value.
+    // 2. Make th eoriginal handler NOT be virtual, as the overridable logic will be delegated
+    //    to the new method from #1.
+    let wayland_weak_transformers: Vec<String> = args
+        .clone()
+        .flat_map(|arg| match arg.cpp_type() {
+            CppType::Object(type_name) => Some(format!(
+                "auto const wrapped_{name} = wayland_rs::Weak<{type_name}>({name});",
+                name = arg.name(),
+                type_name = type_name
+            )),
+            _ => None,
+        })
+        .collect();
+
+    let delegation_args: Vec<String> = args
+        .clone()
+        .flat_map(|arg| {
+            let call_arg = match arg.cpp_type() {
+                CppType::Object(_) => format!("wrapped_{}", arg.name()),
+                _ => arg.name().to_string(),
+            };
+            if let Some(has_name) = arg.has_name() {
+                vec![call_arg, has_name]
+            } else {
+                vec![call_arg]
+            }
+        })
+        .collect();
+
+    let has_retval = retval.is_some();
+    let mut cpp_method = CppMethod::new(
+        method.name.as_str(),
+        retval,
+        wayland_weak_transformers.is_empty(),
+        true,
+        true,
+        true,
+    );
     for arg in args {
         cpp_method.add_arg(arg);
     }
 
     if let Some(type_) = &method.type_ {
         if type_ == "destructor" {
+            assert!(wayland_weak_transformers.is_empty());
             cpp_method.set_body("");
         }
     }
 
-    cpp_method
+    if !wayland_weak_transformers.is_empty() {
+        // Build the body: wrap shared_ptrs in Weak, then delegate to the virtual overload
+        let return_prefix = if has_retval { "return " } else { "" };
+        let delegation_call = format!(
+            "{}{}({});",
+            return_prefix,
+            sanitize_identifier(&method.name),
+            delegation_args.join(", ")
+        );
+        let mut body_lines = wayland_weak_transformers;
+        body_lines.push(delegation_call);
+        cpp_method.set_body(body_lines.join("\n"));
+
+        // Generate the virtual method that protocol implementers override.
+        // This method uses Weak args instead of shared_ptr args.
+        let virtual_retval = method
+            .args
+            .iter()
+            .find(|arg| arg.type_ == WaylandArgType::NewId)
+            .map(|new_id_arg| {
+                CppType::Object(format_wayland_interface_to_cpp_class(
+                    new_id_arg
+                        .interface
+                        .as_ref()
+                        .expect("NewId is missing interface"),
+                ))
+            });
+        let mut virtual_method = CppMethod::new(
+            method.name.as_str(),
+            virtual_retval,
+            true,
+            true,
+            true,
+            false,
+        );
+        for wayland_arg in method
+            .args
+            .iter()
+            .filter(|arg| arg.type_ != WaylandArgType::NewId)
+        {
+            let cpp_arg = wayland_arg_to_cpp_arg(wayland_arg);
+            match cpp_arg.cpp_type() {
+                CppType::Object(type_name) => {
+                    virtual_method.add_arg(CppArg::new(
+                        CppType::Weak(type_name.clone()),
+                        wayland_arg.name.as_str(),
+                        wayland_arg.allow_null.unwrap_or(false),
+                    ));
+                }
+                _ => {
+                    virtual_method.add_arg(cpp_arg);
+                }
+            }
+        }
+
+        vec![cpp_method, virtual_method]
+    } else {
+        vec![cpp_method]
+    }
 }
 
 fn wayland_event_to_cpp_method(event: &WaylandEvent) -> CppMethod {
-    let mut cpp_method = CppMethod::new(format!("send_{}_event", event.name), None, false, false);
+    let mut cpp_method = CppMethod::new(
+        format!("send_{}_event", event.name),
+        None,
+        false,
+        false,
+        false,
+        true,
+    );
     let args = event.args.iter().map(wayland_arg_to_cpp_arg);
 
     let sanitized_args: Vec<String> = args
         .clone()
         .flat_map(|arg| {
-            let arg_name = match arg.cpp_type {
-                CppType::Object(_) => format!("{}->get_box()", sanitize_identifier(&arg.name)),
-                _ => sanitize_identifier(&arg.name),
+            let arg_name = match arg.cpp_type() {
+                CppType::Object(_) => format!("{}->get_box()", sanitize_identifier(&arg.name())),
+                _ => sanitize_identifier(&arg.name()),
             };
-            if let Some(has_name) = arg.has_name {
+            if let Some(has_name) = arg.has_name() {
                 vec![arg_name, has_name]
             } else {
                 vec![arg_name]

--- a/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
+++ b/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <boost/throw_exception.hpp>
 
 namespace mir
 {
@@ -33,11 +34,13 @@ public:
     {
     }
 
+    Weak(Weak const& weak) = default;
+
     auto value() const -> T&
     {
         if (auto locked = ptr_.lock())
             return *locked;
-        throw std::logic_error{"Accessing expired wayland_rs::Weak"};
+        BOOST_THROW_EXCEPTION(std::logic_error{"Accessing expired wayland_rs::Weak"});
     }
 
     operator bool() const

--- a/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
+++ b/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <utility>
 #include <boost/throw_exception.hpp>
 
 namespace mir
@@ -36,10 +37,11 @@ public:
 
     Weak(Weak const& weak) = default;
 
-    auto value() const -> T&
+    template<typename F>
+    decltype(auto) with_value(F&& f) const
     {
         if (auto locked = ptr_.lock())
-            return *locked;
+            return std::forward<F>(f)(*locked);
         BOOST_THROW_EXCEPTION(std::logic_error{"Accessing expired wayland_rs::Weak"});
     }
 

--- a/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
+++ b/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_WAYLANDRS_WEAK
+#define MIR_WAYLANDRS_WEAK
+
+#include <memory>
+#include <stdexcept>
+
+namespace mir
+{
+namespace wayland_rs
+{
+template<typename T>
+class Weak
+{
+public:
+    explicit Weak(std::shared_ptr<T> const& ptr)
+        : ptr_{ptr}
+    {
+    }
+
+    auto value() const -> T&
+    {
+        if (auto locked = ptr_.lock())
+            return *locked;
+        throw std::logic_error{"Accessing expired wayland_rs::Weak"};
+    }
+
+    operator bool() const
+    {
+        return !ptr_.expired();
+    }
+
+    auto is(T const& other) const -> bool
+    {
+        auto locked = ptr_.lock();
+        return locked && locked.get() == &other;
+    }
+
+    auto operator==(Weak<T> const& other) const -> bool
+    {
+        return !ptr_.owner_before(other.ptr_) && !other.ptr_.owner_before(ptr_);
+    }
+
+    auto operator!=(Weak<T> const& other) const -> bool
+    {
+        return !(*this == other);
+    }
+
+    auto operator=(Weak<T> const&) -> Weak<T>& = default;
+
+private:
+    std::weak_ptr<T> ptr_;
+};
+}
+}
+
+#endif  // MIR_WAYLANDRS_WEAK


### PR DESCRIPTION
## What's new?
- Add `wayland_rs::Weak` which is similar to the existing `wayland::Weak`
- Generating a middleware function for all methods in C++ that accept a `shared_ptr` to a wayland object. Instead, we generate _another_ method that needs to be implemented which takes a `wayland_rs::Weak` as a parameter in place of a shared_ptr
- The `wayland_rs::Weak` construct entirely disallows protocol implementers from gaining access to a `shared_ptr` for a protocol object

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
