### PR TITLE
Trim the start and end of keys and values

### DIFF
--- a/src/miral/live_config_ini_file.cpp
+++ b/src/miral/live_config_ini_file.cpp
@@ -29,6 +29,23 @@ public:
     void load_file(std::istream& istream, std::filesystem::path const& path);
 };
 
+namespace
+{
+auto trim_start_and_end(std::string_view string) -> std::string_view
+{
+    constexpr auto whitespace = " \t\n\r\f\v";
+
+    auto const first_non_space = string.find_first_not_of(whitespace);
+    if (first_non_space == std::string::npos)
+    {
+        return string.substr(0, 0);
+    }
+
+    auto const last_non_space = string.find_last_not_of(whitespace);
+    return string.substr(first_non_space, last_non_space - first_non_space + 1);
+}
+}
+
 void mlc::IniFile::Self::load_file(std::istream& istream, std::filesystem::path const& path)
 {
     do_transaction(
@@ -36,12 +53,13 @@ void mlc::IniFile::Self::load_file(std::istream& istream, std::filesystem::path 
         {
             for (std::string line; std::getline(istream, line);)
             {
-                if (!line.starts_with('#') && line.contains("="))
+                auto const line_view = std::string_view{line};
+                if (!line_view.starts_with('#') && line_view.contains("="))
                     try
                     {
-                        auto const eq = line.find_first_of("=");
-                        auto const key = Key{line.substr(0, eq)};
-                        auto const value = line.substr(eq + 1);
+                        auto const eq = line_view.find_first_of("=");
+                        auto const key = Key{trim_start_and_end(line_view.substr(0, eq))};
+                        auto const value = trim_start_and_end(line_view.substr(eq + 1));
 
                         update_key(key, value, path);
                     }


### PR DESCRIPTION
Related: #4829

## What's new?

- Adds whitespace trimming for keys and values.

## How to test

- Tests coming as part of an upcoming PR.
