### PR TITLE
How-to-test-Mir-for-a-release

### DIFF
--- a/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
+++ b/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
@@ -90,7 +90,7 @@ The test script `mir-smoke-test-runner` will automatically test the platforms th
 environment it is run in:
 
 - When run in a hosted environment it will test `virtual`, `wayland`, and `x11`
-- When run in a unhosted environment it will test `atomic-kms`, `eglstream-kms`, `gbm-kms` and `virtual` platforms
+- When run in without a host compositor it will test `atomic-kms`, `eglstream-kms`, `gbm-kms` and `virtual` platforms
   (according to the hardware and drivers available).
 
 ### Manual testing

--- a/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
+++ b/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
@@ -84,6 +84,15 @@ in which we need to test:
 
 <!-- rc-testing:end -->
 
+### Scripted "smoke test"
+The test script `mir-smoke-test-runner` will automatically test the platforms that are expected to work in the
+environment it is run in:
+* When run in a hosted environment it will test `virtual`, `wayland`, and `x11`
+* When run in a native environment it will test `atomic-kms`, `eglstream-kms`, `gbm-kms` and `virtual` platforms
+  (according to the hardware and drivers available).
+
+### Manual testing
+
 To check which display platform we've selected, we can run `miral-app`
 and grep for the platform string as follows:
 

--- a/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
+++ b/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
@@ -73,7 +73,8 @@ in which we need to test:
 <!-- rc-testing:start -->
 
 |                                | 24.04 | 25.10 |
-| ------------------------------ | ----- | ----- |
+|--------------------------------| ----- | ----- |
+| atomic-kms                     |       |       |
 | gbm-kms                        |       |       |
 | eglstream-kms                  |       |       |
 | eglstream-kms + gbm-kms hybrid |       |       |

--- a/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
+++ b/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
@@ -73,7 +73,7 @@ in which we need to test:
 <!-- rc-testing:start -->
 
 |                                | 24.04 | 25.10 |
-|--------------------------------| ----- | ----- |
+| ------------------------------ | ----- | ----- |
 | atomic-kms                     |       |       |
 | gbm-kms                        |       |       |
 | eglstream-kms                  |       |       |
@@ -85,10 +85,12 @@ in which we need to test:
 <!-- rc-testing:end -->
 
 ### Scripted "smoke test"
+
 The test script `mir-smoke-test-runner` will automatically test the platforms that are expected to work in the
 environment it is run in:
-* When run in a hosted environment it will test `virtual`, `wayland`, and `x11`
-* When run in a native environment it will test `atomic-kms`, `eglstream-kms`, `gbm-kms` and `virtual` platforms
+
+- When run in a hosted environment it will test `virtual`, `wayland`, and `x11`
+- When run in a native environment it will test `atomic-kms`, `eglstream-kms`, `gbm-kms` and `virtual` platforms
   (according to the hardware and drivers available).
 
 ### Manual testing

--- a/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
+++ b/doc/sphinx/contributing/how-to/test-mir-for-a-release.md
@@ -72,15 +72,15 @@ in which we need to test:
 
 <!-- rc-testing:start -->
 
-|                                | 24.04 | 25.10 |
-| ------------------------------ | ----- | ----- |
-| atomic-kms                     |       |       |
-| gbm-kms                        |       |       |
-| eglstream-kms                  |       |       |
-| eglstream-kms + gbm-kms hybrid |       |       |
-| x11                            |       |       |
-| wayland                        |       |       |
-| virtual                        |       |       |
+|                                | 24.04 | 26.04 | 26.10 |
+| ------------------------------ | ----- | ----- | ----- |
+| atomic-kms                     |       |       |       |
+| gbm-kms                        |       |       |       |
+| eglstream-kms                  |       |       |       |
+| eglstream-kms + gbm-kms hybrid |       |       |       |
+| x11                            |       |       |       |
+| wayland                        |       |       |       |
+| virtual                        |       |       |       |
 
 <!-- rc-testing:end -->
 
@@ -90,7 +90,7 @@ The test script `mir-smoke-test-runner` will automatically test the platforms th
 environment it is run in:
 
 - When run in a hosted environment it will test `virtual`, `wayland`, and `x11`
-- When run in a native environment it will test `atomic-kms`, `eglstream-kms`, `gbm-kms` and `virtual` platforms
+- When run in a unhosted environment it will test `atomic-kms`, `eglstream-kms`, `gbm-kms` and `virtual` platforms
   (according to the hardware and drivers available).
 
 ### Manual testing


### PR DESCRIPTION
## What's new?

Updates "How to test Mir for a release" doc to mention `atomic-kms` and `mir-smoke-test-runner`
