### PR TITLE
Xdg toplevel windows should be regular windows unless they have a parent which suggests that they are dialogs

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2410,66 +2410,37 @@ void miral::BasicWindowManager::validate_modification_request(WindowSpecificatio
     if (modifications.type().is_set())
     {
         auto const original_type = target_type;
-
         target_type = modifications.type().value();
 
-        switch (original_type)
-        {
-        case mir_window_type_normal:
-        case mir_window_type_utility:
-        case mir_window_type_dialog:
-        case mir_window_type_satellite:
-            switch (target_type)
-            {
-            case mir_window_type_normal:
-            case mir_window_type_utility:
-            case mir_window_type_dialog:
-            case mir_window_type_satellite:
-                break;
+        // Windows can morph between normal and satellite freely.
+        auto const is_normal_satellite_morph =
+            (original_type == mir_window_type_normal && target_type == mir_window_type_satellite) ||
+            (original_type == mir_window_type_satellite && target_type == mir_window_type_normal);
 
-            default:
-                BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface type change"));
-            }
-	    // Falls through.
+        // Freestyle windows can freely morph to any other type.
+        auto const is_freestyle_morph = original_type == mir_window_type_freestyle;
 
-        case mir_window_type_menu:
-            switch (target_type)
-            {
-            case mir_window_type_menu:
-            case mir_window_type_satellite:
-                break;
-
-            default:
-                BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface type change"));
-            }
-	    // Falls through.
-
-        case mir_window_type_gloss:
-        case mir_window_type_freestyle:
-        case mir_window_type_inputmethod:
-        case mir_window_type_tip:
-        case mir_window_type_decoration:
-            if (target_type != original_type)
-                BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface type change"));
-            break;
-
-        default:
-            break;
-        }
+        // Morphing to your own type is always allowed.
+        if (target_type != original_type && !is_normal_satellite_morph && !is_freestyle_morph)
+            BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface type change"));
     }
+
+    auto const has_parent = modifications.parent().is_set()
+        ? !!modifications.parent().value().lock()
+        : !!window_info.parent();
 
     switch (target_type)
     {
     case mir_window_type_normal:
     case mir_window_type_utility:
-        if (modifications.parent().is_set() ? modifications.parent().value().lock() : window_info.parent())
+        if (has_parent)
             BOOST_THROW_EXCEPTION(std::runtime_error("Window type must not have a parent"));
         break;
 
     case mir_window_type_satellite:
     case mir_window_type_gloss:
     case mir_window_type_tip:
-        if (modifications.parent().is_set() ? !modifications.parent().value().lock() : !window_info.parent())
+        if (!has_parent)
             BOOST_THROW_EXCEPTION(std::runtime_error("Window type must have a parent"));
         break;
 

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -435,6 +435,8 @@ mf::XdgToplevelStable::XdgToplevelStable(wl_resource* new_resource, XdgSurfaceSt
           xdg_surface->xdg_shell.surface_registry),
       xdg_surface{xdg_surface}
 {
+    set_type(mir_window_type_normal);
+
     if (version_supports_wm_capabilities())
     {
         std::vector<uint32_t> capabilities{
@@ -467,10 +469,12 @@ void mf::XdgToplevelStable::set_parent(std::optional<struct wl_resource*> const&
     if (parent && parent.value())
     {
         WindowWlSurfaceRole::set_parent(XdgToplevelStable::from(parent.value())->scene_surface());
+        set_type(mir_window_type_dialog);
     }
     else
     {
         WindowWlSurfaceRole::set_parent({});
+        set_type(mir_window_type_normal);
     }
 }
 


### PR DESCRIPTION
Related: WLCS `XdgToplevelStableTest` parent-handling failures reported on this PR

## What's new?

- Improved the logic in `BasicWindowManager::validate_modification_request` for understandability
- Xdg toplevels are now regular windows unless they have a parent which suggests that they are dialogs

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos