### PR TITLE
frontend_wayland: derive SHM formats from the RenderingPlatform

### DIFF
--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -308,7 +308,7 @@ void mf::ShmPool::create_buffer(
     auto const format_supported = std::any_of(
         supported_formats->begin(),
         supported_formats->end(),
-        [&](auto supported) { return static_cast<uint32_t>(supported) == static_cast<uint32_t>(drm_format); });
+        [&drm_format](auto supported) { return supported == drm_format; });
     if (!format_supported)
     {
         throw wayland::ProtocolError{

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -314,7 +314,7 @@ void mf::ShmPool::create_buffer(
         throw wayland::ProtocolError{
             resource,
             wayland::Shm::Error::invalid_format,
-            "Invalid SHM format requested"};
+            "Invalid SHM format %u", format};
     }
     auto const pixel_size = 4; // All supported formats are 4 bytes per pixel
 

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -29,6 +29,8 @@
 #include <boost/throw_exception.hpp>
 #include <wayland-server-protocol.h>
 
+#include <algorithm>
+
 namespace mf = mir::frontend;
 namespace mg = mir::graphics;
 namespace mrs = mir::renderer::software;
@@ -217,10 +219,12 @@ auto mf::ShmBuffer::from(wl_resource* resource) -> ShmBuffer*
 mf::ShmPool::ShmPool(
     struct wl_resource* resource,
     std::shared_ptr<Executor> wayland_executor,
+    std::shared_ptr<std::vector<mg::DRMFormat> const> supported_formats,
     Fd backing_store,
     int32_t claimed_size) :
     wayland::ShmPool(resource, Version<1>{}),
     wayland_executor{std::move(wayland_executor)},
+    supported_formats{std::move(supported_formats)},
     backing_store{shm::rw_pool_from_fd(std::move(backing_store), claimed_size)}
 {
 }
@@ -240,6 +244,22 @@ auto wl_shm_format_to_drm_format(uint32_t format) -> mg::DRMFormat
         return mg::DRMFormat{DRM_FORMAT_XRGB8888};
     default:
         return mg::DRMFormat{format};
+    }
+}
+
+auto drm_format_to_wl_shm_format(mg::DRMFormat format) -> uint32_t
+{
+    /* Inverse of wl_shm_format_to_drm_format(): the two default formats use the
+     * special-cased wl_shm codes, everything else matches its DRM fourcc.
+     */
+    switch (static_cast<uint32_t>(format))
+    {
+    case DRM_FORMAT_ARGB8888:
+        return mf::Shm::Format::argb8888;
+    case DRM_FORMAT_XRGB8888:
+        return mf::Shm::Format::xrgb8888;
+    default:
+        return static_cast<uint32_t>(format);
     }
 }
 }
@@ -278,8 +298,12 @@ void mf::ShmPool::create_buffer(
             stride, width};
     }
 
-    // TODO: Pull supported formats out of RenderingPlatform to support more than the required formats
-    if (format != wayland::Shm::Format::argb8888 && format != wayland::Shm::Format::xrgb8888)
+    auto const drm_format = wl_shm_format_to_drm_format(format);
+    auto const format_supported = std::any_of(
+        supported_formats->begin(),
+        supported_formats->end(),
+        [&](auto supported) { return static_cast<uint32_t>(supported) == static_cast<uint32_t>(drm_format); });
+    if (!format_supported)
     {
         throw wayland::ProtocolError{
             resource,
@@ -293,7 +317,7 @@ void mf::ShmPool::create_buffer(
         std::move(backing_range),
         geometry::Size{width, height},
         geometry::Stride{stride},
-        wl_shm_format_to_drm_format(format)
+        drm_format
     };
 }
 
@@ -302,25 +326,32 @@ void mf::ShmPool::resize(int32_t new_size)
     backing_store->resize(new_size);
 }
 
-mf::WlShm::WlShm(wl_display* display, std::shared_ptr<Executor> wayland_executor)
+mf::WlShm::WlShm(
+    wl_display* display,
+    std::shared_ptr<Executor> wayland_executor,
+    std::vector<mg::DRMFormat> supported_formats)
     : wayland::Shm::Global(display, Version<1>{}),
-      wayland_executor{std::move(wayland_executor)}
+      wayland_executor{std::move(wayland_executor)},
+      supported_formats{std::make_shared<std::vector<mg::DRMFormat> const>(std::move(supported_formats))}
 {
 }
 
 void mf::WlShm::bind(wl_resource* new_wl_shm)
 {
-    new Shm{new_wl_shm, wayland_executor};
+    new Shm{new_wl_shm, wayland_executor, supported_formats};
 }
 
-mf::Shm::Shm(wl_resource* resource, std::shared_ptr<Executor> wayland_executor)
+mf::Shm::Shm(
+    wl_resource* resource,
+    std::shared_ptr<Executor> wayland_executor,
+    std::shared_ptr<std::vector<mg::DRMFormat> const> supported_formats)
     : wayland::Shm(resource, Version<1>{}),
-      wayland_executor{std::move(wayland_executor)}
+      wayland_executor{std::move(wayland_executor)},
+      supported_formats{std::move(supported_formats)}
 {
-    // TODO: send all the formats we support, beyond the mandatory ones.
-    for (auto format : { Format::argb8888, Format::xrgb8888 })
+    for (auto const& format : *this->supported_formats)
     {
-        send_format_event(format);
+        send_format_event(drm_format_to_wl_shm_format(format));
     }
 }
 
@@ -334,5 +365,5 @@ void mf::Shm::create_pool(wl_resource* id, Fd fd, int32_t size)
             "Invalid requested size"};
     }
 
-    new ShmPool{id, wayland_executor, fd, size};
+    new ShmPool{id, wayland_executor, supported_formats, fd, size};
 }

--- a/src/server/frontend_wayland/shm.h
+++ b/src/server/frontend_wayland/shm.h
@@ -19,6 +19,7 @@
 #include "wayland_wrapper.h"
 #include <mir/graphics/drm_formats.h>
 
+#include <vector>
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -76,6 +77,7 @@ private:
     ShmPool(
         struct wl_resource* resource,
         std::shared_ptr<Executor> wayland_executor,
+        std::shared_ptr<std::vector<graphics::DRMFormat> const> supported_formats,
         Fd backing_store,
         int32_t claimed_size);
 
@@ -89,6 +91,7 @@ private:
     void resize(int32_t new_size) override;
 
     std::shared_ptr<Executor> const wayland_executor;
+    std::shared_ptr<std::vector<graphics::DRMFormat> const> const supported_formats;
     std::shared_ptr<shm::ReadWritePool> const backing_store;
 };
 
@@ -97,21 +100,29 @@ class Shm : public wayland::Shm
 public:
 private:
     friend class WlShm;
-    Shm(struct wl_resource* resource, std::shared_ptr<Executor> wayland_executor);
+    Shm(
+        struct wl_resource* resource,
+        std::shared_ptr<Executor> wayland_executor,
+        std::shared_ptr<std::vector<graphics::DRMFormat> const> supported_formats);
 
     void create_pool(struct wl_resource* id, Fd fd, int32_t size) override;
 
     std::shared_ptr<Executor> const wayland_executor;
+    std::shared_ptr<std::vector<graphics::DRMFormat> const> const supported_formats;
 };
 
 class WlShm : public wayland::Shm::Global
 {
 public:
-    WlShm(wl_display* display, std::shared_ptr<Executor> wayland_executor);
+    WlShm(
+        wl_display* display,
+        std::shared_ptr<Executor> wayland_executor,
+        std::vector<graphics::DRMFormat> supported_formats);
 
 private:
     void bind(wl_resource* new_wl_shm) override;
 
     std::shared_ptr<Executor> const wayland_executor;
+    std::shared_ptr<std::vector<graphics::DRMFormat> const> const supported_formats;
 };
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -377,7 +377,12 @@ mf::WaylandConnector::WaylandConnector(
         input_trigger_registry,
         keyboard_state_tracker});
 
-    shm_global = std::make_unique<WlShm>(display.get(), executor);
+    std::vector<mg::DRMFormat> shm_formats;
+    for (auto const pixel_format : this->allocator->supported_pixel_formats())
+    {
+        shm_formats.push_back(mg::DRMFormat::from_mir_format(pixel_format));
+    }
+    shm_global = std::make_unique<WlShm>(display.get(), executor, std::move(shm_formats));
 
     viewporter = std::make_unique<WpViewporter>(display.get());
 


### PR DESCRIPTION
Previously shm.cpp hard-coded the mandatory argb8888/xrgb8888 formats both when advertising supported wl_shm formats and when validating create_buffer requests.

Instead, source the supported formats from the RenderingPlatform via the GraphicBufferAllocator's supported_pixel_formats(). The list is plumbed through WlShm -> Shm -> ShmPool: Shm now advertises a format event for each supported format, and ShmPool::create_buffer validates the requested format against that list. A drm_format_to_wl_shm_format() helper maps DRM fourccs back to wl_shm format codes, special-casing the two default formats.
