### PR TITLE
gh: drop CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-*       @canonical/mir


### PR DESCRIPTION
## What's new?

Drop `CODEOWNERS`, as it doesn't have meaningful impact with _a single_ owner, and breaks some flows (like checking for requested reviews).

## How to test

Need to merge to take effect.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
