### PR TITLE
docs: update documentation for configuring screencasting via ext-image-copy-capture

### DIFF
--- a/doc/sphinx/.custom_wordlist.txt
+++ b/doc/sphinx/.custom_wordlist.txt
@@ -233,6 +233,7 @@ subprocess
 swaybg
 swaylock
 sys
+systemd
 testflinger
 Testflinger
 TilingWindowManagerPolicy
@@ -278,6 +279,7 @@ WL
 wlcs
 WLCS
 wlr
+wmenu
 wofi
 workspaces
 X11

--- a/doc/sphinx/configuring/how-to/enable-screencasting.md
+++ b/doc/sphinx/configuring/how-to/enable-screencasting.md
@@ -4,39 +4,57 @@
 
 ## Requirements
 
+Required wayland extensions to capture the whole output:
+
+- `zwlr_layer_shell_v1` (for the capture source chooser),
+- `ext_image_copy_capture_manager_v1`
+- `ext_output_image_capture_source_manager_v1`
+
+If you want to capture individual windows, you will also need to enable:
+
+- `ext_foreign_toplevel_list_v1`
+- `ext_foreign_toplevel_image_capture_source_manager_v1`
+
 Required packages:
 
-- xdg-desktop-portal (tested with 1.18.4-1ubuntu2.24.04.1)
-- xdg-desktop-portal-wlr (v0.5.0, newer versions will not work)
-
-Required wayland extensions:
-
-- `zwlr_layer_shell_v1` for slurp,
-- `zwlr_xdg_screencopy_manager_v1` for `xdg-desktop-portal-wlr`
+- xdg-desktop-portal
+- xdg-desktop-portal-wlr
+  - at least 0.8.0 for output capture
+  - at least 0.8.2 for toplevel capture
+- wmenu or slurp (as a source chooser)
 
 ## Setup steps
 
-1. The file at `/usr/share/xdg-desktop-portal/portals/<compositor-name>.portal` should contain the following:
+1. The file at `/usr/share/xdg-desktop-portal/<compositor-name>-portals.conf` should contain the following:
 
 ```
-[portal]
-DBusName=org.freedesktop.impl.portal.desktop.wlr
-Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;
-UseIn=my-mir-compsitor
+[preferred]
+default=gtk
+org.freedesktop.impl.portal.Screenshot=wlr
+org.freedesktop.impl.portal.ScreenCast=wlr
 ```
 
-where `my-mir-compositor` is the same value as `XDG_CURRENT_DESKTOP` when your compositor is running. This tells `xdg-desktop-portal` to override the screencast and screenshot implementations by using the `wlr` implementation.
+where `<compositor-name>` is the same value as `XDG_CURRENT_DESKTOP` when your compositor is running. This tells `xdg-desktop-portal` to override the screencast and screenshot implementations by using the `wlr` implementation.
 
 2. The file at `/etc/xdg/xdg-desktop-portal-wlr/config` should contain the following:
 
 ```
 [screencast]
 max_fps=30
+chooser_type=dmenu
+chooser_cmd=wmenu -p 'Select a source to share:' -l 10
+```
+
+Where `chooser_type=dmenu` runs the given `chooser_cmd`. `chooser_cmd` in this case should return the name of the output that's going to be shared. In the above case, `wmenu` will display a menu of capture sources at the top of the screen.
+
+As an alternative, `slurp` can be used as a simpler picker:
+
+```
 chooser_type=simple
 chooser_cmd=slurp -f %o -or
 ```
 
-Where `chooser_type=simple` runs the given `chooser_cmd`. `chooser_cmd` in this case should return the name of the output that's going to be shared. In the example above, `slurp -f %o -or` uses a transparent white overlay to indicate that its running, if you click on a specific output, then it will return the name of that output.
+This chooser shows a transparent white overlay to indicate that it's running. Clicking on an output will select it for the screencast. Note that `slurp` does not provide a way to choose toplevel windows.
 
 3. The following script should run automatically when your compositor starts up. For testing purposes, you can run the script after you start your compositor.
 
@@ -51,9 +69,10 @@ dbus-update-activation-environment --systemd $VARIABLES
 systemd-run --user /usr/libexec/xdg-desktop-portal --replace
 ```
 
-4. Try recording your screen with OBS, or sharing it with google meet. You should get a transparent white overlay to indicate that you're picking an output to share. Once you click on an output, screencasting should automatically work from there.
+4. Try recording your screen with OBS Studio, sharing it with Google Meet, or the [getDisplayMedia() WebRTC sample](https://webrtc.github.io/samples/src/content/getusermedia/getdisplaymedia/). Depending on which source chooser has been configured, you should see a menu at the top of the screen or a transparent white rectangle covering the screen.
 
 ## Notes
 
-- To enable extensions with a mir based compositor, you can append `--add-wayland-extensions=<extension 1>:<extension 2>` to your launch flags. For the steps above, you'd use `--add-wayland-extensions=zwlr_layer_shell_v1:zwlr_screencopy_manager_v1`
-- At the moment, mir's implementation of screencasting only allows sharing whole outputs.
+- To enable extensions with a mir based compositor, you can append `--add-wayland-extensions=<extension 1>:<extension 2>` to your launch flags. For the steps above, you'd use `--add-wayland-extensions=zwlr_layer_shell_v1:ext_image_copy_capture_manager_v1:ext_output_image_capture_source_manager_v1:ext_foreign_toplevel_list_v1:ext_foreign_toplevel_image_capture_source_manager_v1`
+- At present, xdg-desktop-portal-wlr's support for screencasting toplevel windows is a bit buggy. As of version 0.8.2, resizing the source window can trigger a protocol error in the portal service, and stop the cast. This will hopefully be fixed in future releases (see [xdg-desktop-portal-wlr #340](https://github.com/emersion/xdg-desktop-portal-wlr/pull/340)).
+- To operate correctly with xdg-desktop-portal >= 1.21, you will need to integrate with the systemd user session to the extent that `graphical-session.target` is started.

--- a/doc/sphinx/configuring/how-to/enable-screencasting.md
+++ b/doc/sphinx/configuring/how-to/enable-screencasting.md
@@ -20,7 +20,7 @@ Required packages:
 - xdg-desktop-portal
 - xdg-desktop-portal-wlr
   - at least 0.8.0 for output capture
-  - at least 0.8.2 for toplevel capture
+  - at least 0.8.2 for top level window capture
 - wmenu or slurp (as a source chooser)
 
 ## Setup steps
@@ -54,7 +54,7 @@ chooser_type=simple
 chooser_cmd=slurp -f %o -or
 ```
 
-This chooser shows a transparent white overlay to indicate that it's running. Clicking on an output will select it for the screencast. Note that `slurp` does not provide a way to choose toplevel windows.
+This chooser shows a transparent white overlay to indicate that it's running. Clicking on an output will select it for the screencast. Note that `slurp` does not provide a way to choose top level windows.
 
 3. The following script should run automatically when your compositor starts up. For testing purposes, you can run the script after you start your compositor.
 
@@ -74,5 +74,5 @@ systemd-run --user /usr/libexec/xdg-desktop-portal --replace
 ## Notes
 
 - To enable extensions with a mir based compositor, you can append `--add-wayland-extensions=<extension 1>:<extension 2>` to your launch flags. For the steps above, you'd use `--add-wayland-extensions=zwlr_layer_shell_v1:ext_image_copy_capture_manager_v1:ext_output_image_capture_source_manager_v1:ext_foreign_toplevel_list_v1:ext_foreign_toplevel_image_capture_source_manager_v1`
-- At present, xdg-desktop-portal-wlr's support for screencasting toplevel windows is a bit buggy. As of version 0.8.2, resizing the source window can trigger a protocol error in the portal service, and stop the cast. This will hopefully be fixed in future releases (see [xdg-desktop-portal-wlr #340](https://github.com/emersion/xdg-desktop-portal-wlr/pull/340)).
+- At present, xdg-desktop-portal-wlr's support for screencasting top level windows is a bit buggy. As of version 0.8.2, resizing the source window can trigger a protocol error in the portal service, and stop the cast. This will hopefully be fixed in future releases (see [xdg-desktop-portal-wlr #340](https://github.com/emersion/xdg-desktop-portal-wlr/pull/340)).
 - To operate correctly with xdg-desktop-portal >= 1.21, you will need to integrate with the systemd user session to the extent that `graphical-session.target` is started.


### PR DESCRIPTION
## What's new?

Update  the screencasting documentation to instead cover the new ext-image-copy-capture protocol. In particular:

* recommends the ext protocols, with a base set to support output capture, and additional protocols to enable toplevel window capture.
* Bumps the minimum required xdg-desktop-portal-wlr version requirement to 0.8.0, with a note that 0.8.2 is needed for toplevel capture to (mostly) work.
* Document the new way of configuring which portals to use via a `<compositor-name>-portals.conf` file. The suggestion given is to use wlr for screenshots/screencasts and default to gtk for everything else.
* Suggest using wmenu instead of slurp as xdg-desktop-portal-wlr's source chooser, since slurp can't be used to select toplevels.
* Add a note about the bug in xdg-desktop-portal-wlr when resizing a toplevel that is being captured.
* Note that integration with systemd user sessions will be needed to function correctly with xdg-desktop-portal >= 1.21 due to the `After=graphical-session.target` line in its service file.

## Checklist

- [ ] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
