### PR TITLE
Add support for screen-shooting a single surface

### DIFF
--- a/src/include/server/mir/compositor/screen_shooter_factory.h
+++ b/src/include/server/mir/compositor/screen_shooter_factory.h
@@ -26,6 +26,8 @@ class Executor;
 
 namespace compositor
 {
+class Scene;
+
 class ScreenShooterFactory
 {
 public:
@@ -36,6 +38,12 @@ public:
     /// \param executor responsible for queuing the screenshot request
     /// \return a new screen shooter
     virtual auto create(Executor& executor) -> std::unique_ptr<ScreenShooter> = 0;
+
+    /// Creates a new screen shooter for a particular scene
+    /// \param executor responsible for queuing the screenshot request
+    /// \param scene that the screen shooter will capture
+    /// \return a new screen shooter
+    virtual auto create_for_scene(Executor& executor, std::shared_ptr<Scene> const& scene) -> std::unique_ptr<ScreenShooter> = 0;
 };
 }
 }

--- a/src/include/server/mir/scene/surface_scene.h
+++ b/src/include/server/mir/scene/surface_scene.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_SCENE_SURFACE_SCENE_H_
+#define MIR_SCENE_SURFACE_SCENE_H_
+
+#include <memory>
+
+namespace mir
+{
+namespace compositor
+{
+class Scene;
+}
+namespace scene
+{
+class Surface;
+auto create_surface_scene(std::weak_ptr<Surface> const& surface) -> std::shared_ptr<compositor::Scene>;
+}
+}
+
+#endif /* MIR_SCENE_SURFACE_SCENE_H_ */

--- a/src/server/compositor/basic_screen_shooter_factory.cpp
+++ b/src/server/compositor/basic_screen_shooter_factory.cpp
@@ -43,6 +43,11 @@ mc::BasicScreenShooterFactory::BasicScreenShooterFactory(
 
 auto mc::BasicScreenShooterFactory::create(Executor& executor) -> std::unique_ptr<ScreenShooter>
 {
+    return create_for_scene(executor, scene);
+}
+
+auto mc::BasicScreenShooterFactory::create_for_scene(Executor& executor, std::shared_ptr<Scene> const& scene) -> std::unique_ptr<ScreenShooter>
+{
     return std::make_unique<BasicScreenShooter>(
         scene, clock, executor, providers, renderer_factory, buffer_allocator, config, output_filter, cursor);
 }

--- a/src/server/compositor/basic_screen_shooter_factory.h
+++ b/src/server/compositor/basic_screen_shooter_factory.h
@@ -57,6 +57,7 @@ public:
         std::shared_ptr<graphics::OutputFilter> const& output_filter,
         std::shared_ptr<graphics::Cursor> const& cursor);
     auto create(Executor& executor) -> std::unique_ptr<ScreenShooter> override;
+    auto create_for_scene(Executor& executor, std::shared_ptr<Scene> const& scene) -> std::unique_ptr<ScreenShooter> override;
 
 private:
     std::shared_ptr<Scene> const scene;

--- a/src/server/compositor/null_screen_shooter_factory.cpp
+++ b/src/server/compositor/null_screen_shooter_factory.cpp
@@ -23,3 +23,8 @@ auto mc::NullScreenShooterFactory::create(Executor& executor) -> std::unique_ptr
 {
     return std::make_unique<NullScreenShooter>(executor);
 }
+
+auto mc::NullScreenShooterFactory::create_for_scene(Executor& executor, std::shared_ptr<Scene> const&) -> std::unique_ptr<ScreenShooter>
+{
+    return std::make_unique<NullScreenShooter>(executor);
+}

--- a/src/server/compositor/null_screen_shooter_factory.h
+++ b/src/server/compositor/null_screen_shooter_factory.h
@@ -29,6 +29,7 @@ class NullScreenShooterFactory : public ScreenShooterFactory
 {
 public:
     auto create(Executor& executor) -> std::unique_ptr<ScreenShooter> override;
+    auto create_for_scene(Executor& executor, std::shared_ptr<Scene> const& scene) -> std::unique_ptr<ScreenShooter> override;
 };
 }
 }

--- a/src/server/scene/CMakeLists.txt
+++ b/src/server/scene/CMakeLists.txt
@@ -23,6 +23,7 @@ ADD_LIBRARY(
   surface_state_tracker.cpp
   basic_text_input_hub.cpp
   basic_idle_hub.cpp
+  single_surface_scene.cpp
   ${CMAKE_SOURCE_DIR}/src/include/server/mir/scene/surface_observer.h
 )
 

--- a/src/server/scene/single_surface_scene.cpp
+++ b/src/server/scene/single_surface_scene.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <mir/scene/surface_scene.h>
+#include <mir/compositor/scene.h>
+#include <mir/compositor/scene_element.h>
+#include <mir/scene/observer.h>
+#include <mir/scene/surface.h>
+#include "rendering_tracker.h"
+#include "surface_stack.h"
+
+#include <boost/throw_exception.hpp>
+
+namespace ms = mir::scene;
+namespace mc = mir::compositor;
+namespace mg = mir::graphics;
+
+namespace mir::scene
+{
+class SingleSurfaceScene :
+    public compositor::Scene
+{
+public:
+    SingleSurfaceScene(std::weak_ptr<Surface> const& surface);
+
+    // From Scene
+    auto scene_elements_for(mc::CompositorID id) -> mc::SceneElementSequence override;
+    void register_compositor(mc::CompositorID id) override;
+    void unregister_compositor(mc::CompositorID id) override;
+
+    void add_observer(std::shared_ptr<Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<Observer> const& observer) override;
+
+private:
+    SingleSurfaceScene(const SingleSurfaceScene&) = delete;
+    SingleSurfaceScene& operator=(const SingleSurfaceScene&) = delete;
+
+    RecursiveReadWriteMutex guard;
+    std::weak_ptr<Surface> surface;
+    std::shared_ptr<RenderingTracker> rendering_tracker;
+    std::set<compositor::CompositorID> registered_compositors;
+
+    Observers observers;
+};
+}
+
+namespace
+{
+
+class SurfaceSceneElement : public mc::SceneElement
+{
+public:
+    SurfaceSceneElement(
+        std::string name,
+        std::shared_ptr<mg::Renderable> const& renderable,
+        std::shared_ptr<ms::RenderingTracker> const& tracker,
+        mc::CompositorID id)
+        : renderable_{renderable},
+          tracker{tracker},
+          cid{id},
+          surface_name(name)
+    {
+    }
+
+    std::shared_ptr<mg::Renderable> renderable() const override
+    {
+        return renderable_;
+    }
+
+    void rendered() override
+    {
+        tracker->rendered_in(cid);
+    }
+
+    void occluded() override
+    {
+        tracker->occluded_in(cid);
+    }
+
+private:
+    std::shared_ptr<mg::Renderable> const renderable_;
+    std::shared_ptr<ms::RenderingTracker> const tracker;
+    mc::CompositorID cid;
+    std::string const surface_name;
+};
+}
+
+ms::SingleSurfaceScene::SingleSurfaceScene(
+    std::weak_ptr<Surface> const &surface)
+    : surface{surface},
+      rendering_tracker{std::make_shared<ms::RenderingTracker>(surface)}
+{
+}
+
+auto ms::SingleSurfaceScene::scene_elements_for(mc::CompositorID id) -> mc::SceneElementSequence
+{
+    RecursiveReadLock lg(guard);
+
+    mc::SceneElementSequence elements;
+    if (auto const locked = surface.lock())
+    {
+        for (auto& renderable : locked->generate_renderables(id))
+        {
+            elements.emplace_back(
+                std::make_shared<SurfaceSceneElement>(
+                    locked->name(),
+                    renderable,
+                    rendering_tracker,
+                    id));
+        }
+    }
+    return elements;
+}
+
+void ms::SingleSurfaceScene::register_compositor(mc::CompositorID id)
+{
+    RecursiveWriteLock lg(guard);
+
+    registered_compositors.insert(id);
+    rendering_tracker->active_compositors(registered_compositors);
+}
+
+void ms::SingleSurfaceScene::unregister_compositor(mc::CompositorID id)
+{
+    RecursiveWriteLock lg(guard);
+
+    registered_compositors.erase(id);
+    rendering_tracker->active_compositors(registered_compositors);
+}
+
+void ms::SingleSurfaceScene::add_observer(std::shared_ptr<ms::Observer> const& observer)
+{
+    observers.add(observer);
+
+    // Notify observer of our surface.
+    RecursiveReadLock lg(guard);
+    if (auto const locked = surface.lock())
+        observer->surface_exists(locked);
+}
+
+void ms::SingleSurfaceScene::remove_observer(std::weak_ptr<ms::Observer> const& observer)
+{
+    auto o = observer.lock();
+    if (!o)
+        BOOST_THROW_EXCEPTION(std::logic_error("Invalid observer (destroyed)"));
+
+    o->end_observation();
+
+    observers.remove(o);
+}
+
+auto ms::create_surface_scene(std::weak_ptr<Surface> const& surface) -> std::shared_ptr<mc::Scene>
+{
+    return std::make_shared<SingleSurfaceScene>(surface);
+}

--- a/src/server/scene/single_surface_scene.cpp
+++ b/src/server/scene/single_surface_scene.cpp
@@ -21,12 +21,12 @@
 #include <mir/scene/surface.h>
 #include "rendering_tracker.h"
 #include "surface_stack.h"
+#include "surface_scene_element.h"
 
 #include <boost/throw_exception.hpp>
 
 namespace ms = mir::scene;
 namespace mc = mir::compositor;
-namespace mg = mir::graphics;
 
 namespace mir::scene
 {
@@ -54,47 +54,6 @@ private:
     std::set<compositor::CompositorID> registered_compositors;
 
     Observers observers;
-};
-}
-
-namespace
-{
-
-class SurfaceSceneElement : public mc::SceneElement
-{
-public:
-    SurfaceSceneElement(
-        std::string name,
-        std::shared_ptr<mg::Renderable> const& renderable,
-        std::shared_ptr<ms::RenderingTracker> const& tracker,
-        mc::CompositorID id)
-        : renderable_{renderable},
-          tracker{tracker},
-          cid{id},
-          surface_name(name)
-    {
-    }
-
-    std::shared_ptr<mg::Renderable> renderable() const override
-    {
-        return renderable_;
-    }
-
-    void rendered() override
-    {
-        tracker->rendered_in(cid);
-    }
-
-    void occluded() override
-    {
-        tracker->occluded_in(cid);
-    }
-
-private:
-    std::shared_ptr<mg::Renderable> const renderable_;
-    std::shared_ptr<ms::RenderingTracker> const tracker;
-    mc::CompositorID cid;
-    std::string const surface_name;
 };
 }
 

--- a/src/server/scene/surface_scene_element.h
+++ b/src/server/scene/surface_scene_element.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_SCENE_SURFACE_SCENE_ELEMENT_H
+#define MIR_SCENE_SURFACE_SCENE_ELEMENT_H
+
+#include <mir/compositor/compositor_id.h>
+#include <mir/compositor/scene_element.h>
+#include <mir/graphics/renderable.h>
+#include "rendering_tracker.h"
+
+#include <memory>
+
+namespace mir
+{
+namespace graphics
+{
+class Renderable;
+}
+namespace scene
+{
+class RenderingTracker;
+
+class SurfaceSceneElement : public compositor::SceneElement
+{
+public:
+    SurfaceSceneElement(
+        std::string name,
+        std::shared_ptr<graphics::Renderable> const& renderable,
+        std::shared_ptr<RenderingTracker> const& tracker,
+        compositor::CompositorID id)
+        : renderable_{renderable},
+          tracker{tracker},
+          cid{id},
+          surface_name(name)
+    {
+    }
+
+    std::shared_ptr<graphics::Renderable> renderable() const override
+    {
+        return renderable_;
+    }
+
+    void rendered() override
+    {
+        tracker->rendered_in(cid);
+    }
+
+    void occluded() override
+    {
+        tracker->occluded_in(cid);
+    }
+
+private:
+    std::shared_ptr<graphics::Renderable> const renderable_;
+    std::shared_ptr<RenderingTracker> const tracker;
+    compositor::CompositorID cid;
+    std::string const surface_name;
+};
+
+}
+}
+
+#endif /* MIR_SCENE_SURFACE_SCENE_ELEMENT_H */

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -16,6 +16,7 @@
 
 #include "surface_stack.h"
 #include "rendering_tracker.h"
+#include "surface_scene_element.h"
 #include <mir/scene/surface.h>
 #include <mir/scene/null_surface_observer.h>
 #include <mir/scene/scene_report.h>
@@ -42,43 +43,6 @@ namespace geom = mir::geometry;
 
 namespace
 {
-
-class SurfaceSceneElement : public mc::SceneElement
-{
-public:
-    SurfaceSceneElement(
-        std::string name,
-        std::shared_ptr<mg::Renderable> const& renderable,
-        std::shared_ptr<ms::RenderingTracker> const& tracker,
-        mc::CompositorID id)
-        : renderable_{renderable},
-          tracker{tracker},
-          cid{id},
-          surface_name(name)
-    {
-    }
-
-    std::shared_ptr<mg::Renderable> renderable() const override
-    {
-        return renderable_;
-    }
-
-    void rendered() override
-    {
-        tracker->rendered_in(cid);
-    }
-
-    void occluded() override
-    {
-        tracker->occluded_in(cid);
-    }
-
-private:
-    std::shared_ptr<mg::Renderable> const renderable_;
-    std::shared_ptr<ms::RenderingTracker> const tracker;
-    mc::CompositorID cid;
-    std::string const surface_name;
-};
 
 //note: something different than a 2D/HWC overlay
 class OverlaySceneElement : public mc::SceneElement

--- a/tests/unit-tests/scene/test_surface_stack.cpp
+++ b/tests/unit-tests/scene/test_surface_stack.cpp
@@ -19,6 +19,7 @@
 #include <mir/graphics/buffer_properties.h>
 #include <mir/geometry/rectangle.h>
 #include <mir/scene/observer.h>
+#include <mir/scene/surface_scene.h>
 #include <mir/compositor/scene_element.h>
 #include "src/server/report/null_report_factory.h"
 #include <mir/scene/basic_surface.h>
@@ -1312,4 +1313,119 @@ TEST_F(SurfaceStack, multiple_surfaces_can_be_swapped)
             SceneElementForStream(stub_buffer_stream2)));
 
     Mock::VerifyAndClearExpectations(&observer);
+}
+
+namespace
+{
+
+struct SingleSurfaceScene : public ::testing::Test
+{
+    void SetUp() override
+    {
+        capture_surface = std::make_shared<StubSurface>(capture_buffer_stream, executor);
+        hidden_surface = std::make_shared<StubSurface>(hidden_buffer_stream, executor);
+        hidden_surface->hide();
+    }
+
+    void TearDown() override
+    {
+        executor.execute();
+    }
+
+    std::shared_ptr<mc::BufferStream> capture_buffer_stream = std::make_shared<mtd::StubBufferStream>();
+    std::shared_ptr<mc::BufferStream> hidden_buffer_stream = std::make_shared<mtd::StubBufferStream>();
+
+    std::shared_ptr<ms::Surface> capture_surface;
+    std::shared_ptr<ms::Surface> hidden_surface;
+
+    mc::CompositorID const compositor_id{this};
+    mtd::ExplicitExecutor executor;
+    std::shared_ptr<mtd::FakeDisplayConfigurationObserverRegistrar> const display_config_registrar =
+        std::make_shared<mtd::FakeDisplayConfigurationObserverRegistrar>();
+};
+
+}
+
+TEST_F(SingleSurfaceScene, scene_elements_for)
+{
+    auto const scene = ms::create_surface_scene(capture_surface);
+    EXPECT_THAT(
+        scene->scene_elements_for(compositor_id),
+        ElementsAre(
+            SceneElementForStream(capture_buffer_stream)));
+}
+
+TEST_F(SingleSurfaceScene, scene_elements_for_hidden)
+{
+    auto const scene = ms::create_surface_scene(hidden_surface);
+    EXPECT_THAT(
+        scene->scene_elements_for(compositor_id),
+        ElementsAre(
+            SceneElementForStream(hidden_buffer_stream)));
+}
+
+TEST_F(SingleSurfaceScene, scene_observer_informed_of_existing_surface)
+{
+    MockSceneObserver observer;
+
+    EXPECT_CALL(observer, surface_exists(capture_surface)).Times(1);
+
+    auto const scene = ms::create_surface_scene(capture_surface);
+    scene->add_observer(mt::fake_shared(observer));
+}
+
+TEST_F(SingleSurfaceScene, exposes_rendered_surface)
+{
+    mc::CompositorID const compositor_id2{&compositor_id};
+
+    auto const mock_surface = std::make_shared<MockConfigureSurface>(executor);
+    auto const scene = ms::create_surface_scene(mock_surface);
+
+    scene->register_compositor(compositor_id);
+    scene->register_compositor(compositor_id2);
+
+    auto const elements = scene->scene_elements_for(compositor_id);
+    ASSERT_THAT(elements.size(), Eq(1u));
+    auto const elements2 = scene->scene_elements_for(compositor_id2);
+    ASSERT_THAT(elements2.size(), Eq(1u));
+
+    EXPECT_CALL(*mock_surface, configure(mir_window_attrib_visibility, mir_window_visibility_exposed));
+
+    elements.back()->occluded();
+    elements2.back()->rendered();
+}
+
+TEST_F(SingleSurfaceScene, occludes_surface_when_unregistering_all_compositors_that_rendered_it)
+{
+    mc::CompositorID const compositor_id2{&compositor_id};
+    mc::CompositorID const compositor_id3{&compositor_id2};
+
+    auto const mock_surface = std::make_shared<MockConfigureSurface>(executor);
+    auto const scene = ms::create_surface_scene(mock_surface);
+
+    scene->register_compositor(compositor_id);
+    scene->register_compositor(compositor_id2);
+    scene->register_compositor(compositor_id3);
+
+    auto const elements = scene->scene_elements_for(compositor_id);
+    ASSERT_THAT(elements.size(), Eq(1u));
+    auto const elements2 = scene->scene_elements_for(compositor_id2);
+    ASSERT_THAT(elements2.size(), Eq(1u));
+    auto const elements3 = scene->scene_elements_for(compositor_id3);
+    ASSERT_THAT(elements3.size(), Eq(1u));
+
+    EXPECT_CALL(*mock_surface, configure(mir_window_attrib_visibility, mir_window_visibility_exposed))
+        .Times(2);
+
+    elements.back()->occluded();
+    elements2.back()->rendered();
+    elements3.back()->rendered();
+    executor.execute();
+
+    Mock::VerifyAndClearExpectations(mock_surface.get());
+
+    EXPECT_CALL(*mock_surface, configure(mir_window_attrib_visibility, mir_window_visibility_occluded));
+
+    scene->unregister_compositor(compositor_id2);
+    scene->unregister_compositor(compositor_id3);
 }


### PR DESCRIPTION
Related: #4710

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

## What's new?

This adds some infrastructure necessary to implement toplevel capture via `ext_image_copy_capture_v1`. In particular:

1. Add a `mir::compositor::Scene` implementation that only includes the renderables for a single `mir::scene::Surface`.
2. Extend `mir::compositor::ScreenShooterFactory` to allow creating screen shooters for an alternative scene.

Together these will let us implement an `ExtImageCopyBackend` for toplevel capture:

1. Create a screen shooter for the toplevel's Surface.
2. Watch for size changes on the surface to set buffer constraints
3. Watch for damage on the surface rather than on the full surface stack.
4. Screenshot the rectangle where the surface is located in the scene.

One open question is what resolution to capture at. The simplest would be to just capture at 1x. If there are no subsurfaces, a better choice would be to capture at that surface's native resolution. If there are subsurfaces, there's no guarantee that they will have the same scale factor.

## How to test

This doesn't add the Wayland protocol pieces to make use of these changes. I hacked it into the output capture protocol to use a screen shooter for the surface at (100, 100) when the session is started:

https://github.com/user-attachments/assets/4bb1f8e2-4478-4c0f-91d2-813f761ebc91

Here you can see a single window is captured by wayvnc, and continues to render when occluded. For X11 apps, the decorations were a separate surface to the application content. That might need some additional work to support if we care.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
