### PR TITLE
graphics: add bytes-per-pixel to DRMFormat and use it for SHM stride validation

### DIFF
--- a/include/platform/mir/graphics/drm_formats.h
+++ b/include/platform/mir/graphics/drm_formats.h
@@ -50,7 +50,7 @@ public:
          * \note This includes any padding (for example, XRGB8888 reports 4
          *       even though only 24 of its bits carry colour information).
          */
-        auto bytes_per_pixel() const -> uint32_t;
+        auto bytes_per_pixel() const -> size_t;
 
         auto components() const -> std::optional<RGBComponentInfo> const&;
     private:

--- a/include/platform/mir/graphics/drm_formats.h
+++ b/include/platform/mir/graphics/drm_formats.h
@@ -44,6 +44,14 @@ public:
 
         bool has_alpha() const;
 
+        /**
+         * The number of bytes occupied by a single pixel of this format.
+         *
+         * \note This includes any padding (for example, XRGB8888 reports 4
+         *       even though only 24 of its bits carry colour information).
+         */
+        auto bytes_per_pixel() const -> uint32_t;
+
         auto components() const -> std::optional<RGBComponentInfo> const&;
     private:
         friend class DRMFormat;

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -75,7 +75,7 @@ struct mg::DRMFormat::FormatInfo
     std::optional<uint32_t> opaque_equivalent;
     std::optional<uint32_t> alpha_equivalent;
     std::optional<Info::RGBComponentInfo> components;
-    uint32_t bytes_per_pixel;
+    size_t bytes_per_pixel;
 };
 
 namespace
@@ -506,7 +506,7 @@ bool mg::DRMFormat::Info::has_alpha() const
     return info->has_alpha;
 }
 
-auto mg::DRMFormat::Info::bytes_per_pixel() const -> uint32_t
+auto mg::DRMFormat::Info::bytes_per_pixel() const -> size_t
 {
     return info->bytes_per_pixel;
 }

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -75,6 +75,7 @@ struct mg::DRMFormat::FormatInfo
     std::optional<uint32_t> opaque_equivalent;
     std::optional<uint32_t> alpha_equivalent;
     std::optional<Info::RGBComponentInfo> components;
+    uint32_t bytes_per_pixel;
 };
 
 namespace
@@ -88,6 +89,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_XBGR4444,
@@ -97,6 +99,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGBX4444,
@@ -106,6 +109,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGRX4444,
@@ -115,6 +119,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_ARGB4444,
@@ -124,6 +129,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, 4
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_ABGR4444,
@@ -133,6 +139,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, 4
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGBA4444,
@@ -142,6 +149,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, 4
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGRA4444,
@@ -151,6 +159,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             4, 4, 4, 4
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_XRGB1555,
@@ -160,6 +169,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_XBGR1555,
@@ -169,6 +179,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGBX5551,
@@ -178,6 +189,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGRX5551,
@@ -187,6 +199,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_ARGB1555,
@@ -196,6 +209,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, 1
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_ABGR1555,
@@ -205,6 +219,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, 1
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGBA5551,
@@ -214,6 +229,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, 1
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGRA5551,
@@ -223,6 +239,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 5, 5, 1
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGB565,
@@ -232,6 +249,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 6, 5, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGR565,
@@ -241,6 +259,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             5, 6, 5, {}
         },
+        2,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGB888,
@@ -250,6 +269,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
+        3,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGR888,
@@ -259,6 +279,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
+        3,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_XRGB8888,
@@ -268,6 +289,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_XBGR8888,
@@ -277,6 +299,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGBX8888,
@@ -286,6 +309,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGRX8888,
@@ -295,6 +319,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, {}
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_ARGB8888,
@@ -304,6 +329,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, 8
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_ABGR8888,
@@ -313,6 +339,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, 8
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGBA8888,
@@ -322,6 +349,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, 8
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGRA8888,
@@ -331,6 +359,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             8, 8, 8, 8
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_XRGB2101010,
@@ -340,6 +369,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, {}
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_XBGR2101010,
@@ -349,6 +379,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, {}
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGBX1010102,
@@ -358,6 +389,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, {}
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGRX1010102,
@@ -367,6 +399,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, {}
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_ARGB2101010,
@@ -376,6 +409,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, 2
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_ABGR2101010,
@@ -385,6 +419,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, 2
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_RGBA1010102,
@@ -394,6 +429,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, 2
         },
+        4,
     },
     mg::DRMFormat::FormatInfo{
         DRM_FORMAT_BGRA1010102,
@@ -403,6 +439,7 @@ constexpr std::array const formats = {
         mg::DRMFormat::Info::RGBComponentInfo{
             10, 10, 10, 2
         },
+        4,
     },
 };
 
@@ -467,6 +504,11 @@ auto mg::DRMFormat::Info::alpha_equivalent() const -> std::optional<DRMFormat>
 bool mg::DRMFormat::Info::has_alpha() const
 {
     return info->has_alpha;
+}
+
+auto mg::DRMFormat::Info::bytes_per_pixel() const -> uint32_t
+{
+    return info->bytes_per_pixel;
 }
 
 auto mg::DRMFormat::Info::components() const -> std::optional<Info::RGBComponentInfo> const&

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -12,6 +12,7 @@ MIR_PLATFORM_2.24 {
     mir::graphics::DMABufEGLProvider::as_texture*;
     mir::graphics::DRMFormat::DRMFormat*;
     mir::graphics::DRMFormat::Info::alpha_equivalent*;
+    mir::graphics::DRMFormat::Info::bytes_per_pixel*;
     mir::graphics::DRMFormat::Info::components*;
     mir::graphics::DRMFormat::Info::has_alpha*;
     mir::graphics::DRMFormat::Info::opaque_equivalent*;

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -308,7 +308,7 @@ void mf::ShmPool::create_buffer(
     auto const format_supported = std::any_of(
         supported_formats->begin(),
         supported_formats->end(),
-        [&](auto supported) { return static_cast<uint32_t>(supported) == static_cast<uint32_t>(drm_format); });
+        [&drm_format](auto supported) { return supported == drm_format; });
     if (!format_supported)
     {
         throw wayland::ProtocolError{

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -316,6 +316,7 @@ void mf::ShmPool::create_buffer(
             wayland::Shm::Error::invalid_format,
             "Missing pixel-size information for SHM format requested"};
     }
+    // Casting to stop the below calculations being unsigned and then comparing against signed width/height.
     auto const bytes_per_pixel = static_cast<geometry::Size::ValueType>(format_info->bytes_per_pixel());
 
     auto const max_size = std::numeric_limits<geometry::Size::ValueType>::max();

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -288,16 +288,6 @@ void mf::ShmPool::create_buffer(
             "Attempt to create_buffer outside the range of the backing store"};
     }
 
-    // TODO: Extend DRMFormat to include bytes-per-pixel info and drop this hardcoded "4"
-    if (stride < (width * 4))
-    {
-        throw wayland::ProtocolError{
-            resource,
-            wayland::Shm::Error::invalid_stride,
-            "Invalid stride %d (too small for width %d. Did you specify stride in pixels?)",
-            stride, width};
-    }
-
     auto const drm_format = wl_shm_format_to_drm_format(format);
     auto const format_supported = std::any_of(
         supported_formats->begin(),
@@ -309,6 +299,25 @@ void mf::ShmPool::create_buffer(
             resource,
             wayland::Shm::Error::invalid_format,
             "Invalid SHM format requested"};
+    }
+
+    auto const format_info = drm_format.info();
+    if (!format_info)
+    {
+        throw wayland::ProtocolError{
+            resource,
+            wayland::Shm::Error::invalid_format,
+            "Missing pixel-size information for SHM format requested"};
+    }
+    auto const bytes_per_pixel = format_info->bytes_per_pixel();
+
+    if (static_cast<int64_t>(stride) < static_cast<int64_t>(width) * bytes_per_pixel)
+    {
+        throw wayland::ProtocolError{
+            resource,
+            wayland::Shm::Error::invalid_stride,
+            "Invalid stride %d (too small for width %d. Did you specify stride in pixels?)",
+            stride, width};
     }
 
     new ShmBuffer{

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -314,7 +314,7 @@ void mf::ShmPool::create_buffer(
         throw wayland::ProtocolError{
             resource,
             wayland::Shm::Error::invalid_format,
-            "Invalid SHM format requested"};
+            "Invalid SHM format %u", format};
     }
     auto const pixel_size = 4; // All supported formats are 4 bytes per pixel
 

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -29,6 +29,8 @@
 #include <boost/throw_exception.hpp>
 #include <wayland-server-protocol.h>
 
+#include <algorithm>
+
 namespace mf = mir::frontend;
 namespace mg = mir::graphics;
 namespace mrs = mir::renderer::software;
@@ -217,10 +219,12 @@ auto mf::ShmBuffer::from(wl_resource* resource) -> ShmBuffer*
 mf::ShmPool::ShmPool(
     struct wl_resource* resource,
     std::shared_ptr<Executor> wayland_executor,
+    std::shared_ptr<std::vector<mg::DRMFormat> const> supported_formats,
     Fd backing_store,
     int32_t claimed_size) :
     wayland::ShmPool(resource, Version<1>{}),
     wayland_executor{std::move(wayland_executor)},
+    supported_formats{std::move(supported_formats)},
     backing_store{shm::rw_pool_from_fd(std::move(backing_store), claimed_size)}
 {
 }
@@ -240,6 +244,22 @@ auto wl_shm_format_to_drm_format(uint32_t format) -> mg::DRMFormat
         return mg::DRMFormat{DRM_FORMAT_XRGB8888};
     default:
         return mg::DRMFormat{format};
+    }
+}
+
+auto drm_format_to_wl_shm_format(mg::DRMFormat format) -> uint32_t
+{
+    /* Inverse of wl_shm_format_to_drm_format(): the two default formats use the
+     * special-cased wl_shm codes, everything else matches its DRM fourcc.
+     */
+    switch (static_cast<uint32_t>(format))
+    {
+    case DRM_FORMAT_ARGB8888:
+        return mf::Shm::Format::argb8888;
+    case DRM_FORMAT_XRGB8888:
+        return mf::Shm::Format::xrgb8888;
+    default:
+        return static_cast<uint32_t>(format);
     }
 }
 }
@@ -278,8 +298,12 @@ void mf::ShmPool::create_buffer(
             stride, width};
     }
 
-    // TODO: Pull supported formats out of RenderingPlatform to support more than the required formats
-    if (format != wayland::Shm::Format::argb8888 && format != wayland::Shm::Format::xrgb8888)
+    auto const drm_format = wl_shm_format_to_drm_format(format);
+    auto const format_supported = std::any_of(
+        supported_formats->begin(),
+        supported_formats->end(),
+        [&](auto supported) { return static_cast<uint32_t>(supported) == static_cast<uint32_t>(drm_format); });
+    if (!format_supported)
     {
         throw wayland::ProtocolError{
             resource,
@@ -293,7 +317,7 @@ void mf::ShmPool::create_buffer(
         std::move(backing_range),
         geometry::Size{width, height},
         geometry::Stride{stride},
-        wl_shm_format_to_drm_format(format)
+        drm_format
     };
 }
 
@@ -302,25 +326,32 @@ void mf::ShmPool::resize(int32_t new_size)
     backing_store->resize(new_size);
 }
 
-mf::WlShm::WlShm(wl_display* display, std::shared_ptr<Executor> wayland_executor)
+mf::WlShm::WlShm(
+    wl_display* display,
+    std::shared_ptr<Executor> wayland_executor,
+    std::vector<mg::DRMFormat> supported_formats)
     : wayland::Shm::Global(display, Version<1>{}),
-      wayland_executor{std::move(wayland_executor)}
+      wayland_executor{std::move(wayland_executor)},
+      supported_formats{std::make_shared<std::vector<mg::DRMFormat> const>(std::move(supported_formats))}
 {
 }
 
 void mf::WlShm::bind(wl_resource* new_wl_shm)
 {
-    new Shm{new_wl_shm, wayland_executor};
+    new Shm{new_wl_shm, wayland_executor, supported_formats};
 }
 
-mf::Shm::Shm(wl_resource* resource, std::shared_ptr<Executor> wayland_executor)
+mf::Shm::Shm(
+    wl_resource* resource,
+    std::shared_ptr<Executor> wayland_executor,
+    std::shared_ptr<std::vector<mg::DRMFormat> const> supported_formats)
     : wayland::Shm(resource, Version<1>{}),
-      wayland_executor{std::move(wayland_executor)}
+      wayland_executor{std::move(wayland_executor)},
+      supported_formats{std::move(supported_formats)}
 {
-    // TODO: send all the formats we support, beyond the mandatory ones.
-    for (auto format : { Format::argb8888, Format::xrgb8888 })
+    for (auto const& format : *this->supported_formats)
     {
-        send_format_event(format);
+        send_format_event(drm_format_to_wl_shm_format(format));
     }
 }
 
@@ -334,5 +365,5 @@ void mf::Shm::create_pool(wl_resource* id, Fd fd, int32_t size)
             "Invalid requested size"};
     }
 
-    new ShmPool{id, wayland_executor, fd, size};
+    new ShmPool{id, wayland_executor, supported_formats, fd, size};
 }

--- a/src/server/frontend_wayland/shm.h
+++ b/src/server/frontend_wayland/shm.h
@@ -19,6 +19,7 @@
 #include "wayland_wrapper.h"
 #include <mir/graphics/drm_formats.h>
 
+#include <vector>
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -76,6 +77,7 @@ private:
     ShmPool(
         struct wl_resource* resource,
         std::shared_ptr<Executor> wayland_executor,
+        std::shared_ptr<std::vector<graphics::DRMFormat> const> supported_formats,
         Fd backing_store,
         int32_t claimed_size);
 
@@ -89,6 +91,7 @@ private:
     void resize(int32_t new_size) override;
 
     std::shared_ptr<Executor> const wayland_executor;
+    std::shared_ptr<std::vector<graphics::DRMFormat> const> const supported_formats;
     std::shared_ptr<shm::ReadWritePool> const backing_store;
 };
 
@@ -97,21 +100,29 @@ class Shm : public wayland::Shm
 public:
 private:
     friend class WlShm;
-    Shm(struct wl_resource* resource, std::shared_ptr<Executor> wayland_executor);
+    Shm(
+        struct wl_resource* resource,
+        std::shared_ptr<Executor> wayland_executor,
+        std::shared_ptr<std::vector<graphics::DRMFormat> const> supported_formats);
 
     void create_pool(struct wl_resource* id, Fd fd, int32_t size) override;
 
     std::shared_ptr<Executor> const wayland_executor;
+    std::shared_ptr<std::vector<graphics::DRMFormat> const> const supported_formats;
 };
 
 class WlShm : public wayland::Shm::Global
 {
 public:
-    WlShm(wl_display* display, std::shared_ptr<Executor> wayland_executor);
+    WlShm(
+        wl_display* display,
+        std::shared_ptr<Executor> wayland_executor,
+        std::vector<graphics::DRMFormat> supported_formats);
 
 private:
     void bind(wl_resource* new_wl_shm) override;
 
     std::shared_ptr<Executor> const wayland_executor;
+    std::shared_ptr<std::vector<graphics::DRMFormat> const> const supported_formats;
 };
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -377,7 +377,12 @@ mf::WaylandConnector::WaylandConnector(
         input_trigger_registry,
         keyboard_state_tracker});
 
-    shm_global = std::make_unique<WlShm>(display.get(), executor);
+    std::vector<mg::DRMFormat> shm_formats;
+    for (auto const pixel_format : this->allocator->supported_pixel_formats())
+    {
+        shm_formats.push_back(mg::DRMFormat::from_mir_format(pixel_format));
+    }
+    shm_global = std::make_unique<WlShm>(display.get(), executor, std::move(shm_formats));
 
     viewporter = std::make_unique<WpViewporter>(display.get());
 

--- a/tests/unit-tests/graphics/CMakeLists.txt
+++ b/tests/unit-tests/graphics/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_id.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_properties.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_pixel_format_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_drm_formats.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_overlapping_output_grouping.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_software_cursor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_anonymous_shm_file.cpp

--- a/tests/unit-tests/graphics/test_drm_formats.cpp
+++ b/tests/unit-tests/graphics/test_drm_formats.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <mir/graphics/drm_formats.h>
+
+#include <drm_fourcc.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace testing;
+namespace mg = mir::graphics;
+
+TEST(DRMFormatBytesPerPixel, two_byte_formats_report_two)
+{
+    for (auto const fourcc : {DRM_FORMAT_RGB565, DRM_FORMAT_ARGB4444, DRM_FORMAT_XRGB1555, DRM_FORMAT_RGBA5551})
+    {
+        auto const info = mg::DRMFormat{fourcc}.info();
+        ASSERT_THAT(info, Ne(std::nullopt)) << "for format " << mg::DRMFormat{fourcc}.name();
+        EXPECT_THAT(info->bytes_per_pixel(), Eq(2u)) << "for format " << mg::DRMFormat{fourcc}.name();
+    }
+}
+
+TEST(DRMFormatBytesPerPixel, three_byte_formats_report_three)
+{
+    for (auto const fourcc : {DRM_FORMAT_RGB888, DRM_FORMAT_BGR888})
+    {
+        auto const info = mg::DRMFormat{fourcc}.info();
+        ASSERT_THAT(info, Ne(std::nullopt)) << "for format " << mg::DRMFormat{fourcc}.name();
+        EXPECT_THAT(info->bytes_per_pixel(), Eq(3u)) << "for format " << mg::DRMFormat{fourcc}.name();
+    }
+}
+
+TEST(DRMFormatBytesPerPixel, four_byte_formats_report_four)
+{
+    for (auto const fourcc : {DRM_FORMAT_ARGB8888, DRM_FORMAT_ABGR8888, DRM_FORMAT_ARGB2101010})
+    {
+        auto const info = mg::DRMFormat{fourcc}.info();
+        ASSERT_THAT(info, Ne(std::nullopt)) << "for format " << mg::DRMFormat{fourcc}.name();
+        EXPECT_THAT(info->bytes_per_pixel(), Eq(4u)) << "for format " << mg::DRMFormat{fourcc}.name();
+    }
+}
+
+TEST(DRMFormatBytesPerPixel, padding_is_counted_for_opaque_formats)
+{
+    // XRGB8888 only carries 24 bits of colour, but occupies 4 bytes of storage.
+    auto const info = mg::DRMFormat{DRM_FORMAT_XRGB8888}.info();
+    ASSERT_THAT(info, Ne(std::nullopt));
+    EXPECT_THAT(info->bytes_per_pixel(), Eq(4u));
+}


### PR DESCRIPTION
DRMFormat now exposes the storage size of a pixel via
DRMFormat::Info::bytes_per_pixel(), backed by an explicit field in the
internal format table. This is stored rather than derived because opaque
"X" formats (e.g. XRGB8888) are padded and so cannot be computed from their
component bit counts alone.

shm.cpp's create_buffer() previously hard-coded 4 bytes-per-pixel when
checking that a client's stride was large enough. It now validates the
requested format first, looks up its bytes-per-pixel, and performs the
stride check with overflow-safe 64-bit arithmetic. A supported format with
missing metadata is rejected rather than silently bypassing the check.

Adds unit tests for bytes_per_pixel(), including the padded-format case.