### PR TITLE
ci: align check names with upstream, and add missed spelling

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -30,7 +30,7 @@ jobs:
         filters: .github/filters.yaml
 
   spelling-check:
-    name: Spell check
+    name: ${{ needs.check-paths.outputs.should-run == 'true' && 'Documentation spelling check' || 'Documentation spelling check / Check spelling in the documentation' }}
     needs: [check-paths]
     if: needs.check-paths.outputs.should-run == 'true'
     permissions:
@@ -40,7 +40,7 @@ jobs:
       working-directory: doc/sphinx
 
   inclusive-language-check:
-    name: Inclusive language check
+    name: ${{ needs.check-paths.outputs.should-run == 'true' && 'Documentation inclusive language check' || 'Documentation inclusive language check / Check for inclusive language in the documentation' }}
     needs: [check-paths]
     if: needs.check-paths.outputs.should-run == 'true'
     permissions:
@@ -50,7 +50,7 @@ jobs:
       working-directory: doc/sphinx
 
   link-check:
-    name: Link check
+    name: ${{ needs.check-paths.outputs.should-run == 'true' && 'Documentation link check' || 'Documentation link check / Check links in the documentation' }}
     needs: [check-paths]
     if: needs.check-paths.outputs.should-run == 'true'
     permissions:

--- a/doc/sphinx/.custom_wordlist.txt
+++ b/doc/sphinx/.custom_wordlist.txt
@@ -129,6 +129,7 @@ kms
 libEGL
 libhybris
 libinput
+libmiral
 libmirclient
 libVA
 linux


### PR DESCRIPTION
## What's new?

This ensures that both skipped doc checks, and those that get skipped, have the same name.

## How to test

See that a commit that resulted in skipped doc checks (741e45daa3a496d0953fd3c7233ddb24fbd4104d) has the same name that the ones here, completed, do.

## Checklist

- [x] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
