### PR TITLE
Symbols map generator performance improvements

### DIFF
--- a/tools/symbols_map_generator/main.py
+++ b/tools/symbols_map_generator/main.py
@@ -187,10 +187,20 @@ def has_virtual_base_class(node: clang.cindex.Cursor):
 
 def is_function_inline(node: clang.cindex.CursorKind):
     # This method assumes that the node is a FUNCTION_DECL.
-    # There is no explicit way to check if a function is inlined
-    # but seeing that if it is a FUNCTION_DECL and it has
-    # a definition is good enough.
-    return node.is_definition()
+    # Use libclang's dedicated query rather than node.is_definition(): the
+    # latter is only a proxy for "inline" and, crucially, reports False once
+    # PARSE_SKIP_FUNCTION_BODIES is in effect (the body it would key off is
+    # skipped), which would wrongly emit symbols for inline free functions.
+    # clang_Cursor_isFunctionInlined answers the question directly and is
+    # stable regardless of whether function bodies were parsed.
+    #
+    # Also skip functions with internal linkage (static storage class): they
+    # are never exported from the shared library regardless of whether they
+    # are defined inline.  StorageClass is a declaration-level property and
+    # is equally stable under PARSE_SKIP_FUNCTION_BODIES.
+    if node.storage_class == clang.cindex.StorageClass.STATIC:
+        return True
+    return bool(clang.cindex.conf.lib.clang_Cursor_isFunctionInlined(node))
 
 
 def get_namespace_str(node: clang.cindex.Cursor) -> list[str]:
@@ -337,14 +347,17 @@ def process_directory(directory: Path, search_dirs: Optional[list[str]]) -> set[
     for dir in search_dirs:
         args.append(f"-I{dir}")
 
+    # PARSE_SKIP_FUNCTION_BODIES tells libclang not to parse the bodies of
+    # functions or methods.  We only need declarations (names, types,
+    # virtual-ness) to extract symbols, so this is always safe here and
+    # significantly reduces parse time for headers with non-trivial inline
+    # definitions.
+    parse_options = clang.cindex.TranslationUnit.PARSE_SKIP_FUNCTION_BODIES
+
     for file in files:
         _logger.debug(f"Processing header file: {file.as_posix()}")
-        file_args = args.copy()
         idx = clang.cindex.Index.create()
-        tu = idx.parse(
-            file.as_posix(),
-            args=file_args,
-            options=0)
+        tu = idx.parse(file.as_posix(), args=args, options=parse_options)
         root = tu.cursor
         list(traverse_ast(root, file.as_posix(), result))
 

--- a/tools/symbols_map_generator/main.py
+++ b/tools/symbols_map_generator/main.py
@@ -18,6 +18,7 @@ import logging
 import sys
 import os
 import argparse
+import concurrent.futures
 from pathlib import Path
 from typing import TypedDict, Optional
 from collections import OrderedDict
@@ -338,30 +339,43 @@ def traverse_ast(node: clang.cindex.Cursor, filename: str, result: set[str]) -> 
     return result
 
 
-def process_directory(directory: Path, search_dirs: Optional[list[str]]) -> set[str]:
-    result = set()
 
-    files = directory.rglob('*.h')
+def _parse_single_header(file_path: str, parse_args: list[str]) -> set[str]:
+    """Parse a single header file and return the set of symbol strings it defines.
+
+    Defined at module level (not as a closure) so it is picklable for use with
+    concurrent.futures.ProcessPoolExecutor.  On Linux, ProcessPoolExecutor uses
+    fork by default, so the clang.cindex.Config already set up in the parent
+    process (SO path, library path) is inherited by each worker without any
+    extra initialisation.
+    """
+    idx = clang.cindex.Index.create()
+    parse_options = clang.cindex.TranslationUnit.PARSE_SKIP_FUNCTION_BODIES
+    tu = idx.parse(file_path, args=parse_args, options=parse_options)
+    result: set[str] = set()
+    traverse_ast(tu.cursor, file_path, result)
+    return result
+
+
+def process_directory(directory: Path, search_dirs: Optional[list[str]]) -> set[str]:
+    files = list(directory.rglob('*.h'))
 
     args = ['-std=c++23', '-x', 'c++-header']
     for dir in search_dirs:
         args.append(f"-I{dir}")
 
-    # PARSE_SKIP_FUNCTION_BODIES tells libclang not to parse the bodies of
-    # functions or methods.  We only need declarations (names, types,
-    # virtual-ness) to extract symbols, so this is always safe here and
-    # significantly reduces parse time for headers with non-trivial inline
-    # definitions.
-    parse_options = clang.cindex.TranslationUnit.PARSE_SKIP_FUNCTION_BODIES
+    # Parse all header files in parallel.  Each worker creates its own
+    # clang.cindex.Index so libclang state is never shared across processes.
+    combined: set[str] = set()
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        futures = [
+            executor.submit(_parse_single_header, f.as_posix(), args)
+            for f in files
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            combined |= future.result()
 
-    for file in files:
-        _logger.debug(f"Processing header file: {file.as_posix()}")
-        idx = clang.cindex.Index.create()
-        tu = idx.parse(file.as_posix(), args=args, options=parse_options)
-        root = tu.cursor
-        list(traverse_ast(root, file.as_posix(), result))
-
-    return result
+    return combined
 
 
 def read_symbols_from_file(f: argparse.FileType, library_name: str) -> list[Symbol]:

--- a/tools/symbols_map_generator/main.py
+++ b/tools/symbols_map_generator/main.py
@@ -20,7 +20,7 @@ import os
 import argparse
 import concurrent.futures
 from pathlib import Path
-from typing import TypedDict, Optional
+from typing import TypedDict
 from collections import OrderedDict
 import bisect
 
@@ -186,7 +186,7 @@ def has_virtual_base_class(node: clang.cindex.Cursor):
     return result
 
 
-def is_function_inline(node: clang.cindex.CursorKind):
+def is_function_inline(node: clang.cindex.Cursor):
     # This method assumes that the node is a FUNCTION_DECL.
     # Use libclang's dedicated query rather than node.is_definition(): the
     # latter is only a proxy for "inline" and, crucially, reports False once
@@ -357,7 +357,7 @@ def _parse_single_header(file_path: str, parse_args: list[str]) -> set[str]:
     return result
 
 
-def process_directory(directory: Path, search_dirs: Optional[list[str]]) -> set[str]:
+def process_directory(directory: Path, search_dirs: list[str]) -> set[str]:
     files = list(directory.rglob('*.h'))
 
     args = ['-std=c++23', '-x', 'c++-header']


### PR DESCRIPTION
## What's new

Implements two performance optimizations for the symbols map generator:
- Instructs libclang to skip function bodies (unnecessary for symbols)
  - This exposed a bug where we accidentally emitted symbols for inline functions after the optimization was applied. The changes to `is_function_inline` correctly check for inline-ness.
- Parses all headers in parallel

Depending on your hardware, expect performance gains of ~10x+. Below are the results on my machine:
 | Variant                        | Median  | vs baseline | Speedup |
 |-------------------------------|---------|-------------|---------|
 | Baseline (serial, full parse)  | 33.94s  | —           | 1×      |
 | Skip-bodies only (serial)      | 23.67s  | −10.27s     | 1.4×    |
 | Parallel only (full parse)     |  3.50s  | −30.44s     | 9.7×    |
 | Combined                       |  2.29s  | −31.64s     | 14.8×   |
 
 A few more optimizations were explored along the way but were dropped due to negligible effect (< 5% improvement). Correctness was verified by quickly vibing a test suite, which did discover a couple of new (now solved) and pre-existing bugs. That will follow in a future PR.
 
 ## How to test:
 Check for new/removed symbols (diff mode — read-only):
```
 cmake --build <path to build> --target check-miral-symbols-map
 cmake --build <path to build> --target check-miroil-symbols-map
````
Update symbols.map in-place with any new symbols:
```
 cmake --build <path to build> --target generate-miral-symbols-map
 cmake --build <path to build> --target generate-miroil-symbols-map
 ```