### PR TITLE
Symbols generator tests

### DIFF
--- a/tools/symbols_map_generator/tests/.gitignore
+++ b/tools/symbols_map_generator/tests/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/symbols_map_generator/tests/fixtures/access.h
+++ b/tools/symbols_map_generator/tests/fixtures/access.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Access control.  Private members are never emitted.  Protected members
+// ARE emitted (they are part of the ABI: derived classes can call them),
+// even though the traverse_ast comment only mentions "private".  This
+// fixture pins that behaviour so it is not changed by accident.
+
+namespace mir
+{
+
+class AccessLevels
+{
+public:
+    void public_method();
+
+protected:
+    void protected_method();
+
+private:
+    void private_method();
+    int private_field;
+};
+
+}

--- a/tools/symbols_map_generator/tests/fixtures/inheritance.h
+++ b/tools/symbols_map_generator/tests/fixtures/inheritance.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Inheritance-driven vtable detection.  `Inheritor` declares no virtual
+// methods of its own but inherits a vtable from `PolyBase`.  Correct
+// behaviour is that it should still emit a vtable symbol.  Virtual
+// inheritance (VB1/VB2/Diamond) additionally requires VTT symbols.
+
+namespace mir
+{
+
+struct PolyBase
+{
+    virtual ~PolyBase();
+    virtual void poly();
+};
+
+struct Inheritor : PolyBase
+{
+    void non_virtual_helper();
+};
+
+struct VB1 : virtual PolyBase
+{
+};
+
+struct VB2 : virtual PolyBase
+{
+};
+
+struct Diamond : VB1, VB2
+{
+};
+
+}

--- a/tools/symbols_map_generator/tests/fixtures/plain.h
+++ b/tools/symbols_map_generator/tests/fixtures/plain.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// A non-polymorphic class: no virtual methods, so no vtable should be
+// emitted, but typeinfo is always emitted for class/struct definitions.
+// Private members must never be emitted.
+
+namespace mir
+{
+
+class Plain
+{
+public:
+    Plain();
+    ~Plain();
+    void do_thing();
+    int value() const;
+
+private:
+    void hidden();
+    int secret;
+};
+
+void free_function(int a);
+
+}

--- a/tools/symbols_map_generator/tests/fixtures/polymorphic.h
+++ b/tools/symbols_map_generator/tests/fixtures/polymorphic.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Polymorphism: classes with virtual methods, an override in a derived
+// class, and a pure-virtual (abstract) class.  Each polymorphic class
+// should emit vtable/typeinfo and non-virtual-thunk symbols.  A
+// pure-virtual method itself must NOT be emitted.
+
+namespace mir
+{
+
+struct Base
+{
+    virtual ~Base();
+    virtual void poly();
+    void non_virtual();
+};
+
+struct Derived : Base
+{
+    void poly() override;
+};
+
+class Abstract
+{
+public:
+    virtual void pure() = 0;
+    virtual void concrete();
+};
+
+}

--- a/tools/symbols_map_generator/tests/fixtures/scopes.h
+++ b/tools/symbols_map_generator/tests/fixtures/scopes.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Namespacing, enums, inline functions and variables.  Nested namespaces
+// produce a "::"-joined prefix.  Enums (scoped or unscoped) emit no
+// symbols.  An inline (in-header defined) free function is skipped, while
+// a declared-only free function and an extern variable are emitted.
+
+namespace mir
+{
+namespace nested
+{
+
+enum class ScopedEnum
+{
+    First,
+    Second
+};
+
+enum UnscopedEnum
+{
+    Alpha,
+    Beta
+};
+
+inline void inline_free_function()
+{
+}
+
+void declared_free_function();
+
+extern int extern_variable;
+
+}
+}

--- a/tools/symbols_map_generator/tests/fixtures/template_instantiation.h
+++ b/tools/symbols_map_generator/tests/fixtures/template_instantiation.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Explicit template instantiations exercise the angle-bracket / comma
+// mangling in symbol names: '<' and '>' become '?', and ',' becomes '*'.
+
+namespace mir
+{
+
+template<typename T>
+struct Single
+{
+    T value;
+};
+
+template<typename A, typename B>
+struct Couple
+{
+};
+
+template struct Single<int>;
+template struct Couple<int, char>;
+
+}

--- a/tools/symbols_map_generator/tests/fixtures/templates.h
+++ b/tools/symbols_map_generator/tests/fixtures/templates.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Template classes and operator overloads.  Template angle brackets and
+// commas are mangled into '?' and '*' respectively in the emitted
+// symbol names; operator names are normalised to "operator".
+
+namespace mir
+{
+
+template<typename T>
+class Holder
+{
+public:
+    void store(T value);
+    T const& get() const;
+};
+
+class Number
+{
+public:
+    bool operator==(Number const& other) const;
+    Number operator+(Number const& other) const;
+};
+
+}

--- a/tools/symbols_map_generator/tests/test_symbols_map_generator.py
+++ b/tools/symbols_map_generator/tests/test_symbols_map_generator.py
@@ -37,7 +37,6 @@ Run with::
     python3 -m unittest discover -s tools/symbols_map_generator/tests
 """
 
-import importlib.util
 import os
 import sys
 import unittest
@@ -73,13 +72,23 @@ def _configure_libclang():
 
 
 def _load_generator():
-    """Import the generator's main.py as a module under a synthetic name."""
-    spec = importlib.util.spec_from_file_location(
-        "symbols_map_generator_main", TOOL_DIR / "main.py"
-    )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    """Import the generator's main.py as an importable on-disk module.
+
+    The tool's directory is placed on sys.path and the module imported by its
+    real name ("main").  Loading it as a genuinely importable module (rather
+    than via spec_from_file_location under a synthetic name) is what allows
+    ProcessPoolExecutor workers to re-import the module-level worker function
+    used by process_directory.  This matters on Python start methods other than
+    ``fork`` (e.g. ``forkserver``/``spawn``, the default on Python 3.14+), where
+    each worker is a fresh interpreter that imports the module by name instead
+    of inheriting it from the parent.
+    """
+    tool_dir = str(TOOL_DIR)
+    if tool_dir not in sys.path:
+        sys.path.insert(0, tool_dir)
+    import main  # noqa: PLC0415 — the tool's main.py, importable via TOOL_DIR
+
+    return main
 
 
 def _try_import_clang():

--- a/tools/symbols_map_generator/tests/test_symbols_map_generator.py
+++ b/tools/symbols_map_generator/tests/test_symbols_map_generator.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+# Copyright © Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 or 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Golden / characterization tests for the symbols-map generator.
+
+These tests parse the small C++ fixture headers in ``fixtures/`` with the real
+libclang and assert the exact set of symbol strings the generator emits.  They
+serve two purposes:
+
+* As a regression guard: behaviour-preserving refactors of the generator (for
+  example reusing a clang Index, skipping function bodies, parallelising the
+  parse, or reordering the system-header guard) must not change the emitted
+  symbols.  The ``test_*_symbols`` cases below pin the full expected set.
+
+* As living documentation of a bug that still needs fixing: ``has_vtable`` looks
+  up base classes on ``node.semantic_parent.get_children()`` instead of
+  ``node.get_children()``, so a class that inherits a vtable without declaring
+  any virtual method of its own does NOT currently get a ``vtable?for?`` symbol.
+  ``test_inherited_vtable_is_detected`` (and the inheritance golden set) assert
+  the CORRECT behaviour, so they FAIL on origin/main and pass once the
+  has_vtable base-class lookup is fixed.
+
+Run with::
+
+    python3 -m unittest discover -s tools/symbols_map_generator/tests
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+
+
+TOOL_DIR = Path(__file__).resolve().parent.parent
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+# Candidate locations for libclang.so.  The first that exists is used.  Mirrors
+# the discovery the generator itself performs in main(), but kept independent so
+# the tests can configure libclang before importing the module under test.
+_CLANG_SO_CANDIDATES = [
+    os.environ.get("MIR_SYMBOLS_MAP_GENERATOR_CLANG_SO_PATH"),
+    "/usr/lib/x86_64-linux-gnu/libclang-19.so.1",
+    "/usr/lib/x86_64-linux-gnu/libclang-18.so.1",
+    "/usr/lib/aarch64-linux-gnu/libclang-19.so.1",
+    "/usr/lib/aarch64-linux-gnu/libclang-18.so.1",
+    "/usr/lib/llvm-19/lib/libclang.so.1",
+    "/usr/lib/llvm-18/lib/libclang.so",
+    "/usr/lib/libclang.so.1",
+]
+
+
+def _configure_libclang():
+    import clang.cindex
+
+    for candidate in _CLANG_SO_CANDIDATES:
+        if candidate and os.path.isfile(candidate):
+            clang.cindex.Config.set_library_file(candidate)
+            return candidate
+    return None
+
+
+def _load_generator():
+    """Import the generator's main.py as a module under a synthetic name."""
+    spec = importlib.util.spec_from_file_location(
+        "symbols_map_generator_main", TOOL_DIR / "main.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _try_import_clang():
+    try:
+        import clang.cindex  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@unittest.skipUnless(_try_import_clang(), "python3-clang (clang.cindex) is not installed")
+class SymbolsMapGeneratorGoldenTest(unittest.TestCase):
+    """Parses fixture headers and pins the exact emitted symbol set."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._clang_so = _configure_libclang()
+        if cls._clang_so is None:
+            raise unittest.SkipTest("libclang.so could not be located")
+        cls.generator = _load_generator()
+
+    def _symbols_for(self, header_name: str) -> set:
+        """Parse a single fixture header and return its emitted symbol set."""
+        import clang.cindex
+
+        path = FIXTURES / header_name
+        args = ["-std=c++23", "-x", "c++-header"]
+        idx = clang.cindex.Index.create()
+        tu = idx.parse(path.as_posix(), args=args, options=0)
+
+        # Surface fatal parse diagnostics rather than silently asserting on an
+        # empty/garbage symbol set.
+        fatal = [
+            d
+            for d in tu.diagnostics
+            if d.severity >= clang.cindex.Diagnostic.Error
+        ]
+        self.assertEqual(
+            [], [d.spelling for d in fatal], f"libclang reported errors parsing {header_name}"
+        )
+
+        result: set = set()
+        self.generator.traverse_ast(tu.cursor, path.as_posix(), result)
+        return result
+
+    def test_plain_symbols(self):
+        # A non-polymorphic class: typeinfo but no vtable; private members
+        # (hidden(), secret) are never emitted; free functions are emitted.
+        self.assertEqual(
+            self._symbols_for("plain.h"),
+            {
+                "mir::Plain::Plain*;",
+                "mir::Plain::?Plain*;",
+                "mir::Plain::do_thing*;",
+                "mir::Plain::value*;",
+                "mir::free_function*;",
+                "typeinfo?for?mir::Plain;",
+            },
+        )
+
+    def test_polymorphic_symbols(self):
+        # Classes that declare virtual methods (directly or via override) get
+        # vtable + typeinfo + non-virtual-thunk symbols.  A pure-virtual method
+        # (Abstract::pure) is NOT emitted.
+        self.assertEqual(
+            self._symbols_for("polymorphic.h"),
+            {
+                "mir::Base::?Base*;",
+                "mir::Base::poly*;",
+                "mir::Base::non_virtual*;",
+                "mir::Derived::poly*;",
+                "mir::Abstract::concrete*;",
+                "non-virtual?thunk?to?mir::Base::?Base*;",
+                "non-virtual?thunk?to?mir::Base::poly*;",
+                "non-virtual?thunk?to?mir::Derived::poly*;",
+                "non-virtual?thunk?to?mir::Abstract::concrete*;",
+                "typeinfo?for?mir::Base;",
+                "typeinfo?for?mir::Derived;",
+                "typeinfo?for?mir::Abstract;",
+                "vtable?for?mir::Base;",
+                "vtable?for?mir::Derived;",
+                "vtable?for?mir::Abstract;",
+            },
+        )
+
+    def test_templates_and_operators_symbols(self):
+        # A class template (Holder) emits nothing because it is a CLASS_TEMPLATE
+        # cursor, not CLASS_DECL.  Operator overloads normalise to "operator" and
+        # therefore collapse to a single deduplicated symbol.
+        self.assertEqual(
+            self._symbols_for("templates.h"),
+            {
+                "mir::Number::operator*;",
+                "typeinfo?for?mir::Number;",
+            },
+        )
+
+    def test_inheritance_symbols(self):
+        # Golden set for inheritance.h reflecting the CORRECT behaviour: a class
+        # that inherits a vtable from a polymorphic base must get its own
+        # vtable?for? symbol even when it declares no virtual method of its own.
+        # This therefore includes vtable?for?mir::Inheritor / VB1 / VB2 /
+        # Diamond.  On origin/main this assertion FAILS because has_vtable looks
+        # up base classes on node.semantic_parent.get_children() instead of
+        # node.get_children(); it passes once that bug is fixed.
+        self.assertEqual(
+            self._symbols_for("inheritance.h"),
+            {
+                "mir::PolyBase::?PolyBase*;",
+                "mir::PolyBase::poly*;",
+                "mir::Inheritor::non_virtual_helper*;",
+                "non-virtual?thunk?to?mir::PolyBase::?PolyBase*;",
+                "non-virtual?thunk?to?mir::PolyBase::poly*;",
+                "typeinfo?for?mir::PolyBase;",
+                "typeinfo?for?mir::Inheritor;",
+                "typeinfo?for?mir::VB1;",
+                "typeinfo?for?mir::VB2;",
+                "typeinfo?for?mir::Diamond;",
+                "vtable?for?mir::PolyBase;",
+                "vtable?for?mir::Inheritor;",
+                "vtable?for?mir::VB1;",
+                "vtable?for?mir::VB2;",
+                "vtable?for?mir::Diamond;",
+                "VTT?for?mir::VB1;",
+                "VTT?for?mir::VB2;",
+                "VTT?for?mir::Diamond;",
+            },
+        )
+
+    def test_inherited_vtable_is_detected(self):
+        # A class/struct that inherits a vtable from a polymorphic base, but
+        # declares no virtual method of its own, must still be emitted with a
+        # vtable?for? symbol.  Anything with a typeinfo?for? (and certainly
+        # anything with a VTT?for?) is polymorphic and therefore has a vtable;
+        # emitting one without the other is internally inconsistent.
+        symbols = self._symbols_for("inheritance.h")
+
+        # The base, which declares virtual methods directly, is detected.
+        self.assertIn("vtable?for?mir::PolyBase;", symbols)
+
+        # Each inheriting class must also get a vtable, consistent with the
+        # typeinfo (and, for virtual bases, VTT) already emitted for it.
+        for derived in ("Inheritor", "VB1", "VB2", "Diamond"):
+            self.assertIn(f"typeinfo?for?mir::{derived};", symbols)
+            self.assertIn(
+                f"vtable?for?mir::{derived};",
+                symbols,
+                f"vtable?for?mir::{derived} is missing — a class that inherits "
+                f"a vtable must emit one (has_vtable base-class lookup bug).",
+            )
+
+    def test_process_directory_unions_all_headers(self):
+        # process_directory should return the union of every header's symbols.
+        # This exercises the public entry point (and, on branches that
+        # parallelise it, the worker plumbing) and guards against regressions in
+        # how per-file results are combined.
+        combined = self.generator.process_directory(FIXTURES, [])
+        expected = set()
+        for header in ("plain.h", "polymorphic.h", "templates.h", "inheritance.h"):
+            expected |= self._symbols_for(header)
+        self.assertEqual(combined, expected)
+
+
+class ReadSymbolsFromFileTest(unittest.TestCase):
+    """Unit tests for the symbols.map parser, which needs no libclang."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.generator = _load_generator()
+
+    def test_parses_versions_and_classifies_c_and_cpp_symbols(self):
+        import io
+
+        content = (
+            'MIRAL_5.0 {\n'
+            'global:\n'
+            '  extern "C++" {\n'
+            '    mir::Foo::Foo*;\n'
+            '    mir::Foo::bar*;\n'
+            '  };\n'
+            '  some_c_symbol;\n'
+            '};\n'
+        )
+        symbols = self.generator.read_symbols_from_file(io.StringIO(content), "miral")
+
+        names = {s.name for s in symbols}
+        self.assertIn("mir::Foo::Foo*;", names)
+        self.assertIn("mir::Foo::bar*;", names)
+        self.assertIn("some_c_symbol;", names)
+
+        by_name = {s.name: s for s in symbols}
+        self.assertFalse(by_name["mir::Foo::Foo*;"].is_c_symbol)
+        self.assertTrue(by_name["some_c_symbol;"].is_c_symbol)
+        for s in symbols:
+            self.assertEqual(s.version, "5.0")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/symbols_map_generator/tests/test_symbols_map_generator.py
+++ b/tools/symbols_map_generator/tests/test_symbols_map_generator.py
@@ -178,6 +178,59 @@ class SymbolsMapGeneratorGoldenTest(unittest.TestCase):
             },
         )
 
+    def test_access_levels(self):
+        # Private members are never emitted.  Protected members ARE emitted
+        # (they are part of the ABI), despite the "private and protected"
+        # wording of the traverse_ast comment.  This pins current behaviour so a
+        # refactor of the access check does not silently change it.
+        self.assertEqual(
+            self._symbols_for("access.h"),
+            {
+                "mir::AccessLevels::public_method*;",
+                "mir::AccessLevels::protected_method*;",
+                "typeinfo?for?mir::AccessLevels;",
+            },
+        )
+
+    def test_scopes_enums_inline_and_vars(self):
+        # Nested namespaces produce a "::"-joined prefix.  Enums (scoped or
+        # unscoped) emit no symbols.  An inline (in-header) function is skipped
+        # while a declared-only function and an extern variable are emitted.
+        self.assertEqual(
+            self._symbols_for("scopes.h"),
+            {
+                "mir::nested::declared_free_function*;",
+                "mir::nested::extern_variable*;",
+            },
+        )
+
+    def test_template_instantiation_mangling(self):
+        # Explicit instantiations carry template arguments in the symbol name.
+        # '<' and '>' are mangled to '?' and ',' to '*'.
+        self.assertEqual(
+            self._symbols_for("template_instantiation.h"),
+            {
+                "typeinfo?for?mir::Single?int?;",
+                "typeinfo?for?mir::Couple?int*char?;",
+            },
+        )
+
+    def test_hidden_symbols_are_filtered(self):
+        # Symbols present in HIDDEN_SYMBOLS are dropped from the output, while
+        # their siblings are kept.  HIDDEN_SYMBOLS is patched to a known value so
+        # the test does not depend on the (evolving) real contents of the set.
+        generator = self.generator
+        original = generator.HIDDEN_SYMBOLS
+        try:
+            generator.HIDDEN_SYMBOLS = {"mir::Plain::do_thing*;"}
+            symbols = self._symbols_for("plain.h")
+        finally:
+            generator.HIDDEN_SYMBOLS = original
+
+        self.assertNotIn("mir::Plain::do_thing*;", symbols)
+        # A sibling that is not hidden is still emitted.
+        self.assertIn("mir::Plain::value*;", symbols)
+
     def test_inheritance_symbols(self):
         # Golden set for inheritance.h reflecting the CORRECT behaviour: a class
         # that inherits a vtable from a polymorphic base must get its own
@@ -233,14 +286,15 @@ class SymbolsMapGeneratorGoldenTest(unittest.TestCase):
             )
 
     def test_process_directory_unions_all_headers(self):
-        # process_directory should return the union of every header's symbols.
-        # This exercises the public entry point (and, on branches that
+        # process_directory should return the union of every fixture header's
+        # symbols.  This exercises the public entry point (and, on branches that
         # parallelise it, the worker plumbing) and guards against regressions in
-        # how per-file results are combined.
+        # how per-file results are combined.  Expected is derived from the same
+        # per-file extraction so new fixtures are picked up automatically.
         combined = self.generator.process_directory(FIXTURES, [])
         expected = set()
-        for header in ("plain.h", "polymorphic.h", "templates.h", "inheritance.h"):
-            expected |= self._symbols_for(header)
+        for header in sorted(FIXTURES.glob("*.h")):
+            expected |= self._symbols_for(header.name)
         self.assertEqual(combined, expected)
 
 
@@ -276,6 +330,75 @@ class ReadSymbolsFromFileTest(unittest.TestCase):
         self.assertTrue(by_name["some_c_symbol;"].is_c_symbol)
         for s in symbols:
             self.assertEqual(s.version, "5.0")
+
+    def test_internal_stanza_is_classified_as_internal(self):
+        import io
+
+        content = (
+            'MIRAL_5.0 {\n'
+            'global:\n'
+            '  extern "C++" {\n'
+            '    mir::Foo::bar*;\n'
+            '  };\n'
+            '};\n'
+            'MIRAL_INTERNAL_5.0 {\n'
+            'global:\n'
+            '  extern "C++" {\n'
+            '    mir::Internal::secret*;\n'
+            '  };\n'
+            '};\n'
+        )
+        by_name = {
+            s.name: s
+            for s in self.generator.read_symbols_from_file(io.StringIO(content), "miral")
+        }
+        self.assertEqual(by_name["mir::Foo::bar*;"].version, "5.0")
+        self.assertFalse(by_name["mir::Foo::bar*;"].is_internal())
+        self.assertEqual(by_name["mir::Internal::secret*;"].version, "INTERNAL_5.0")
+        self.assertTrue(by_name["mir::Internal::secret*;"].is_internal())
+
+
+class PureHelperTest(unittest.TestCase):
+    """Tests for the version/diff helpers that need no libclang."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.generator = _load_generator()
+
+    def test_get_version_from_library_version_str(self):
+        fn = self.generator.get_version_from_library_version_str
+        self.assertEqual(fn("MIR_SERVER_INTERNAL_5.0.0"), "5.0.0")
+        self.assertEqual(fn("MIRAL_5.0"), "5.0")
+
+    def test_get_major_version_from_str(self):
+        fn = self.generator.get_major_version_from_str
+        self.assertEqual(fn("5.0.0"), 5)
+        self.assertEqual(fn("12.3"), 12)
+
+    def test_symbol_is_internal_classification(self):
+        Symbol = self.generator.Symbol
+        self.assertTrue(Symbol("x;", "INTERNAL_5.0", False).is_internal())
+        self.assertFalse(Symbol("x;", "5.0", False).is_internal())
+
+    def test_get_added_symbols_returns_only_genuinely_new_names(self):
+        # added = new symbols whose name does not already appear in the previous
+        # set, sorted.  Names already present are dropped regardless of the
+        # internal/external flag.
+        Symbol = self.generator.Symbol
+        previous = [
+            Symbol("a;", "MIRAL_5.0", False),
+            Symbol("b;", "MIRAL_5.0", False),
+        ]
+        new = {"a;", "c;", "d;"}
+        self.assertEqual(
+            self.generator.get_added_symbols(previous, new, False),
+            ["c;", "d;"],
+        )
+
+    def test_get_added_symbols_empty_when_nothing_new(self):
+        Symbol = self.generator.Symbol
+        previous = [Symbol("a;", "MIRAL_5.0", False)]
+        self.assertEqual(self.generator.get_added_symbols(previous, {"a;"}, False), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

This pull request adds a comprehensive set of C++ header fixtures and a `.gitignore` file for the `tools/symbols_map_generator/tests` directory. These fixtures cover a variety of language features and will be useful for testing the symbols generator.

Addition of C++ test fixtures:

* Introduced multiple C++ header files in the `tests/fixtures` directory, each targeting specific language features for symbol extraction testing:
  - [`access.h`](diffhunk://#diff-0d84f771f5614d69f4499f4198bde96be102e1ad6bdd13a783bcedca1b84e595R1-R38): Tests access control levels (public, protected, private).
  - [`inheritance.h`](diffhunk://#diff-4e68300605d21f5b7df982ec6b148a69814142be27dee1bcb5733e7aa74a7f27R1-R48): Covers inheritance, including virtual inheritance and vtable emission.
  - [`plain.h`](diffhunk://#diff-7f379d64f0dbd8c52d1c19d8a391a3f506fc0c106295f670c5f16996b82df464R1-R39): Contains a non-polymorphic class and a free function.
  - [`polymorphic.h`](diffhunk://#diff-dd21180f41f37cad8b4ac03476ca4ae382010f572c01dcdffcf83f3bc8e9a2b7R1-R44): Demonstrates polymorphism, virtual methods, overrides, and abstract classes.
  - [`scopes.h`](diffhunk://#diff-8bd41d25788e8944349f879290e8a98f61ad36d498d0307a844e267d0ef88669R1-R48): Explores namespaces, enums, inline functions, and extern variables.
  - [`template_instantiation.h`](diffhunk://#diff-9fe2c8f87283a78cd44fc656c23a536df4945634e09b554a4752b93b205ae3a9R1-R37): Focuses on explicit template instantiations and symbol mangling.
  - [`templates.h`](diffhunk://#diff-b6cfe82370918fb470e5d7a3d7d8ab011ff97e7ae9a20f6348bfc3c2a9d38638R1-R39): Tests template classes and operator overloads, including mangling of template parameters and operators.