### PR TITLE
Pushing the 2-step initialization required by Dispatch implementation s from C++ to Rust so that C++ implementers need not think about it

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -542,6 +542,7 @@ impl CppMethod {
     }
 }
 
+#[derive(Clone)]
 pub enum CppType {
     CppI32,
     CppU32,
@@ -787,6 +788,7 @@ pub fn sanitize_identifier(name: &str) -> String {
     }
 }
 
+#[derive(Clone)]
 pub struct CppArg {
     cpp_type: CppType,
     name: String,

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -78,7 +78,9 @@ fn create_global_factory(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
             .filter(|interface| interface.name != "wl_display" && interface.name != "wl_registry")
             .for_each(|global_interface| {
                 let class_name = format_wayland_interface_to_cpp_class(&global_interface.name);
+                let ext_name = format_wayland_interface_to_rust_extension_struct(&global_interface.name);
                 namespace.add_forward_declaration_class(&class_name);
+                namespace.add_forward_declaration_struct(&snake_to_pascal(&ext_name));
 
                 let mut method = CppMethod::new(
                     format!("create_{}", global_interface.name),
@@ -93,6 +95,12 @@ fn create_global_factory(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
                     "client",
                     false,
                 ));
+                method.add_arg(CppArg::new(
+                    CppType::Box(snake_to_pascal(&ext_name)),
+                    "instance",
+                    false,
+                ));
+                method.add_arg(CppArg::new(CppType::CppU32, "object_id", false));
                 class.add_method(method);
             })
     });
@@ -212,7 +220,6 @@ fn create_cpp_builder(protocol: &WaylandProtocol) -> CppBuilder {
     builder.add_header_include("\"ffi_fwd.h\"");
     builder.add_header_include("\"weak.h\"");
     builder.add_header_include("<memory>");
-    builder.add_header_include("<optional>");
     builder.add_header_include("<cstdint>");
     builder.add_header_include("<rust/cxx.h>");
 
@@ -243,27 +250,20 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
         class.add_enum(enum_);
     }
 
-    // Add the method that associates the boxed rust interface with the C++ class.
-    let mut associate_method = CppMethod::new("associate", None, true, false, true, true);
-    associate_method.add_arg(CppArg::new(
-        CppType::Box(snake_to_pascal(
-            &format_wayland_interface_to_rust_extension_struct(&interface.name),
-        )),
-        "instance",
-        false,
-    ));
-    associate_method.add_arg(CppArg::new(CppType::CppU32, "object_id", false));
-    associate_method.set_body("object_id_ = object_id;\ninstance_ = std::move(instance);");
-    class.add_method(associate_method);
+    // The middleware Box and object ID are passed as constructor arguments so that
+    // the C++ object is fully initialized from the start (no two-step associate).
+    // NOTE: These are declared as private members below but initialized via the constructor.
+    // The add_protected_constructor_arg calls are ordered to match member declaration order
+    // (public members before private members) to avoid -Wreorder warnings.
+
+    // Declare the corresponding private members.
     class.add_private_member(CppArg::new(
         CppType::Box(snake_to_pascal(
             &format_wayland_interface_to_rust_extension_struct(&interface.name),
         )),
         "instance_",
-        true,
+        false,
     ));
-
-    // Add a private member for the object ID of the associated resource.
     class.add_private_member(CppArg::new(CppType::CppU32, "object_id_", false));
 
     // Add a public accessor for the object ID so that C++ implementations
@@ -279,7 +279,7 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     object_id_method.set_body("return object_id_;");
     class.add_method(object_id_method);
 
-    // Add the "get_box" method that will return the boxes rust interface. This is used
+    // Add the "get_box" method that will return the boxed rust interface. This is used
     // when sending a Box from C++ to Rust.
     let mut get_box_method = CppMethod::new(
         "get_box",
@@ -291,9 +291,7 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
         true,
         true,
     );
-    get_box_method.set_body(
-        "if (!instance_) { throw \"get_box() called before associate()\"; }\nreturn instance_.value();",
-    );
+    get_box_method.set_body("return instance_;");
     class.add_method(get_box_method);
 
     // Add a post_error method that posts a protocol error to the client for this resource.
@@ -303,7 +301,7 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     post_error_method.add_arg(CppArg::new(CppType::CppU32, "code", false));
     post_error_method.add_arg(CppArg::new(CppType::String, "message", false));
     post_error_method
-        .set_body("assert(instance_.has_value());\ninstance_.value()->post_error(code, message);");
+        .set_body("instance_->post_error(code, message);");
     class.add_method(post_error_method);
 
     // Add a protected constructor and member so that subclasses know which client
@@ -313,6 +311,16 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
         "client",
         false,
     ));
+    // Add instance_ and object_id_ constructor args after client to match declaration order
+    // (public members are declared before private members in the generated header).
+    class.add_protected_constructor_arg(CppArg::new(
+        CppType::Box(snake_to_pascal(
+            &format_wayland_interface_to_rust_extension_struct(&interface.name),
+        )),
+        "instance_",
+        false,
+    ));
+    class.add_protected_constructor_arg(CppArg::new(CppType::CppU32, "object_id_", false));
     class
         .add_public_member(CppArg::new(
             CppType::Box("WaylandClient".to_string()),
@@ -435,6 +443,32 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
         .collect();
 
     let has_retval = retval.is_some();
+
+    // If the method creates a child object (has NewId), we need to pass the child's
+    // middleware Box and object_id so the child is fully initialized at construction.
+    let new_id_ext_args: Vec<CppArg> = if let Some(new_id_arg) = method
+        .args
+        .iter()
+        .find(|arg| arg.type_ == WaylandArgType::NewId)
+    {
+        let ext_name = format_wayland_interface_to_rust_extension_struct(
+            new_id_arg
+                .interface
+                .as_ref()
+                .expect("NewId is missing interface"),
+        );
+        vec![
+            CppArg::new(
+                CppType::Box(snake_to_pascal(&ext_name)),
+                "child_instance",
+                false,
+            ),
+            CppArg::new(CppType::CppU32, "child_object_id", false),
+        ]
+    } else {
+        vec![]
+    };
+
     let mut cpp_method = CppMethod::new(
         method.name.as_str(),
         retval,
@@ -444,6 +478,9 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
         true,
     );
     for arg in args {
+        cpp_method.add_arg(arg);
+    }
+    for arg in new_id_ext_args.clone() {
         cpp_method.add_arg(arg);
     }
 
@@ -457,11 +494,16 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
     if !wayland_weak_transformers.is_empty() {
         // Build the body: wrap shared_ptrs in Weak, then delegate to the virtual overload
         let return_prefix = if has_retval { "return " } else { "" };
+        let mut all_delegation_args = delegation_args;
+        // Forward child_instance and child_object_id to the virtual method
+        for arg in &new_id_ext_args {
+            all_delegation_args.push(format!("std::move({})", arg.name()));
+        }
         let delegation_call = format!(
             "{}{}({});",
             return_prefix,
             sanitize_identifier(&method.name),
-            delegation_args.join(", ")
+            all_delegation_args.join(", ")
         );
         let mut body_lines = wayland_weak_transformers;
         body_lines.push(delegation_call);
@@ -508,6 +550,10 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
                 }
             }
         }
+        // Add the child middleware args to the virtual method too
+        for arg in new_id_ext_args {
+            virtual_method.add_arg(arg);
+        }
 
         vec![cpp_method, virtual_method]
     } else {
@@ -546,7 +592,7 @@ fn wayland_event_to_cpp_method(event: &WaylandEvent) -> CppMethod {
     }
 
     cpp_method.set_body(format!(
-        "if (!instance_.has_value()) {{\n    throw \"Wayland event sender used before associate()\";\n}}\ninstance_.value()->{}({});",
+        "instance_->{}({});",
         event.name,
         sanitized_args.join(", ")
     ));

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -78,7 +78,8 @@ fn create_global_factory(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
             .filter(|interface| interface.name != "wl_display" && interface.name != "wl_registry")
             .for_each(|global_interface| {
                 let class_name = format_wayland_interface_to_cpp_class(&global_interface.name);
-                let ext_name = format_wayland_interface_to_rust_extension_struct(&global_interface.name);
+                let ext_name =
+                    format_wayland_interface_to_rust_extension_struct(&global_interface.name);
                 namespace.add_forward_declaration_class(&class_name);
                 namespace.add_forward_declaration_struct(&snake_to_pascal(&ext_name));
 
@@ -300,8 +301,7 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     let mut post_error_method = CppMethod::new("post_error", None, false, false, false, true);
     post_error_method.add_arg(CppArg::new(CppType::CppU32, "code", false));
     post_error_method.add_arg(CppArg::new(CppType::String, "message", false));
-    post_error_method
-        .set_body("instance_->post_error(code, message);");
+    post_error_method.set_body("instance_->post_error(code, message);");
     class.add_method(post_error_method);
 
     // Add a protected constructor and member so that subclasses know which client

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -421,21 +421,6 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
         })
         .collect();
 
-    let delegation_args: Vec<String> = args
-        .clone()
-        .flat_map(|arg| {
-            let call_arg = match arg.cpp_type() {
-                CppType::Object(_) => format!("wrapped_{}", arg.name()),
-                _ => arg.name().to_string(),
-            };
-            if let Some(has_name) = arg.has_name() {
-                vec![call_arg, has_name]
-            } else {
-                vec![call_arg]
-            }
-        })
-        .collect();
-
     let has_retval = retval.is_some();
 
     // If the method creates a child object (has NewId), we need to pass the child's
@@ -471,7 +456,7 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
         true,
         true,
     );
-    for arg in args {
+    for arg in args.clone() {
         cpp_method.add_arg(arg);
     }
     for arg in new_id_ext_args.clone() {
@@ -488,7 +473,21 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
     if !wayland_weak_transformers.is_empty() {
         // Build the body: wrap shared_ptrs in Weak, then delegate to the virtual overload
         let return_prefix = if has_retval { "return " } else { "" };
-        let mut all_delegation_args = delegation_args;
+        let mut all_delegation_args: Vec<String> = args
+            .clone()
+            .flat_map(|arg| {
+                let call_arg = match arg.cpp_type() {
+                    CppType::Object(_) => format!("wrapped_{}", arg.name()),
+                    _ => arg.name().to_string(),
+                };
+                if let Some(has_name) = arg.has_name() {
+                    vec![call_arg, has_name]
+                } else {
+                    vec![call_arg]
+                }
+            })
+            .collect();
+
         // Forward child_instance and child_object_id to the virtual method
         for arg in &new_id_ext_args {
             all_delegation_args.push(format!("std::move({})", arg.name()));

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -78,7 +78,8 @@ fn create_global_factory(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
             .filter(|interface| interface.name != "wl_display" && interface.name != "wl_registry")
             .for_each(|global_interface| {
                 let class_name = format_wayland_interface_to_cpp_class(&global_interface.name);
-                let ext_name = format_wayland_interface_to_rust_extension_struct(&global_interface.name);
+                let ext_name =
+                    format_wayland_interface_to_rust_extension_struct(&global_interface.name);
                 namespace.add_forward_declaration_class(&class_name);
                 namespace.add_forward_declaration_struct(&snake_to_pascal(&ext_name));
 
@@ -250,12 +251,6 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
         class.add_enum(enum_);
     }
 
-    // The middleware Box and object ID are passed as constructor arguments so that
-    // the C++ object is fully initialized from the start (no two-step associate).
-    // NOTE: These are declared as private members below but initialized via the constructor.
-    // The add_protected_constructor_arg calls are ordered to match member declaration order
-    // (public members before private members) to avoid -Wreorder warnings.
-
     // Declare the corresponding private members.
     class.add_private_member(CppArg::new(
         CppType::Box(snake_to_pascal(
@@ -300,8 +295,7 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     let mut post_error_method = CppMethod::new("post_error", None, false, false, false, true);
     post_error_method.add_arg(CppArg::new(CppType::CppU32, "code", false));
     post_error_method.add_arg(CppArg::new(CppType::String, "message", false));
-    post_error_method
-        .set_body("instance_->post_error(code, message);");
+    post_error_method.set_body("instance_->post_error(code, message);");
     class.add_method(post_error_method);
 
     // Add a protected constructor and member so that subclasses know which client

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -100,6 +100,7 @@ fn generate_global_dispatch_impl(
         "{}",
         format_wayland_interface_to_rust_extension_struct(&interface.name)
     );
+    let wrapper_struct_name = format_ident!("{}Wrapper", snake_to_pascal(&interface.name));
     let create_global_method = format_ident!("create_{}", &interface.name);
     let interface_name_str = &interface.name;
     quote! {
@@ -118,31 +119,24 @@ fn generate_global_dispatch_impl(
                 data_init: &mut wayland_server::DataInit<'_, Self>,
             ) {
                 use crate::ffi;
-                let wayland_client = Box::new(WaylandClient::new(client.clone(), handle.clone()));
-                let mut guard = global_data.lock().unwrap();
 
-                // Methods on C++ classes must operate on Pin<&mut X> because those are the
-                // only ones that can cross the FFI boundary from Rust -> C++.
-                let global = (&mut *guard).pin_mut().#create_global_method(wayland_client);
-                let arc = Arc::new(Mutex::new(global));
-
-                // The initialization strategy here requires a "double initialization". First,
-                // we associate the C++ implementation with the Rust data. Afterwards, we wrap
-                // the Rust resource in an "extension" object that ferries the data from C++ -> Rust.
-                // Finally, we associate this "extension" object with our C++ object.
-                let instance = data_init.init(resource, arc.clone());
+                // Step 1: Create a wrapper with no inner value and register it via data_init.
+                let wrapper = Arc::new(Mutex::new(#wrapper_struct_name { inner: None }));
+                let instance = data_init.init(resource, wrapper.clone());
                 register_resource(&instance);
                 let protocol_id = Resource::id(&instance).protocol_id();
+
+                // Step 2: Create the middleware object wrapping the wayland resource.
                 let boxed = Box::new(crate::middleware::#ext_interface_struct_name{ wrapped: instance });
-                let mut guard = arc.lock().unwrap();
-                // SAFETY: `guard` is a `MutexGuard`, so we have exclusive access to the
-                // underlying C++ object for the duration of this call and cannot concurrently
-                // create any aliasing references to it. The pointee is owned by `UniquePtr`,
-                // so taking a pinned mutable reference here does not move it, and the pinned
-                // reference is used only for this immediate FFI call and does not escape.
-                unsafe {
-                    guard.pin_mut_unchecked().associate(boxed, protocol_id);
-                }
+
+                // Step 3: Call the C++ factory with client, middleware, and object_id
+                // so the C++ object is fully initialized from the start.
+                let wayland_client = Box::new(WaylandClient::new(client.clone(), handle.clone()));
+                let mut guard = global_data.lock().unwrap();
+                let global = (&mut *guard).pin_mut().#create_global_method(wayland_client, boxed, protocol_id);
+
+                // Step 4: Store the fully-initialized C++ object in the wrapper.
+                wrapper.lock().unwrap().inner = Some(global);
             }
 
             fn can_view(client: Client, global_data: &Arc<Mutex<cxx::UniquePtr<ffi::GlobalFactory>>>) -> bool {
@@ -173,7 +167,8 @@ fn transform_argument_for_cpp(arg: &WaylandArg) -> Option<TokenStream> {
     match arg.type_ {
         // The Wayland Rust crate will provide us with raw Wayland Rust objects.
         // C++ expects the shared_ptr data that backs these rust objects to be sent
-        // as parameters for objects.
+        // as parameters for objects. We lock the wrapper and clone the SharedPtr
+        // to avoid holding a mutex guard across the FFI boundary.
         WaylandArgType::Object => {
             let arg_type = format_ident!(
                 "{}",
@@ -181,18 +176,30 @@ fn transform_argument_for_cpp(arg: &WaylandArg) -> Option<TokenStream> {
                     arg.interface.as_ref().expect("Object is missing interface"),
                 )
             );
+            let wrapper_type = format_ident!(
+                "{}Wrapper",
+                snake_to_pascal(arg.interface.as_ref().expect("Object is missing interface"))
+            );
             if arg.allow_null.unwrap_or(false) {
                 let has_arg_name = format_has_arg_ident(&arg.name);
                 Some(quote! {
                     let #has_arg_name = #arg_name.is_some();
-                    let #arg_name: &cxx::SharedPtr<ffi::#arg_type> = match #arg_name.as_ref() {
-                        Some(o) => o.data().unwrap(),
-                        None => &cxx::SharedPtr::<ffi::#arg_type>::null()
+                    let #arg_name: cxx::SharedPtr<ffi::#arg_type> = match #arg_name.as_ref() {
+                        Some(o) => {
+                            let guard = o.data::<Arc<Mutex<#wrapper_type>>>().unwrap().lock().unwrap();
+                            guard.inner.clone().unwrap_or_else(|| cxx::SharedPtr::null())
+                        }
+                        None => cxx::SharedPtr::<ffi::#arg_type>::null()
                     };
+                    let #arg_name = &#arg_name;
                 })
             } else {
                 Some(quote! {
-                    let #arg_name: &cxx::SharedPtr<ffi::#arg_type> = #arg_name.data().unwrap();
+                    let #arg_name: cxx::SharedPtr<ffi::#arg_type> = {
+                        let guard = #arg_name.data::<Arc<Mutex<#wrapper_type>>>().unwrap().lock().unwrap();
+                        guard.inner.clone().unwrap_or_else(|| cxx::SharedPtr::null())
+                    };
+                    let #arg_name = &#arg_name;
                 })
             }
         }
@@ -250,6 +257,15 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
                     .expect("NewId is missing interface")
             )
         );
+        let child_wrapper_struct_name = format_ident!(
+            "{}Wrapper",
+            snake_to_pascal(
+                new_id_arg
+                    .interface
+                    .as_ref()
+                    .expect("NewId is missing interface")
+            )
+        );
         let call_arg_names: Vec<TokenStream> = request
             .args
             .iter()
@@ -258,30 +274,25 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
             .collect();
 
         quote! {
+            // Step 1: Create a wrapper with no inner value and register it via data_init.
+            let child_wrapper = Arc::new(Mutex::new(#child_wrapper_struct_name { inner: None }));
+            let instance = data_init.init(#new_id_name, child_wrapper.clone());
+            register_resource(&instance);
+            let protocol_id = Resource::id(&instance).protocol_id();
+
+            // Step 2: Create the middleware object wrapping the child resource.
+            let boxed = Box::new(crate::middleware::#ext_interface_struct_name{ wrapped: instance });
+
+            // Step 3: Call the parent's request method with the child middleware so the
+            // child C++ object is fully initialized from the start.
             let mut guard = data.lock().unwrap();
-            // SAFETY: The mutex guard provides the only mutable access to this child while
-            // the call is in progress, so this cannot introduce aliased mutable access across
-            // FFI. The unchecked pin is used only for the duration of the `associate()` call,
-            // and the guarded value is not moved while that temporary `Pin<&mut _>` exists.
-            match unsafe { (&mut *guard).pin_mut_unchecked().#snake_request_name(#( #call_arg_names ),*) } {
+            let inner = guard.inner.as_mut().expect("Request dispatched on uninitialized resource");
+            // SAFETY: The mutex guard provides the only mutable access while the call is
+            // in progress. The pinned reference is used only for this FFI call.
+            match unsafe { inner.pin_mut_unchecked().#snake_request_name(#( #call_arg_names, )* boxed, protocol_id) } {
                 Ok(child) => {
-                    let arc = Arc::new(Mutex::new(child));
-
-                    // The initialization strategy here mirrors the global bind flow: First,
-                    // we associate the C++ implementation with the Rust data. Afterwards, we wrap
-                    // the Rust resource in an "extension" object that ferries the data from C++ -> Rust.
-                    // Finally, we associate this "extension" object with our C++ object.
-                    let instance = data_init.init(#new_id_name, arc.clone());
-                    register_resource(&instance);
-                    let protocol_id = Resource::id(&instance).protocol_id();
-                    let boxed = Box::new(crate::middleware::#ext_interface_struct_name{ wrapped: instance });
-                    let mut guard = arc.lock().unwrap();
-
-                    // SAFETY: The mutex guard provides the only mutable access to this child while
-                    // the call is in progress, so this cannot introduce aliased mutable access across
-                    // FFI. The unchecked pin is used only for the duration of the `associate()` call,
-                    // and the guarded value is not moved while that temporary `Pin<&mut _>` exists.
-                    unsafe { guard.pin_mut_unchecked().associate(boxed, protocol_id); };
+                    // Step 4: Store the fully-initialized child C++ object in the wrapper.
+                    child_wrapper.lock().unwrap().inner = Some(child);
                 }
                 Err(err) => {
                     let (object_id, code, message) = parse_post_error(err.what());
@@ -295,11 +306,10 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
 
         quote! {
             let mut guard = data.lock().unwrap();
-            // SAFETY: The mutex guard provides the only mutable access to this child while
-            // the call is in progress, so this cannot introduce aliased mutable access across
-            // FFI. The unchecked pin is used only for the duration of the `associate()` call,
-            // and the guarded value is not moved while that temporary `Pin<&mut _>` exists.
-            if let Err(err) = unsafe { (&mut *guard).pin_mut_unchecked().#snake_request_name(#( #call_arg_names ),*) } {
+            let inner = guard.inner.as_mut().expect("Request dispatched on uninitialized resource");
+            // SAFETY: The mutex guard provides the only mutable access while the call is
+            // in progress. The pinned reference is used only for this FFI call.
+            if let Err(err) = unsafe { inner.pin_mut_unchecked().#snake_request_name(#( #call_arg_names ),*) } {
                 let (object_id, code, message) = parse_post_error(err.what());
                 post_protocol_error(resource, object_id, code, message);
             }
@@ -365,6 +375,7 @@ fn generate_dispatch_impl(
     let protocol_struct_name = format_ident!("{}", snake_to_pascal(&interface.name));
     let ext_struct_name =
         format_ident!("{}", format_wayland_interface_to_cpp_class(&interface.name));
+    let wrapper_struct_name = format_ident!("{}Wrapper", snake_to_pascal(&interface.name));
 
     let mut request_handler_arms =
         generate_request_handler_arms(interface, namespace_name, &interface_name);
@@ -426,7 +437,11 @@ fn generate_dispatch_impl(
         unsafe impl Send for ffi::#ext_struct_name {}
         unsafe impl Sync for ffi::#ext_struct_name {}
 
-        impl Dispatch<#namespace_name::#interface_name::#protocol_struct_name, Arc<Mutex<cxx::SharedPtr<ffi::#ext_struct_name>>>>
+        struct #wrapper_struct_name {
+            inner: Option<cxx::SharedPtr<ffi::#ext_struct_name>>,
+        }
+
+        impl Dispatch<#namespace_name::#interface_name::#protocol_struct_name, Arc<Mutex<#wrapper_struct_name>>>
             for ServerState
         {
             fn request(
@@ -434,7 +449,7 @@ fn generate_dispatch_impl(
                 _client: &Client,
                 #resource_name: &#namespace_name::#interface_name::#protocol_struct_name,
                 request: <#namespace_name::#interface_name::#protocol_struct_name as wayland_server::Resource>::Request,
-                #data_name: &Arc<Mutex<cxx::SharedPtr<ffi::#ext_struct_name>>>,
+                #data_name: &Arc<Mutex<#wrapper_struct_name>>,
                 _dhandle: &DisplayHandle,
                 #data_init_name: &mut DataInit<'_, Self>,
             ) {
@@ -447,7 +462,7 @@ fn generate_dispatch_impl(
                 _state: &mut Self,
                 _client: ClientId,
                 resource: &#namespace_name::#interface_name::#protocol_struct_name,
-                _data: &Arc<Mutex<cxx::SharedPtr<ffi::#ext_struct_name>>>,
+                _data: &Arc<Mutex<#wrapper_struct_name>>,
             ) {
                 unregister_resource(resource);
             }

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -286,7 +286,9 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
             // Step 3: Call the parent's request method with the child middleware so the
             // child C++ object is fully initialized from the start.
             let mut guard = data.lock().unwrap();
-            let inner = guard.inner.as_mut().expect("Request dispatched on uninitialized resource");
+            let Some(inner) = guard.inner.as_mut() else {
+                return;
+            };
             // SAFETY: The mutex guard provides the only mutable access while the call is
             // in progress. The pinned reference is used only for this FFI call.
             match unsafe { inner.pin_mut_unchecked().#snake_request_name(#( #call_arg_names, )* boxed, protocol_id) } {
@@ -306,7 +308,9 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
 
         quote! {
             let mut guard = data.lock().unwrap();
-            let inner = guard.inner.as_mut().expect("Request dispatched on uninitialized resource");
+            let Some(inner) = guard.inner.as_mut() else {
+                return;
+            };
             // SAFETY: The mutex guard provides the only mutable access while the call is
             // in progress. The pinned reference is used only for this FFI call.
             if let Err(err) = unsafe { inner.pin_mut_unchecked().#snake_request_name(#( #call_arg_names ),*) } {


### PR DESCRIPTION
## What's new?
**Problem**: The `C++` implementations in `wayland-rs` had a two step initialization process previously: first we constructed them, and then we called `associate` to associate the Rust middleware with the C++ implementation. The reason for this is that C++ needs access to the protocol object returned by `data_init.init` so that it can perform actions on it, but the `data_init.init` needs to associate with the data, which was the C++ class.

This led to a whole host of problems where work done inside of the C++ constructor was invalid because we didn't yet have a middleware `instance` yet.

**Solution**: implement a wrapper around each type in Rust. That wrapper will be the data associated with each `Dispatch` protocol. Afterward, we can initialize and use the C++ implementation directly without having to consider if it is fully initialized.

**Downsides**: we are pushing the 2-step initialization from C++ to Rust. We cannot make it go away fully, but this lessens the cognitive overhead when implementing a protocol in C++ considerably.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
