### PR TITLE
Include `mutex` to appease rawhide's compiler

### DIFF
--- a/src/miral/basic_store.cpp
+++ b/src/miral/basic_store.cpp
@@ -6,6 +6,7 @@
 #include <format>
 #include <list>
 #include <map>
+#include <mutex>
 #include <ranges>
 #include <set>
 


### PR DESCRIPTION
## What's new?

- Includes `mutex` in `basic_store.cpp` to appease Rawhide's compiler.

## How to test

- Code must compile on Fedora Rawhide
