### PR TITLE
Apply live configuration in `start_callback()`

### DIFF
--- a/src/miral/input_configuration.cpp
+++ b/src/miral/input_configuration.cpp
@@ -354,9 +354,9 @@ public:
         config.keyboard.merge(keyboard());
         config.touchpad.merge(touchpad());
 
-        mouse(config.mouse);
-        touchpad(config.touchpad);
-        keyboard(config.keyboard);
+        apply(config.mouse);
+        apply(config.touchpad);
+        apply(config.keyboard);
     }
 };
 

--- a/tests/miral/test_input_configuration.cpp
+++ b/tests/miral/test_input_configuration.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <mir_toolkit/mir_input_device_types.h>
+#include <miral/accessibility_test_server.h>
 #include <miral/test_server.h>
 #include <miral/input_configuration.h>
 
@@ -589,6 +590,29 @@ TEST_F(TestLiveInputConfigurationAtStartup, touchpad_live_config_is_applied_when
     start_server();
 
     EXPECT_THAT(input_config.touchpad().tap_to_click(), Eq(std::optional<bool>{true}));
+}
+
+struct TestLiveKeyboardInputConfigurationAtStartup : miral::TestAccessibilityManager
+{
+    mlc::BasicStore config_store;
+    miral::InputConfiguration input_config{config_store};
+};
+
+TEST_F(TestLiveKeyboardInputConfigurationAtStartup, keyboard_repeat_settings_are_applied_to_accessibility_manager_on_start)
+{
+    auto const config_path = std::filesystem::temp_directory_path() /
+        "mir-test-input-configuration-keyboard.settings";
+
+    config_store.do_transaction([&]
+    {
+        config_store.update_key({"keyboard", "repeat_rate"}, "25", config_path);
+        config_store.update_key({"keyboard", "repeat_delay"}, "400", config_path);
+    });
+
+    EXPECT_CALL(*accessibility_manager, repeat_rate_and_delay(std::optional<int>{25}, std::optional<int>{400}));
+
+    add_server_init(input_config);
+    start_server();
 }
 
 struct TestTouchpadMergeOneProperty : public TestInputConfiguration, testing::WithParamInterface<TouchpadProperty>


### PR DESCRIPTION
A last piece to migrate input configuration to "live".

## What's new?

The initial "live" configuration was not being applied: Devices have already been added when `start_callback()` is called. An active `apply()` is needed, not just a passive update to the settings.

A new test `keyboard_repeat_settings_are_applied_to_accessibility_manager_on_start` has been added to verify that keyboard repeat settings from the live config are applied to the accessibility manager on server startup — ensuring this active `apply()` path does not regress to a cache-only update.

## How to test

Miriway uses "live config" for it's .settings file. And the `settings-update` branch (https://github.com/Miriway/Miriway/pull/207) tries to use it exclusively.

Using that Miriway branch it is apparent that options that are only in .settings (and not in .config) are not applied until the .settings file is touched. I noticed it with `touchpad_tap_to_click=true`).

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos