### PR TITLE
tics: don't restore ccache on QServer runs for a full analysis

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -125,6 +125,7 @@ jobs:
           glmark2-es2 \
           glmark2-es2-wayland \
           lcov \
+          llvm \
           libclang-rt-dev \
           mesa-utils \
           ninja-build \
@@ -135,6 +136,13 @@ jobs:
         sudo --preserve-env apt-get build-dep --yes ./
 
         echo "PATH=/usr/lib/rust-1.82/bin:${PATH}" >> "$GITHUB_ENV"
+
+        mkdir --parents ~/.local/bin
+        cat <<'EOF' > ~/.local/bin/gcov
+        #!/bin/sh
+        exec llvm-cov gcov "$@"
+        EOF
+        chmod +x ~/.local/bin/gcov
 
     - name: Configure
       run: >

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -95,20 +95,17 @@ jobs:
         # and evicting those we care for - from `main`
         echo "merge-base=$( git merge-base origin/main ${{ github.sha }} )" >> "$GITHUB_OUTPUT"
 
-    - name: CCache
-      if: ${{ github.event_name == 'push' }}
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+    # CCache is only _saved_ on push/workflow_dispatch, to run a complete build for TiCS analysis (QServer runs)
+    # For PRs and merge groups, on the other hand, we want quicker runs that won't affect cache (QClient runs)
+    - name: Restore CCache
+      if: ${{ contains(fromJSON('["pull_request", "merge_group"]'), github.event_name) }}
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with: &ccache_with
         key: ccache-coverage-${{ steps.setup-ccache.outputs.merge-base }}
         # if exact match isn't found, use the most recent entry for the task
         restore-keys: |
           ccache-coverage-
         path: ${{ env.CCACHE_DIR }}
-
-    - name: Restore CCache
-      if: ${{ github.event_name != 'push' }}
-      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-      with: *ccache_with
 
     - name: Ensure ccache size
       run: |
@@ -145,6 +142,8 @@ jobs:
         -DCMAKE_BUILD_TYPE=Debug
         -DMIR_ENABLE_COVERAGE=ON
         -DMIR_RUN_PERFORMANCE_TESTS=OFF
+        -DCMAKE_C_COMPILER=clang
+        -DCMAKE_CXX_COMPILER=clang++
         -DCMAKE_C_COMPILER_LAUNCHER=ccache
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         -GNinja
@@ -156,6 +155,11 @@ jobs:
 
     - name: Clear CCache stats
       run: ccache --show-stats --zero-stats
+
+    - name: Store CCache
+      if: ${{ !contains(fromJSON('["pull_request", "merge_group"]'), github.event_name) }}
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with: *ccache_with
 
     - name: Measure coverage
       timeout-minutes: 45

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,13 @@ if(MIR_ENABLE_COVERAGE)
         NAME coverage-html
         EXECUTABLE ctest --test-dir ${CMAKE_BINARY_DIR} --output-on-failure
         EXCLUDE "tests/*" "${CMAKE_BINARY_DIR}/*"
-        LCOV_ARGS --ignore-errors inconsistent --ignore-errors mismatch
+        LCOV_ARGS --ignore-errors inconsistent --ignore-errors mismatch --ignore-errors unused
+          --exclude "*/examples/*"
+          --exclude "*/src/server/console/logind-*"
+          --exclude "*/*.tp.h"
+          --substitute "s@${CMAKE_SOURCE_DIR}/((?:src/platform/graphics|src/wayland|tests/miral)/[^/]+_wrapper.(?:cpp|h))$@/${CMAKE_BINARY_DIR}/$1@"
+          --substitute "s@${CMAKE_SOURCE_DIR}/target@${CMAKE_BINARY_DIR}/target@"
+          --substitute "s@${CMAKE_SOURCE_DIR}/miral-generated@${CMAKE_BINARY_DIR}/miral-generated@"
         GENHTML_ARGS --ignore-errors inconsistent --ignore-errors corrupt
     )
 


### PR DESCRIPTION
## What's new?

To avoid rebuilds inside TiCS, run a full build on QServer (push and manual) runs.

Also use clang, as that's what we're configured for.

## How to test

These runs: https://github.com/canonical/mir/actions/workflows/tics.yml?query=branch%3Atics-no-rebuild

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
