### PR TITLE
evdev: Fix FDs being removed by libinput

### DIFF
--- a/src/platforms/evdev/fd_store.cpp
+++ b/src/platforms/evdev/fd_store.cpp
@@ -38,11 +38,6 @@ mir::Fd mie::FdStore::take_fd(char const* path)
     }
     catch (std::out_of_range const&)
     {
-        if (removed.first == path)
-        {
-            mir::log_warning("Requested fd for path %s was removed", path);
-            return fds.insert(std::move(removed)).first->second;
-        }
         mir::log_warning("Failed to find requested fd for path %s", path);
     }
     return mir::Fd{};
@@ -64,8 +59,6 @@ void mie::FdStore::remove_fd(int fd)
     }
     else
     {
-        // We keep the last removed element in case libinput asks for it
-        removed = *element;
         fds.erase(element);
     }
 }

--- a/src/platforms/evdev/fd_store.h
+++ b/src/platforms/evdev/fd_store.h
@@ -42,13 +42,6 @@ private:
     FdStore& operator=(FdStore const&) = delete;
 
     std::unordered_map<std::string, mir::Fd> fds;
-
-    // LibInputPtr calls remove_fd() for touchpads on suspend but
-    // continues to use take_fd() to access the fd after resume!
-    // As a workaround, we remember the last removed fd and reinstate
-    // it if asked for.
-    //                  https://github.com/canonical/mir/issues/1612
-    std::pair<std::string, mir::Fd> removed;
 };
 
 }

--- a/src/platforms/evdev/libinput_ptr.cpp
+++ b/src/platforms/evdev/libinput_ptr.cpp
@@ -42,11 +42,10 @@ int fd_open(const char* path, int flags, void* userdata)
     return fd_store->take_fd(path);
 }
 
-void fd_close(int fd, void* userdata)
+void fd_close(int /*fd*/, void* /*userdata*/)
 {
-    auto fd_store = static_cast<mie::FdStore*>(userdata);
-
-    fd_store->remove_fd(fd);
+    // Mir controls the lifetime of these FDs itself, by using a udev monitor to track devices.
+    // We don't really care what libinput wants, we will control the FDs ourselves.
 }
 
 const libinput_interface fd_ops = {fd_open, fd_close};

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -203,10 +203,10 @@ public:
                 if (!libinput_path_add_device(lib.get(), devnode.c_str()))
                 {
                     /* Oops, libinput didn't want this after all.
-                     * libinput will have closed the FD as a part of failing to add
-                     * the device, so we only need to release our Device handle.
-                     */
+                     * Since we handle FDs ourselves, we need to clean up the FD we took for this device, otherwise we'll leak it.
+                    */
                     device_watchers.erase(devnum);
+                    device_fds.remove_fd(device_fds.take_fd(devnode.c_str()));
                 }
             });
     }
@@ -216,7 +216,9 @@ public:
         action_queue->enqueue(
             [
                 &devices = devices,
-                syspath = syspath
+                &device_fds = device_fds,
+                syspath = syspath,
+                devnode = devnode
             ]()
             {
                 for (auto const& input_device : devices)
@@ -228,6 +230,9 @@ public:
                         if (syspath == udev_device_get_syspath(device_udev))
                         {
                             libinput_path_remove_device(input_device->device());
+
+                            // Don't depend on libinput to remove the FD, since we control it ourselves; clear it ourselves.
+                            device_fds.remove_fd(device_fds.take_fd(devnode.c_str()));
                         }
                     }
                 }
@@ -239,7 +244,9 @@ public:
         action_queue->enqueue(
             [
                 &devices = devices,
-                syspath = syspath
+                &device_fds = device_fds,
+                syspath = syspath,
+                devnode = devnode
             ]()
             {
                 for (auto const& input_device : devices)
@@ -251,6 +258,8 @@ public:
                         if (syspath == udev_device_get_syspath(device_udev))
                         {
                             libinput_path_remove_device(input_device->device());
+
+                            device_fds.remove_fd(device_fds.take_fd(devnode.c_str()));
                         }
                     }
                 }


### PR DESCRIPTION
Closes https://github.com/canonical/mir/issues/4818

Related: https://github.com/canonical/mir/issues/1612

## What's new?

This PR makes the evdev plugin ignore fd_close events from libinput, as we don't want any external lib meddling with Mir's internal structure of FDs and their ownership.

## How to test

* Test with a device that is capable of suspending input devices. E.g. a laptop with lid closed and connected to a monitor, or a 2-in-1 flipped back.
* If patch works properly, the input devices should still work after reverting to the original state.

## Checklist

- [ ] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos