### PR TITLE
Accept EGL_TEXTURE_EXTERNAL_WL

### DIFF
--- a/src/platform/graphics/egl_wayland_allocator.cpp
+++ b/src/platform/graphics/egl_wayland_allocator.cpp
@@ -122,7 +122,9 @@ public:
           egl_format{get_wl_egl_format(buffer, extensions)},
           egl_delegate{std::move(egl_delegate)}
     {
-        if (egl_format != EGL_TEXTURE_RGB && egl_format != EGL_TEXTURE_RGBA)
+        if (egl_format != EGL_TEXTURE_RGB &&
+            egl_format != EGL_TEXTURE_RGBA &&
+            egl_format != EGL_TEXTURE_EXTERNAL_WL)
         {
             BOOST_THROW_EXCEPTION((std::runtime_error{"YUV textures unimplemented"}));
         }


### PR DESCRIPTION
On devices running libhybris based OS the EGL driver selects gralloc based formats that are exposed to Mir as EGL_TEXTURE_EXTERNAL_WL, accept the external format so apps can render in that case
