### PR TITLE
Generated C++ implementations in wayland-rs take a std::optional instead of a value + has_value field in the implementor-facing API

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -564,27 +564,13 @@ pub enum CppType {
 /// Convert a CppType intended as a return value to its corresponding
 /// C++ source code string in the function signature.
 fn cpp_return_type_to_cpp_source(cpp_type: &CppType) -> String {
+    // Return types always use the standard-library spelling (never the cxx.rs
+    // wrapper), so `originates_from_rust` is `false`. The only reference-qualified
+    // return type is `rust::Box`, which is returned by `const&`.
+    let bare = cpp_bare_type_to_cpp_source(cpp_type, false);
     match cpp_type {
-        CppType::CppI32 => "int32_t".to_string(),
-        CppType::CppU32 => "uint32_t".to_string(),
-        CppType::CppF64 => "double".to_string(),
-        CppType::String => "std::string".to_string(),
-        CppType::Str => "rust::Str".to_string(),
-        CppType::Object(name) => {
-            format!("std::shared_ptr<{}>", name)
-        }
-        CppType::Weak(name) => {
-            format!("wayland_rs::Weak<{}>", name)
-        }
-        CppType::Array => "std::vector<uint8_t>".to_string(),
-        CppType::Fd => "int32_t".to_string(),
-        CppType::Box(name) => {
-            format!("rust::Box<{}> const&", name)
-        }
-        CppType::Bool => "bool".to_string(),
-        CppType::Optional(inner) => {
-            format!("std::optional<{}>", cpp_return_type_to_cpp_source(inner))
-        }
+        CppType::Box(_) => format!("{} const&", bare),
+        _ => bare,
     }
 }
 
@@ -594,37 +580,29 @@ fn cpp_return_type_to_cpp_source(cpp_type: &CppType) -> String {
 /// If the method is called from Rust, we will use the cxx.rs C++ wrapper
 /// for the type instead of the standard library type.
 fn cpp_arg_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) -> String {
-    match (cpp_type, originates_from_rust) {
-        (CppType::CppI32, _) => "int32_t".into(),
-        (CppType::CppU32, _) => "uint32_t".into(),
-        (CppType::CppF64, _) => "double".into(),
-        (CppType::Fd, _) => "int32_t".into(),
-        (CppType::Object(name), _) => format!("std::shared_ptr<{}> const&", name),
-        (CppType::Weak(name), _) => format!("wayland_rs::Weak<{}> const&", name),
-        (CppType::Box(name), _) => {
-            if originates_from_rust {
-                format!("rust::Box<{}>", name)
-            } else {
-                format!("rust::Box<{}> const&", name)
-            }
-        }
-        (CppType::String, true) => "rust::String".into(),
-        (CppType::String, false) => "std::string const&".into(),
-        (CppType::Str, _) => "rust::Str".into(),
-        (CppType::Array, true) => "rust::Vec<uint8_t>".into(),
-        (CppType::Array, false) => "std::vector<uint8_t> const&".into(),
-        (CppType::Bool, _) => "bool".to_string(),
-        (CppType::Optional(inner), o) => {
-            format!(
-                "std::optional<{}> const&",
-                cpp_bare_type_to_cpp_source(inner, o)
-            )
-        }
+    let bare = cpp_bare_type_to_cpp_source(cpp_type, originates_from_rust);
+    if cpp_type_passed_by_const_ref(cpp_type, originates_from_rust) {
+        format!("{} const&", bare)
+    } else {
+        bare
+    }
+}
+
+/// Whether an argument of this type is passed by `const&` (rather than by value)
+/// in C++ method signatures. The cxx.rs wrapper types (`rust::String`,
+/// `rust::Vec`, `rust::Box`) are passed by value when crossing from Rust.
+fn cpp_type_passed_by_const_ref(cpp_type: &CppType, originates_from_rust: bool) -> bool {
+    match cpp_type {
+        CppType::Object(_) | CppType::Weak(_) | CppType::Optional(_) => true,
+        CppType::Box(_) | CppType::String | CppType::Array => !originates_from_rust,
+        _ => false,
     }
 }
 
 /// Convert a CppType to its bare (unqualified, non-reference) C++ source type,
-/// e.g. for use as the inner type of a `std::optional<...>`.
+/// e.g. for use as the inner type of a `std::optional<...>`. This is the single
+/// canonical type renderer; `cpp_arg_type_to_cpp_source` and
+/// `cpp_return_type_to_cpp_source` build on it by adding reference qualifiers.
 fn cpp_bare_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) -> String {
     match (cpp_type, originates_from_rust) {
         (CppType::CppI32, _) => "int32_t".into(),

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -615,7 +615,10 @@ fn cpp_arg_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) ->
         (CppType::Array, false) => "std::vector<uint8_t> const&".into(),
         (CppType::Bool, _) => "bool".to_string(),
         (CppType::Optional(inner), o) => {
-            format!("std::optional<{}> const&", cpp_bare_type_to_cpp_source(inner, o))
+            format!(
+                "std::optional<{}> const&",
+                cpp_bare_type_to_cpp_source(inner, o)
+            )
         }
     }
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -555,6 +555,10 @@ pub enum CppType {
     Fd,
     Box(String),
     Bool,
+    /// A nullable argument exposed on the public C++ surface as `std::optional`.
+    /// This type never crosses the FFI boundary; the boundary uses the
+    /// `(value, has_value)` representation instead.
+    Optional(Box<CppType>),
 }
 
 /// Convert a CppType intended as a return value to its corresponding
@@ -578,6 +582,9 @@ fn cpp_return_type_to_cpp_source(cpp_type: &CppType) -> String {
             format!("rust::Box<{}> const&", name)
         }
         CppType::Bool => "bool".to_string(),
+        CppType::Optional(inner) => {
+            format!("std::optional<{}>", cpp_return_type_to_cpp_source(inner))
+        }
     }
 }
 
@@ -607,6 +614,32 @@ fn cpp_arg_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) ->
         (CppType::Array, true) => "rust::Vec<uint8_t>".into(),
         (CppType::Array, false) => "std::vector<uint8_t> const&".into(),
         (CppType::Bool, _) => "bool".to_string(),
+        (CppType::Optional(inner), o) => {
+            format!("std::optional<{}> const&", cpp_bare_type_to_cpp_source(inner, o))
+        }
+    }
+}
+
+/// Convert a CppType to its bare (unqualified, non-reference) C++ source type,
+/// e.g. for use as the inner type of a `std::optional<...>`.
+fn cpp_bare_type_to_cpp_source(cpp_type: &CppType, originates_from_rust: bool) -> String {
+    match (cpp_type, originates_from_rust) {
+        (CppType::CppI32, _) => "int32_t".into(),
+        (CppType::CppU32, _) => "uint32_t".into(),
+        (CppType::CppF64, _) => "double".into(),
+        (CppType::Fd, _) => "int32_t".into(),
+        (CppType::Object(name), _) => format!("std::shared_ptr<{}>", name),
+        (CppType::Weak(name), _) => format!("wayland_rs::Weak<{}>", name),
+        (CppType::Box(name), _) => format!("rust::Box<{}>", name),
+        (CppType::String, true) => "rust::String".into(),
+        (CppType::String, false) => "std::string".into(),
+        (CppType::Str, _) => "rust::Str".into(),
+        (CppType::Array, true) => "rust::Vec<uint8_t>".into(),
+        (CppType::Array, false) => "std::vector<uint8_t>".into(),
+        (CppType::Bool, _) => "bool".into(),
+        (CppType::Optional(inner), o) => {
+            format!("std::optional<{}>", cpp_bare_type_to_cpp_source(inner, o))
+        }
     }
 }
 
@@ -631,6 +664,7 @@ fn cpp_return_type_to_rust_source(cpp_type: &CppType) -> TokenStream {
             quote! { &Box<#type_name> }
         }
         CppType::Bool => quote! { bool },
+        CppType::Optional(_) => unreachable!("Optional type should not generate Rust code"),
     }
 }
 
@@ -674,6 +708,7 @@ fn cpp_arg_type_to_rust_source(cpp_type: &CppType, originates_from_rust: bool) -
             }
         }
         CppType::Bool => quote! { bool },
+        CppType::Optional(_) => unreachable!("Optional type should not generate Rust code"),
     }
 }
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -245,6 +245,7 @@ fn create_cpp_builder(protocol: &WaylandProtocol) -> CppBuilder {
     builder.add_header_include("<memory>");
     builder.add_header_include("<cstdint>");
     builder.add_header_include("<string>");
+    builder.add_header_include("<optional>");
     builder.add_header_include("<rust/cxx.h>");
 
     builder.add_cpp_include("\"wayland_rs/src/ffi.rs.h\"");
@@ -423,34 +424,11 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
         None => None,
     };
 
-    let args = method
+    let cpp_args: Vec<CppArg> = method
         .args
         .iter()
         .filter(|arg| arg.type_ != WaylandArgType::NewId)
-        .map(wayland_arg_to_cpp_arg);
-
-    // If a C++ argument is being sent from Rust to C++ as a shared_ptr, we do NOT want
-    // to encourage the protocol implementer to hold a shared reference to the object, as
-    // that muddies up the lifetimes significantly. Only the Rust Wayland frontend should
-    // have access to the lifetime. However, it is important for the protocol business logic
-    // to be able to interact with other protocol implementations. Hence, we wrap the shared_ptr
-    // in our own "Weak" construct.
-    //
-    // If this is the case, we need to do the following:
-    // 1. Generate a different virtual method that is NOT called from Rust which will handle
-    //    the logic using the weak value.
-    // 2. Make the original handler NOT be virtual, as the overridable logic will be delegated
-    //    to the new method from #1.
-    let wayland_weak_transformers: Vec<String> = args
-        .clone()
-        .flat_map(|arg| match arg.cpp_type() {
-            CppType::Object(type_name) => Some(format!(
-                "auto const wrapped_{name} = wayland_rs::Weak<{type_name}>({name});",
-                name = arg.name(),
-                type_name = type_name
-            )),
-            _ => None,
-        })
+        .map(wayland_arg_to_cpp_arg)
         .collect();
 
     let has_retval = retval.is_some();
@@ -480,109 +458,136 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
         vec![]
     };
 
+    let is_destructor = method
+        .type_
+        .as_deref()
+        .map(|type_| type_ == "destructor")
+        .unwrap_or(false);
+
+    // A C++ argument sent from Rust as a shared_ptr (an Object) must not be handed to the
+    // protocol implementer directly: only the Rust Wayland frontend should own its lifetime.
+    // Instead we wrap it in a "Weak" construct so the implementer can still interact with
+    // other protocol implementations without muddying lifetimes.
+    //
+    // Additionally, nullable (`allow_null`) arguments arrive as a `(value, has_value)` pair,
+    // since `std::optional` cannot cross the FFI boundary. We do not want that boolean to
+    // leak into the public API, so we present such arguments as `std::optional<...>`.
+    //
+    // In either case the public surface differs from the FFI surface, so we:
+    // 1. Generate a virtual method (overridden by implementers) using Weak/optional args.
+    // 2. Make the FFI-facing handler non-virtual and delegate to the virtual method,
+    //    performing the Weak-wrapping and optional-packaging in between.
+    let needs_split = !is_destructor
+        && cpp_args.iter().any(|arg| {
+            matches!(arg.cpp_type(), CppType::Object(_)) || arg.has_name().is_some()
+        });
+
     let mut cpp_method = CppMethod::new(
         method.name.as_str(),
         retval,
-        wayland_weak_transformers.is_empty(),
+        !needs_split,
         true,
         true,
         true,
     );
-    for arg in args.clone() {
-        cpp_method.add_arg(arg);
+    for arg in &cpp_args {
+        cpp_method.add_arg(arg.clone());
     }
     for arg in new_id_ext_args.clone() {
         cpp_method.add_arg(arg);
     }
 
-    if let Some(type_) = &method.type_ {
-        if type_ == "destructor" {
-            assert!(wayland_weak_transformers.is_empty());
-            cpp_method.set_body("");
-        }
+    if is_destructor {
+        cpp_method.set_body("");
     }
 
-    if !wayland_weak_transformers.is_empty() {
-        // Build the body: wrap shared_ptrs in Weak, then delegate to the virtual overload
-        let return_prefix = if has_retval { "return " } else { "" };
-        let mut all_delegation_args: Vec<String> = args
-            .clone()
-            .flat_map(|arg| {
-                let call_arg = match arg.cpp_type() {
-                    CppType::Object(_) => format!("wrapped_{}", arg.name()),
-                    _ => arg.name().to_string(),
-                };
-                if let Some(has_name) = arg.has_name() {
-                    vec![call_arg, has_name]
-                } else {
-                    vec![call_arg]
-                }
-            })
-            .collect();
+    if !needs_split {
+        return vec![cpp_method];
+    }
 
-        // Forward child_instance and child_object_id to the virtual method
-        for arg in &new_id_ext_args {
-            all_delegation_args.push(format!("std::move({})", arg.name()));
-        }
-        let delegation_call = format!(
-            "{}{}({});",
-            return_prefix,
-            sanitize_identifier(&method.name),
-            all_delegation_args.join(", ")
-        );
-        let mut body_lines = wayland_weak_transformers;
-        body_lines.push(delegation_call);
-        cpp_method.set_body(body_lines.join("\n"));
+    // Build the FFI-facing body: package each argument into its public form, then delegate
+    // to the virtual overload.
+    let return_prefix = if has_retval { "return " } else { "" };
+    let mut all_delegation_args: Vec<String> = cpp_args
+        .iter()
+        .map(|arg| delegation_argument_expression(arg))
+        .collect();
 
-        // Generate the virtual method that protocol implementers override.
-        // This method uses Weak args instead of shared_ptr args.
-        let virtual_retval = method
-            .args
-            .iter()
-            .find(|arg| arg.type_ == WaylandArgType::NewId)
-            .map(|new_id_arg| {
-                CppType::Object(format_wayland_interface_to_cpp_class(
-                    new_id_arg
-                        .interface
-                        .as_ref()
-                        .expect("NewId is missing interface"),
-                ))
-            });
-        let mut virtual_method = CppMethod::new(
-            method.name.as_str(),
-            virtual_retval,
-            true,
-            true,
-            true,
-            false,
-        );
-        for wayland_arg in method
-            .args
-            .iter()
-            .filter(|arg| arg.type_ != WaylandArgType::NewId)
-        {
-            let cpp_arg = wayland_arg_to_cpp_arg(wayland_arg);
-            match cpp_arg.cpp_type() {
-                CppType::Object(type_name) => {
-                    virtual_method.add_arg(CppArg::new(
-                        CppType::Weak(type_name.clone()),
-                        wayland_arg.name.as_str(),
-                        wayland_arg.allow_null.unwrap_or(false),
-                    ));
-                }
-                _ => {
-                    virtual_method.add_arg(cpp_arg);
-                }
-            }
-        }
-        // Add the child middleware args to the virtual method too
-        for arg in new_id_ext_args {
-            virtual_method.add_arg(arg);
-        }
+    // Forward child_instance and child_object_id to the virtual method
+    for arg in &new_id_ext_args {
+        all_delegation_args.push(format!("std::move({})", arg.name()));
+    }
+    let delegation_call = format!(
+        "{}{}({});",
+        return_prefix,
+        sanitize_identifier(&method.name),
+        all_delegation_args.join(", ")
+    );
+    cpp_method.set_body(delegation_call);
 
-        vec![cpp_method, virtual_method]
+    // Generate the virtual method that protocol implementers override.
+    // This method uses Weak args instead of shared_ptr args, and std::optional for
+    // nullable args.
+    let virtual_retval = method
+        .args
+        .iter()
+        .find(|arg| arg.type_ == WaylandArgType::NewId)
+        .map(|new_id_arg| {
+            CppType::Object(format_wayland_interface_to_cpp_class(
+                new_id_arg
+                    .interface
+                    .as_ref()
+                    .expect("NewId is missing interface"),
+            ))
+        });
+    let mut virtual_method = CppMethod::new(
+        method.name.as_str(),
+        virtual_retval,
+        true,
+        true,
+        true,
+        false,
+    );
+    for arg in &cpp_args {
+        virtual_method.add_arg(public_argument(arg));
+    }
+    // Add the child middleware args to the virtual method too
+    for arg in new_id_ext_args {
+        virtual_method.add_arg(arg);
+    }
+
+    vec![cpp_method, virtual_method]
+}
+
+/// Returns the public-facing `CppArg` for a request argument: Object args become `Weak`,
+/// and nullable args are wrapped in `std::optional`, dropping the `has_X` boolean.
+fn public_argument(arg: &CppArg) -> CppArg {
+    let public_type = match arg.cpp_type() {
+        CppType::Object(type_name) => CppType::Weak(type_name.clone()),
+        other => other.clone(),
+    };
+    if arg.has_name().is_some() {
+        CppArg::new(CppType::Optional(Box::new(public_type)), arg.name(), false)
     } else {
-        vec![cpp_method]
+        CppArg::new(public_type, arg.name(), false)
+    }
+}
+
+/// Builds the expression used to forward an argument from the FFI-facing handler to the
+/// virtual method that protocol implementers override.
+fn delegation_argument_expression(arg: &CppArg) -> String {
+    let name = arg.name();
+    match (arg.cpp_type(), arg.has_name()) {
+        (CppType::Object(type_name), Some(has_name)) => format!(
+            "{has_name} ? std::make_optional(wayland_rs::Weak<{type_name}>({name})) : std::nullopt"
+        ),
+        (CppType::Object(type_name), None) => {
+            format!("wayland_rs::Weak<{type_name}>({name})")
+        }
+        (_, Some(has_name)) => {
+            format!("{has_name} ? std::make_optional(std::move({name})) : std::nullopt")
+        }
+        (_, None) => name.to_string(),
     }
 }
 
@@ -590,24 +595,17 @@ fn wayland_event_to_cpp_methods(event: &WaylandEvent) -> Vec<CppMethod> {
     let since = event.since.unwrap_or(1);
     let needs_version_guard = since > 1;
 
-    let args = event.args.iter().map(wayland_arg_to_cpp_arg);
+    let cpp_args: Vec<CppArg> = event.args.iter().map(wayland_arg_to_cpp_arg).collect();
 
-    let sanitized_args: Vec<String> = args
-        .clone()
-        .flat_map(|arg| {
-            let arg_name = match arg.cpp_type() {
-                CppType::Object(_) => format!("{}->get_box()", sanitize_identifier(&arg.name())),
-                _ => sanitize_identifier(&arg.name()),
-            };
-            if let Some(has_name) = arg.has_name() {
-                vec![arg_name, has_name]
-            } else {
-                vec![arg_name]
-            }
-        })
+    // Build the arguments forwarded across the FFI boundary to the Rust middleware. Nullable
+    // values are unpacked here from their public `std::optional` form into the
+    // `(value, has_value)` (or raw-pointer, for objects) representation the FFI expects.
+    let ffi_call_args: Vec<String> = cpp_args
+        .iter()
+        .flat_map(event_ffi_call_expressions)
         .collect();
 
-    let send_call = format!("instance_->{}({});", event.name, sanitized_args.join(", "));
+    let send_call = format!("instance_->{}({});", event.name, ffi_call_args.join(", "));
 
     // Generate the `send_x_event` method
     let send_body = if needs_version_guard {
@@ -627,10 +625,10 @@ fn wayland_event_to_cpp_methods(event: &WaylandEvent) -> Vec<CppMethod> {
         false,
         false,
         false,
-        true,
+        false,
     );
-    for arg in args.clone() {
-        send_method.add_arg(arg);
+    for arg in &cpp_args {
+        send_method.add_arg(event_public_argument(arg));
     }
     send_method.set_body(send_body);
 
@@ -650,14 +648,57 @@ fn wayland_event_to_cpp_methods(event: &WaylandEvent) -> Vec<CppMethod> {
             false,
             false,
             false,
-            true,
+            false,
         );
-        for arg in args {
-            if_supported_method.add_arg(arg);
+        for arg in &cpp_args {
+            if_supported_method.add_arg(event_public_argument(arg));
         }
         if_supported_method.set_body(if_supported_body);
         methods.push(if_supported_method);
     }
 
     methods
+}
+
+/// Returns the public-facing `CppArg` for an event argument: nullable arguments are wrapped
+/// in `std::optional`, dropping the `has_X` boolean.
+fn event_public_argument(arg: &CppArg) -> CppArg {
+    if arg.has_name().is_some() {
+        CppArg::new(
+            CppType::Optional(Box::new(arg.cpp_type().clone())),
+            arg.name(),
+            false,
+        )
+    } else {
+        arg.clone()
+    }
+}
+
+/// Builds the expression(s) used to forward an event argument from the public
+/// `send_x_event` method to the underlying Rust middleware call.
+fn event_ffi_call_expressions(arg: &CppArg) -> Vec<String> {
+    let name = arg.name();
+    match (arg.cpp_type(), arg.has_name()) {
+        // A nullable object is forwarded as a raw pointer to its middleware box (or null).
+        (CppType::Object(_), Some(_)) => {
+            vec![format!("{name}.has_value() ? &(*{name})->get_box() : nullptr")]
+        }
+        (CppType::Object(_), None) => vec![format!("{name}->get_box()")],
+        // A nullable non-object is forwarded as a `(value, has_value)` pair.
+        (other, Some(_)) => {
+            let empty = match other {
+                CppType::String => "std::string{}".to_string(),
+                CppType::Array => "std::vector<uint8_t>{}".to_string(),
+                _ => format!(
+                    "std::remove_cvref_t<decltype(*{name})>{{}}",
+                    name = name
+                ),
+            };
+            vec![
+                format!("{name}.has_value() ? *{name} : {empty}"),
+                format!("{name}.has_value()"),
+            ]
+        }
+        (_, None) => vec![name.to_string()],
+    }
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -478,18 +478,12 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
     // 2. Make the FFI-facing handler non-virtual and delegate to the virtual method,
     //    performing the Weak-wrapping and optional-packaging in between.
     let needs_split = !is_destructor
-        && cpp_args.iter().any(|arg| {
-            matches!(arg.cpp_type(), CppType::Object(_)) || arg.has_name().is_some()
-        });
+        && cpp_args
+            .iter()
+            .any(|arg| matches!(arg.cpp_type(), CppType::Object(_)) || arg.has_name().is_some());
 
-    let mut cpp_method = CppMethod::new(
-        method.name.as_str(),
-        retval,
-        !needs_split,
-        true,
-        true,
-        true,
-    );
+    let mut cpp_method =
+        CppMethod::new(method.name.as_str(), retval, !needs_split, true, true, true);
     for arg in &cpp_args {
         cpp_method.add_arg(arg.clone());
     }
@@ -681,7 +675,9 @@ fn event_ffi_call_expressions(arg: &CppArg) -> Vec<String> {
     match (arg.cpp_type(), arg.has_name()) {
         // A nullable object is forwarded as a raw pointer to its middleware box (or null).
         (CppType::Object(_), Some(_)) => {
-            vec![format!("{name}.has_value() ? &(*{name})->get_box() : nullptr")]
+            vec![format!(
+                "{name}.has_value() ? &(*{name})->get_box() : nullptr"
+            )]
         }
         (CppType::Object(_), None) => vec![format!("{name}->get_box()")],
         // A nullable non-object is forwarded as a `(value, has_value)` pair.
@@ -689,10 +685,7 @@ fn event_ffi_call_expressions(arg: &CppArg) -> Vec<String> {
             let empty = match other {
                 CppType::String => "std::string{}".to_string(),
                 CppType::Array => "std::vector<uint8_t>{}".to_string(),
-                _ => format!(
-                    "std::remove_cvref_t<decltype(*{name})>{{}}",
-                    name = name
-                ),
+                _ => format!("std::remove_cvref_t<decltype(*{name})>{{}}", name = name),
             };
             vec![
                 format!("{name}.has_value() ? *{name} : {empty}"),

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -11,7 +11,9 @@ use crate::cpp_builder::{sanitize_identifier, CppBuilder};
 use crate::helpers::format_wayland_interface_to_rust_extension_struct;
 
 use super::protocol_middleware_generation::wayland_arg_to_ffi_rust_str;
-use crate::protocol_parser::{InterfaceItem, WaylandEvent, WaylandInterface, WaylandProtocol};
+use crate::protocol_parser::{
+    InterfaceItem, WaylandArgType, WaylandEvent, WaylandInterface, WaylandProtocol,
+};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
@@ -115,6 +117,15 @@ fn generate_ffi_for_interface(interface: &WaylandInterface) -> TokenStream {
     }
 }
 
+/// An event carries a raw pointer across the FFI boundary (and therefore must be declared
+/// `unsafe fn`) when it has a nullable object argument.
+fn event_uses_raw_pointer(event: &WaylandEvent) -> bool {
+    event.args.iter().any(|arg| {
+        arg.allow_null.unwrap_or(false)
+            && matches!(arg.type_, WaylandArgType::Object | WaylandArgType::NewId)
+    })
+}
+
 fn generate_ffi_for_event(interface: &WaylandInterface, event: &WaylandEvent) -> TokenStream {
     let interface_name = format_ident!(
         "{}",
@@ -131,7 +142,13 @@ fn generate_ffi_for_event(interface: &WaylandInterface, event: &WaylandEvent) ->
         })
         .collect();
 
-    quote! {
-        fn #event_name(self: &mut #interface_name, #(#args),*);
+    if event_uses_raw_pointer(event) {
+        quote! {
+            unsafe fn #event_name(self: &mut #interface_name, #(#args),*);
+        }
+    } else {
+        quote! {
+            fn #event_name(self: &mut #interface_name, #(#args),*);
+        }
     }
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
@@ -191,23 +191,33 @@ fn generate_extension_method_for_event(event: &WaylandEvent, interface_name: &st
 
 pub fn wayland_arg_to_ffi_rust_str(arg: &WaylandArg) -> String {
     let name = sanitize_identifier(&arg.name);
+    let nullable = arg.allow_null.unwrap_or(false);
+    let is_object = matches!(arg.type_, WaylandArgType::Object | WaylandArgType::NewId);
     let mut arg_str = match arg.type_ {
         WaylandArgType::Int => format!("{}: {}", name, "i32"),
         WaylandArgType::Uint => format!("{}: {}", name, "u32"),
         WaylandArgType::Fixed => format!("{}: {}", name, "f64"),
         WaylandArgType::String => format!("{}: {}", name, "&CxxString"),
-        WaylandArgType::Object | WaylandArgType::NewId => format!(
-            "{}: &Box<{}>",
-            name,
-            format_wayland_interface_to_rust_extension_struct(
-                arg.interface.as_ref().expect("Object is missing interface")
-            )
-        ),
+        WaylandArgType::Object | WaylandArgType::NewId => {
+            let ext = format_wayland_interface_to_rust_extension_struct(
+                arg.interface.as_ref().expect("Object is missing interface"),
+            );
+            // A nullable object is passed as a raw pointer so that absence can be
+            // represented by null. Neither `std::optional` nor `Option<&Box<_>>` can
+            // cross the cxx FFI boundary, but a raw pointer can.
+            if nullable {
+                format!("{}: *const Box<{}>", name, ext)
+            } else {
+                format!("{}: &Box<{}>", name, ext)
+            }
+        }
         WaylandArgType::Array => format!("{}: {}", name, "&CxxVector<u8>"),
         WaylandArgType::Fd => format!("{}: {}", name, "i32"),
     };
 
-    if arg.allow_null.unwrap_or(false) {
+    // Nullable non-object arguments are still ferried as a `(value, has_value)` pair,
+    // since their value type can always be sent across the boundary.
+    if nullable && !is_object {
         arg_str.push_str(&format!(", has_{}: bool", arg.name));
     }
 
@@ -217,7 +227,7 @@ pub fn wayland_arg_to_ffi_rust_str(arg: &WaylandArg) -> String {
 fn wayland_arg_to_rust_param_str(arg: &WaylandArg, interface_name: &str) -> String {
     let name = sanitize_identifier(&arg.name);
     let mut param = match arg.type_ {
-        WaylandArgType::Int | WaylandArgType::Uint | WaylandArgType::Fixed => name,
+        WaylandArgType::Int | WaylandArgType::Uint | WaylandArgType::Fixed => name.clone(),
         WaylandArgType::String => format!("{}.to_string()", name),
         WaylandArgType::Object | WaylandArgType::NewId => format!("&{}.wrapped", name),
         WaylandArgType::Array => format!("{}.iter().cloned().collect()", name),
@@ -239,7 +249,14 @@ fn wayland_arg_to_rust_param_str(arg: &WaylandArg, interface_name: &str) -> Stri
     }
 
     if arg.allow_null.unwrap_or(false) {
-        param = format!("if has_{} {{ Some({}) }} else {{ None }}", arg.name, param);
+        param = match arg.type_ {
+            // The nullable object arrives as a raw pointer; dereference it to recover the
+            // `Option<&wrapped>` the underlying Wayland method expects.
+            WaylandArgType::Object | WaylandArgType::NewId => {
+                format!("unsafe {{ {name}.as_ref() }}.map(|__opt| &__opt.wrapped)")
+            }
+            _ => format!("if has_{} {{ Some({}) }} else {{ None }}", arg.name, param),
+        };
     }
 
     param


### PR DESCRIPTION
## What's new?
- The `Middleware` object for each C++ method now handles the conversion from `(value, has_value)` to `std::optional<>(value)`.
- Going from C++ -> Rust (because of a Wayland event) now provides objects as pointers when they can be null. Afterward, they are manually unwrapped.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
