### PR TITLE
spread: use the Azure mirror for Ubuntu builds

### DIFF
--- a/spread/sbuild/task.yaml
+++ b/spread/sbuild/task.yaml
@@ -54,6 +54,10 @@ execute: |
       ${RELEASE}
     )
 
+    if [[ "${SPREAD_VARIANT}" == *"ubuntu"* ]]; then
+      MKSBUILD_OPTS+=("--debootstrap-mirror=http://azure.archive.ubuntu.com/ubuntu/")
+    fi
+
     SBUILD_OPTS=(
       --jobs=$(nproc)
       --verbose
@@ -84,6 +88,10 @@ execute: |
     # Cross building
     if [ "${DEB_BUILD_ARCH}" != "${DEB_HOST_ARCH}" ]; then
       MKSBUILD_OPTS+=("--arch=${DEB_BUILD_ARCH}" "--target=${DEB_HOST_ARCH}")
+
+      if [[ "${SPREAD_VARIANT}" == *"ubuntu"* ]]; then
+        MKSBUILD_OPTS+=("--debootstrap-mirror-host=http://azure.ports.ubuntu.com/ubuntu-ports/")
+      fi
 
       SCHROOT_NAME="${SCHROOT_NAME}-${DEB_HOST_ARCH}"
 


### PR DESCRIPTION
## What's new?

Use the Azure mirrors to avoid the longer trip to Ubuntu archives in sbuild jobs.

## How to test

CI

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
