### PR TITLE
fix-wrong-foreign-toplevel-logic

### DIFF
--- a/src/server/frontend_wayland/desktop_file_manager.cpp
+++ b/src/server/frontend_wayland/desktop_file_manager.cpp
@@ -69,6 +69,10 @@ std::string mf::DesktopFileManager::resolve_app_id(scene::Surface const& surface
     // For more info on the checks happening here, see:
     // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/src/shell-window-tracker.c?ref_type=heads#L387
 
+    // When packaged as a snap or flatpack the resulting desktop entry may not follow
+    // the naming style expected by the app. So we find the name based on the packaging
+    // and ignore the name provided by the application.
+    // https://github.com/canonical/mir/issues/4954#issuecomment-4510527223
     if (auto session = surface.session().lock())
     {
         auto pid = session->process_id();

--- a/src/server/frontend_wayland/desktop_file_manager.cpp
+++ b/src/server/frontend_wayland/desktop_file_manager.cpp
@@ -60,7 +60,7 @@ mf::DesktopFileManager::DesktopFileManager(std::shared_ptr<DesktopFileCache> cac
 {
 }
 
-std::string mf::DesktopFileManager::resolve_app_id(const scene::Surface* surface)
+std::string mf::DesktopFileManager::resolve_app_id(scene::Surface const& surface)
 {
     // In this method, we're attempting to resolve a Surface back to it's GAppInfo so that
     // we can report a best-effort app_id to the user.
@@ -68,13 +68,12 @@ std::string mf::DesktopFileManager::resolve_app_id(const scene::Surface* surface
     // Hence, we jump through a series of hoops in the hope that we'll find what we're looking for.
     // For more info on the checks happening here, see:
     // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/src/shell-window-tracker.c?ref_type=heads#L387
-    auto app_id = surface->application_id();
+    auto app_id = surface.application_id();
     rtrim(app_id); // Sometimes, the app id has a space at the end
     mir::log_info("Attempting to resolve app id from app_id=%s", app_id.c_str());
 
     // First, let's see if this is just a WM_CLASS
-    auto app = cache->lookup_by_wm_class(app_id);
-    if (app)
+    if (auto const app = cache->lookup_by_wm_class(app_id))
     {
         mir::log_info("Successfully resolved app id from wm_class, id=%s", app->id.c_str());
         return app->id;
@@ -90,8 +89,7 @@ std::string mf::DesktopFileManager::resolve_app_id(const scene::Surface* surface
     }
 
     // Second, let's see if we can map it straight to a desktop file
-    auto found = lookup_basename(app_id);
-    if (found)
+    if (auto const found = lookup_basename(app_id))
     {
         mir::log_info("Successfully resolved app id from basename, id=%s", found->id.c_str());
         return found->id;
@@ -102,37 +100,33 @@ std::string mf::DesktopFileManager::resolve_app_id(const scene::Surface* surface
     for(char &ch : lowercase_desktop_file)
         ch = std::tolower(ch);
 
-    found = lookup_basename(lowercase_desktop_file);
-    if (found)
+    if (auto const found = lookup_basename(lowercase_desktop_file))
     {
         mir::log_info("Successfully resolved app id from lowercase basename, id=%s", found->id.c_str());
         return found->id;
     }
 
-    if (auto session = surface->session().lock())
+    if (auto session = surface.session().lock())
     {
         auto pid = session->process_id();
         auto socket_fd = session->socket_fd();
 
         // Fourth, check if the window belongs to snap
-        found = resolve_if_snap(pid, socket_fd);
-        if (found)
+        if (auto const found = resolve_if_snap(pid, socket_fd))
         {
             mir::log_info("Successfully resolved app id from snap, id=%s", found->id.c_str());
             return found->id;
         }
 
         // Fifth, check if the window belongs to flatpak
-        found = resolve_if_flatpak(pid);
-        if (found)
+        if (auto const found = resolve_if_flatpak(pid))
         {
             mir::log_info("Successfully resolved app id from flatpak, id=%s", found->id.c_str());
             return found->id;
         }
 
         // Sixth, get the exec command from our pid and see if we can match it to a GAppInfo's Exec
-        found = resolve_if_executable_matches(pid);
-        if (found)
+        if (auto const found = resolve_if_executable_matches(pid))
         {
             mir::log_info("Successfully resolved app id from executable, id=%s", found->id.c_str());
             return found->id;

--- a/src/server/frontend_wayland/desktop_file_manager.cpp
+++ b/src/server/frontend_wayland/desktop_file_manager.cpp
@@ -109,32 +109,34 @@ std::string mf::DesktopFileManager::resolve_app_id(const scene::Surface* surface
         return found->id;
     }
 
-    auto session = surface->session().lock();
-    auto pid = session->process_id();
-    auto socket_fd = session->socket_fd();
-
-    // Fourth, check if the window belongs to snap
-    found = resolve_if_snap(pid, socket_fd);
-    if (found)
+    if (auto session = surface->session().lock())
     {
-        mir::log_info("Successfully resolved app id from snap, id=%s", found->id.c_str());
-        return found->id;
-    }
+        auto pid = session->process_id();
+        auto socket_fd = session->socket_fd();
 
-    // Fifth, check if the window belongs to flatpak
-    found = resolve_if_flatpak(pid);
-    if (found)
-    {
-        mir::log_info("Successfully resolved app id from flatpak, id=%s", found->id.c_str());
-        return found->id;
-    }
+        // Fourth, check if the window belongs to snap
+        found = resolve_if_snap(pid, socket_fd);
+        if (found)
+        {
+            mir::log_info("Successfully resolved app id from snap, id=%s", found->id.c_str());
+            return found->id;
+        }
 
-    // Sixth, get the exec command from our pid and see if we can match it to a GAppInfo's Exec
-    found = resolve_if_executable_matches(pid);
-    if (found)
-    {
-        mir::log_info("Successfully resolved app id from executable, id=%s", found->id.c_str());
-        return found->id;
+        // Fifth, check if the window belongs to flatpak
+        found = resolve_if_flatpak(pid);
+        if (found)
+        {
+            mir::log_info("Successfully resolved app id from flatpak, id=%s", found->id.c_str());
+            return found->id;
+        }
+
+        // Sixth, get the exec command from our pid and see if we can match it to a GAppInfo's Exec
+        found = resolve_if_executable_matches(pid);
+        if (found)
+        {
+            mir::log_info("Successfully resolved app id from executable, id=%s", found->id.c_str());
+            return found->id;
+        }
     }
 
     // NOTE: Here is the list of things that we aren't doing, as we don't have a good way of doing it:

--- a/src/server/frontend_wayland/desktop_file_manager.cpp
+++ b/src/server/frontend_wayland/desktop_file_manager.cpp
@@ -68,11 +68,32 @@ std::string mf::DesktopFileManager::resolve_app_id(scene::Surface const& surface
     // Hence, we jump through a series of hoops in the hope that we'll find what we're looking for.
     // For more info on the checks happening here, see:
     // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/src/shell-window-tracker.c?ref_type=heads#L387
+
+    if (auto session = surface.session().lock())
+    {
+        auto pid = session->process_id();
+        auto socket_fd = session->socket_fd();
+
+        // First, check if the window belongs to snap
+        if (auto const found = resolve_if_snap(pid, socket_fd))
+        {
+            mir::log_info("Successfully resolved app id from snap, id=%s", found->id.c_str());
+            return found->id;
+        }
+
+        // Second, check if the window belongs to flatpak
+        if (auto const found = resolve_if_flatpak(pid))
+        {
+            mir::log_info("Successfully resolved app id from flatpak, id=%s", found->id.c_str());
+            return found->id;
+        }
+    }
+
     auto app_id = surface.application_id();
     rtrim(app_id); // Sometimes, the app id has a space at the end
     mir::log_info("Attempting to resolve app id from app_id=%s", app_id.c_str());
 
-    // First, let's see if this is just a WM_CLASS
+    // Third, let's see if this is just a WM_CLASS
     if (auto const app = cache->lookup_by_wm_class(app_id))
     {
         mir::log_info("Successfully resolved app id from wm_class, id=%s", app->id.c_str());
@@ -88,14 +109,14 @@ std::string mf::DesktopFileManager::resolve_app_id(scene::Surface const& surface
         }
     }
 
-    // Second, let's see if we can map it straight to a desktop file
+    // Fourth, let's see if we can map it straight to a desktop file
     if (auto const found = lookup_basename(app_id))
     {
         mir::log_info("Successfully resolved app id from basename, id=%s", found->id.c_str());
         return found->id;
     }
 
-    // Third, lowercase it and try again
+    // Fifth, lowercase it and try again
     auto lowercase_desktop_file = app_id;
     for(char &ch : lowercase_desktop_file)
         ch = std::tolower(ch);
@@ -109,21 +130,6 @@ std::string mf::DesktopFileManager::resolve_app_id(scene::Surface const& surface
     if (auto session = surface.session().lock())
     {
         auto pid = session->process_id();
-        auto socket_fd = session->socket_fd();
-
-        // Fourth, check if the window belongs to snap
-        if (auto const found = resolve_if_snap(pid, socket_fd))
-        {
-            mir::log_info("Successfully resolved app id from snap, id=%s", found->id.c_str());
-            return found->id;
-        }
-
-        // Fifth, check if the window belongs to flatpak
-        if (auto const found = resolve_if_flatpak(pid))
-        {
-            mir::log_info("Successfully resolved app id from flatpak, id=%s", found->id.c_str());
-            return found->id;
-        }
 
         // Sixth, get the exec command from our pid and see if we can match it to a GAppInfo's Exec
         if (auto const found = resolve_if_executable_matches(pid))

--- a/src/server/frontend_wayland/desktop_file_manager.h
+++ b/src/server/frontend_wayland/desktop_file_manager.h
@@ -55,7 +55,7 @@ public:
     DesktopFileManager(std::shared_ptr<DesktopFileCache> cache);
     ~DesktopFileManager() = default;
 
-    std::string resolve_app_id(const scene::Surface*);
+    std::string resolve_app_id(scene::Surface const&);
     static std::string parse_snap_security_profile_to_desktop_id(std::string const& contents);
 private:
     std::shared_ptr<DesktopFileCache> cache;

--- a/src/server/frontend_wayland/foreign_toplevel_handle_creation.h
+++ b/src/server/frontend_wayland/foreign_toplevel_handle_creation.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_FRONTEND_FOREIGN_TOPLEVEL_HANDLE_CREATION_H
+#define MIR_FRONTEND_FOREIGN_TOPLEVEL_HANDLE_CREATION_H
+
+#include "mir/scene/surface.h"
+
+#include <mir_toolkit/common.h>
+
+namespace mir::frontend
+{
+/**
+ * Returns true when a surface should be exposed via the foreign-toplevel protocols.
+ *
+ * Eligibility requires a live session, and only includes
+ * focusable application-layer normal/utility/freestyle windows.
+ */
+inline auto should_create_foreign_toplevel_handle(
+    scene::Surface const& surface) -> bool
+{
+    if (!surface.session().lock())
+        return false;
+
+    auto const type = surface.type();
+    if (type != mir_window_type_normal &&
+        type != mir_window_type_utility &&
+        type != mir_window_type_freestyle)
+        return false;
+
+    if (surface.depth_layer() != mir_depth_layer_application)
+        return false;
+
+    return surface.focus_mode() != mir_focus_mode_disabled;
+}
+}
+
+#endif // MIR_FRONTEND_FOREIGN_TOPLEVEL_HANDLE_CREATION_H

--- a/src/server/frontend_wayland/foreign_toplevel_list_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_list_v1.cpp
@@ -383,13 +383,8 @@ void mf::ForeignSurfaceObserver::cease_and_desist()
 
 void mf::ForeignSurfaceObserver::create_or_close_toplevel_handle_as_needed()
 {
-    bool should_have_handle = false;
-
     auto const surface = weak_surface.lock();
-    if (surface)
-    {
-        should_have_handle = should_create_foreign_toplevel_handle(*surface);
-    }
+    bool const should_have_handle = surface && should_create_foreign_toplevel_handle(*surface);
 
     if (should_have_handle != has_handle)
     {
@@ -467,8 +462,11 @@ void mf::ForeignSurfaceObserver::application_id_set_to(
 
     if (handle)
     {
-        handle.value().send_app_id_event(desktop_file_manager->resolve_app_id(*surface));
-        handle.value().send_done_event();
+        if (auto const app_id = desktop_file_manager->resolve_app_id(*surface); !app_id.empty())
+        {
+            handle.value().send_app_id_event(app_id);
+            handle.value().send_done_event();
+        }
     };
 }
 

--- a/src/server/frontend_wayland/foreign_toplevel_list_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_list_v1.cpp
@@ -18,6 +18,7 @@
 
 #include "wayland_utils.h"
 #include "desktop_file_manager.h"
+#include "foreign_toplevel_handle_creation.h"
 #include "mir/wayland/weak.h"
 #include "mir/frontend/surface_stack.h"
 #include "mir/shell/surface_specification.h"
@@ -121,6 +122,7 @@ private:
     void attrib_changed(scene::Surface const*, MirWindowAttrib attrib, int) override;
     void renamed(scene::Surface const*, std::string const& name) override;
     void application_id_set_to(scene::Surface const*, std::string const& application_id) override;
+    void depth_layer_set_to(scene::Surface const*, MirDepthLayer) override;
     ///@}
 
     wayland::Weak<ExtForeignToplevelListV1> const manager;
@@ -381,39 +383,12 @@ void mf::ForeignSurfaceObserver::cease_and_desist()
 
 void mf::ForeignSurfaceObserver::create_or_close_toplevel_handle_as_needed()
 {
-    bool should_have_handle = true;
+    bool should_have_handle = false;
 
     auto const surface = weak_surface.lock();
     if (surface)
     {
-        switch(surface->state())
-        {
-        case mir_window_state_attached:
-            should_have_handle = false;
-            break;
-
-        default:
-            break;
-        }
-
-        switch (surface->type())
-        {
-        case mir_window_type_normal:
-        case mir_window_type_utility:
-        case mir_window_type_freestyle:
-            break;
-
-        default:
-            should_have_handle = false;
-            break;
-        }
-
-        if (surface->session().expired())
-            should_have_handle = false;
-    }
-    else
-    {
-        should_have_handle = false;
+        should_have_handle = should_create_foreign_toplevel_handle(*surface);
     }
 
     if (should_have_handle != has_handle)
@@ -424,9 +399,9 @@ void mf::ForeignSurfaceObserver::create_or_close_toplevel_handle_as_needed()
             if (!manager)
                 return;
 
-            std::string toplevel_id = id_map->toplevel_id(surface);
-            std::string name = surface->name();
-            std::string app_id = desktop_file_manager->resolve_app_id(surface.get());
+            auto const toplevel_id = id_map->toplevel_id(surface);
+            auto const name = surface->name();
+            auto const app_id = desktop_file_manager->resolve_app_id(*surface);
 
             // Remember Wayland objects manage their own lifetime
             auto const handle_ptr = new ExtForeignToplevelHandleV1{manager.value(), surface};
@@ -480,18 +455,26 @@ void mf::ForeignSurfaceObserver::renamed(ms::Surface const*, std::string const& 
 
 void mf::ForeignSurfaceObserver::application_id_set_to(
     scene::Surface const* surface,
-    std::string const& application_id)
+    std::string const& /*application_id*/)
 {
-    std::string id = application_id;
+    bool const toplevel_handle_existed_before{has_handle};
+    create_or_close_toplevel_handle_as_needed();
+
+    if (!toplevel_handle_existed_before)
+    {
+        return;
+    }
+
     if (handle)
     {
-        auto app_id = desktop_file_manager->resolve_app_id(surface);
-        if (!app_id.empty())
-        {
-            handle.value().send_app_id_event(app_id);
-            handle.value().send_done_event();
-        }
+        handle.value().send_app_id_event(desktop_file_manager->resolve_app_id(*surface));
+        handle.value().send_done_event();
     };
+}
+
+void mf::ForeignSurfaceObserver::depth_layer_set_to(scene::Surface const*, MirDepthLayer)
+{
+    create_or_close_toplevel_handle_as_needed();
 }
 
 // ExtForeignToplevelListV1

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -473,8 +473,11 @@ void mf::ForeignSurfaceObserver::application_id_set_to(
 
     with_toplevel_handle(lock, [&](ForeignToplevelHandleV1& handle)
         {
-            handle.send_app_id_event(desktop_file_manager->resolve_app_id(*surface));
-            handle.send_done_event();
+            if (auto const app_id = desktop_file_manager->resolve_app_id(*surface); !app_id.empty())
+            {
+                handle.send_app_id_event(app_id);
+                handle.send_done_event();
+            }
         });
 }
 

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -353,15 +353,10 @@ void mf::ForeignSurfaceObserver::with_toplevel_handle(
 
 void mf::ForeignSurfaceObserver::create_or_close_toplevel_handle_as_needed(std::lock_guard<std::mutex>& lock)
 {
-    bool should_have_handle = false;
-
     auto const surface = weak_surface.lock();
-    if (surface)
-    {
-        should_have_handle = should_create_foreign_toplevel_handle(*surface);
-    }
-
+    bool const should_have_handle = surface && should_create_foreign_toplevel_handle(*surface);
     bool const currently_have_handle{handle};
+
     if (should_have_handle != currently_have_handle)
     {
         if (should_have_handle)
@@ -391,9 +386,9 @@ void mf::ForeignSurfaceObserver::create_or_close_toplevel_handle_as_needed(std::
         else
         {
             with_toplevel_handle(lock, [](ForeignToplevelHandleV1& handle)
-                {
-                    handle.should_close();
-                });
+            {
+                handle.should_close();
+            });
             handle = {};
         }
     }

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -18,6 +18,7 @@
 
 #include "wayland_utils.h"
 #include "desktop_file_manager.h"
+#include "foreign_toplevel_handle_creation.h"
 
 #include <mir/constexpr_utils.h>
 #include <mir/executor.h>
@@ -134,6 +135,7 @@ private:
     void attrib_changed(scene::Surface const*, MirWindowAttrib attrib, int) override;
     void renamed(scene::Surface const*, std::string const& name) override;
     void application_id_set_to(scene::Surface const*, std::string const& application_id) override;
+    void depth_layer_set_to(scene::Surface const*, MirDepthLayer) override;
     ///@}
 
     wayland::Weak<ForeignToplevelManagerV1> const manager;
@@ -351,39 +353,12 @@ void mf::ForeignSurfaceObserver::with_toplevel_handle(
 
 void mf::ForeignSurfaceObserver::create_or_close_toplevel_handle_as_needed(std::lock_guard<std::mutex>& lock)
 {
-    bool should_have_handle = true;
+    bool should_have_handle = false;
 
     auto const surface = weak_surface.lock();
     if (surface)
     {
-        switch(surface->state())
-        {
-        case mir_window_state_attached:
-            should_have_handle = false;
-            break;
-
-        default:
-            break;
-        }
-
-        switch (surface->type())
-        {
-        case mir_window_type_normal:
-        case mir_window_type_utility:
-        case mir_window_type_freestyle:
-            break;
-
-        default:
-            should_have_handle = false;
-            break;
-        }
-
-        if (!surface->session().lock())
-            should_have_handle = false;
-    }
-    else
-    {
-        should_have_handle = false;
+        should_have_handle = should_create_foreign_toplevel_handle(*surface);
     }
 
     bool const currently_have_handle{handle};
@@ -397,8 +372,8 @@ void mf::ForeignSurfaceObserver::create_or_close_toplevel_handle_as_needed(std::
 
             handle = std::make_shared<mw::Weak<ForeignToplevelHandleV1>>();
 
-            std::string name = surface->name();
-            std::string app_id = desktop_file_manager->resolve_app_id(surface.get());
+            auto const name = surface->name();
+            auto const app_id = desktop_file_manager->resolve_app_id(*surface);
             auto const focused = surface->focus_state();
             auto const state = surface->state_tracker();
 
@@ -484,20 +459,29 @@ void mf::ForeignSurfaceObserver::renamed(ms::Surface const*, std::string const& 
 
 void mf::ForeignSurfaceObserver::application_id_set_to(
     scene::Surface const* surface,
-    std::string const& application_id)
+    std::string const& /*application_id*/)
 {
     std::lock_guard lock{mutex};
 
-    std::string id = application_id;
+    bool const toplevel_handle_existed_before{handle};
+    create_or_close_toplevel_handle_as_needed(lock);
+
+    if (!toplevel_handle_existed_before)
+    {
+        return;
+    }
+
     with_toplevel_handle(lock, [&](ForeignToplevelHandleV1& handle)
         {
-            auto app_id = desktop_file_manager->resolve_app_id(surface);
-            if (!app_id.empty())
-            {
-                handle.send_app_id_event(app_id);
-                handle.send_done_event();
-            }
+            handle.send_app_id_event(desktop_file_manager->resolve_app_id(*surface));
+            handle.send_done_event();
         });
+}
+
+void mf::ForeignSurfaceObserver::depth_layer_set_to(scene::Surface const*, MirDepthLayer)
+{
+    std::lock_guard lock{mutex};
+    create_or_close_toplevel_handle_as_needed(lock);
 }
 
 // GDesktopFileCache

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -60,6 +60,7 @@ struct MockSurface : public scene::BasicSurface
     ~MockSurface() noexcept {}
 
     MOCK_METHOD(MirWindowType, type, (), (const));
+    MOCK_METHOD(MirWindowState, state, (), (const));
     MOCK_METHOD(void, hide, ());
     MOCK_METHOD(void, show, ());
     MOCK_METHOD(bool, visible, (), (const));

--- a/tests/unit-tests/frontend_wayland/CMakeLists.txt
+++ b/tests/unit-tests/frontend_wayland/CMakeLists.txt
@@ -3,6 +3,7 @@ list(
   ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_timespec.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_screencopy_v1_damage_tracker.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_desktop_file_manager.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_foreign_toplevel_handle_creation.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_g_desktop_file_cache.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_output_manager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_keyboard_state_tracker.cpp

--- a/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
+++ b/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
@@ -108,7 +108,7 @@ TEST_F(DesktopFileManager, can_find_app_when_app_id_matches)
 {
     auto new_file = std::make_shared<mf::DesktopFile>(DESKTOP_FILE_APP_ID, nullptr, nullptr);
     cache->files.push_back(new_file);
-    auto app_id = file_manager->resolve_app_id(&surface);
+    auto app_id = file_manager->resolve_app_id(surface);
     EXPECT_THAT(app_id, Eq(new_file->id));
 }
 
@@ -116,7 +116,7 @@ TEST_F(DesktopFileManager, can_find_gnome_terminal_server)
 {
     ON_CALL(surface, application_id())
         .WillByDefault(testing::Invoke([]() { return "gnome-terminal-server"; }));
-    auto app_id = file_manager->resolve_app_id(&surface);
+    auto app_id = file_manager->resolve_app_id(surface);
     EXPECT_THAT(app_id, "org.gnome.Terminal");
 }
 
@@ -124,7 +124,7 @@ TEST_F(DesktopFileManager, can_find_app_when_wm_class_matches)
 {
     auto new_file = std::make_shared<mf::DesktopFile>(nullptr, APPLICATION_ID, nullptr);
     cache->files.push_back(new_file);
-    auto app_id = file_manager->resolve_app_id(&surface);
+    auto app_id = file_manager->resolve_app_id(surface);
     EXPECT_THAT(app_id, Eq(new_file->id));
 }
 
@@ -139,13 +139,13 @@ TEST_F(DesktopFileManager, can_find_app_when_app_id_matches_despite_being_upperc
 
     auto new_file = std::make_shared<mf::DesktopFile>(DESKTOP_FILE_APP_ID, nullptr, nullptr);
     cache->files.push_back(new_file);
-    auto app_id = file_manager->resolve_app_id(&surface);
+    auto app_id = file_manager->resolve_app_id(surface);
     EXPECT_THAT(app_id, Eq(new_file->id));
 }
 
 TEST_F(DesktopFileManager, when_every_check_fails_then_application_id_is_returned)
 {
-    auto app_id = file_manager->resolve_app_id(&surface);
+    auto app_id = file_manager->resolve_app_id(surface);
     EXPECT_THAT(app_id, Eq(APPLICATION_ID));
 }
 
@@ -158,7 +158,7 @@ TEST_P(DesktopFileManagerParameterizedTestFixture, can_find_app_when_app_id_matc
     const std::string prefixed = prefix + DESKTOP_FILE_APP_ID;
     auto new_file = std::make_shared<mf::DesktopFile>(prefixed.c_str(), nullptr, nullptr);
     cache->files.push_back(new_file);
-    auto app_id = file_manager->resolve_app_id(&surface);
+    auto app_id = file_manager->resolve_app_id(surface);
     EXPECT_THAT(app_id, Eq(new_file->id));
 }
 
@@ -221,7 +221,7 @@ TEST_F(DesktopFileManager, can_resolve_from_valid_flatpak_info)
 
     auto new_file = std::make_shared<mf::DesktopFile>(desktop_app_id, nullptr, nullptr);
     cache->files.push_back(new_file);
-    auto found_app_id = file_manager->resolve_app_id(&surface);
+    auto found_app_id = file_manager->resolve_app_id(surface);
     EXPECT_THAT(found_app_id, Eq(desktop_app_id));
     ::unlink(tmp_file_name);
 }
@@ -259,7 +259,7 @@ TEST_F(DesktopFileManager, app_id_will_not_resolve_from_flatpak_info_when_name_i
 
     auto new_file = std::make_shared<mf::DesktopFile>(desktop_app_id, nullptr, nullptr);
     cache->files.push_back(new_file);
-    auto found_app_id = file_manager->resolve_app_id(&surface);
+    auto found_app_id = file_manager->resolve_app_id(surface);
     EXPECT_NE(found_app_id, desktop_app_id);
     EXPECT_EQ(found_app_id, APPLICATION_ID);
     ::unlink(tmp_file_name);

--- a/tests/unit-tests/frontend_wayland/test_foreign_toplevel_handle_creation.cpp
+++ b/tests/unit-tests/frontend_wayland/test_foreign_toplevel_handle_creation.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "src/server/frontend_wayland/foreign_toplevel_handle_creation.h"
+#include <mir/test/doubles/mock_scene_session.h>
+#include <mir/test/doubles/mock_surface.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace mf = mir::frontend;
+namespace ms = mir::scene;
+namespace mtd = mir::test::doubles;
+using namespace testing;
+
+namespace
+{
+
+class ForeignToplevelHandleCreation : public Test
+{
+public:
+    NiceMock<mtd::MockSurface> surface;
+    std::shared_ptr<NiceMock<mtd::MockSceneSession>> session{
+        std::make_shared<NiceMock<mtd::MockSceneSession>>()};
+
+    void SetUp() override
+    {
+        ON_CALL(surface, type())
+            .WillByDefault(Return(mir_window_type_normal));
+        ON_CALL(surface, session())
+            .WillByDefault(Return(std::weak_ptr<ms::Session>{session}));
+    }
+};
+
+}
+
+TEST_F(ForeignToplevelHandleCreation, creates_handles_for_application_layer_normal_windows)
+{
+    EXPECT_TRUE(mf::should_create_foreign_toplevel_handle(surface));
+}
+
+TEST_F(ForeignToplevelHandleCreation, creates_handles_for_freestyle_windows)
+{
+    ON_CALL(surface, type())
+        .WillByDefault(Return(mir_window_type_freestyle));
+    EXPECT_TRUE(mf::should_create_foreign_toplevel_handle(surface));
+}
+
+TEST_F(ForeignToplevelHandleCreation, creates_handles_for_utility_windows_in_application_layer)
+{
+    ON_CALL(surface, type())
+        .WillByDefault(Return(mir_window_type_utility));
+    surface.set_depth_layer(mir_depth_layer_application);
+    EXPECT_TRUE(mf::should_create_foreign_toplevel_handle(surface));
+}
+
+TEST_F(ForeignToplevelHandleCreation, does_not_create_handles_for_non_application_layer_windows)
+{
+    surface.set_depth_layer(mir_depth_layer_above);
+    EXPECT_FALSE(mf::should_create_foreign_toplevel_handle(surface));
+}
+
+TEST_F(ForeignToplevelHandleCreation, does_not_create_handles_for_non_focusable_windows)
+{
+    surface.set_focus_mode(mir_focus_mode_disabled);
+    EXPECT_FALSE(mf::should_create_foreign_toplevel_handle(surface));
+}
+
+TEST_F(ForeignToplevelHandleCreation, does_not_create_handles_without_session)
+{
+    ON_CALL(surface, session())
+        .WillByDefault(Return(std::weak_ptr<ms::Session>{}));
+    EXPECT_FALSE(mf::should_create_foreign_toplevel_handle(surface));
+}

--- a/tests/unit-tests/frontend_wayland/test_foreign_toplevel_handle_creation.cpp
+++ b/tests/unit-tests/frontend_wayland/test_foreign_toplevel_handle_creation.cpp
@@ -52,6 +52,13 @@ TEST_F(ForeignToplevelHandleCreation, creates_handles_for_application_layer_norm
     EXPECT_TRUE(mf::should_create_foreign_toplevel_handle(surface));
 }
 
+TEST_F(ForeignToplevelHandleCreation, creates_handles_for_attached_windows)
+{
+    ON_CALL(surface, state())
+        .WillByDefault(Return(mir_window_state_attached));
+    EXPECT_TRUE(mf::should_create_foreign_toplevel_handle(surface));
+}
+
 TEST_F(ForeignToplevelHandleCreation, creates_handles_for_freestyle_windows)
 {
     ON_CALL(surface, type())


### PR DESCRIPTION
Closes #4944


## What's new?

Docked application windows are not skipped, system dialogs in the overlay layer are skipped.

## How to test

The app switcher in miral-shell uses these protocols (as does the Frame launcher)

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
