### PR TITLE
Enable daily scheduled PPA uploads and workflow dispatch

### DIFF
--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -20,7 +20,34 @@ on:
 permissions: {}
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+    - name: Check for new commits since last successful run
+      id: check
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if [ "${{ github.event_name }}" != "schedule" ]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        last_sha=$(gh api \
+          "repos/${{ github.repository }}/actions/workflows/ppa-upload.yml/runs?status=success&branch=main&per_page=1" \
+          --jq '.workflow_runs[0].head_sha // empty')
+        if [ "$last_sha" != "${{ github.sha }}" ]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+        fi
+
   PPAUpload:
+    needs: check
+    if: needs.check.outputs.should_run == 'true'
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -1,9 +1,11 @@
 name: PPA Upload
 
 on:
+  schedule:
+  - cron: "0 7 * * *" # Daily at 07:00 UTC
+  workflow_dispatch:
   push:
     branches:
-    - main
     - release/[0-9]+.[0-9]+
     tags:
     - v[0-9]+.[0-9]+.[0-9]+


### PR DESCRIPTION
## What's new?

- Disables uploading to the dev PPA on pushes to main. Instead, we push everyday at 7 AM UTC.

## How to test

- Wait until 7 AM UTC or manually dispatch the workflow using GitHub's UI.
