### PR TITLE
Add `MIR_PIN_COMPOSITING_TO` to allow pinning a certain provider for display

### DIFF
--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -360,6 +360,7 @@ protected:
     auto the_options_provider() const -> std::shared_ptr<options::Configuration>;
     std::shared_ptr<input::DefaultInputDeviceHub>  the_default_input_device_hub();
     std::shared_ptr<input::SeatObserver> the_seat_observer();
+    std::shared_ptr<graphics::RenderingPlatform> find_pinned_rendering_platform();
 
     virtual std::shared_ptr<scene::MediatingDisplayChanger> the_mediating_display_changer();
 

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -383,6 +383,7 @@ protected:
     // after everything else.
     std::vector<std::shared_ptr<graphics::DisplayPlatform>> display_platforms;
     std::vector<std::shared_ptr<graphics::RenderingPlatform>> rendering_platforms;
+    std::map<graphics::RenderingPlatform*, std::string> rendering_platform_names;
     std::shared_ptr<input::InputManager>    input_manager;
 
     CachedPtr<frontend::Connector>   wayland_connector;

--- a/src/server/compositor/default_configuration.cpp
+++ b/src/server/compositor/default_configuration.cpp
@@ -30,6 +30,9 @@
 #include <mir/graphics/platform.h>
 #include <mir/options/configuration.h>
 
+#include <cstdlib>
+#include <algorithm>
+
 namespace mc = mir::compositor;
 namespace ms = mir::scene;
 namespace mg = mir::graphics;
@@ -52,6 +55,36 @@ mir::DefaultServerConfiguration::the_display_buffer_compositor_factory()
             if (providers.empty())
             {
                 BOOST_THROW_EXCEPTION((std::runtime_error{"Selected rendering platform does not support GL"}));
+            }
+
+            if (auto const pin_to = getenv("MIR_PIN_COMPOSITING_TO"))
+            {
+                auto const provider_it = std::ranges::find_if(
+                    the_rendering_platforms(),
+                    [&](auto const& platform)
+                    {
+                        auto it = rendering_platform_names.find(platform.get());
+                        return it != rendering_platform_names.end() && it->second == pin_to;
+                    });
+
+                if (provider_it == the_rendering_platforms().end())
+                {
+                    mir::log_warning(
+                        "MIR_PIN_COMPOSITING_TO is set to '%s', but no such rendering platform was found", pin_to);
+                }
+                else if (
+                    auto gl_provider = mg::RenderingPlatform::acquire_provider<mg::GLRenderingProvider>(*provider_it))
+                {
+                    mir::log_info("Pinning all compositing to provider: %s", pin_to);
+                    providers = {gl_provider};
+                }
+                else
+                {
+                    mir::log_warning(
+                        "MIR_PIN_COMPOSITING_TO is set to '%s', but that rendering platform does not support GL "
+                        "compositing",
+                        pin_to);
+                }
             }
 
             return wrap_display_buffer_compositor_factory(

--- a/src/server/compositor/default_configuration.cpp
+++ b/src/server/compositor/default_configuration.cpp
@@ -31,7 +31,6 @@
 #include <mir/options/configuration.h>
 
 #include <cstdlib>
-#include <algorithm>
 
 namespace mc = mir::compositor;
 namespace ms = mir::scene;
@@ -57,25 +56,11 @@ mir::DefaultServerConfiguration::the_display_buffer_compositor_factory()
                 BOOST_THROW_EXCEPTION((std::runtime_error{"Selected rendering platform does not support GL"}));
             }
 
-            if (auto const pin_to = getenv("MIR_PIN_COMPOSITING_TO"))
+            if (auto pinned = find_pinned_rendering_platform())
             {
-                auto const provider_it = std::ranges::find_if(
-                    the_rendering_platforms(),
-                    [&](auto const& platform)
-                    {
-                        auto it = rendering_platform_names.find(platform.get());
-                        return it != rendering_platform_names.end() && it->second == pin_to;
-                    });
-
-                if (provider_it == the_rendering_platforms().end())
+                if (auto gl_provider = mg::RenderingPlatform::acquire_provider<mg::GLRenderingProvider>(pinned))
                 {
-                    mir::log_warning(
-                        "MIR_PIN_COMPOSITING_TO is set to '%s', but no such rendering platform was found", pin_to);
-                }
-                else if (
-                    auto gl_provider = mg::RenderingPlatform::acquire_provider<mg::GLRenderingProvider>(*provider_it))
-                {
-                    mir::log_info("Pinning all compositing to provider: %s", pin_to);
+                    mir::log_info("Pinning all compositing to provider: %s", getenv("MIR_PIN_COMPOSITING_TO"));
                     providers = {gl_provider};
                 }
                 else
@@ -83,7 +68,7 @@ mir::DefaultServerConfiguration::the_display_buffer_compositor_factory()
                     mir::log_warning(
                         "MIR_PIN_COMPOSITING_TO is set to '%s', but that rendering platform does not support GL "
                         "compositing",
-                        pin_to);
+                        getenv("MIR_PIN_COMPOSITING_TO"));
                 }
             }
 

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -359,6 +359,24 @@ auto mir::DefaultServerConfiguration::the_platform_libaries()
     return platform_libraries;
 }
 
+std::shared_ptr<mg::RenderingPlatform>
+mir::DefaultServerConfiguration::find_pinned_rendering_platform()
+{
+    auto const pin_to = std::getenv("MIR_PIN_COMPOSITING_TO");
+    if (!pin_to)
+        return nullptr;
+
+    for (auto const& platform : the_rendering_platforms())
+    {
+        auto const it = rendering_platform_names.find(platform.get());
+        if (it != rendering_platform_names.end() && it->second == pin_to)
+            return platform;
+    }
+
+    mir::log_warning("MIR_PIN_COMPOSITING_TO is set to '%s', but no such rendering platform was found", pin_to);
+    return nullptr;
+}
+
 std::shared_ptr<mg::GraphicBufferAllocator>
 mir::DefaultServerConfiguration::the_buffer_allocator()
 {
@@ -366,6 +384,8 @@ mir::DefaultServerConfiguration::the_buffer_allocator()
         [&]() -> std::shared_ptr<graphics::GraphicBufferAllocator>
         {
             auto rendering_platforms = the_rendering_platforms();
+            if (auto pinned = find_pinned_rendering_platform())
+                rendering_platforms = {pinned};
             auto best_provider = graphics::select_buffer_allocating_renderer(
                 *the_display(),
                 rendering_platforms);

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -299,13 +299,18 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
                 }
 
                 // TODO: Do we want to be able to continue on partial failure here?
-                rendering_platform_map.emplace(
-                    description->name,
-                    create_rendering_platform(
-                        device,
-                        display_targets,
-                        *the_options_provider()->options_for(*platform),
-                        *the_emergency_cleanup()));
+                auto rendering_platform = create_rendering_platform(
+                    device,
+                    display_targets,
+                    *the_options_provider()->options_for(*platform),
+                    *the_emergency_cleanup());
+
+                // Use the device node as the pin identifier when available (unique per physical GPU),
+                // falling back to the module name for deviceless platforms (e.g. mir:virtual).
+                auto const pin_id = device.device ? device.device->devnode() : description->name;
+                rendering_platform_names[rendering_platform.get()] = pin_id;
+
+                rendering_platform_map.emplace(description->name, std::move(rendering_platform));
                 // Add this module to the list searched by the input stack later
                 // TODO: Come up with a more principled solution for combined input/rendering/output platforms
                 platform_libraries.push_back(platform);


### PR DESCRIPTION
Supersedes #4640

## What's new?

Works around display warping on systems with Intel + Nvidia GPUs.

In a multi-GPU setup, Mir normally picks the best rendering provider per display — Intel for Intel-connected
displays, Nvidia for Nvidia-connected displays. When buffers cross GPU boundaries via DMA-BUF for compositing,
Nvidia assumes a 32-byte stride/alignment, ignoring the actual stride. This causes output windows to appear warped.

Setting `MIR_PIN_COMPOSITING_TO=<devnode>` (e.g. `/dev/dri/renderD128`) forces all displays to be composited by one GLprovider. For displays not physically on that GPU, Mir falls back to a CPU copy path (`glReadPixels` into a
CPU-addressable framebuffer), bypassing the DMA-BUF import entirely.

The device node is used as the identifier because it is unique per physical GPU, handling systems with multiple GPUs of the same driver type (e.g. two AMD cards). Available nodes can be discovered with ls `/dev/dri/renderD*`

## How to test

On a system with Intel + Nvidia GPUs and a display on each:
```
 MIR_PIN_COMPOSITING_TO=/dev/dri/<intel render node> <mir-shell>
```
Verify that previously warped windows on the Nvidia-connected display are now rendered correctly.

You can find reproduction steps in #4640