### PR TITLE
tools: encode template symbols as glob wildcards in version scripts

### DIFF
--- a/tools/symbols_map_generator/main.py
+++ b/tools/symbols_map_generator/main.py
@@ -231,7 +231,7 @@ def traverse_ast(node: clang.cindex.Cursor, filename: str, result: set[str]) -> 
 
         def add_symbol_str(s: str):
             if '<' in s or '>' in s:
-                s = f'"{s}"'
+                s = s.replace('<', '?').replace('>', '?').replace(',', '*')
             s += ';'
             if not s in HIDDEN_SYMBOLS:
                 result.add(s)


### PR DESCRIPTION
## What's new?

- Instead of the symbol generator trying to match quoted strings from the symbols map exactly, it will first replace angled brackets and commas. This should allow the current symbols map to pass the symbols check.

## How to test

- The symbols check should pass successfully.