### PR TITLE
Bring wayland_rs::Weak inline with the API of wayland::Weak for better compatibility

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
+++ b/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
@@ -18,8 +18,6 @@
 #define MIR_WAYLANDRS_WEAK
 
 #include <memory>
-#include <stdexcept>
-#include <utility>
 #include <boost/throw_exception.hpp>
 
 namespace mir
@@ -30,6 +28,8 @@ template<typename T>
 class Weak
 {
 public:
+    Weak() = default;
+
     explicit Weak(std::shared_ptr<T> const& ptr)
         : ptr_{ptr}
     {
@@ -37,12 +37,16 @@ public:
 
     Weak(Weak const& weak) = default;
 
-    template<typename F>
-    decltype(auto) with_value(F&& f) const
+    T& value() const
     {
-        if (auto locked = ptr_.lock())
-            return std::forward<F>(f)(*locked);
-        BOOST_THROW_EXCEPTION(std::logic_error{"Accessing expired wayland_rs::Weak"});
+        if (ptr_.expired())
+        {
+            BOOST_THROW_EXCEPTION(
+                std::logic_error(
+                    std::string{"Attempted access of null wayland_rs::Weak<"} +
+                    typeid(T).name() + ">"));
+        }
+        return *ptr_.lock();
     }
 
     operator bool() const


### PR DESCRIPTION
## What's new?
- Now that we guarantee single-threadedness in wayland-rs, we can just implement a `value()` method instead of a `with_value()`, which brings the API in line with what currently exists

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
