### PR TITLE
Run symbols check when the generator source code or symbol maps change.

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -24,6 +24,8 @@ spread:
 symbols:
   - '.github/workflows/symbols-check.yml'
   - 'include/**/*.h'
+  - 'tools/symbols-map-generator/main.py'
+  - '**/symbols.map'
 
 tics:
   - '.github/workflows/tics.yml'


### PR DESCRIPTION
## What's new?

- Update the GitHub workflow filters to run the symbols check whenever the generator source code or maps change.

## How to test

- Make a PR with a change matching the newly added patterns and watch the machinery come alive (hopefully)