### PR TITLE
spread: use the Azure mirror for Ubuntu builds and variables

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -102,6 +102,19 @@ jobs:
           lxc profile device add default "loop${i}" unix-block "source=/dev/loop${i}"
         done
 
+        if [[ "${MATRIX_SPREAD_TASK}" == *"ubuntu"* ]]; then
+          # Use the Azure Ubuntu mirror
+          lxc profile set default user.user-data - <<EOF
+        #cloud-config
+        apt:
+          sources_list: |
+            Types: deb
+            URIs: http://azure.archive.ubuntu.com/ubuntu/
+            Suites: noble noble-updates noble-security
+            Components: main universe
+        EOF
+        fi
+
         sudo apt-get update
         sudo apt-get install --yes binfmt-support qemu-user-static
         echo "LXD_DIR=/var/snap/lxd/common/lxd" >> "$GITHUB_ENV"

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -27,40 +27,18 @@ jobs:
     steps:
     - id: set-matrix
       name: Determine BuildAndTest matrix
+      env:
+        SPREAD_JOBS_MAIN: ${{ vars.SPREAD_JOBS_MAIN }}
+        SPREAD_JOBS_COMMON: ${{ vars.SPREAD_JOBS_COMMON }}
       run: |
         set -euo pipefail
 
         TASKS=()
         if ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}; then
-          TASKS+=(
-            "lxd:...:spread/ubuntu:tsan"
-            "lxd:...:spread/ubuntu:tsan_clang"
-          )
+           mapfile -O "${#TASKS[@]}" -t TASKS <<< "${SPREAD_JOBS_MAIN//$'\r'/}"
         fi
 
-        TASKS+=(
-          "lxd:...:debian_sid"
-          "lxd:...:fedora_42"
-          "lxd:...:fedora_43"
-          "lxd:...:fedora_clang"
-          "lxd:...:fedora_rawhide"
-          "lxd:...:spread/ubuntu:asan"
-          "lxd:...:spread/ubuntu:asan_clang"
-          "lxd:...:spread/ubuntu:clang"
-          "lxd:...:spread/ubuntu:mold"
-          "lxd:...:spread/ubuntu:ubsan"
-          "lxd:...:spread/ubuntu:ubsan_clang"
-          "lxd:...:ubuntu"
-          "lxd:...:ubuntu_arm64"
-          "lxd:...:ubuntu_armhf"
-          "lxd:...:ubuntu_devel"
-          "lxd:...:ubuntu_proposed"
-          "lxd:...:ubuntu_questing"
-          "lxd:alpine-3.21:...:amd64"
-          "lxd:alpine-3.22:...:amd64"
-          "lxd:alpine-3.23:...:amd64"
-          "lxd:alpine-edge:...:amd64"
-        )
+        mapfile -O "${#TASKS[@]}" -t TASKS <<< "${SPREAD_JOBS_COMMON//$'\r'/}"
 
         jq -cn '{"spread-task": $ARGS.positional}' --args "${TASKS[@]}" | awk '{ print "matrix=" $0 }' >> "$GITHUB_OUTPUT"
 
@@ -102,9 +80,8 @@ jobs:
           lxc profile device add default "loop${i}" unix-block "source=/dev/loop${i}"
         done
 
-        if [[ "${MATRIX_SPREAD_TASK}" == *"ubuntu"* ]]; then
-          # Use the Azure Ubuntu mirror
-          lxc profile set default user.user-data - <<EOF
+        # Use the Azure Ubuntu mirror
+        lxc profile set default user.user-data - <<EOF
         #cloud-config
         apt:
           sources_list: |
@@ -113,7 +90,6 @@ jobs:
             Suites: noble noble-updates noble-security
             Components: main universe
         EOF
-        fi
 
         sudo apt-get update
         sudo apt-get install --yes binfmt-support qemu-user-static

--- a/spread/sbuild/task.yaml
+++ b/spread/sbuild/task.yaml
@@ -54,6 +54,11 @@ execute: |
       ${RELEASE}
     )
 
+    if [[ "${SPREAD_VARIANT}" == *"ubuntu"* ]]; then
+      MKSBUILD_OPTS+=("--debootstrap-mirror=http://azure.archive.ubuntu.com/ubuntu/")
+      export SOURCES_SECURITY_URL=http://azure.archive.ubuntu.com/ubuntu/
+    fi
+
     SBUILD_OPTS=(
       --jobs=$(nproc)
       --verbose
@@ -84,6 +89,7 @@ execute: |
     # Cross building
     if [ "${DEB_BUILD_ARCH}" != "${DEB_HOST_ARCH}" ]; then
       MKSBUILD_OPTS+=("--arch=${DEB_BUILD_ARCH}" "--target=${DEB_HOST_ARCH}")
+      unset SOURCES_SECURITY_URL
 
       SCHROOT_NAME="${SCHROOT_NAME}-${DEB_HOST_ARCH}"
 


### PR DESCRIPTION
## What's new?

Use the Azure mirrors to avoid the longer trip to Ubuntu archives in sbuild jobs.
Also, rely on variables rather than hardcoded tasks to run.
Cross-building is untouched, since `-ports` isn't mirrored into Azure.

## How to test

CI

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
