### PR TITLE
debian: drop ~dev suffix from changelog

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -78,11 +78,11 @@ jobs:
           sudo apt-get install --yes --no-install-recommends devscripts
 
           # Ensure there's a matching "Begin Release Candidate" entry
-          dch --newversion "${VERSION}~rc" ""
+          dch --newversion "${VERSION}" ""
 
           # Remove "Begin" lines and append release notes
           awk --include=inplace \
-            --assign version_pat="^mir \\\(${VERSION}~rc\\\)" '
+            --assign version_pat="^mir \\\(${VERSION}\\\)" '
             $0~version_pat {
               in_target = 1
               print

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -55,19 +55,6 @@ jobs:
             exit 1
           fi
 
-      - name: Release Debian symbols
-        run: |
-          awk --include=inplace \
-            -v version_pat="${INPUTS_VERSION}~dev$" \
-            -v version="${INPUTS_VERSION}" '
-            $0~version_pat {
-              gsub(version "~dev$", version)
-            }
-            { print }
-          ' debian/*.symbols
-
-          git add debian/*.symbols
-
       - name: Update CMake version
         run: |
           sed --in-place -E "s/(VERSION\s+)[0-9]+\.[0-9]+\.[0-9]+/\1${INPUTS_VERSION}/" CMakeLists.txt
@@ -96,7 +83,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends devscripts
 
-          debchange --newversion "${INPUTS_VERSION}~rc" "Begin Release Candidate for ${INPUTS_VERSION} release"
+          debchange --newversion "${INPUTS_VERSION}" "Begin Release Candidate for ${INPUTS_VERSION} release"
           git add debian/changelog
 
       - name: Update the RPM changelog
@@ -315,7 +302,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends devscripts
 
-          debchange --newversion "${NEXT_VERSION}~dev" ''
+          debchange --newversion "${NEXT_VERSION}" ''
           git add debian/changelog
 
       - name: Update the RPM changelog

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-mir (2.27.0~dev) UNRELEASED; urgency=medium
+mir (2.27.0) UNRELEASED; urgency=medium
 
   * Begin development for 2.27.0 release
 


### PR DESCRIPTION
## What's new?

This avoids messing with dpkg-gensymbols unnecessarily.

## How to test

Nothing should change immediately, but `dpkg-gensymbols` diff will be sane next time.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
