### PR TITLE
Drop obsolete `WindowManager::{add,remove}_display()` methods

### DIFF
--- a/src/include/server/mir/shell/system_compositor_window_manager.h
+++ b/src/include/server/mir/shell/system_compositor_window_manager.h
@@ -82,10 +82,6 @@ private:
         std::shared_ptr<scene::Session> const& session,
         std::weak_ptr<scene::Surface> const& surface) override;
 
-    void add_display(geometry::Rectangle const& area) override;
-
-    void remove_display(geometry::Rectangle const& area) override;
-
     bool handle_keyboard_event(MirKeyboardEvent const* event) override;
 
     bool handle_touch_event(MirTouchEvent const* event) override;

--- a/src/include/server/mir/shell/window_manager.h
+++ b/src/include/server/mir/shell/window_manager.h
@@ -57,10 +57,6 @@ public:
         std::shared_ptr<scene::Session> const& session,
         std::weak_ptr<scene::Surface> const& surface) = 0;
 
-    virtual void add_display(geometry::Rectangle const& area) = 0;
-
-    virtual void remove_display(geometry::Rectangle const& area) = 0;
-
     virtual bool handle_keyboard_event(MirKeyboardEvent const* event) = 0;
 
     virtual bool handle_touch_event(MirTouchEvent const* event) = 0;

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -361,19 +361,6 @@ void miral::BasicWindowManager::erase(miral::WindowInfo const& info)
     window_info.erase(info.window());
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-void miral::BasicWindowManager::add_display(geometry::Rectangle const& /*area*/)
-{
-    // OBSOLETE
-}
-#pragma GCC diagnostic pop
-
-void miral::BasicWindowManager::remove_display(geometry::Rectangle const& /*area*/)
-{
-    // OBSOLETE
-}
-
 bool miral::BasicWindowManager::handle_keyboard_event(MirKeyboardEvent const* event)
 {
     Locker lock{this};

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -95,11 +95,6 @@ public:
         std::shared_ptr<mir::scene::Session> const& session,
         std::weak_ptr<mir::scene::Surface> const& surface) override;
 
-    [[deprecated("Mir doesn't reliably call this: it is ignored. Use add_display_for_testing() instead")]]
-    void add_display(mir::geometry::Rectangle const& area) override;
-
-    void remove_display(mir::geometry::Rectangle const& area) override;
-
     bool handle_keyboard_event(MirKeyboardEvent const* event) override;
 
     bool handle_touch_event(MirTouchEvent const* event) override;

--- a/src/miral/system_compositor_window_manager.cpp
+++ b/src/miral/system_compositor_window_manager.cpp
@@ -151,14 +151,6 @@ void miral::SystemCompositorWindowManager::remove_surface(
     output_map.erase(surface);
 }
 
-void miral::SystemCompositorWindowManager::add_display(mir::geometry::Rectangle const& /*area*/)
-{
-}
-
-void miral::SystemCompositorWindowManager::remove_display(mir::geometry::Rectangle const& /*area*/)
-{
-}
-
 bool miral::SystemCompositorWindowManager::handle_keyboard_event(MirKeyboardEvent const* event)
 {
     static unsigned int const shift_states =

--- a/src/miral/system_compositor_window_manager.h
+++ b/src/miral/system_compositor_window_manager.h
@@ -99,10 +99,6 @@ private:
         std::shared_ptr<mir::scene::Session> const& session,
         std::weak_ptr<mir::scene::Surface> const& surface) override;
 
-    void add_display(mir::geometry::Rectangle const& area) override;
-
-    void remove_display(mir::geometry::Rectangle const& area) override;
-
     bool handle_keyboard_event(MirKeyboardEvent const* event) override;
 
     bool handle_touch_event(MirTouchEvent const* event) override;

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -677,13 +677,11 @@ void msh::AbstractShell::add_grabbing_popup(std::shared_ptr<scene::Surface> cons
 void msh::AbstractShell::add_display(geometry::Rectangle const& area)
 {
     report->adding_display(area);
-    window_manager->add_display(area);
 }
 
 void msh::AbstractShell::remove_display(geometry::Rectangle const& area)
 {
     report->removing_display(area);
-    window_manager->remove_display(area);
 }
 
 bool msh::AbstractShell::handle(MirEvent const& event)

--- a/src/server/shell/system_compositor_window_manager.cpp
+++ b/src/server/shell/system_compositor_window_manager.cpp
@@ -142,31 +142,6 @@ void msh::SystemCompositorWindowManager::remove_surface(
     output_map.erase(surface);
 }
 
-void msh::SystemCompositorWindowManager::add_display(mir::geometry::Rectangle const& /*area*/)
-{
-    std::lock_guard lock{mutex};
-
-    for (auto const& so : output_map)
-    {
-        if (auto surface = so.first.lock())
-        {
-            auto const output_id = so.second;
-
-            mir::geometry::Rectangle rect{surface->top_left(), surface->window_size()};
-
-            if (display_layout->place_in_output(output_id, rect))
-            {
-                surface->move_to(rect.top_left);
-                surface->resize(rect.size);
-            }
-        }
-    }
-}
-
-void msh::SystemCompositorWindowManager::remove_display(mir::geometry::Rectangle const& /*area*/)
-{
-}
-
 bool msh::SystemCompositorWindowManager::handle_keyboard_event(MirKeyboardEvent const* /*event*/)
 {
     return false;

--- a/tests/include/mir/test/doubles/mock_window_manager.h
+++ b/tests/include/mir/test/doubles/mock_window_manager.h
@@ -50,9 +50,6 @@ struct MockWindowManager : shell::WindowManager
     MOCK_METHOD(void, modify_surface, (std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, shell::SurfaceSpecification const&), (override));
     MOCK_METHOD(void, remove_surface, (std::shared_ptr<scene::Session> const&, std::weak_ptr<scene::Surface> const&), (override));
 
-    MOCK_METHOD(void, add_display, (geometry::Rectangle const&), (override));
-    MOCK_METHOD(void, remove_display, (geometry::Rectangle const&), (override));
-
     MOCK_METHOD(bool, handle_keyboard_event, (MirKeyboardEvent const*), (override));
     MOCK_METHOD(bool, handle_touch_event, (MirTouchEvent const*), (override));
     MOCK_METHOD(bool, handle_pointer_event, (MirPointerEvent const*), (override));

--- a/tests/miral/display_reconfiguration.cpp
+++ b/tests/miral/display_reconfiguration.cpp
@@ -78,8 +78,5 @@ TEST_F(DisplayConfiguration, given_fullscreen_windows_reconfiguring_displays_doe
     mods.state() = mir_window_state_fullscreen;
     window_manager_tools.modify_window(window, mods);
 
-    Rectangle const new_display{
-        display_area.top_left + Displacement{as_delta(display_width), 0}, display_area.size};
-
     notify_configuration_applied(create_fake_display_configuration({display_area}));
 }

--- a/tests/miral/display_reconfiguration.cpp
+++ b/tests/miral/display_reconfiguration.cpp
@@ -82,5 +82,4 @@ TEST_F(DisplayConfiguration, given_fullscreen_windows_reconfiguring_displays_doe
         display_area.top_left + Displacement{as_delta(display_width), 0}, display_area.size};
 
     notify_configuration_applied(create_fake_display_configuration({display_area}));
-    basic_window_manager.remove_display(new_display);
 }

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -381,24 +381,6 @@ TEST_F(AbstractShell, destroy_surface_removes_surface_from_window_manager)
     shell.destroy_surface(session, surface);
 }
 
-TEST_F(AbstractShell, add_display_adds_display_to_window_manager)
-{
-    geom::Rectangle const arbitrary_area{{0,0}, {__LINE__,__LINE__}};
-
-    EXPECT_CALL(*wm, add_display(arbitrary_area));
-
-    shell.add_display(arbitrary_area);
-}
-
-TEST_F(AbstractShell, remove_display_adds_display_to_window_manager)
-{
-    geom::Rectangle const arbitrary_area{{0,0}, {__LINE__,__LINE__}};
-
-    EXPECT_CALL(*wm, remove_display(arbitrary_area));
-
-    shell.remove_display(arbitrary_area);
-}
-
 TEST_F(AbstractShell, key_input_events_are_handled_by_window_manager)
 {
     MirKeyboardAction const action{mir_keyboard_action_down};


### PR DESCRIPTION
These methods don't do anything useful.

The only implementation is in `msh::SystemCompositorWindowManager` which is only used as a default by test fixtures, and the tests don't use these functions. (Also see https://github.com/canonical/mir/issues/5022)