### PR TITLE
Fix 'occured' -> 'occurred' typos in toolkit event headers and hover click

### DIFF
--- a/include/common/mir_toolkit/events/input/keyboard_event.h
+++ b/include/common/mir_toolkit/events/input/keyboard_event.h
@@ -73,7 +73,7 @@ int mir_keyboard_event_scan_code(MirKeyboardEvent const* event);
 char const* mir_keyboard_event_key_text(MirKeyboardEvent const* event);
 
 /**
- * Retrieve the modifier keys pressed when the key action occured.
+ * Retrieve the modifier keys pressed when the key action occurred.
  *
  *   \param [in] event The key event
  *   \return           The modifier mask

--- a/include/common/mir_toolkit/events/input/pointer_event.h
+++ b/include/common/mir_toolkit/events/input/pointer_event.h
@@ -37,7 +37,7 @@ typedef struct MirPointerEvent MirPointerEvent;
 MirPointerAxisSource mir_pointer_event_axis_source(MirPointerEvent const* event);
 
 /**
- * Retrieve the modifier keys pressed when the pointer action occured.
+ * Retrieve the modifier keys pressed when the pointer action occurred.
  *
  *   \param [in] event The pointer event
  *   \return           The modifier mask
@@ -45,7 +45,7 @@ MirPointerAxisSource mir_pointer_event_axis_source(MirPointerEvent const* event)
 MirInputEventModifiers mir_pointer_event_modifiers(MirPointerEvent const* event);
 
 /**
- * Retrieve the action which occured to generate a given pointer event.
+ * Retrieve the action which occurred to generate a given pointer event.
  *
  *  \param [in] event       The pointer event
  *  \return                 Action performed by the pointer

--- a/include/common/mir_toolkit/events/input/touch_event.h
+++ b/include/common/mir_toolkit/events/input/touch_event.h
@@ -34,7 +34,7 @@ typedef struct MirTouchEvent MirTouchEvent;
 typedef int32_t MirTouchId;
 
 /**
- * Retrieve the modifier keys pressed when the touch action occured.
+ * Retrieve the modifier keys pressed when the touch action occurred.
  *
  *   \param [in] event The key event
  *   \return           The modifier mask
@@ -60,7 +60,7 @@ unsigned int mir_touch_event_point_count(MirTouchEvent const* event);
 MirTouchId mir_touch_event_id(MirTouchEvent const* event, size_t touch_index);
 
 /**
- * Retrieve the action which occured for a touch at given index.
+ * Retrieve the action which occurred for a touch at given index.
  *
  *  \param [in] event       The touch event
  *  \param [in] touch_index The touch index. Must be less than (touch_count - 1).

--- a/include/miral/miral/toolkit_event.h
+++ b/include/miral/miral/toolkit_event.h
@@ -157,7 +157,7 @@ int mir_keyboard_event_scan_code(MirKeyboardEvent const* event);
 char const* mir_keyboard_event_key_text(MirKeyboardEvent const* event);
 
 /**
- * Retrieve the modifier keys pressed when the key action occured.
+ * Retrieve the modifier keys pressed when the key action occurred.
  *
  *   \param [in] event The key event
  *   \return           The modifier mask
@@ -173,7 +173,7 @@ MirInputEventModifiers mir_keyboard_event_modifiers(MirKeyboardEvent const* even
 MirInputEvent const* mir_keyboard_event_input_event(MirKeyboardEvent const* event);
 
 /**
- * Retrieve the modifier keys pressed when the touch action occured.
+ * Retrieve the modifier keys pressed when the touch action occurred.
  *
  *   \param [in] event The key event
  *   \return           The modifier mask
@@ -199,7 +199,7 @@ unsigned int mir_touch_event_point_count(MirTouchEvent const* event);
 MirTouchId mir_touch_event_id(MirTouchEvent const* event, unsigned int touch_index);
 
 /**
- * Retrieve the action which occured for a touch at given index.
+ * Retrieve the action which occurred for a touch at given index.
  *
  *  \param [in] event       The touch event
  *  \param [in] touch_index The touch index. Must be less than (touch_count - 1).
@@ -237,7 +237,7 @@ MirInputEvent const* mir_touch_event_input_event(MirTouchEvent const* event);
 
 
 /**
- * Retrieve the modifier keys pressed when the pointer action occured.
+ * Retrieve the modifier keys pressed when the pointer action occurred.
  *
  *   \param [in] event The pointer event
  *   \return           The modifier mask
@@ -245,7 +245,7 @@ MirInputEvent const* mir_touch_event_input_event(MirTouchEvent const* event);
 MirInputEventModifiers mir_pointer_event_modifiers(MirPointerEvent const* event);
 
 /**
- * Retrieve the action which occured to generate a given pointer event.
+ * Retrieve the action which occurred to generate a given pointer event.
  *
  *  \param [in] event       The pointer event
  *  \return                 Action performed by the pointer

--- a/src/server/shell/basic_hover_click_transformer.cpp
+++ b/src/server/shell/basic_hover_click_transformer.cpp
@@ -43,7 +43,7 @@ public:
         auto const state = mutable_state.lock();
         state->potential_position = {abs_x, abs_y};
 
-        // If a click already occured in the past. Only start a new hover click if
+        // If a click already occurred in the past. Only start a new hover click if
         // the cursor moved "significantly" from the last position.
         auto const hover_click_origin = state->hover_click_origin;
 


### PR DESCRIPTION
Fix 11 instances of \`occured\` → \`occurred\` across 5 files in the public event headers and basic_hover_click_transformer.

| File | Instances |
|------|-----------|
| \`include/miral/miral/toolkit_event.h\` | 3 |
| \`include/common/mir_toolkit/events/input/pointer_event.h\` | 2 |
| \`include/common/mir_toolkit/events/input/touch_event.h\` | 2 |
| \`include/common/mir_toolkit/events/input/keyboard_event.h\` | 1 |
| \`src/server/shell/basic_hover_click_transformer.cpp\` | 1 |

These are doc comments on public API methods (\`mir_pointer_event_modifiers\`, \`mir_keyboard_event_modifiers\`, \`mir_touch_event_action\`, etc.), so the misspelling is visible in generated API documentation.

Comment-only change.