### PR TITLE
Raise invalid_size from xdg_surface.set_window_geometry

### DIFF
--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -238,7 +238,7 @@ void mf::XdgSurfaceStable::set_window_geometry(int32_t x, int32_t y, int32_t wid
     {
         throw mw::ProtocolError{
             resource,
-            mw::generic_error_code,
+            Error::invalid_size,
             "Invalid %s size %dx%d", interface_name, width, height};
     }
     if (window_role_)


### PR DESCRIPTION
Per the xdg-shell spec, the width and height of the window geometry must be greater than zero and "setting an invalid size will raise an invalid_size error". The handler raised the generic error code instead of the xdg_surface invalid_size error, so the client received the wrong code.
