### PR TITLE
core: Rename “core” tag to “base”

### DIFF
--- a/debian/libmircore2.symbols
+++ b/debian/libmircore2.symbols
@@ -66,7 +66,7 @@ libmircore.so.2 libmircore2 #MINVER#
  (c++)"mir::logging::create_tag(mir::logging::Tag const&, std::basic_string_view<char, std::char_traits<char> >)@MIR_CORE_2.27" 2.27.0
  (c++)"mir::logging::window_management()@MIR_CORE_2.27" 2.27.0
  (c++)"mir::logging::log(mir::logging::Severity, std::initializer_list<std::reference_wrapper<mir::logging::Tag const> const>, std::basic_string_view<char, std::char_traits<char> >)@MIR_CORE_2.27" 2.27.0
- (c++)"mir::logging::core()@MIR_CORE_2.27" 2.27.0
+ (c++)"mir::logging::base()@MIR_CORE_2.27" 2.27.0
  (c++)"mir::logging::input()@MIR_CORE_2.27" 2.27.0
  (c++)"mir::logging::Logger::log(mir::logging::Severity, std::initializer_list<std::reference_wrapper<mir::logging::Tag const> const>, std::basic_string_view<char, std::char_traits<char> >)@MIR_CORE_2.27" 2.27.0
  (c++)"mir::logging::wayland()@MIR_CORE_2.27" 2.27.0

--- a/include/core/mir/logging/logger.h
+++ b/include/core/mir/logging/logger.h
@@ -47,7 +47,7 @@ struct Tag;
  */
 Tag const& create_tag(Tag const& parent, std::string_view name);
 
-Tag const& core();
+Tag const& base();
 Tag const& input();
 Tag const& wayland();
 Tag const& graphics();

--- a/src/core/logging/logger.cpp
+++ b/src/core/logging/logger.cpp
@@ -41,7 +41,7 @@ struct ml::Tag
     Tag const* parent;
 };
 
-mir::Synchronised<std::list<ml::Tag>> known_tags{std::list<ml::Tag>{ml::Tag { "core", nullptr}}}; //TICS !cppcoreguidelines-avoid-non-const-global-variables - This is the list of tags, shared within this module
+mir::Synchronised<std::list<ml::Tag>> known_tags{std::list<ml::Tag>{ml::Tag { "base", nullptr}}}; //TICS !cppcoreguidelines-avoid-non-const-global-variables - This is the list of tags, shared within this module
 
 auto ml::create_tag(Tag const& parent, std::string_view name) -> Tag const&
 {
@@ -50,7 +50,7 @@ auto ml::create_tag(Tag const& parent, std::string_view name) -> Tag const&
     return locked_tags->back();
 }
 
-auto ml::core() -> Tag const&
+auto ml::base() -> Tag const&
 {
     static Tag const& core = known_tags.lock()->front();
     return core;
@@ -58,25 +58,25 @@ auto ml::core() -> Tag const&
 
 auto ml::input() -> Tag const&
 {
-    static Tag const& input = create_tag(core(), "input");
+    static Tag const& input = create_tag(base(), "input");
     return input;
 }
 
 auto ml::wayland() -> Tag const&
 {
-    static Tag const& wayland = create_tag(core(), "wayland");
+    static Tag const& wayland = create_tag(base(), "wayland");
     return wayland;
 }
 
 auto ml::graphics() -> Tag const&
 {
-    static Tag const& graphics = create_tag(core(), "graphics");
+    static Tag const& graphics = create_tag(base(), "graphics");
     return graphics;
 }
 
 auto ml::window_management() -> Tag const&
 {
-    static Tag const& window_management = create_tag(core(), "window-management");
+    static Tag const& window_management = create_tag(base(), "window-management");
     return window_management;
 }
 

--- a/src/core/symbols.map
+++ b/src/core/symbols.map
@@ -93,7 +93,7 @@ MIR_CORE_2.27 {
     _ZN3mir7logging6Logger3logENS0_8SeverityESt16initializer_listIKSt17reference_wrapperIKNS0_3TagEEESt17basic_string_viewIcSt11char_traitsIcEE;
     extern "C++" {
       mir::logging::create_tag*;
-      mir::logging::core*;
+      mir::logging::base*;
       mir::logging::input*;
       mir::logging::wayland*;
       mir::logging::graphics*;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -400,7 +400,7 @@ void mir::Server::run()
 {
     try
     {
-        mir::log_info({logging::core()}, "Starting");
+        mir::log_info({logging::base()}, "Starting");
         mir::security_log(
             logging::Severity::warning,
             "sys_startup",
@@ -460,7 +460,7 @@ auto mir::Server::supported_pixel_formats() const -> std::vector<MirPixelFormat>
 
 void mir::Server::stop()
 {
-    mir::log_info({logging::core()}, "Stopping");
+    mir::log_info({logging::base()}, "Stopping");
     if (self->server_config)
         if (auto const main_loop = the_main_loop().get())
         {

--- a/tests/unit-tests/logging/test_logging.cpp
+++ b/tests/unit-tests/logging/test_logging.cpp
@@ -59,9 +59,9 @@ TEST_F(TestLog, log_calls_logger)
     auto const severity = mir::logging::Severity::informational;
     auto const message = "test message";
 
-    EXPECT_CALL(*logger, log(severity, message, "core"));
+    EXPECT_CALL(*logger, log(severity, message, "base"));
 
-    mir::log(severity, {ml::core()}, message);
+    mir::log(severity, {ml::base()}, message);
 }
 
 TEST_F(TestLog, log_calls_logger_with_colon_separated_component_for_multiple_tags)
@@ -82,10 +82,10 @@ TEST_F(TestLog, log_debug_works)
     auto const value = "Twice";
     auto const message = std::format(fmt_string, value);
 
-    EXPECT_CALL(*logger, log(ml::Severity::debug, message, "core")).Times(2);
+    EXPECT_CALL(*logger, log(ml::Severity::debug, message, "base")).Times(2);
 
-    mir::log_debug({ml::core()}, message);
-    mir::log_debug({ml::core()}, fmt_string, value);
+    mir::log_debug({ml::base()}, message);
+    mir::log_debug({ml::base()}, fmt_string, value);
 }
 
 TEST_F(TestLog, log_info_works)
@@ -94,10 +94,10 @@ TEST_F(TestLog, log_info_works)
     auto const value = 18;
     auto const message = std::format(fmt_string, value);
 
-    EXPECT_CALL(*logger, log(ml::Severity::informational, message, "core")).Times(2);
+    EXPECT_CALL(*logger, log(ml::Severity::informational, message, "base")).Times(2);
 
-    mir::log_info({ml::core()}, message);
-    mir::log_info({ml::core()}, fmt_string, value);
+    mir::log_info({ml::base()}, message);
+    mir::log_info({ml::base()}, fmt_string, value);
 }
 
 TEST_F(TestLog, log_warning_works)
@@ -106,10 +106,10 @@ TEST_F(TestLog, log_warning_works)
     auto const value = 23.22222222;
     auto const message = std::format(fmt_string, value);
 
-    EXPECT_CALL(*logger, log(ml::Severity::warning, message, "core")).Times(2);
+    EXPECT_CALL(*logger, log(ml::Severity::warning, message, "base")).Times(2);
 
-    mir::log_warning({ml::core()}, message);
-    mir::log_warning({ml::core()}, fmt_string, value);
+    mir::log_warning({ml::base()}, message);
+    mir::log_warning({ml::base()}, fmt_string, value);
 }
 
 TEST_F(TestLog, log_error_works)
@@ -118,10 +118,10 @@ TEST_F(TestLog, log_error_works)
     auto const value = 100;
     auto const message = std::format(fmt_string, value);
 
-    EXPECT_CALL(*logger, log(ml::Severity::error, message, "core")).Times(2);
+    EXPECT_CALL(*logger, log(ml::Severity::error, message, "base")).Times(2);
 
-    mir::log_error({ml::core()}, message);
-    mir::log_error({ml::core()}, fmt_string, value);
+    mir::log_error({ml::base()}, message);
+    mir::log_error({ml::base()}, fmt_string, value);
 }
 
 TEST_F(TestLog, log_critical_works)
@@ -130,10 +130,10 @@ TEST_F(TestLog, log_critical_works)
     auto const value = "ENOCAKE";
     auto const message = std::format(fmt_string, value);
 
-    EXPECT_CALL(*logger, log(ml::Severity::critical, message, "core")).Times(2);
+    EXPECT_CALL(*logger, log(ml::Severity::critical, message, "base")).Times(2);
 
-    mir::log_critical({ml::core()}, message);
-    mir::log_critical({ml::core()}, fmt_string, value);
+    mir::log_critical({ml::base()}, message);
+    mir::log_critical({ml::base()}, fmt_string, value);
 }
 
 TEST_F(TestLog, can_use_format_string)


### PR DESCRIPTION
Came up in [review of follow-on work](https://github.com/canonical/mir/pull/4928#discussion_r3340504841)