### PR TITLE
Generating C++ classes for wayland-rs with names that are inline withthe existing ones

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -168,7 +168,7 @@ fn create_ffi_fwd_builder(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
     // WaylandServer is declared in ffi.rs but used nowhere in the protocol headers;
     // include it for completeness so all Rust types are forward-declared.
     namespace.add_forward_declaration_class("WaylandServer");
-    // WaylandClient is used in the protected constructor of every generated XxxImpl.
+    // WaylandClient is used in the protected constructor of every generated C++ implementation.
     namespace.add_forward_declaration_class("WaylandClient");
 
     for protocol in protocols {

--- a/src/server/frontend_wayland/wayland_rs/build_script/helpers.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/helpers.rs
@@ -48,16 +48,29 @@ pub fn snake_to_pascal(s: &str) -> String {
         .collect()
 }
 
+/// This removes the "wl_", "ext_", etc. prefix from the interface in order to
+/// more closely match the former C++ implementation and reduce
+/// migration cost.
+fn strip_wayland_interface_prefix(s: &str) -> &str {
+    if let Some(index) = s.find('_') {
+        &s[index + 1..]
+    } else {
+        s
+    }
+}
+
 /// Formats the Wayland interface name to the name of the class that
 /// provides its C++ implementation.
 pub fn format_wayland_interface_to_cpp_class(s: &str) -> String {
-    format!("{}Impl", snake_to_pascal(s))
+    let s = strip_wayland_interface_prefix(s);
+    format!("{}", snake_to_pascal(s))
 }
 
 /// Formats the Wayland interface name to the name of the struct that
 /// provides its Rust extension implementation.
 pub fn format_wayland_interface_to_rust_extension_struct(s: &str) -> String {
-    format!("{}Ext", snake_to_pascal(s))
+    let s = strip_wayland_interface_prefix(s);
+    format!("{}Middleware", snake_to_pascal(s))
 }
 
 pub fn format_has_arg(s: &str) -> String {

--- a/src/server/frontend_wayland/wayland_rs/build_script/helpers.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/helpers.rs
@@ -48,10 +48,25 @@ pub fn snake_to_pascal(s: &str) -> String {
         .collect()
 }
 
+/// Some interfaces produce naming collisions after prefix stripping and must
+/// be kept intact. Currently known collisions:
+///   - `xdg_surface` vs `wl_surface` — both would strip to "surface"
+///   - `zwlr_foreign_toplevel_handle_v1` vs `ext_foreign_toplevel_handle_v1`
+///     — both would strip to "foreign_toplevel_handle_v1"
+///
+/// If a new protocol is added whose stripped name collides with an existing
+/// one, add it to this list so that the full name (with prefix) is used
+/// instead.
+const COLLISION_INTERFACES: &[&str] = &["xdg_surface", "zwlr_foreign_toplevel_handle_v1"];
+
 /// This removes the "wl_", "ext_", etc. prefix from the interface in order to
 /// more closely match the former C++ implementation and reduce
 /// migration cost.
 fn strip_wayland_interface_prefix(s: &str) -> &str {
+    if COLLISION_INTERFACES.contains(&s) {
+        return s;
+    }
+
     if let Some(index) = s.find('_') {
         &s[index + 1..]
     } else {

--- a/src/server/frontend_wayland/wayland_rs/build_script/helpers.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/helpers.rs
@@ -48,30 +48,36 @@ pub fn snake_to_pascal(s: &str) -> String {
         .collect()
 }
 
-/// Some interfaces produce naming collisions after prefix stripping and must
-/// be kept intact. Currently known collisions:
-///   - `xdg_surface` vs `wl_surface` — both would strip to "surface"
-///   - `zwlr_foreign_toplevel_handle_v1` vs `ext_foreign_toplevel_handle_v1`
-///     — both would strip to "foreign_toplevel_handle_v1"
+/// Strips known Wayland protocol/vendor prefixes from an interface name to
+/// produce a type name matching existing C++ conventions.
 ///
-/// If a new protocol is added whose stripped name collides with an existing
-/// one, add it to this list so that the full name (with prefix) is used
-/// instead.
-const COLLISION_INTERFACES: &[&str] = &["xdg_surface", "zwlr_foreign_toplevel_handle_v1"];
-
-/// This removes the "wl_", "ext_", etc. prefix from the interface in order to
-/// more closely match the former C++ implementation and reduce
-/// migration cost.
+/// Only prefixes in [`KNOWN_PREFIXES`] are stripped. Interfaces with
+/// unrecognized prefixes (e.g., `xdg_`, `ext_`) keep their full name.
 fn strip_wayland_interface_prefix(s: &str) -> &str {
-    if COLLISION_INTERFACES.contains(&s) {
-        return s;
-    }
+    /// Known Wayland protocol/vendor prefixes and how many characters to strip.
+    /// Ordered longest-first to ensure correct greedy matching.
+    ///
+    /// The strip length may differ from the match length: for `zxdg_` we strip
+    /// only the `z` instability marker, preserving `xdg_` as part of the type
+    /// name (matching existing C++ types like `XdgOutputManagerV1`).
+    ///
+    /// Prefixes NOT listed here (e.g., `xdg_`, `ext_`) are intentionally kept
+    /// as part of the type name (e.g., `XdgActivationV1`, `ExtForeignToplevelListV1`).
+    const KNOWN_PREFIXES: &[(&str, usize)] = &[
+        ("org_kde_kwin_", "org_kde_kwin_".len()),
+        ("zwlr_", "zwlr_".len()),
+        ("zwp_", "zwp_".len()),
+        ("zxdg_", 1), // strip only the 'z' instability marker
+        ("wl_", "wl_".len()),
+        ("wp_", "wp_".len()),
+    ];
 
-    if let Some(index) = s.find('_') {
-        &s[index + 1..]
-    } else {
-        s
+    for &(prefix, strip_len) in KNOWN_PREFIXES {
+        if s.starts_with(prefix) {
+            return &s[strip_len..];
+        }
     }
+    s
 }
 
 /// Formats the Wayland interface name to the name of the class that


### PR DESCRIPTION
## What's new?
Renamed the generated C++ classes from:

- `NamespaceProcolNameImpl` -> `ProtocolName`
- `NamespaceProcolNameExt` -> `ProtocolNameMiddleware`

This reduces the size of the diff when we do the actual migration by keeping the same class names as the exiting implementation.


## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
