### PR TITLE
Don't use BOOST_THROW_EXCEPTION for Wayland protocol errors

### DIFF
--- a/src/server/frontend_wayland/data_control_v1.cpp
+++ b/src/server/frontend_wayland/data_control_v1.cpp
@@ -68,11 +68,10 @@ private:
     void offer(std::string const& mime_type) override
     {
         if (finalized_)
-            BOOST_THROW_EXCEPTION(
-                wayland::ProtocolError(
-                    resource,
-                    wayland::DataControlSourceV1::Error::invalid_offer,
-                    "Cannot add MIME types after source is set"));
+            throw wayland::ProtocolError{
+                resource,
+                wayland::DataControlSourceV1::Error::invalid_offer,
+                "Cannot add MIME types after source is set"};
         mime_types_.push_back(mime_type);
     }
 
@@ -205,9 +204,8 @@ private:
                 return nullptr;
 
             if (!source->try_finalize())
-                BOOST_THROW_EXCEPTION(
-                    wayland::ProtocolError(
-                        resource, wayland::DataControlDeviceV1::Error::used_source, "Source already used"));
+                throw wayland::ProtocolError{
+                    resource, wayland::DataControlDeviceV1::Error::used_source, "Source already used"};
 
             return std::make_shared<DataExchangeSource>(wayland::Weak{source}, seat);
         }

--- a/src/server/frontend_wayland/ext_image_capture_v1.cpp
+++ b/src/server/frontend_wayland/ext_image_capture_v1.cpp
@@ -705,9 +705,9 @@ void mf::ExtImageCopyCaptureSessionV1::create_frame(
 {
     if (current_frame)
     {
-        BOOST_THROW_EXCEPTION(wayland::ProtocolError(
+        throw wayland::ProtocolError{
             resource, Error::duplicate_frame,
-            "A frame already exists for this session"));
+            "A frame already exists for this session"};
     }
     current_frame = wayland::make_weak(
         new ExtImageCopyCaptureFrameV1{new_resource, this});
@@ -726,9 +726,9 @@ void mf::ExtImageCopyCaptureFrameV1::attach_buffer(
 {
     if (capture_has_been_called)
     {
-        BOOST_THROW_EXCEPTION(wayland::ProtocolError(
+         throw wayland::ProtocolError{
             resource, Error::already_captured,
-            "Cannot attach buffer after capture"));
+            "Cannot attach buffer after capture"};
     }
 
     auto buf = wayland::Buffer::from(buffer);
@@ -750,9 +750,9 @@ void mf::ExtImageCopyCaptureFrameV1::damage_buffer(
 {
     if (x < 0 || y < 0 || width <= 0 || height <= 0)
     {
-        BOOST_THROW_EXCEPTION(wayland::ProtocolError(
+        throw wayland::ProtocolError{
             resource, Error::invalid_buffer_damage,
-            "invalid buffer damage coordinates"));
+            "invalid buffer damage coordinates"};
     }
 
     auto new_damage = geom::Rectangle{{x, y}, {width, height}};
@@ -770,15 +770,15 @@ void mf::ExtImageCopyCaptureFrameV1::capture()
 {
     if (capture_has_been_called)
     {
-        BOOST_THROW_EXCEPTION(wayland::ProtocolError(
+        throw wayland::ProtocolError{
             resource, Error::already_captured,
-            "capture already called"));
+            "capture already called"};
     }
     if (!target)
     {
-        BOOST_THROW_EXCEPTION(wayland::ProtocolError(
+        throw wayland::ProtocolError{
             resource, Error::no_buffer,
-            "no buffer attached"));
+            "no buffer attached"};
     }
     capture_has_been_called = true;
 
@@ -996,10 +996,10 @@ void mf::ExtImageCopyCaptureCursorSessionV1::get_capture_session(
 {
     if (cursor_image_session)
     {
-        BOOST_THROW_EXCEPTION(wayland::ProtocolError(
+        throw wayland::ProtocolError{
             resource, Error::duplicate_session,
             "An ext_image_copy_capture_session_v1 already exists for this "
-            "ext_image_copy_capture_cursor_session_v1"));
+            "ext_image_copy_capture_cursor_session_v1"};
     }
     auto backend_factory = [this](auto *session, [[maybe_unused]] bool overlay_cursor)
         {

--- a/src/server/frontend_wayland/ext_image_capture_v1.cpp
+++ b/src/server/frontend_wayland/ext_image_capture_v1.cpp
@@ -726,7 +726,7 @@ void mf::ExtImageCopyCaptureFrameV1::attach_buffer(
 {
     if (capture_has_been_called)
     {
-         throw wayland::ProtocolError{
+        throw wayland::ProtocolError{
             resource, Error::already_captured,
             "Cannot attach buffer after capture"};
     }

--- a/src/server/frontend_wayland/fractional_scale_v1.cpp
+++ b/src/server/frontend_wayland/fractional_scale_v1.cpp
@@ -20,7 +20,6 @@
 #include <mir/wayland/protocol_error.h>
 #include "wl_surface.h"
 
-#include <boost/throw_exception.hpp>
 #include <memory>
 
 namespace mir
@@ -77,8 +76,8 @@ void mf::FractionalScaleManagerV1::get_fractional_scale(struct wl_resource* id, 
     auto surf = WlSurface::from(surface);
     if (surf->get_fractional_scale())
     {
-        BOOST_THROW_EXCEPTION(mir::wayland::ProtocolError(
-            resource, Error::fractional_scale_exists, "Surface already has a fractional scale component attached"));
+        throw mir::wayland::ProtocolError{
+            resource, Error::fractional_scale_exists, "Surface already has a fractional scale component attached"};
     }
 
     surf->set_fractional_scale(new FractionalScaleV1{id});

--- a/src/server/frontend_wayland/input_trigger_action_v1.cpp
+++ b/src/server/frontend_wayland/input_trigger_action_v1.cpp
@@ -72,12 +72,11 @@ private:
         {
             if (action_group_manager->was_revoked(token))
             {
-                BOOST_THROW_EXCEPTION(
-                    mw::ProtocolError(
-                        resource,
-                        Error::invalid_token,
-                        "ext_input_trigger_action_manager_v1.get_input_trigger_action: trying to use a token (%s) that's no longer valid",
-                        token.c_str()));
+                throw mw::ProtocolError{
+                    resource,
+                    Error::invalid_token,
+                    "ext_input_trigger_action_manager_v1.get_input_trigger_action: trying to use a token (%s) that's no longer valid",
+                    token.c_str()};
             }
 
             if (auto const& action_group = action_group_manager->get_action_group(token))
@@ -94,13 +93,12 @@ private:
             else
             {
                 // Token is not currently valid, nor was it previously revoked. It must be an invalid token.
-                BOOST_THROW_EXCEPTION(
-                    mw::ProtocolError(
-                        resource,
-                        Error::invalid_token,
-                        "ext_input_trigger_action_manager_v1.get_input_trigger_action: trying to use a token (%s) we "
-                        "never issued",
-                        token.c_str()));
+                throw mw::ProtocolError{
+                    resource,
+                    Error::invalid_token,
+                    "ext_input_trigger_action_manager_v1.get_input_trigger_action: trying to use a token (%s) we "
+                    "never issued",
+                    token.c_str()};
             }
         }
 

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -570,11 +570,11 @@ void mf::LayerSurfaceV1::set_keyboard_interactivity(uint32_t keyboard_interactiv
         break;
 
     default:
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+         throw mw::ProtocolError{
             resource,
             Error::invalid_keyboard_interactivity,
             "Invalid keyboard interactivity %d",
-            keyboard_interactivity));
+            keyboard_interactivity};
     }
     msh::SurfaceSpecification spec;
     spec.focus_mode = current_focus_mode;
@@ -617,9 +617,9 @@ void mf::LayerSurfaceV1::ack_configure(uint32_t serial)
         // It might be zwlr_layer_surface_v1::error::invalid_surface_state but
         // that's not mentioned in the documentation or the wlroots source.
         // Update this when we know the correct error code.
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource, mw::generic_error_code,
-            "Could not find acked configure with serial %u", serial));
+            "Could not find acked configure with serial %u", serial};
     }
 
     auto const acked_configure_size = acked_event->second;
@@ -693,17 +693,17 @@ void mf::LayerSurfaceV1::handle_commit()
     bool const vert_stretched = anchors.committed().top && anchors.committed().bottom;
     if (!horiz_stretched && !width_set_by_client)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_size,
-            "Width may be unspecified only when surface is anchored to left and right edges"));
+            "Width may be unspecified only when surface is anchored to left and right edges"};
     }
     if (!vert_stretched && !height_set_by_client)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_size,
-            "Height may be unspecified only when surface is anchored to top and bottom edges"));
+            "Height may be unspecified only when surface is anchored to top and bottom edges"};
     }
 
     if (configure_on_next_commit)

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -570,7 +570,7 @@ void mf::LayerSurfaceV1::set_keyboard_interactivity(uint32_t keyboard_interactiv
         break;
 
     default:
-         throw mw::ProtocolError{
+        throw mw::ProtocolError{
             resource,
             Error::invalid_keyboard_interactivity,
             "Invalid keyboard interactivity %d",

--- a/src/server/frontend_wayland/linux_drm_syncobj.cpp
+++ b/src/server/frontend_wayland/linux_drm_syncobj.cpp
@@ -22,7 +22,6 @@
 #include <mir/wayland/protocol_error.h>
 #include <mir/wayland/weak.h>
 #include "wl_surface.h"
-#include <boost/throw_exception.hpp>
 #include <drm.h>
 #include <stdexcept>
 #include <system_error>
@@ -127,19 +126,17 @@ auto mf::SyncTimeline::claim_timeline() -> Points
 {
     if (!acquire_point)
     {
-        BOOST_THROW_EXCEPTION((
-            wayland::ProtocolError{
-                resource,
-                Error::no_acquire_point,
-                "Buffer does not have an acquire point set"}));
+        throw wayland::ProtocolError{
+            resource,
+            Error::no_acquire_point,
+            "Buffer does not have an acquire point set"};
     }
     if (!release_point)
     {
-        BOOST_THROW_EXCEPTION((
-            wayland::ProtocolError{
-                resource,
-                Error::no_release_point,
-                "Buffer does not have a release point set"}));
+        throw wayland::ProtocolError{
+            resource,
+            Error::no_release_point,
+            "Buffer does not have a release point set"};
     }
 
     return Points {

--- a/src/server/frontend_wayland/mir_shell.cpp
+++ b/src/server/frontend_wayland/mir_shell.cpp
@@ -169,10 +169,10 @@ void MirPositioner::set_size(int32_t width, int32_t height)
 {
     if (width <= 0 || height <= 0)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::MirPositionerV1::Error::invalid_input,
-            "Invalid popup positioner size: %dx%d", width, height));
+            "Invalid popup positioner size: %dx%d", width, height};
     }
     this->width = Width{width};
     this->height = Height{height};
@@ -182,10 +182,10 @@ void MirPositioner::set_anchor_rect(int32_t x, int32_t y, int32_t width, int32_t
 {
     if (width < 0 || height < 0)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::MirPositionerV1::Error::invalid_input,
-            "Invalid popup anchor rect size: %dx%d", width, height));
+            "Invalid popup anchor rect size: %dx%d", width, height};
     }
     aux_rect = Rectangle{{x, y}, {width, height}};
 }
@@ -278,10 +278,10 @@ void MirPositioner::set_gravity(uint32_t gravity)
         break;
 
     default:
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::MirPositionerV1::Error::invalid_input,
-            "Invalid gravity value %d", gravity));
+            "Invalid gravity value %d", gravity};
     }
 
     surface_placement_gravity = placement;

--- a/src/server/frontend_wayland/session_lock_v1.cpp
+++ b/src/server/frontend_wayland/session_lock_v1.cpp
@@ -246,10 +246,10 @@ void mf::SessionLockV1::destroy()
     }
     else
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_destroy,
-            "Destroy requested but session is still locked"));
+            "Destroy requested but session is still locked"};
     }
 }
 
@@ -257,10 +257,10 @@ void mf::SessionLockV1::unlock_and_destroy()
 {
     if (!manager.try_unlock(this))
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_unlock,
-            "Unlock requested but locked event was never sent"));
+            "Unlock requested but locked event was never sent"};
     }
     else
     {

--- a/src/server/frontend_wayland/virtual_pointer_v1.cpp
+++ b/src/server/frontend_wayland/virtual_pointer_v1.cpp
@@ -31,7 +31,6 @@
 #include <mir/wayland/protocol_error.h>
 #include <mir/wayland/weak.h>
 
-#include <boost/throw_exception.hpp>
 #include <linux/input-event-codes.h>
 
 namespace mf = mir::frontend;
@@ -222,8 +221,7 @@ void mf::VirtualPointerV1::motion_absolute(uint32_t time, uint32_t x, uint32_t y
     if (x > x_extent || y > y_extent)
     {
         // FIXME: Specific error proposed in https://gitlab.freedesktop.org/wlroots/wlr-protocols/-/merge_requests/143
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(resource, mw::generic_error_code, "Absolute motion coordinates %u,%u out of bounds %u,%u", x, y, x_extent, y_extent));
+        throw mw::ProtocolError{resource, mw::generic_error_code, "Absolute motion coordinates %u,%u out of bounds %u,%u", x, y, x_extent, y_extent};
     }
 
     pending.timestamp = std::chrono::milliseconds{time};
@@ -255,8 +253,7 @@ void mf::VirtualPointerV1::button(uint32_t time, uint32_t button, uint32_t state
             break;
 
         default:
-            BOOST_THROW_EXCEPTION(
-                mw::ProtocolError(resource, mw::generic_error_code, "Invalid button state %d", state));
+            throw mw::ProtocolError{resource, mw::generic_error_code, "Invalid button state %d", state};
         }
     }
     else
@@ -280,8 +277,7 @@ void mf::VirtualPointerV1::axis(uint32_t time, uint32_t axis, double value)
         break;
 
     default:
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(resource, Error::invalid_axis, "Unknown axis %d", axis));
+        throw mw::ProtocolError{resource, Error::invalid_axis, "Unknown axis %d", axis};
     }
 }
 
@@ -358,8 +354,7 @@ void mf::VirtualPointerV1::axis_source(uint32_t axis_source)
     case mw::Pointer::AxisSource::continuous: pending.axis_source = mir_pointer_axis_source_continuous; break;
     case mw::Pointer::AxisSource::wheel_tilt: pending.axis_source = mir_pointer_axis_source_wheel_tilt; break;
     default:
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(resource, Error::invalid_axis_source, "Unknown axis source %d", axis_source));
+        throw mw::ProtocolError{resource, Error::invalid_axis_source, "Unknown axis source %d", axis_source};
     }
 }
 
@@ -371,8 +366,7 @@ void mf::VirtualPointerV1::axis_stop(uint32_t time, uint32_t axis)
     case mw::Pointer::Axis::horizontal_scroll: pending.scroll_h.stop = true; break;
     case mw::Pointer::Axis::vertical_scroll: pending.scroll_v.stop = true; break;
     default:
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(resource, Error::invalid_axis, "Unknown axis %d", axis));
+        throw mw::ProtocolError{resource, Error::invalid_axis, "Unknown axis %d", axis};
     }
 }
 
@@ -394,8 +388,7 @@ void mf::VirtualPointerV1::axis_discrete(uint32_t time, uint32_t axis, double va
         break;
 
     default:
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(resource, Error::invalid_axis, "Unknown axis %d", axis));
+        throw mw::ProtocolError{resource, Error::invalid_axis, "Unknown axis %d", axis};
     }
 }
 

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -101,24 +101,24 @@ public:
     {
         if (!mf::validate_dnd_actions(dnd_actions))
         {
-            throw mw::ProtocolError(
+            throw mw::ProtocolError{
                 resource,
                 Error::invalid_action_mask,
-                "Invalid DnD actions 0x%x", dnd_actions);
+                "Invalid DnD actions 0x%x", dnd_actions};
         }
         if (!mf::validate_dnd_action(preferred_action))
         {
-            throw mw::ProtocolError(
+            throw mw::ProtocolError{
                 resource,
                 Error::invalid_action,
-                "Invalid DnD action 0x%x", preferred_action);
+                "Invalid DnD action 0x%x", preferred_action};
         }
         if (preferred_action != mw::DataDeviceManager::DndAction::none && (dnd_actions & preferred_action) == 0)
         {
-            throw mw::ProtocolError(
+            throw mw::ProtocolError{
                 resource,
                 Error::invalid_action,
-                "Preferred action 0x%x not in DnD actions 0x%x", preferred_action, dnd_actions);
+                "Preferred action 0x%x not in DnD actions 0x%x", preferred_action, dnd_actions};
         }
 
         const auto action = source->offer_set_actions(dnd_actions, preferred_action);
@@ -209,8 +209,7 @@ void mf::WlDataDevice::start_drag(
     // "The client must have an active implicit grab that matches the serial"
     if (!weak_surface || weak_surface.value().client != client || WlSurface::from(origin)->client != client)
     {
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(resource, Error::role, "The client must have an active implicit grab"));
+        throw mw::ProtocolError{resource, Error::role, "The client must have an active implicit grab"};
     }
 
     validate_pointer_event(client->event_for(serial));
@@ -239,15 +238,13 @@ void mf::WlDataDevice::validate_pointer_event(std::optional<std::shared_ptr<MirE
 {
     if (!drag_event || !drag_event.value() || mir_event_get_type(drag_event.value().get()) != mir_event_type_input)
     {
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(this->resource, Error::role, "Serial does not correspond to an input event"));
+        throw mw::ProtocolError{this->resource, Error::role, "Serial does not correspond to an input event"};
     }
 
     auto const input_ev = mir_event_get_input_event(drag_event.value().get());
     if (mir_input_event_get_type(input_ev) != mir_input_event_type_pointer)
     {
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(this->resource, Error::role, "Serial does not correspond to a pointer event"));
+        throw mw::ProtocolError{this->resource, Error::role, "Serial does not correspond to a pointer event"};
     }
 }
 

--- a/src/server/frontend_wayland/wl_data_source.cpp
+++ b/src/server/frontend_wayland/wl_data_source.cpp
@@ -251,10 +251,10 @@ void mf::WlDataSource::set_actions(uint32_t dnd_actions)
 {
     if (!mf::validate_dnd_actions(dnd_actions))
     {
-        throw mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_action_mask,
-            "Invalid DnD actions 0x%x", dnd_actions);
+            "Invalid DnD actions 0x%x", dnd_actions};
     }
     this->dnd_actions = dnd_actions;
 }

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -149,18 +149,18 @@ void mf::WlSubsurface::place_above(struct wl_resource* sibling)
 
     if (sibling_surface == surface)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::Subsurface::Error::bad_surface,
-            "wl_subsurface.place_above: sibling cannot be the subsurface itself"));
+            "wl_subsurface.place_above: sibling cannot be the subsurface itself"};
     }
 
     if (sibling_surface != &parent.value() && !parent.value().has_subsurface_with_surface(sibling_surface))
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::Subsurface::Error::bad_surface,
-            "wl_subsurface.place_above: sibling must be the parent or a sibling subsurface"));
+            "wl_subsurface.place_above: sibling must be the parent or a sibling subsurface"};
     }
 
     parent.value().reorder_subsurface(this, sibling_surface, WlSurface::SubsurfacePlacement::above);
@@ -178,18 +178,18 @@ void mf::WlSubsurface::place_below(struct wl_resource* sibling)
 
     if (sibling_surface == surface)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::Subsurface::Error::bad_surface,
-            "wl_subsurface.place_below: sibling cannot be the subsurface itself"));
+            "wl_subsurface.place_below: sibling cannot be the subsurface itself"};
     }
 
     if (sibling_surface != &parent.value() && !parent.value().has_subsurface_with_surface(sibling_surface))
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::Subsurface::Error::bad_surface,
-            "wl_subsurface.place_below: sibling must be the parent or a sibling subsurface"));
+            "wl_subsurface.place_below: sibling must be the parent or a sibling subsurface"};
     }
 
     parent.value().reorder_subsurface(this, sibling_surface, WlSurface::SubsurfacePlacement::below);

--- a/src/server/frontend_wayland/wlr_screencopy_v1.cpp
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.cpp
@@ -33,7 +33,6 @@
 #include "output_manager.h"
 #include "shm.h"
 
-#include <boost/throw_exception.hpp>
 #include <mutex>
 #include <optional>
 
@@ -453,48 +452,48 @@ void mf::WlrScreencopyFrameV1::prepare_target(wl_resource* buffer)
 {
     if (copy_has_been_called)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::already_used,
-            "Attempted to copy frame multiple times"));
+            "Attempted to copy frame multiple times"};
     }
     copy_has_been_called = true;
     auto shm_buffer = mf::ShmBuffer::from(buffer);
     if (!shm_buffer)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_buffer,
-            "Copy target is not a wl_shm buffer"));
+            "Copy target is not a wl_shm buffer"};
     }
     auto shm_data = shm_buffer->data();
     if (shm_data->format() != mir_pixel_format_argb_8888)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_buffer,
             "Invalid pixel format %d",
-            shm_data->format()));
+            shm_data->format()};
     }
     if (shm_data->size() != params.buffer_size)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_buffer,
             "Invalid buffer size %dx%d, should be %dx%d",
             shm_data->size().width.as_int(),
             shm_data->size().height.as_int(),
             params.buffer_size.width.as_int(),
-            params.buffer_size.height.as_int()));
+            params.buffer_size.height.as_int()};
     }
     if (shm_data->stride() != stride)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_buffer,
             "Invalid stride %d, should be %d",
             shm_data->stride().as_int(),
-            stride.as_int()));
+            stride.as_int()};
     }
 
     target = std::shared_ptr<mir::renderer::software::WriteMappable>{

--- a/src/server/frontend_wayland/xdg_activation_v1.cpp
+++ b/src/server/frontend_wayland/xdg_activation_v1.cpp
@@ -474,7 +474,6 @@ void mf::XdgActivationTokenV1::commit()
             resource,
             Error::already_used,
             "The activation token has already been used"};
-        return;
     }
 
     used = true;

--- a/src/server/frontend_wayland/xdg_activation_v1.cpp
+++ b/src/server/frontend_wayland/xdg_activation_v1.cpp
@@ -470,10 +470,10 @@ void mf::XdgActivationTokenV1::commit()
 {
     if (used)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::already_used,
-            "The activation token has already been used"));
+            "The activation token has already been used"};
         return;
     }
 

--- a/src/server/frontend_wayland/xdg_decoration_unstable_v1.cpp
+++ b/src/server/frontend_wayland/xdg_decoration_unstable_v1.cpp
@@ -140,8 +140,8 @@ void mir::frontend::XdgDecorationManagerV1::get_toplevel_decoration(wl_resource*
     auto decoration = new XdgToplevelDecorationV1{id, tl, decoration_strategy};
     if (!toplevels_with_decorations->register_toplevel(toplevel))
     {
-        BOOST_THROW_EXCEPTION(mir::wayland::ProtocolError(
-            resource, Error::already_constructed, "Decoration already constructed for this toplevel"));
+        throw mir::wayland::ProtocolError{
+            resource, Error::already_constructed, "Decoration already constructed for this toplevel"};
     }
 
     decoration->add_destroy_listener(
@@ -166,8 +166,8 @@ void mir::frontend::XdgDecorationManagerV1::get_toplevel_decoration(wl_resource*
             {
                 mir::log_warning("Toplevel destroyed before attached decoration!");
                 // https://github.com/canonical/mir/issues/3452
-                /* BOOST_THROW_EXCEPTION(mir::wayland::ProtocolError( */
-                /*     resource, Error::orphaned, "Toplevel destroyed before its attached decoration")); */
+                /* throw mir::wayland::ProtocolError{ */
+                /*     resource, Error::orphaned, "Toplevel destroyed before its attached decoration"}; */
             }
         });
 }

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -173,17 +173,17 @@ void mf::XdgSurfaceStable::get_toplevel(wl_resource* new_toplevel)
 {
     if (!surface)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::generic_error_code,
-            "Tried to create toplevel after destroying surface"));
+            "Tried to create toplevel after destroying surface"};
     }
     if (window_role_)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::already_constructed,
-            "Tried to create toplevel on surface with existing role"));
+            "Tried to create toplevel on surface with existing role"};
     }
     auto toplevel = new XdgToplevelStable{new_toplevel, this, &surface.value()};
     window_role_ = mw::make_weak<WindowWlSurfaceRole>(toplevel);
@@ -215,17 +215,17 @@ void mf::XdgSurfaceStable::get_popup(
 
     if (!surface)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::generic_error_code,
-            "Tried to create popup after destroying surface"));
+            "Tried to create popup after destroying surface"};
     }
     if (window_role_)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::already_constructed,
-            "Tried to create popup on surface with existing role"));
+            "Tried to create popup on surface with existing role"};
     }
 
     auto popup = new XdgPopupStable{new_popup, this, parent_role, *xdg_positioner, &surface.value()};
@@ -236,10 +236,10 @@ void mf::XdgSurfaceStable::set_window_geometry(int32_t x, int32_t y, int32_t wid
 {
     if (width <= 0 || height <= 0)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::generic_error_code,
-            "Invalid %s size %dx%d", interface_name, width, height));
+            "Invalid %s size %dx%d", interface_name, width, height};
     }
     if (window_role_)
     {
@@ -538,10 +538,10 @@ void mf::XdgToplevelStable::resize(struct wl_resource* /*seat*/, uint32_t serial
         break;
 
     default:
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_resize_edge,
-            "Invalid resize edge %d", edges));
+            "Invalid resize edge %d", edges};
     }
 
     initiate_interactive_resize(edge, serial);
@@ -551,10 +551,10 @@ void mf::XdgToplevelStable::set_max_size(int32_t width, int32_t height)
 {
     if (width < 0 || height < 0)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_size,
-            "Invalid maximum size %dx%d", width, height));
+            "Invalid maximum size %dx%d", width, height};
     }
     WindowWlSurfaceRole::set_max_size(width, height);
 }
@@ -563,10 +563,10 @@ void mf::XdgToplevelStable::set_min_size(int32_t width, int32_t height)
 {
     if (width < 0 || height < 0)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_size,
-            "Invalid minimum size %dx%d", width, height));
+            "Invalid minimum size %dx%d", width, height};
     }
     WindowWlSurfaceRole::set_min_size(width, height);
 }
@@ -731,10 +731,10 @@ void mf::XdgPositionerStable::ensure_complete() const
 {
     if (!width || !height || !aux_rect)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::XdgWmBase::Error::invalid_positioner,
-            "Incomplete positioner"));
+            "Incomplete positioner"};
     }
 }
 
@@ -742,10 +742,10 @@ void mf::XdgPositionerStable::set_size(int32_t width, int32_t height)
 {
     if (width <= 0 || height <= 0)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::XdgPositioner::Error::invalid_input,
-            "Invalid popup positioner size: %dx%d", width, height));
+            "Invalid popup positioner size: %dx%d", width, height};
     }
     this->width = geom::Width{width};
     this->height = geom::Height{height};
@@ -755,10 +755,10 @@ void mf::XdgPositionerStable::set_anchor_rect(int32_t x, int32_t y, int32_t widt
 {
     if (width < 0 || height < 0)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             mw::XdgPositioner::Error::invalid_input,
-            "Invalid popup anchor rect size: %dx%d", width, height));
+            "Invalid popup anchor rect size: %dx%d", width, height};
     }
     aux_rect = geom::Rectangle{{x, y}, {width, height}};
 }
@@ -806,10 +806,10 @@ void mf::XdgPositionerStable::set_anchor(uint32_t anchor)
             break;
 
         default:
-            BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            throw mw::ProtocolError{
                 resource,
                 mw::XdgPositioner::Error::invalid_input,
-                "Invalid anchor value %u", anchor));
+                "Invalid anchor value %u", anchor};
     }
 
     aux_rect_placement_gravity = placement;
@@ -858,10 +858,10 @@ void mf::XdgPositionerStable::set_gravity(uint32_t gravity)
             break;
 
         default:
-            BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            throw mw::ProtocolError{
                 resource,
                 mw::XdgPositioner::Error::invalid_input,
-                "Invalid gravity value %d", gravity));
+                "Invalid gravity value %d", gravity};
     }
 
     surface_placement_gravity = placement;
@@ -912,10 +912,10 @@ void mf::XdgPositionerStable::set_parent_size(int32_t parent_width, int32_t pare
 {
     if (parent_width <= 0 || parent_height <= 0)
     {
-        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+        throw mw::ProtocolError{
             resource,
             Error::invalid_input,
-            "Invalid popup positioner parent size: %dx%d", parent_width, parent_height));
+            "Invalid popup positioner parent size: %dx%d", parent_width, parent_height};
     }
     parent_size = geom::Size{parent_width, parent_height};
 }


### PR DESCRIPTION
These exceptions are always handled and passed back to the remote client. The additional functionality from boost is not required.
