### PR TITLE
doc: migrate to canonical.com

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -210,7 +210,7 @@ jobs:
 
             const commentBody = [
               `## ${process.env.INPUTS_VERSION}~rc1`,
-              'Please test this release candidate following the [test-mir-for-a-release](https://canonical-mir.readthedocs.io/en/latest/contributing/how-to/test-mir-for-a-release.html) document.',
+              'Please test this release candidate following the [test-mir-for-a-release](https://canonical.com/mir/docs/latest/contributing/how-to/test-mir-for-a-release) document.',
               ...markedSections,
             ].join('\n\n');
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -20,7 +20,7 @@ $ cmake ..
 $ make guides
 ```
 
-(Or online, [here](https://canonical-mir.readthedocs-hosted.com/latest/_static/cppguide)).
+(Or online, [here](https://canonical.com/mir/docs/latest/_static/cppguide)).
 
 ## Code structure
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ API.
 
 ## Resources
 
-- For information on how to use Mir, refer to [the official documentation](https://canonical-mir.readthedocs-hosted.com).
+- For information on how to use Mir, refer to [the official documentation](https://canonical.com/mir/docs).
 - For data sheets and whitepapers, check out [the Mir website](https://canonical.com/mir).
 - Mir is [hosted on GitHub](https://github.com/canonical/mir).
 - For announcements and other discussions on Mir see [Ubuntu Discourse](https://discourse.ubuntu.com/c/mir/15) or join

--- a/doc/sphinx/_static/js/overwrite_links.js
+++ b/doc/sphinx/_static/js/overwrite_links.js
@@ -1,0 +1,37 @@
+ // Replace oldDomain with newDomain
+ const oldDomain = 'canonical-mir-documentation.readthedocs-hosted.com';
+ const newDomain = 'canonical.com/mir/docs';
+
+ // Set up a mutation observer to monitor changes in the DOM
+ // RTD flyout is created dynamically, so we need to wait for it to appear
+ const targetNode = document.body;
+ const config = { childList: true, subtree: true };
+
+ // Callback function to execute when mutation is observed
+ function waitForElement(element, callback){
+     var foo = setInterval(function(){
+         // console.log(`Waiting for element: ${element}...`)
+         if(document.querySelector(element)){
+             clearInterval(foo);
+             // console.log(`Element found: ${element}.`)
+             callback();
+         }
+     }, 100);
+ }
+
+ // Start observing the target node (rtd-flyout)
+ // execute the overwrite when the element is loaded
+ waitForElement("readthedocs-flyout", function(){
+     // console.log(`Triggering URL rewrite`)
+     const rtdFlyout = document.querySelector('readthedocs-flyout');
+     rtdFlyout.addEventListener('click', function(e) {
+         // Access the shadow DOM of the 'readthedocs-flyout' element
+         const shadowRoot = rtdFlyout.shadowRoot;
+         const anchors = shadowRoot.querySelectorAll('a');
+         anchors.forEach(anchor => {
+             // console.log(`Checking URL for replacement: ${anchor.href}`);
+             anchor.href = anchor.href.replace(new RegExp(oldDomain, 'g'), newDomain);
+             // console.log(`URL now: ${anchor.href}`);
+         });
+     });
+ });

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -80,7 +80,7 @@ copyright = '%s, %s' % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical-mir.readthedocs-hosted.com/"
+ogp_site_url = "https://canonical.com/mir/docs/"
 
 
 # Preview name of the documentation website
@@ -186,7 +186,7 @@ html_theme_options = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'mir/docs'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
@@ -194,11 +194,11 @@ html_theme_options = {
 
 # Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
 
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+html_baseurl = "https://canonical.com/mir/docs/"
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 
-sitemap_url_scheme = '{link}'
+sitemap_url_scheme = f"{os.environ.get('READTHEDOCS_VERSION', '')}/{{link}}"
 
 # Include `lastmod` dates in the sitemap:
 
@@ -219,7 +219,7 @@ sitemap_excludes = [
 # Template and asset locations #
 ################################
 
-# html_static_path = ["_static"]
+html_static_path = ["_static"]
 templates_path = ["_templates"]
 
 
@@ -343,6 +343,7 @@ html_css_files = [
 # Adds custom JavaScript files, located under 'html_static_path'
 
 html_js_files = [
+    "js/overwrite_links.js",
     "https://assets.ubuntu.com/v1/287a5e8f-bundle.js",
 ]
 

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -402,6 +402,7 @@ if os.path.exists('./reuse/substitutions.yaml'):
 # Add configuration for intersphinx mapping
 # Map only the Sphinx documentation sets that you need to link to from your docs set.
 intersphinx_mapping = {
+    'frame': ("https://ubuntu.com/frame/docs/24", None),
     'checkbox': ("https://canonical-checkbox.readthedocs-hosted.com/latest/", None),
     'server': ('https://documentation.ubuntu.com/server/', None),
     'snapcraft': ('https://documentation.ubuntu.com/snapcraft/stable/', None),

--- a/doc/sphinx/contributing/how-to/use-checkbox-mir.md
+++ b/doc/sphinx/contributing/how-to/use-checkbox-mir.md
@@ -8,7 +8,7 @@ This document explains how to use checkbox-mir to validate the graphical environ
 
 To support graphics on Linux on a given piece of hardware, usually a kernel and userspace driver is required. When using snaps, the kernel driver is managed by the operating system, but the userspace driver needs to be available to your application.
 
-The recommended approach for this is using a content snap, through the appropriate content interface. The current iteration is `gpu-2404`, see here for more information on that setup: [The gpu-2404 interface](https://canonical.com/mir/docs/the-gpu-2404-snap-interface).
+The recommended approach for this is using a content snap, through the appropriate content interface. See here for more information on that setup: {ref}`frame:use-snap-graphics`.
 
 ## Checkbox
 

--- a/doc/sphinx/robots.txt
+++ b/doc/sphinx/robots.txt
@@ -3,4 +3,4 @@ User-agent: *
 # Allow everything
 Disallow:
 
-Sitemap: https://canonical-mir.readthedocs-hosted.com/stable/sitemapindex.xml
+Sitemap: https://canonical.com/mir/docs/stable/sitemapindex.xml

--- a/doc/sphinx/sitemapindex.xml
+++ b/doc/sphinx/sitemapindex.xml
@@ -1,8 +1,11 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <sitemap>
-<loc>https://canonical-mir.readthedocs-hosted.com/stable/sitemap.xml</loc>
+<loc>https://canonical.com/mir/docs/stable/sitemap.xml</loc>
 </sitemap>
 <sitemap>
-<loc>https://canonical-mir.readthedocs-hosted.com/2.17.2/sitemap.xml</loc>
+<loc>https://canonical.com/mir/docs/2.26/sitemap.xml</loc>
+</sitemap>
+<sitemap>
+<loc>https://canonical.com/mir/docs/2.17/sitemap.xml</loc>
 </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## What's new?

Migrate docs to canonical.com/mir/docs

## How to test

Check https://staging.canonical.com/mir/docs/latest (VPN required).
Verify all paths from https://discourse.ubuntu.com/t/mir-documentation/27559#heading--navigation get a proper redirect to the new location.

## Checklist

- [ ] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
