### PR TITLE
Tidy up parse_output_sizes

### DIFF
--- a/src/platforms/virtual/platform.cpp
+++ b/src/platforms/virtual/platform.cpp
@@ -61,11 +61,11 @@ auto mgv::Platform::parse_output_sizes(std::vector<std::string> virtual_outputs)
     std::vector<VirtualOutputConfig> configs;
     for (auto const& output : virtual_outputs)
     {
-        std::vector<geom::Size > sizes;
-        for (int start = 0, end; start - 1 < (int)output.size(); start = end + 1)
+        std::vector<geom::Size> sizes;
+        for (size_t start = 0, end; start <= output.size(); start = end + 1)
         {
             end = output.find(':', start);
-            if (end == (int)std::string::npos)
+            if (end == std::string::npos)
                 end = output.size();
             sizes.push_back(common::parse_size(output.substr(start, end - start)));
         }

--- a/src/platforms/x11/graphics/platform.cpp
+++ b/src/platforms/x11/graphics/platform.cpp
@@ -41,10 +41,10 @@ auto parse_size(std::string const& str) -> mgx::X11OutputConfig
 auto mgx::Platform::parse_output_sizes(std::string output_sizes) -> std::vector<mgx::X11OutputConfig>
 {
     std::vector<mgx::X11OutputConfig> sizes;
-    for (int start = 0, end; start - 1 < (int)output_sizes.size(); start = end + 1)
+    for (size_t start = 0, end; start <= output_sizes.size(); start = end + 1)
     {
         end = output_sizes.find(':', start);
-        if (end == (int)std::string::npos)
+        if (end == std::string::npos)
             end = output_sizes.size();
         sizes.push_back(parse_size(output_sizes.substr(start, end - start)));
     }


### PR DESCRIPTION
Remove cast (always use size_t) and simplify length check.
