### PR TITLE
DecorationProvider example: Don't constrain character size

### DIFF
--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -176,7 +176,7 @@ void Printer::printhelp(BackgroundInfo const& region)
             "  o To exit: Ctrl-Alt-BkSp",
         };
 
-    auto const min_char_width = std::min({region_size.width.as_int()/60, region_size.height.as_int()/35, 20});
+    auto const min_char_width = std::min({region_size.width.as_int()/60, region_size.height.as_int()/35});
     FT_Set_Pixel_Sizes(face, min_char_width, 0);
     Width help_width;
     Height help_height;


### PR DESCRIPTION
With HIDPI screens limiting the maximum number of physical pixels a character can take is annoying: the text is small.