### PR TITLE
frontend_wayland: reject xdg_toplevel max size smaller than min size

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -294,6 +294,32 @@ auto mf::WindowWlSurfaceRole::pending_size() const -> geom::Size
     return size;
 }
 
+auto mf::WindowWlSurfaceRole::pending_min_size() const -> geom::Size
+{
+    auto result = committed_min_size;
+    if (pending_changes)
+    {
+        if (pending_changes->min_width)
+            result.width = pending_changes->min_width.value();
+        if (pending_changes->min_height)
+            result.height = pending_changes->min_height.value();
+    }
+    return result;
+}
+
+auto mf::WindowWlSurfaceRole::pending_max_size() const -> geom::Size
+{
+    auto result = committed_max_size;
+    if (pending_changes)
+    {
+        if (pending_changes->max_width)
+            result.width = pending_changes->max_width.value();
+        if (pending_changes->max_height)
+            result.height = pending_changes->max_height.value();
+    }
+    return result;
+}
+
 auto mf::WindowWlSurfaceRole::current_size() const -> geom::Size
 {
     if (surface)

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -122,6 +122,13 @@ protected:
     /// The size the window will be after the next commit
     auto pending_size() const -> geometry::Size;
 
+    /// The min/max size the window will have after the next commit (the value requested this cycle if any,
+    /// otherwise the committed value). A zero min or "unlimited" max indicates no constraint.
+    /// @{
+    auto pending_min_size() const -> geometry::Size;
+    auto pending_max_size() const -> geometry::Size;
+    /// @}
+
     /// The size the window currently is (the committed size, or a reasonable default if it has never committed)
     auto current_size() const -> geometry::Size;
 

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -596,6 +596,24 @@ void mf::XdgToplevelStable::set_min_size(int32_t width, int32_t height)
     WindowWlSurfaceRole::set_min_size(width, height);
 }
 
+void mf::XdgToplevelStable::handle_commit()
+{
+    auto const min_size = pending_min_size();
+    auto const max_size = pending_max_size();
+
+    // A zero max dimension means "no limit" (stored as the maximum possible size) and a zero min means
+    // "no minimum", so this comparison only triggers when the client has set genuinely conflicting constraints.
+    if (max_size.width < min_size.width || max_size.height < min_size.height)
+    {
+        throw mw::ProtocolError{
+            resource,
+            Error::invalid_size,
+            "Maximum size %dx%d is smaller than minimum size %dx%d",
+            max_size.width.as_int(), max_size.height.as_int(),
+            min_size.width.as_int(), min_size.height.as_int()};
+    }
+}
+
 void mf::XdgToplevelStable::set_maximized()
 {
     // We must process this request immediately (i.e. don't defer until commit())

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -126,7 +126,7 @@ public:
     void unset_fullscreen() override;
     void set_minimized() override;
 
-    void handle_commit() override {};
+    void handle_commit() override;
     void handle_state_change(MirWindowState /*new_state*/) override;
     void handle_active_change(bool /*is_now_active*/) override;
     void handle_resize(std::optional<geometry::Point> const& new_top_left, geometry::Size const& new_size) override;


### PR DESCRIPTION
The xdg-shell protocol specifies that set_max_size and set_min_size must raise an invalid_size error if the resulting maximum size is smaller than the minimum size in either dimension. These constraints are double-buffered (applied on commit), so the check is performed at commit time using the effective (pending this cycle, otherwise committed) min and max sizes.

A zero max dimension means "no limit" (stored internally as the maximum possible size) and a zero min means "no minimum", so the comparison only triggers for genuinely conflicting client-set constraints. An equal min and max is permitted (fixed size window).
