### PR TITLE
miral: fix constrain resizes of windows without a size

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1164,16 +1164,20 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
         }
     }
 
-    if (modifications.size().is_set() || modifications.top_left().is_set() ||
-        modifications.min_width().is_set() || modifications.min_height().is_set() ||
-        modifications.max_width().is_set() || modifications.max_height().is_set() ||
-        modifications.width_inc().is_set() || modifications.height_inc().is_set())
+    bool const constrain_resize = modifications.size().is_set() ||
+                                  modifications.min_width().is_set() || modifications.min_height().is_set() ||
+                                  modifications.max_width().is_set() || modifications.max_height().is_set() ||
+                                  modifications.width_inc().is_set() || modifications.height_inc().is_set();
+
+    if (modifications.top_left().is_set() || constrain_resize)
     {
         Point new_pos = modifications.top_left().is_set() ? modifications.top_left().value() : window.top_left();
         Size new_size = modifications.size().is_set() ? modifications.size().value() : window.size();
 
         // The new size constraints have already been applied to window_info and constrain_resize() will use them
-        window_info.constrain_resize(new_pos, new_size);
+        if (constrain_resize)
+            window_info.constrain_resize(new_pos, new_size);
+
         place_and_size(window_info, new_pos, new_size);
     }
 


### PR DESCRIPTION
## What's new?
If a client asks Mir to place a window on a position with a size of 0x0, Mir will incorrectly constrain the resize and apply a default size, which further breaks the window positioning formula, as the window doesn't have a previous size. Windows can have a size assigned to them after they have been positioned. Therefore, don't constrain resize of a window until the window has an actual size.

## How to test
Open a window in Lomiri. It will now spawn correctly on-screen instead of out of bounds

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
