### PR TITLE
Modernize type-trait usage to C++17 helper templates

### DIFF
--- a/include/common/mir/assert_module_entry_point.h
+++ b/include/common/mir/assert_module_entry_point.h
@@ -24,7 +24,7 @@ namespace mir
 template<typename ReferenceTypename, typename EntryPoint>
 void assert_entry_point_signature(EntryPoint)
 {
-    static_assert(std::is_same<EntryPoint, ReferenceTypename>::value,
+    static_assert(std::is_same_v<EntryPoint, ReferenceTypename>,
                   "Signature of platform entry point does not match.");
 }
 }

--- a/include/common/mir/raii.h
+++ b/include/common/mir/raii.h
@@ -49,7 +49,7 @@ private:
  */
 template <typename Creator, typename Deleter>
 inline auto paired_calls(Creator&& creator, Deleter&& deleter)
--> std::unique_ptr<typename std::remove_reference<decltype(*creator())>::type, Deleter>
+-> std::unique_ptr<std::remove_reference_t<decltype(*creator())>, Deleter>
 {
     return {creator(), deleter};
 }

--- a/include/core/mir/flags.h
+++ b/include/core/mir/flags.h
@@ -35,7 +35,7 @@ namespace mir
 template<typename Enum>
 struct Flags
 {
-    using value_type = typename std::underlying_type<Enum>::type;
+    using value_type = std::underlying_type_t<Enum>;
 
     explicit constexpr Flags(value_type flag_value = 0) noexcept
         : flag_value{flag_value} {}

--- a/include/core/mir/geometry/dimensions.h
+++ b/include/core/mir/geometry/dimensions.h
@@ -68,13 +68,13 @@ struct Value
     using TagType = Tag;
 
     template <typename Q = T>
-    constexpr typename std::enable_if<std::is_integral<Q>::value, int>::type as_int() const
+    constexpr std::enable_if_t<std::is_integral_v<Q>, int> as_int() const
     {
         return this->value;
     }
 
     template <typename Q = T>
-    constexpr typename std::enable_if<std::is_integral<Q>::value, uint32_t>::type as_uint32_t() const
+    constexpr std::enable_if_t<std::is_integral_v<Q>, uint32_t> as_uint32_t() const
     {
         return this->value;
     }
@@ -134,7 +134,7 @@ struct Value
     {
     }
 
-    template<typename U, typename std::enable_if<std::is_scalar<U>::value, bool>::type = true>
+    template<typename U, std::enable_if_t<std::is_scalar_v<U>, bool> = true>
     explicit constexpr Value(U const& value) noexcept
         : value{static_cast<T>(value)}
     {

--- a/include/core/mir/geometry/displacement.h
+++ b/include/core/mir/geometry/displacement.h
@@ -54,14 +54,14 @@ struct Displacement
     constexpr Displacement(DeltaXType&& dx, DeltaYType&& dy) : dx{dx}, dy{dy} {}
 
     template <typename Q = T>
-    constexpr typename std::enable_if<std::is_integral<Q>::value, long long>::type length_squared() const
+    constexpr std::enable_if_t<std::is_integral_v<Q>, long long> length_squared() const
     {
         long long x = dx.as_value(), y = dy.as_value();
         return x * x + y * y;
     }
 
     template <typename Q = T>
-    constexpr typename std::enable_if<!std::is_integral<Q>::value, T>::type length_squared() const
+    constexpr std::enable_if_t<!std::is_integral_v<Q>, T> length_squared() const
     {
         T x = dx.as_value(), y = dy.as_value();
         return x * x + y * y;

--- a/include/core/mir/geometry/size.h
+++ b/include/core/mir/geometry/size.h
@@ -38,7 +38,7 @@ struct Displacement;
 template<typename T, typename U>
 concept is_exactly_representable = requires
 {
-    typename std::enable_if<std::numeric_limits<T>::digits >= std::numeric_limits<U>::digits, U>::type;
+    typename std::enable_if_t<std::numeric_limits<T>::digits >= std::numeric_limits<U>::digits, U>;
     requires std::floating_point<T>;
 };
 

--- a/src/include/server/mir/glib_main_loop.h
+++ b/src/include/server/mir/glib_main_loop.h
@@ -103,7 +103,7 @@ public:
     template<
         typename Callable,
         typename =
-        std::enable_if_t<!std::is_same<std::invoke_result_t<Callable>, void>::value>
+        std::enable_if_t<!std::is_same_v<std::invoke_result_t<Callable>, void>>
     >
     std::future<std::invoke_result_t<Callable>> run_with_context_as_thread_default(Callable code)
     {
@@ -131,7 +131,7 @@ public:
     template<
         typename Callable,
         typename =
-            std::enable_if_t<std::is_same<std::invoke_result_t<Callable>, void>::value>
+            std::enable_if_t<std::is_same_v<std::invoke_result_t<Callable>, void>>
         >
     std::future<void> run_with_context_as_thread_default(Callable code)
     {

--- a/src/platform/graphics/cpu_addressable_fb.cpp
+++ b/src/platform/graphics/cpu_addressable_fb.cpp
@@ -49,7 +49,7 @@ class mg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappable
 
         ~Mapping()
         {
-            if (::munmap(const_cast<typename std::remove_const<T>::type *>(data_), len_) == -1)
+            if (::munmap(const_cast<std::remove_const_t<T> *>(data_), len_) == -1)
             {
                 // It's unclear how this could happen, but tell *someone* about it if it does!
                 log_error("Failed to unmap CPU buffer: %s (%i)", mir::errno_to_cstr(errno), errno);

--- a/src/platform/graphics/cpu_addressable_fb.cpp
+++ b/src/platform/graphics/cpu_addressable_fb.cpp
@@ -49,7 +49,7 @@ class mg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappable
 
         ~Mapping()
         {
-            if (::munmap(const_cast<std::remove_const_t<T> *>(data_), len_) == -1)
+            if (::munmap(const_cast<std::remove_const_t<T>*>(data_), len_) == -1)
             {
                 // It's unclear how this could happen, but tell *someone* about it if it does!
                 log_error("Failed to unmap CPU buffer: %s (%i)", mir::errno_to_cstr(errno), errno);

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -79,7 +79,7 @@ auto make_extension_builder(
     std::function<std::shared_ptr<typename T::Global>(mf::WaylandExtensions::Context const& ctx)> build)
 -> ExtensionBuilder
 {
-    static_assert(std::is_base_of<mw::Resource, T>::value, "make_extension_builder() not given a resource");
+    static_assert(std::is_base_of_v<mw::Resource, T>, "make_extension_builder() not given a resource");
     return ExtensionBuilder{T::interface_name, build};
 }
 

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -649,5 +649,5 @@ auto mf::XCBConnection::xcb_type_atom(XCBType type) const -> xcb_atom_t
 
     BOOST_THROW_EXCEPTION(std::runtime_error(
         "Invalid XCB type " +
-        std::to_string(static_cast<std::underlying_type<XCBType>::type>(type))));
+        std::to_string(static_cast<std::underlying_type_t<XCBType>>(type))));
 }

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -335,7 +335,7 @@ private:
     template<XCBType type>
     static inline constexpr uint8_t xcb_type_format()
     {
-        static_assert(!std::is_same<typename NativeXCBType<type>::type, void>::value, "Missing Native specialization");
+        static_assert(!std::is_same_v<typename NativeXCBType<type>::type, void>, "Missing Native specialization");
         auto const format = sizeof(typename NativeXCBType<type>::type) * 8;
         static_assert(format == 8 || format == 16 || format == 32, "Invalid format");
         return format;
@@ -345,9 +345,9 @@ private:
     static inline void validate_xcb_type()
     {
         // Accidentally sending a pointer instead of the actual data is an easy error to make
-        static_assert(!std::is_pointer<T>::value, "Data type should not be a pointer");
-        static_assert(!std::is_same<typename NativeXCBType<type>::type, void>::value, "Missing Native specialization");
-        static_assert(std::is_same<typename NativeXCBType<type>::type, T>::value, "Specified type does not match data type");
+        static_assert(!std::is_pointer_v<T>, "Data type should not be a pointer");
+        static_assert(!std::is_same_v<typename NativeXCBType<type>::type, void>, "Missing Native specialization");
+        static_assert(std::is_same_v<typename NativeXCBType<type>::type, T>, "Specified type does not match data type");
     }
 
     template<XCBType type, typename T>

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -880,7 +880,7 @@ auto mf::XWaylandSurface::StateTracker::with_wm_state(WmState wm_state) const ->
 
     default:
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Invalid WM_STATE: " + std::to_string(static_cast<std::underlying_type<WmState>::type>(wm_state))));
+            "Invalid WM_STATE: " + std::to_string(static_cast<std::underlying_type_t<WmState>>(wm_state))));
     }
 }
 
@@ -1275,7 +1275,7 @@ void mf::XWaylandSurface::prep_surface_spec(ProofOfMutexLock const&, msh::Surfac
         {
             if (optional_prop)
             {
-                using ValueType = typename std::remove_reference<decltype(optional_prop.value())>::type;
+                using ValueType = std::remove_reference_t<decltype(optional_prop.value())>;
                 using UnderlyingType = typename ValueType::ValueType;
                 auto constexpr raw_max = std::numeric_limits<UnderlyingType>::max();
 


### PR DESCRIPTION
Replace pre-C++17 `typename std::X<...>::type` and `std::X<...>::value` with the C++17 `std::X_t<...>` and `std::X_v<...>` helper templates.
