### PR TITLE
Simpler array clearing

### DIFF
--- a/include/miral/miral/live_config.h
+++ b/include/miral/miral/live_config.h
@@ -94,6 +94,10 @@ public:
     virtual void add_string_attribute(Key const& key, std::string_view description, std::string_view preset, HandleString handler) = 0;
     virtual void add_strings_attribute(Key const& key, std::string_view description, std::span<std::string const> preset, HandleStrings handler) = 0;
 
+    virtual void set_ints_value(Key const& key, std::span<int const> values) = 0;
+    virtual void set_floats_value(Key const& key, std::span<float const> values) = 0;
+    virtual void set_strings_value(Key const& key, std::span<std::string const> values) = 0;
+
     /// Called following a set of related updates (e.g. a file reload) to allow
     /// multiple attributes to be updated transactionally
     virtual void on_done(HandleDone handler) = 0;

--- a/include/miral/miral/live_config_ini_file.h
+++ b/include/miral/miral/live_config_ini_file.h
@@ -48,6 +48,10 @@ public:
     void add_string_attribute(Key const& key, std::string_view description, std::string_view preset, HandleString handler) override;
     void add_strings_attribute(Key const& key, std::string_view description, std::span<std::string const> preset, HandleStrings handler) override;
 
+    void set_ints_value(Key const& key, std::span<int const> values) override;
+    void set_floats_value(Key const& key, std::span<float const> values) override;
+    void set_strings_value(Key const& key, std::span<std::string const> values) override;
+
     void on_done(HandleDone handler) override;
 
     void load_file(std::istream& istream, std::filesystem::path const& path);

--- a/src/miral/basic_store.cpp
+++ b/src/miral/basic_store.cpp
@@ -62,6 +62,22 @@ public:
     void add_key(Key const& key, std::string_view description, std::optional<std::vector<std::string>> preset, HandleStrings handler);
 
     void update_key(Key const& key, std::string_view value, std::filesystem::path const& modification_path);
+    template <typename T> void set_value(Key const& key, std::span<T const> values)
+    {
+        if (auto array_iter = array_attribute_handlers.find(key); array_iter != array_attribute_handlers.end())
+        {
+            auto& details = array_iter->second;
+            auto const str_values = values | std::views::transform([](auto const& v) -> std::string {
+                if constexpr (!std::is_same_v<T, std::string>) {
+                    return std::to_string(v);
+                } else {
+                    return v;
+                }
+            });
+            details.parsed_values = std::vector<std::string>{str_values.begin(), str_values.end()};
+        }
+    }
+
     void do_transaction(std::function<void()> transaction_body);
 
     void on_done(HandleDone handler);
@@ -518,6 +534,21 @@ void mlc::BasicStore::add_string_attribute(Key const& key, std::string_view desc
 void mlc::BasicStore::add_strings_attribute(Key const& key, std::string_view description, std::span<std::string const> preset, HandleStrings handler)
 {
     self->add_key(key, description, std::vector<std::string>{preset.begin(), preset.end()}, handler);
+}
+
+void mlc::BasicStore::set_ints_value(Key const& key, std::span<int const> values)
+{
+    self->set_value(key, values);
+}
+
+void mlc::BasicStore::set_floats_value(Key const& key, std::span<float const> values)
+{
+    self->set_value(key, values);
+}
+
+void mlc::BasicStore::set_strings_value(Key const& key, std::span<std::string const> values)
+{
+    self->set_value(key, values);
 }
 
 void mlc::BasicStore::on_done(HandleDone handler)

--- a/src/miral/basic_store.cpp
+++ b/src/miral/basic_store.cpp
@@ -1,5 +1,6 @@
 #include "basic_store.h"
 
+#include <algorithm>
 #include <mir/log.h>
 
 #include <boost/throw_exception.hpp>
@@ -106,7 +107,7 @@ private:
         std::string const description;
         std::optional<std::vector<std::string>> const preset;
         std::vector<std::string> parsed_values;
-        std::set<std::filesystem::path> modification_paths;
+        std::vector<std::filesystem::path> modification_paths;
     };
 
     std::mutex mutex;
@@ -169,7 +170,8 @@ void mlc::BasicStore::Self::update_key(Key const& key, std::string_view value, s
         else
             details.parsed_values.push_back(std::string{value});
 
-        details.modification_paths.insert(modification_path);
+        if (!std::ranges::contains(details.modification_paths, modification_path))
+            details.modification_paths.push_back(modification_path);
     }
     else
     {

--- a/src/miral/basic_store.cpp
+++ b/src/miral/basic_store.cpp
@@ -163,7 +163,12 @@ void mlc::BasicStore::Self::update_key(Key const& key, std::string_view value, s
     else if (auto const details_iter = array_attribute_handlers.find(key); details_iter != array_attribute_handlers.end())
     {
         auto& details = details_iter->second;
-        details.parsed_values.push_back(std::string{value});
+
+        if (value.empty())
+            details.parsed_values.clear();
+        else
+            details.parsed_values.push_back(std::string{value});
+
         details.modification_paths.insert(modification_path);
     }
     else

--- a/src/miral/basic_store.h
+++ b/src/miral/basic_store.h
@@ -52,6 +52,10 @@ public:
         std::span<std::string const> preset,
         HandleStrings handler) override;
 
+    void set_ints_value(Key const& key, std::span<int const> values) override;
+    void set_floats_value(Key const& key, std::span<float const> values) override;
+    void set_strings_value(Key const& key, std::span<std::string const> values) override;
+
     void on_done(HandleDone handler) override;
 
     void update_key(Key const& key, std::string_view value, std::filesystem::path const& modification_path);

--- a/src/miral/live_config_ini_file.cpp
+++ b/src/miral/live_config_ini_file.cpp
@@ -156,6 +156,21 @@ void mlc::IniFile::add_strings_attribute(
     self->add_strings_attribute(key, description, preset, std::move(handler));
 }
 
+void mlc::IniFile::set_ints_value(Key const& key, std::span<int const> values)
+{
+   self->set_ints_value(key, values);
+}
+
+void mlc::IniFile::set_floats_value(Key const& key, std::span<float const> values)
+{
+   self->set_floats_value(key, values);
+}
+
+void mlc::IniFile::set_strings_value(Key const& key, std::span<std::string const> values)
+{
+   self->set_strings_value(key, values);
+}
+
 void mlc::IniFile::on_done(HandleDone handler)
 {
     self->on_done(std::move(handler));

--- a/tests/miral/basic_store.cpp
+++ b/tests/miral/basic_store.cpp
@@ -16,6 +16,7 @@
 
 #include "basic_store.h"
 
+#include "gtest/gtest.h"
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -378,6 +379,59 @@ TEST_F(BasicStoreTest, strings_handler_receives_nullopt_when_no_preset_and_no_va
     EXPECT_CALL(*this, strings_handler(a_strings_key, Eq(std::nullopt)));
 
     run_empty();
+}
+
+TEST_F(BasicStoreTest, strings_handler_receives_empty_array_reset_when_cleared_with_no_values)
+{
+    store.add_strings_attribute(a_strings_key, "some strings", [this](auto k, auto v){ strings_handler(k, v); });
+
+    EXPECT_CALL(*this, strings_handler(a_strings_key, Eq(std::nullopt)));
+
+    store.do_transaction([&]
+    {
+        store.update_key(a_strings_key, "", a_path);
+    });
+}
+
+TEST_F(BasicStoreTest, ints_handler_receives_array_reset_with_values_when_cleared_then_values_set)
+{
+    store.add_ints_attribute(an_ints_key, "some ints", [this](auto k, auto v){ ints_handler(k, v); });
+
+    EXPECT_CALL(*this, ints_handler(an_ints_key, Optional(ElementsAre(1, 2))));
+
+    store.do_transaction([&]
+    {
+        store.update_key(an_ints_key, "", a_path);
+        store.update_key(an_ints_key, "1", a_path);
+        store.update_key(an_ints_key, "2", a_path);
+    });
+}
+
+TEST_F(BasicStoreTest, ints_preset_is_used_as_reset_when_cleared_and_all_values_cannot_be_parsed)
+{
+    std::vector<int> const preset_vals{10, 20};
+    store.add_ints_attribute(an_ints_key, "some ints", preset_vals, [this](auto k, auto v){ ints_handler(k, v); });
+
+    EXPECT_CALL(*this, ints_handler(an_ints_key, Optional(ElementsAreArray(preset_vals))));
+
+    store.do_transaction([&]
+    {
+        store.update_key(an_ints_key, "", a_path);
+        store.update_key(an_ints_key, "not_a_number", a_path);
+    });
+}
+
+TEST_F(BasicStoreTest, ints_handler_receives_nullopt_when_cleared_and_all_values_are_bad_and_no_preset)
+{
+    store.add_ints_attribute(an_ints_key, "some ints", [this](auto k, auto v){ ints_handler(k, v); });
+
+    EXPECT_CALL(*this, ints_handler(an_ints_key, Eq(std::nullopt)));
+
+    store.do_transaction([&]
+    {
+        store.update_key(an_ints_key, "", a_path);
+        store.update_key(an_ints_key, "not_a_number", a_path);
+    });
 }
 
 TEST_F(BasicStoreTest, ints_handler_receives_nullopt_when_no_preset_and_all_values_are_bad)

--- a/tests/miral/basic_store.cpp
+++ b/tests/miral/basic_store.cpp
@@ -457,3 +457,79 @@ TEST_F(BasicStoreTest, floats_handler_receives_nullopt_when_no_preset_and_all_va
         store.update_key(a_floats_key, "not_a_float", a_path);
     });
 }
+
+TEST_F(BasicStoreTest, set_ints_value_values_are_handled)
+{
+    store.add_ints_attribute(an_ints_key, "some ints", [this](auto k, auto v){ ints_handler(k, v); });
+
+    EXPECT_CALL(*this, ints_handler(an_ints_key, Optional(ElementsAre(7, 8, 9))));
+
+    store.do_transaction([&]
+    {
+        store.set_ints_value(an_ints_key, std::vector<int>{7, 8, 9});
+    });
+}
+
+TEST_F(BasicStoreTest, set_floats_value_values_are_handled)
+{
+    store.add_floats_attribute(a_floats_key, "some floats", [this](auto k, auto v){ floats_handler(k, v); });
+
+    EXPECT_CALL(*this, floats_handler(a_floats_key, Optional(ElementsAre(FloatEq(1.5f), FloatEq(2.5f)))));
+
+    store.do_transaction([&]
+    {
+        store.set_floats_value(a_floats_key, std::vector<float>{1.5f, 2.5f});
+    });
+}
+
+TEST_F(BasicStoreTest, set_strings_value_values_are_handled)
+{
+    store.add_strings_attribute(a_strings_key, "some strings", [this](auto k, auto v){ strings_handler(k, v); });
+
+    EXPECT_CALL(*this, strings_handler(a_strings_key, Optional(ElementsAre("hello", "world"))));
+
+    store.do_transaction([&]
+    {
+        store.set_strings_value(a_strings_key, std::vector<std::string>{"hello", "world"});
+    });
+}
+
+TEST_F(BasicStoreTest, set_ints_value_replaces_values_accumulated_via_update_key)
+{
+    store.add_ints_attribute(an_ints_key, "some ints", [this](auto k, auto v){ ints_handler(k, v); });
+
+    EXPECT_CALL(*this, ints_handler(an_ints_key, Optional(ElementsAre(99))));
+
+    store.do_transaction([&]
+    {
+        store.update_key(an_ints_key, "1", a_path);
+        store.update_key(an_ints_key, "2", a_path);
+        store.set_ints_value(an_ints_key, std::vector<int>{99});
+    });
+}
+
+TEST_F(BasicStoreTest, set_ints_value_overrides_preset)
+{
+    std::vector<int> const preset_vals{10, 20};
+    store.add_ints_attribute(an_ints_key, "some ints", preset_vals, [this](auto k, auto v){ ints_handler(k, v); });
+
+    EXPECT_CALL(*this, ints_handler(an_ints_key, Optional(ElementsAre(42))));
+
+    store.do_transaction([&]
+    {
+        store.set_ints_value(an_ints_key, std::vector<int>{42});
+    });
+}
+
+TEST_F(BasicStoreTest, update_key_appends_to_values_set_via_set_ints_value)
+{
+    store.add_ints_attribute(an_ints_key, "some ints", [this](auto k, auto v){ ints_handler(k, v); });
+
+    EXPECT_CALL(*this, ints_handler(an_ints_key, Optional(ElementsAre(99, 100))));
+
+    store.do_transaction([&]
+    {
+        store.set_ints_value(an_ints_key, std::vector<int>{99});
+        store.update_key(an_ints_key, "100", a_path);
+    });
+}


### PR DESCRIPTION
## What's new?

- Re-implements array clearing in a simpler way by allowing external users to force the initial value of `parsed_values`. Which are then used as is, cleared, or appended onto.

## How to test

`<path/to/build>/bin/miral-test-internal --gtest_filter=BasicStoreTest.*`

## Checklist

- [x] Tests added and pass