### PR TITLE
Fix boolean logic checking for DnD actions

### DIFF
--- a/src/server/frontend_wayland/wl_data_source.cpp
+++ b/src/server/frontend_wayland/wl_data_source.cpp
@@ -261,7 +261,7 @@ uint32_t mf::WlDataSource::drag_n_drop_set_actions(uint32_t dnd_actions, uint32_
 
     if (dnd_actions & DndAction::ask)
     {
-        preferred_action |= DndAction::move;
+        preferred_action = DndAction::move;
     }
 
     auto const acceptable_options = this->dnd_actions | dnd_actions;

--- a/src/server/frontend_wayland/wl_data_source.cpp
+++ b/src/server/frontend_wayland/wl_data_source.cpp
@@ -259,7 +259,7 @@ uint32_t mf::WlDataSource::drag_n_drop_set_actions(uint32_t dnd_actions, uint32_
         preferred_action = DndAction::move;
     }
 
-    if (dnd_actions | DndAction::ask)
+    if (dnd_actions & DndAction::ask)
     {
         preferred_action |= DndAction::move;
     }
@@ -268,7 +268,7 @@ uint32_t mf::WlDataSource::drag_n_drop_set_actions(uint32_t dnd_actions, uint32_
 
     for (auto action : {preferred_action, DndAction::copy, DndAction::move, DndAction::none})
     {
-        if (action | acceptable_options)
+        if (action & acceptable_options)
         {
             if (!dnd_action || dnd_action.value() != action)
             {

--- a/src/server/frontend_wayland/wl_data_source.cpp
+++ b/src/server/frontend_wayland/wl_data_source.cpp
@@ -264,7 +264,7 @@ uint32_t mf::WlDataSource::drag_n_drop_set_actions(uint32_t dnd_actions, uint32_
         preferred_action = DndAction::move;
     }
 
-    auto const acceptable_options = this->dnd_actions | dnd_actions;
+    auto const acceptable_options = this->dnd_actions & dnd_actions;
 
     for (auto action : {preferred_action, DndAction::copy, DndAction::move, DndAction::none})
     {


### PR DESCRIPTION
Or was used instead of and, meaning these checks were always true. The first check would always add move to the preferred action, and the second check would mark all actions as acceptable.
