### PR TITLE
Implement destroy_and_delete on C++ interfaces generated by wayland_rs

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -299,6 +299,15 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     post_error_method.set_body("instance_->post_error(code, message);");
     class.add_method(post_error_method);
 
+    // Add a destroy_and_delete method for server-initiated resource destruction.
+    // This is the equivalent of wl_resource_destroy() in the old C API: it destroys the
+    // underlying Wayland resource, which triggers the Dispatch::destroyed() callback,
+    // unregisters the resource, and ultimately drops the C++ object.
+    let mut destroy_and_delete_method =
+        CppMethod::new("destroy_and_delete", None, false, false, false, true);
+    destroy_and_delete_method.set_body("instance_->destroy_and_delete();");
+    class.add_method(destroy_and_delete_method);
+
     // Add a protected constructor and member so that subclasses know which client
     // they are serving and can interact with it as they please.
     class.add_protected_constructor_arg(CppArg::new(

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -302,7 +302,7 @@ fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     // Add a destroy_and_delete method for server-initiated resource destruction.
     // This is the equivalent of wl_resource_destroy() in the old C API: it destroys the
     // underlying Wayland resource, which triggers the Dispatch::destroyed() callback,
-    // unregisters the resource, and ultimately drops the C++ object.
+    // unregisters the resource, and allows the C++ object to be dropped once all shared owners release it.
     let mut destroy_and_delete_method =
         CppMethod::new("destroy_and_delete", None, false, false, false, true);
     destroy_and_delete_method.set_body("instance_->destroy_and_delete();");

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -109,6 +109,7 @@ fn generate_ffi_for_interface(interface: &WaylandInterface) -> TokenStream {
     quote! {
         fn post_error(self: &mut #interface_name_ext, code: u32, message: &CxxString);
         fn version(self: &#interface_name_ext) -> u32;
+        fn destroy_and_delete(self: &#interface_name_ext);
         #(#events)*
     }
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
@@ -144,10 +144,12 @@ fn generate_extension_for_interface(interface: &WaylandInterface) -> Option<Toke
 
             pub fn destroy_and_delete(&self) {
                 use wayland_server::Resource;
-                if let Some(handle) = self.wrapped.handle().upgrade() {
-                    let _ = handle.destroy_object::<crate::wayland_server_core::ServerState>(
-                        &self.wrapped.id()
-                    );
+                if self.wrapped.is_alive() {
+                    if let Some(handle) = self.wrapped.handle().upgrade() {
+                        let _ = handle.destroy_object::<crate::wayland_server_core::ServerState>(
+                            &self.wrapped.id(),
+                        );
+                    }
                 }
             }
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
@@ -144,8 +144,8 @@ fn generate_extension_for_interface(interface: &WaylandInterface) -> Option<Toke
 
             pub fn destroy_and_delete(&self) {
                 use wayland_server::Resource;
-                if self.wrapped.is_alive() {
-                    let _ = self.wrapped.destroy_object::<crate::wayland_server_core::ServerState>(
+                if let Some(handle) = self.wrapped.handle().upgrade() {
+                    let _ = handle.destroy_object::<crate::wayland_server_core::ServerState>(
                         &self.wrapped.id()
                     );
                 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
@@ -142,6 +142,15 @@ fn generate_extension_for_interface(interface: &WaylandInterface) -> Option<Toke
                 self.wrapped.version()
             }
 
+            pub fn destroy_and_delete(&self) {
+                use wayland_server::Resource;
+                if let Some(handle) = self.wrapped.handle().upgrade() {
+                    let _ = handle.destroy_object::<crate::wayland_server_core::ServerState>(
+                        &self.wrapped.id()
+                    );
+                }
+            }
+
             #(#event_extensions)*
         }
     })

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
@@ -144,8 +144,8 @@ fn generate_extension_for_interface(interface: &WaylandInterface) -> Option<Toke
 
             pub fn destroy_and_delete(&self) {
                 use wayland_server::Resource;
-                if let Some(handle) = self.wrapped.handle().upgrade() {
-                    let _ = handle.destroy_object::<crate::wayland_server_core::ServerState>(
+                if self.wrapped.is_alive() {
+                    let _ = self.wrapped.destroy_object::<crate::wayland_server_core::ServerState>(
                         &self.wrapped.id()
                     );
                 }


### PR DESCRIPTION
## What's new?
Implemented `destroy_and_delete` on the generated C++ interface. This method calls back into Rust where the handle is manually destroyed

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
