### PR TITLE
frontend_wayland: raise invalid_fd when SHM pool fd cannot be mapped

### DIFF
--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -441,7 +441,7 @@ void mf::Shm::create_pool(wl_resource* id, Fd fd, int32_t size)
         throw wayland::ProtocolError{
             resource,
             wayland::Shm::Error::invalid_fd,
-            "Failed to map client-provided SHM pool file descriptor: %s",
+            "%s",
             err.what()};
     }
 }

--- a/src/server/frontend_wayland/shm.cpp
+++ b/src/server/frontend_wayland/shm.cpp
@@ -430,5 +430,18 @@ void mf::Shm::create_pool(wl_resource* id, Fd fd, int32_t size)
             "Invalid requested size"};
     }
 
-    new ShmPool{id, wayland_executor, supported_formats, fd, size};
+    try
+    {
+        new ShmPool{id, wayland_executor, supported_formats, fd, size};
+    }
+    catch (shm::MmapError const& err)
+    {
+        // The pool is backed by mmap()ing the client-provided file descriptor. Per the wl_shm spec a
+        // failure to mmap the file descriptor must be reported with the invalid_fd error.
+        throw wayland::ProtocolError{
+            resource,
+            wayland::Shm::Error::invalid_fd,
+            "Failed to map client-provided SHM pool file descriptor: %s",
+            err.what()};
+    }
 }

--- a/src/server/shm_backing.cpp
+++ b/src/server/shm_backing.cpp
@@ -414,7 +414,7 @@ auto ShmBacking::resize(size_t new_size) -> std::expected<void, mir::shm::Resize
     void* mapped_address = mmap(nullptr, new_size, prot, MAP_SHARED, backing_store, 0);
     if (mapped_address == MAP_FAILED)
     {
-        BOOST_THROW_EXCEPTION((std::system_error{
+        BOOST_THROW_EXCEPTION((mir::shm::MmapError{
             errno,
             std::system_category(),
             "Failed to map client-provided SHM pool"}));

--- a/src/server/shm_backing.h
+++ b/src/server/shm_backing.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <expected>
 #include <sys/mman.h>
+#include <system_error>
 
 namespace mir
 {
@@ -108,6 +109,13 @@ public:
 enum class ResizeError
 {
     invalid_size,
+};
+
+/// Thrown when the client-provided backing file descriptor cannot be mmap()ed
+class MmapError : public std::system_error
+{
+public:
+    using std::system_error::system_error;
 };
 
 class ReadMappableRange


### PR DESCRIPTION
wl_shm.create_pool mmap()s the client-provided file descriptor to back the pool. When that mapping fails the wl_shm spec requires the invalid_fd error (value 2, "mmapping the file descriptor failed") to be raised on the wl_shm object.

Previously the mmap failure surfaced as a std::system_error which the generated request dispatcher caught in its catch-all branch and reported as a generic wl_display implementation error rather than the specific wl_shm.invalid_fd error.

Introduce a dedicated mir::shm::MmapError exception thrown at the mmap failure site and catch it in create_pool to re-raise it as the correct protocol error. Using a specific exception type (rather than the broad std::system_error) ensures only genuine mapping failures are translated to invalid_fd, while other failures continue to be reported as internal errors.
