### PR TITLE
Raise invalid_offset for non-zero wl_surface.attach offset (v5+)

### DIFF
--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -376,6 +376,16 @@ void mf::WlSurface::attach(std::optional<wl_resource*> const& buffer, int32_t x,
 {
     if (x != 0 || y != 0)
     {
+        if (wl_resource_get_version(resource) >= 5)
+        {
+            throw wayland::ProtocolError{
+                resource,
+                Error::invalid_offset,
+                "Non-zero offset (%d, %d) given to wl_surface.attach, but since version 5 "
+                "the offset must be set with wl_surface.offset instead",
+                x, y};
+        }
+
         mir::log_warning("Client requested unimplemented non-zero attach offset. Rendering will be incorrect.");
     }
 


### PR DESCRIPTION
Since wl_surface version 5, the x/y offset arguments to wl_surface.attach must be zero; the offset is instead supplied via wl_surface.offset. Passing a non-zero offset is a protocol error (invalid_offset).

Mir advertises wl_surface version 6 but previously only logged a warning and silently dropped the offset for every version. Raise the invalid_offset protocol error for surfaces bound at version 5 or later, while keeping the existing (legacy) warning for older clients where the offset is permitted.

This behaviour is exercised by the WLCS test suite.
