### PR TITLE
tools: fix PPA upload when equal to `-rc` tag

### DIFF
--- a/tools/ppa-upload.sh
+++ b/tools/ppa-upload.sh
@@ -58,8 +58,8 @@ if [[ "${GIT_BRANCH}" =~ ${RELEASE_RE} ]]; then
     MIR_VERSION=${BASH_REMATCH[1]}
   else
     # determine the release candidate version string
-    if [[ "$( git describe --match="*-rc" )" =~ ^${VERSION_RE}-rc-${SUFFIX_RE} ]]; then
-      MIR_VERSION="${BASH_REMATCH[1]}~rc${BASH_REMATCH[5]}-${BASH_REMATCH[6]}"
+    if [[ "$( git describe --match="*-rc" )" =~ ^${VERSION_RE}-rc(?:-${SUFFIX_RE})? ]]; then
+      MIR_VERSION="${BASH_REMATCH[1]}~rc${BASH_REMATCH[5]}-${BASH_REMATCH[6]:-0}"
     else
       echo "ERROR: could not parse git describe output" >&2
       exit 4


### PR DESCRIPTION
## What's new?

There's no suffix when describing _on tag_.

## How to test

With a local tag, or see that `2.27.0~rc0` shows up in https://launchpad.net/~mir-team/+archive/ubuntu/rc

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
