### PR TITLE
Validate anchor enum provided to positioner

### DIFF
--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -769,6 +769,10 @@ void mf::XdgPositionerStable::set_anchor(uint32_t anchor)
 
     switch (anchor)
     {
+        case Anchor::none:
+            placement = mir_placement_gravity_center;
+            break;
+
         case Anchor::top:
             placement = mir_placement_gravity_north;
             break;

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -802,7 +802,10 @@ void mf::XdgPositionerStable::set_anchor(uint32_t anchor)
             break;
 
         default:
-            placement = mir_placement_gravity_center;
+            BOOST_THROW_EXCEPTION(mw::ProtocolError(
+                resource,
+                mw::XdgPositioner::Error::invalid_input,
+                "Invalid anchor value %d", anchor));
     }
 
     aux_rect_placement_gravity = placement;

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -805,7 +805,7 @@ void mf::XdgPositionerStable::set_anchor(uint32_t anchor)
             BOOST_THROW_EXCEPTION(mw::ProtocolError(
                 resource,
                 mw::XdgPositioner::Error::invalid_input,
-                "Invalid anchor value %d", anchor));
+                "Invalid anchor value %u", anchor));
     }
 
     aux_rect_placement_gravity = placement;


### PR DESCRIPTION
This is currently done in Mutter, and specified for the gravity anchor. See https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/507 for this to be formalized in the specification.
