### PR TITLE
Revert "doc: improve titles and SEO (#4910)"

### DIFF
--- a/doc/sphinx/configuring/explanation/index.md
+++ b/doc/sphinx/configuring/explanation/index.md
@@ -1,6 +1,6 @@
 (configuring-explanation-index)=
 
-# Configuring Mir: explanations
+# Explanation
 
 These pages provide additional detail about a number of aspects related to using Mir.
 

--- a/doc/sphinx/configuring/how-to/index.md
+++ b/doc/sphinx/configuring/how-to/index.md
@@ -1,6 +1,6 @@
 (configuring-how-to-index)=
 
-# Configuring Mir: how-to guides
+# How-to guides
 
 These how-to guides cover the key aspects of configuring Mir based compositors as an end-user.
 

--- a/doc/sphinx/configuring/reference/index.md
+++ b/doc/sphinx/configuring/reference/index.md
@@ -1,6 +1,6 @@
 (configuring-reference-index)=
 
-# Mir configuration reference
+# Reference
 
 These pages provide detailed reference on configuring Mir compositors.
 

--- a/doc/sphinx/contributing/explanation/architecture.md
+++ b/doc/sphinx/contributing/explanation/architecture.md
@@ -1,6 +1,6 @@
 (mir-architecture)=
 
-# Mir architecture
+# Architecture
 
 This document introduces the architecture of *Mir* at a high-level.
 

--- a/doc/sphinx/contributing/explanation/index.md
+++ b/doc/sphinx/contributing/explanation/index.md
@@ -1,6 +1,6 @@
 (contributing-explanation-index)=
 
-# Contributing to Mir: explanations
+# Explanation
 
 These pages provide additional detail about contributing to Mir.
 

--- a/doc/sphinx/contributing/explanation/input_platform.md
+++ b/doc/sphinx/contributing/explanation/input_platform.md
@@ -1,6 +1,6 @@
 (mir-input-platform)=
 
-# Mir input platform APIs
+# Input platform APIs
 
 This document explains the input platform API. Developers may implement this
 API in order to define their own input platform. The Mir project ships with

--- a/doc/sphinx/contributing/explanation/libraries.md
+++ b/doc/sphinx/contributing/explanation/libraries.md
@@ -1,6 +1,6 @@
 (mir-libraries)=
 
-# Mir libraries and module architecture
+# Libraries and module architecture
 
 The Mir project is a collection of C++ libraries for writing Wayland
 compositors. This document describes what those libraries are and how they

--- a/doc/sphinx/contributing/how-to/index.md
+++ b/doc/sphinx/contributing/how-to/index.md
@@ -1,6 +1,6 @@
 (contributing-how-to-index)=
 
-# Contributing to Mir: how-to guides
+# How-to guides
 
 These how-to guides cover the key aspects of working on Mir.
 

--- a/doc/sphinx/contributing/reference/index.md
+++ b/doc/sphinx/contributing/reference/index.md
@@ -1,6 +1,6 @@
 (contributing-reference-index)=
 
-# Mir contributor reference
+# Reference
 
 These pages provide detailed reference to Mir's development practices.
 

--- a/doc/sphinx/explanation/accessibility-methods.md
+++ b/doc/sphinx/explanation/accessibility-methods.md
@@ -1,4 +1,4 @@
-# Accessibility methods in Mir
+# Accessibility methods
 
 Accessibility methods are options which
 accommodate users with disabilities. Mir offers a variety of accessibility

--- a/doc/sphinx/explanation/consumer-libraries.md
+++ b/doc/sphinx/explanation/consumer-libraries.md
@@ -1,4 +1,4 @@
-# Mir libraries for compositor authors
+# Libraries for compositor authors
 
 These are the principal libraries *Mir* provides compositor authors.
 

--- a/doc/sphinx/explanation/driver-quirks.md
+++ b/doc/sphinx/explanation/driver-quirks.md
@@ -1,4 +1,4 @@
-# Graphics driver quirks in Mir
+# Graphics driver quirks
 
 The gbm-kms and atomic-kms graphics platform modules provide a
 `--driver-quirks` option that can control how the module behaves.

--- a/doc/sphinx/explanation/index.md
+++ b/doc/sphinx/explanation/index.md
@@ -1,4 +1,4 @@
-# Mir explanation guides
+# Explanation
 
 These pages provide additional detail about a number of aspects related to using Mir.
 

--- a/doc/sphinx/explanation/performance.md
+++ b/doc/sphinx/explanation/performance.md
@@ -1,4 +1,4 @@
-# Performance considerations for Mir-based compositors
+# Performance
 
 This document aims to explore in depth the performance considerations around Mir
 based compositors.

--- a/doc/sphinx/explanation/platform-support.md
+++ b/doc/sphinx/explanation/platform-support.md
@@ -1,6 +1,6 @@
 (exp-mir-graphics-support)=
 
-# Mir platform support: graphics and input backends
+# Platform support
 
 This document describes the requirements for running Mir.
 

--- a/doc/sphinx/explanation/security.md
+++ b/doc/sphinx/explanation/security.md
@@ -1,4 +1,4 @@
-# Security considerations for Mir-based compositors
+# Security
 
 This document aims to explore in depth the security considerations around Mir
 based compositors.

--- a/doc/sphinx/explanation/xdg-portal.md
+++ b/doc/sphinx/explanation/xdg-portal.md
@@ -6,7 +6,7 @@ myst:
 
 (exp-xdg-portals-support)=
 
-# XDG portal support in Mir
+# XDG portal support
 
 Mir does not have built-in support for XDG portals, but it is possible to use
 them with Mir-based compositors. This document provides an overview of how to

--- a/doc/sphinx/how-to/index.md
+++ b/doc/sphinx/how-to/index.md
@@ -1,6 +1,6 @@
 (how-to-index)=
 
-# Mir how-to guides
+# How-to guides
 
 These guides cover the key aspects of developing a Wayland compositor with Mir.
 

--- a/doc/sphinx/how-to/specifying-csd-ssd-preference.md
+++ b/doc/sphinx/how-to/specifying-csd-ssd-preference.md
@@ -1,4 +1,4 @@
-# Specifying CSD/SSD preference in Mir compositors
+# Specifying client-/server-side decoration preference
 
 Clients can ask the compositor to use server or client side decorations, or request the compositor to choose for them. {class}`miral::Decorations` allows you to customize how the server deals with these requests.
 

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -1,4 +1,4 @@
-# Mir: A Wayland compositor library
+# Mir documentation
 
 Mir is a compositor library designed to operate across a variety of Linux-based
 devices, including traditional desktops, IoT and embedded systems.

--- a/doc/sphinx/reference/index.md
+++ b/doc/sphinx/reference/index.md
@@ -1,4 +1,4 @@
-# Mir reference
+# Reference
 
 These pages provide detailed reference to Mir APIs and other interfaces.
 

--- a/doc/sphinx/release-notes.md
+++ b/doc/sphinx/release-notes.md
@@ -1,6 +1,6 @@
 (release-notes)=
 
-# Mir release notes
+# Release Notes
 
 <!--
 

--- a/doc/sphinx/tutorial/index.md
+++ b/doc/sphinx/tutorial/index.md
@@ -1,6 +1,6 @@
 (tutorial-index)=
 
-# Tutorials for building Wayland compositors with Mir
+# Tutorials
 
 These pages provide first-time introductions to key Mir aspects
 


### PR DESCRIPTION
## What's new?

These were wrong in the table of contents, better solution TBD.

This reverts parts of commit 699c9aac6816807ed41dc0ee9d8fed0bd95c9dcc.

## How to test

Doc build vs. https://canonical.com/mir/docs/latest/

## Checklist

- [ ] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
