### PR TITLE
miral: add missing `PhysicalSizeMM::operator==` symbol

### DIFF
--- a/debian/libmiral8.symbols
+++ b/debian/libmiral8.symbols
@@ -301,6 +301,7 @@ libmiral.so.8 libmiral8 #MINVER#
  (c++)"miral::MouseKeysConfig::set_max_speed(double, double) const@MIRAL_6.0" 6.0.0
  (c++)"miral::Output::Output(mir::graphics::DisplayConfigurationOutput const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::Output::Output(miral::Output const&)@MIRAL_6.0" 6.0.0
+ (c++)"miral::Output::PhysicalSizeMM::operator==(miral::Output::PhysicalSizeMM const&) const@MIRAL_6.0" 6.0.0
  (c++)"miral::Output::attribute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const@MIRAL_6.0" 6.0.0
  (c++)"miral::Output::attributes_map[abi:cxx11]() const@MIRAL_6.0" 6.0.0
  (c++)"miral::Output::connected() const@MIRAL_6.0" 6.0.0


### PR DESCRIPTION
## What's new?

A missing symbol.

## How to test

Build `regenerate-miral-debian-symbols`.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
