### PR TITLE
ci: we _can_ ignore paths on `push` events

### DIFF
--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -7,6 +7,13 @@ on:
     - release/[0-9]+.[0-9]+
     tags:
     - v[0-9]+.[0-9]+.[0-9]+
+    paths-ignore:
+    - ".github/**"
+    - "!.github/workflows/ppa-upload.yml"
+    - "doc/**"
+    - "rpm/**"
+    - "snap/**"
+    - "spread/**"
 
 permissions: {}
 

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -7,6 +7,11 @@ on:
     - release/[0-9]+.[0-9]+
     tags:
     - v[0-9]+[0-9]+.[0-9]+
+    paths-ignore:
+    - ".github/**"
+    - "!.github/workflows/spread.yml"
+    - "doc/**"
+    - "snap/**"
   merge_group:
     types: [checks_requested]
   pull_request:

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
     - main
+    paths-ignore:
+    - ".github/**"
+    - "!.github/workflows/tics.yml"
+    - "doc/**"
+    - "snap/**"
+    - "spread.yaml"
+    - "spread/**"
   pull_request:
   merge_group:
     types: [checks_requested]


### PR DESCRIPTION
## What's new?

While we can't use these on pull requests or merge checks, we _can_ on push.

We'll be maintaining docs in `release/X.YY` branches, and need this to not blow up in PPAs etc.

## How to test

Upon merging, see that https://github.com/canonical/mir/actions?query=branch%3Amain+event%3Apush didn't run these.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
