### PR TITLE
correct include paths pkgconfig

### DIFF
--- a/src/common/input/CMakeLists.txt
+++ b/src/common/input/CMakeLists.txt
@@ -17,4 +17,5 @@ target_include_directories(mircommoninput
 target_link_libraries(mircommoninput
   PUBLIC
     mircore
+    PkgConfig::XKBCOMMON
 )

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -198,6 +198,7 @@ target_include_directories(miral
 target_link_libraries(miral-external
     PUBLIC
         mircore
+        PkgConfig::XKBCOMMON
     PRIVATE
         miral-internal
         mirserver


### PR DESCRIPTION

## What's new?

Changes needed to deal with openSUSE being a problem, as usual, putting the xkbcommon headers in a non-standard location.

## How to test

Build for openSUSE: https://build.opensuse.org/package/live_build_log/home:sfalken:branches:X11:Wayland/mir/openSUSE_Tumbleweed/x86_64


