### PR TITLE
miral: Make std::formatter<live_config::Key> a strong symbol

### DIFF
--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -808,6 +808,7 @@ global:
     typeinfo?for?miral::live_config::OverridesList;
     typeinfo?for?miral::live_config::IniFileWithOverrides;
     vtable?for?miral::live_config::IniFileWithOverrides;
-    "std::formatter<miral::live_config::Key, char>::format(miral::live_config::Key const&, std::basic_format_context<std::__format::_Sink_iter<char>, char>&) const";
+    "std::formatter<miral::live_config::Key,char>::format*";
+    "typeinfo?for?std::formatter<miral::live_config::Key,char>";
   };
 } MIRAL_5.7;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -808,7 +808,7 @@ global:
     typeinfo?for?miral::live_config::OverridesList;
     typeinfo?for?miral::live_config::IniFileWithOverrides;
     vtable?for?miral::live_config::IniFileWithOverrides;
-    "std::formatter<miral::live_config::Key,char>::format*";
-    "typeinfo?for?std::formatter<miral::live_config::Key,char>";
+    std::formatter?miral::live_config::Key*char?::format*;
+    typeinfo?for?std::formatter?miral::live_config::Key*char?;
   };
 } MIRAL_5.7;


### PR DESCRIPTION
This ensures the symbol reliably exists, so the symbols check reliably passes.