### PR TITLE
Make `wayland_rs::Weak`'s semantics match that of the existing `wayland::Weak` more closely + generate a `from<Dervied>` on generated wayland-rs Impls for backwards compatibilty

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -129,6 +129,15 @@ impl CppBuilder {
                 // Virtual destructor
                 result.push_str(&format!("    virtual ~{}() = default;\n\n", class.name));
 
+                // Verbatim header-only public declarations (e.g. static templated helpers).
+                for decl in &class.raw_public_decls {
+                    result.push_str(decl);
+                    result.push('\n');
+                }
+                if !class.raw_public_decls.is_empty() {
+                    result.push('\n');
+                }
+
                 // Generate methods
                 for method in &class.methods {
                     let args_str = Self::build_arg_str_for_cpp(method);
@@ -404,6 +413,10 @@ pub struct CppClass {
     pub protected_constructor_args: Vec<CppArg>,
     pub protected_members: Vec<CppArg>,
     pub private_members: Vec<CppArg>,
+    /// Verbatim header-only declarations emitted in the `public:` section. Unlike `CppMethod`,
+    /// these are never emitted to the .cpp source or the generated Rust/cxx bindings, so they are
+    /// suitable for header-only helpers such as static templated methods.
+    pub raw_public_decls: Vec<String>,
 }
 
 impl CppClass {
@@ -417,11 +430,17 @@ impl CppClass {
             protected_constructor_args: vec![],
             protected_members: vec![],
             private_members: vec![],
+            raw_public_decls: vec![],
         }
     }
 
     pub fn set_superclass(&mut self, name: impl Into<String>) {
         self.superclass = Some(name.into());
+    }
+
+    /// Add a verbatim declaration to the class's `public:` section (header only).
+    pub fn add_raw_public_decl(&mut self, decl: impl Into<String>) {
+        self.raw_public_decls.push(decl.into());
     }
 
     pub fn add_method(&mut self, method: CppMethod) -> &mut CppMethod {

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -254,8 +254,24 @@ fn create_cpp_builder(protocol: &WaylandProtocol) -> CppBuilder {
 
 fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {
     let class_name = format_wayland_interface_to_cpp_class(&interface.name);
-    let mut class = CppClass::new(class_name);
+    let mut class = CppClass::new(class_name.clone());
     class.set_superclass("LifetimeTracker");
+
+    // Backwards-compatible recovery helper, replacing the legacy `Concrete::from(wl_resource*)`.
+    // The generator only knows this abstract base, not the hand-written concrete subclass, so the
+    // method is templated on the caller's concrete type `Self`. It downcasts the weak's referent
+    // (preserving the destroyed-flag) and returns a `Self*`, or nullptr if the weak is
+    // null/expired or does not refer to a `Self`. Usage: `Surface::from<WlSurfaceImpl>(weak)`.
+    class.add_raw_public_decl(format!(
+        "    template<typename Self>\n\
+         \x20   static auto from(::mir::wayland_rs::Weak<{class_name}> const& weak) -> Self*\n\
+         \x20   {{\n\
+         \x20       return ::mir::wayland_rs::as_nullable_ptr(\n\
+         \x20           ::mir::wayland_rs::weak_cast<Self>(weak));\n\
+         \x20   }}",
+        class_name = class_name
+    ));
+
     let methods = interface
         .items
         .iter()

--- a/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
+++ b/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
@@ -18,59 +18,139 @@
 #define MIR_WAYLANDRS_WEAK
 
 #include <memory>
+#include <string>
+#include <typeinfo>
 #include <boost/throw_exception.hpp>
 
 namespace mir
 {
 namespace wayland_rs
 {
+/// A weak handle to a Wayland object (any LifetimeTracker subclass).
+///
+/// Unlike a std::weak_ptr, a Weak does not require the pointed-at object to be owned by a
+/// std::shared_ptr, and creating one never requires std::enable_shared_from_this: the object's
+/// own destroyed-flag (provided by LifetimeTracker) is used as the control block. This means an
+/// object can hand out a weak reference to itself with `make_weak(this)`.
+///
+/// May only be safely used from the Wayland thread.
 template<typename T>
 class Weak
 {
 public:
-    Weak() = default;
+    Weak() : resource{nullptr}, destroyed_flag{nullptr} {}
 
-    explicit Weak(std::shared_ptr<T> const& ptr)
-        : ptr_{ptr}
+    explicit Weak(T* resource)
+        : resource{resource},
+          destroyed_flag{resource ? resource->destroyed_flag() : nullptr}
     {
     }
 
-    Weak(Weak const& weak) = default;
-
-    T& value() const
+    /// Convenience overload: the dispatch layer owns objects via std::shared_ptr. The Weak does
+    /// not keep the object alive; it only borrows the raw pointer and the object's destroyed-flag.
+    explicit Weak(std::shared_ptr<T> const& resource)
+        : Weak{resource.get()}
     {
-        if (ptr_.expired())
+    }
+
+    Weak(Weak<T> const&) = default;
+    auto operator=(Weak<T> const&) -> Weak<T>& = default;
+
+    auto operator==(Weak<T> const& other) const -> bool
+    {
+        if (*this && other)
         {
-            BOOST_THROW_EXCEPTION(
-                std::logic_error(
-                    std::string{"Attempted access of null wayland_rs::Weak<"} +
-                    typeid(T).name() + ">"));
+            return resource == other.resource;
         }
-        return *ptr_.lock();
+        else
+        {
+            return (!*this && !other);
+        }
     }
 
-    operator bool() const
+    auto operator!=(Weak<T> const& other) const -> bool
     {
-        return !ptr_.expired();
+        return !(*this == other);
     }
 
     auto is(T const& other) const -> bool
     {
-        auto locked = ptr_.lock();
-        return locked && locked.get() == &other;
+        if (*this)
+        {
+            return resource == &other;
+        }
+        else
+        {
+            return false;
+        }
     }
 
-    auto operator==(Weak<T> const& other) const -> bool
+    operator bool() const { return resource && !*destroyed_flag; }
+
+    auto value() const -> T&
     {
-        return !ptr_.owner_before(other.ptr_) && !other.ptr_.owner_before(ptr_);
+        if (!*this)
+        {
+            BOOST_THROW_EXCEPTION(
+                std::logic_error(
+                    std::string{"Attempted access of "} + (resource ? "destroyed" : "null") +
+                    " wayland_rs::Weak<" + typeid(T).name() + ">"));
+        }
+        return *resource;
     }
 
-    auto operator=(Weak<T> const&) -> Weak<T>& = default;
+    /// Returns a Weak to the same object viewed as U (a base or derived class), or an empty Weak
+    /// if this Weak is null/expired or the dynamic_cast fails. The destroyed-flag is preserved
+    /// because the resulting Weak is re-derived from the very same (live) object.
+    template<typename U>
+    auto as() const -> Weak<U>
+    {
+        if (!*this)
+        {
+            return Weak<U>{};
+        }
+        return Weak<U>{dynamic_cast<U*>(resource)};
+    }
 
 private:
-    std::weak_ptr<T> ptr_;
+    T* resource;
+    /// Is null if and only if resource is null.
+    /// If the target bool is true then resource has been freed and should not be used.
+    std::shared_ptr<bool const> destroyed_flag;
 };
+
+template<typename T>
+auto make_weak(T* resource) -> Weak<T>
+{ return Weak<T>{resource}; }
+
+template<typename T>
+auto make_weak(std::shared_ptr<T> const& resource) -> Weak<T>
+{ return Weak<T>{resource}; }
+
+template<typename T>
+auto as_nullable_ptr(Weak<T> const& weak) -> T*
+{ return weak ? &weak.value() : nullptr; }
+
+/// Casts a Weak<T> to a Weak<U> between related (base/derived) types, preserving the
+/// destroyed-flag. Yields an empty Weak<U> when the source is null/expired or the cast fails.
+template<typename U, typename T>
+auto weak_cast(Weak<T> const& weak) -> Weak<U>
+{ return weak.template as<U>(); }
 }
 }
+
+/// Declares a backwards-compatible `static Derived* from(Weak<Base> const&)` recovery method on a
+/// concrete Wayland implementation, mirroring the legacy `Concrete::from(wl_resource*)` ergonomics.
+/// Returns the concrete pointer, or nullptr if the Weak is null/expired or does not refer to a
+/// Derived. Built on weak_cast<>/as_nullable_ptr.
+///
+/// Usage (inside the class body of Derived):
+///     MIR_WAYLANDRS_DECLARE_FROM(WlSurfaceImpl, Surface)
+#define MIR_WAYLANDRS_DECLARE_FROM(Derived, Base)                              \
+    static auto from(::mir::wayland_rs::Weak<Base> const& weak) -> Derived*    \
+    {                                                                          \
+        return ::mir::wayland_rs::as_nullable_ptr(                             \
+            ::mir::wayland_rs::weak_cast<Derived>(weak));                      \
+    }
 
 #endif  // MIR_WAYLANDRS_WEAK

--- a/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
+++ b/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/weak.h
@@ -139,18 +139,4 @@ auto weak_cast(Weak<T> const& weak) -> Weak<U>
 }
 }
 
-/// Declares a backwards-compatible `static Derived* from(Weak<Base> const&)` recovery method on a
-/// concrete Wayland implementation, mirroring the legacy `Concrete::from(wl_resource*)` ergonomics.
-/// Returns the concrete pointer, or nullptr if the Weak is null/expired or does not refer to a
-/// Derived. Built on weak_cast<>/as_nullable_ptr.
-///
-/// Usage (inside the class body of Derived):
-///     MIR_WAYLANDRS_DECLARE_FROM(WlSurfaceImpl, Surface)
-#define MIR_WAYLANDRS_DECLARE_FROM(Derived, Base)                              \
-    static auto from(::mir::wayland_rs::Weak<Base> const& weak) -> Derived*    \
-    {                                                                          \
-        return ::mir::wayland_rs::as_nullable_ptr(                             \
-            ::mir::wayland_rs::weak_cast<Derived>(weak));                      \
-    }
-
 #endif  // MIR_WAYLANDRS_WEAK

--- a/tests/wayland_rs/CMakeLists.txt
+++ b/tests/wayland_rs/CMakeLists.txt
@@ -1,5 +1,6 @@
 mir_add_wrapped_executable(mir_wayland_rs_tests NOINSTALL
   ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_executor.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_weak.cpp
   ${PROJECT_SOURCE_DIR}/tests/mir_test_framework/temporary_environment_value.cpp
 )
 

--- a/tests/wayland_rs/test_weak.cpp
+++ b/tests/wayland_rs/test_weak.cpp
@@ -45,14 +45,37 @@ class Concrete : public Base
 public:
     explicit Concrete(int id) : id{id} {}
 
-    // The backwards-compatible recovery method, replacing the legacy from(wl_resource*).
-    MIR_WAYLANDRS_DECLARE_FROM(Concrete, Base)
-
     int const id;
 };
 
 /// A second, unrelated concrete type used to verify failed downcasts.
 class OtherConcrete : public Base
+{
+};
+
+/// Mirrors the `from<Self>` template that the wayland_rs generator now emits on every generated
+/// base class. Kept in sync with cpp_protocol_generation.rs::wayland_interface_to_cpp_class.
+class GeneratedBase : public mrs::LifetimeTracker
+{
+public:
+    virtual ~GeneratedBase() = default;
+
+    template<typename Self>
+    static auto from(::mir::wayland_rs::Weak<GeneratedBase> const& weak) -> Self*
+    {
+        return ::mir::wayland_rs::as_nullable_ptr(
+            ::mir::wayland_rs::weak_cast<Self>(weak));
+    }
+};
+
+class GeneratedConcrete : public GeneratedBase
+{
+public:
+    explicit GeneratedConcrete(int id) : id{id} {}
+    int const id;
+};
+
+class OtherGeneratedConcrete : public GeneratedBase
 {
 };
 }
@@ -170,29 +193,31 @@ TEST(WaylandRsWeak, downcast_of_expired_weak_yields_empty_weak)
     EXPECT_FALSE(mrs::weak_cast<Concrete>(base_weak));
 }
 
-TEST(WaylandRsWeak, from_macro_recovers_concrete_pointer)
-{
-    Concrete object{55};
-    auto const base_weak = mrs::make_weak<Base>(&object);
+// The following mirror the generator-emitted `from<Self>` template (see GeneratedBase above).
 
-    auto* const recovered = Concrete::from(base_weak);
-    ASSERT_THAT(recovered, Eq(&object));
-    EXPECT_THAT(recovered->id, Eq(55));
+TEST(WaylandRsWeak, generated_from_recovers_concrete_pointer)
+{
+    GeneratedConcrete object{77};
+    auto const base_weak = mrs::make_weak<GeneratedBase>(&object);
+
+    // Both the direct and inherited (via the concrete) spellings must work.
+    EXPECT_THAT(GeneratedBase::from<GeneratedConcrete>(base_weak), Eq(&object));
+    EXPECT_THAT(GeneratedConcrete::from<GeneratedConcrete>(base_weak), Eq(&object));
 }
 
-TEST(WaylandRsWeak, from_macro_returns_nullptr_for_wrong_type)
+TEST(WaylandRsWeak, generated_from_returns_nullptr_for_wrong_type)
 {
-    OtherConcrete object;
-    auto const base_weak = mrs::make_weak<Base>(&object);
+    OtherGeneratedConcrete object;
+    auto const base_weak = mrs::make_weak<GeneratedBase>(&object);
 
-    EXPECT_THAT(Concrete::from(base_weak), Eq(nullptr));
+    EXPECT_THAT(GeneratedBase::from<GeneratedConcrete>(base_weak), Eq(nullptr));
 }
 
-TEST(WaylandRsWeak, from_macro_returns_nullptr_for_expired_weak)
+TEST(WaylandRsWeak, generated_from_returns_nullptr_for_expired_weak)
 {
-    auto object = std::make_unique<Concrete>(8);
-    auto const base_weak = mrs::make_weak<Base>(object.get());
+    auto object = std::make_unique<GeneratedConcrete>(9);
+    auto const base_weak = mrs::make_weak<GeneratedBase>(object.get());
     object.reset();
 
-    EXPECT_THAT(Concrete::from(base_weak), Eq(nullptr));
+    EXPECT_THAT(GeneratedBase::from<GeneratedConcrete>(base_weak), Eq(nullptr));
 }

--- a/tests/wayland_rs/test_weak.cpp
+++ b/tests/wayland_rs/test_weak.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "lifetime_tracker.h"
+#include "weak.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace mrs = mir::wayland_rs;
+
+using namespace testing;
+
+namespace
+{
+/// An abstract-style base, mirroring a generated wayland_rs interface class.
+class Base : public mrs::LifetimeTracker
+{
+public:
+    virtual ~Base() = default;
+
+    /// A LifetimeTracker subclass can hand out a weak reference to itself without
+    /// std::enable_shared_from_this, because the control block is its own destroyed-flag.
+    auto weak_to_self() -> mrs::Weak<Base> { return mrs::make_weak(this); }
+};
+
+/// A concrete implementation, mirroring a hand-written C++ protocol implementation.
+class Concrete : public Base
+{
+public:
+    explicit Concrete(int id) : id{id} {}
+
+    // The backwards-compatible recovery method, replacing the legacy from(wl_resource*).
+    MIR_WAYLANDRS_DECLARE_FROM(Concrete, Base)
+
+    int const id;
+};
+
+/// A second, unrelated concrete type used to verify failed downcasts.
+class OtherConcrete : public Base
+{
+};
+}
+
+TEST(WaylandRsWeak, default_constructed_weak_is_falsey)
+{
+    mrs::Weak<Base> const weak;
+    EXPECT_FALSE(weak);
+    EXPECT_THAT(mrs::as_nullable_ptr(weak), Eq(nullptr));
+}
+
+TEST(WaylandRsWeak, weak_to_live_object_is_truthy_and_resolves)
+{
+    Concrete object{42};
+    auto const weak = mrs::make_weak<Base>(&object);
+
+    EXPECT_TRUE(weak);
+    EXPECT_THAT(&weak.value(), Eq(static_cast<Base*>(&object)));
+    EXPECT_THAT(mrs::as_nullable_ptr(weak), Eq(static_cast<Base*>(&object)));
+}
+
+TEST(WaylandRsWeak, object_can_hand_out_weak_to_itself_without_shared_from_this)
+{
+    Concrete object{7};
+    auto const weak = object.weak_to_self();
+
+    EXPECT_TRUE(weak);
+    EXPECT_TRUE(weak.is(object));
+    EXPECT_THAT(&weak.value(), Eq(static_cast<Base*>(&object)));
+}
+
+TEST(WaylandRsWeak, weak_expires_when_object_is_destroyed)
+{
+    auto object = std::make_unique<Concrete>(1);
+    auto const weak = mrs::make_weak<Base>(object.get());
+
+    ASSERT_TRUE(weak);
+    object.reset();
+
+    EXPECT_FALSE(weak);
+    EXPECT_THAT(mrs::as_nullable_ptr(weak), Eq(nullptr));
+    EXPECT_THROW(weak.value(), std::logic_error);
+}
+
+TEST(WaylandRsWeak, shared_ptr_constructor_borrows_without_owning)
+{
+    auto object = std::make_shared<Concrete>(5);
+    mrs::Weak<Base> const weak{std::static_pointer_cast<Base>(object)};
+
+    ASSERT_TRUE(weak);
+    EXPECT_THAT(object.use_count(), Eq(1)) << "Weak must not keep the object alive";
+
+    object.reset();
+    EXPECT_FALSE(weak);
+}
+
+TEST(WaylandRsWeak, equality_and_is_use_object_identity)
+{
+    Concrete a{1};
+    Concrete b{2};
+
+    auto const weak_a = mrs::make_weak<Base>(&a);
+    auto const weak_a_again = mrs::make_weak<Base>(&a);
+    auto const weak_b = mrs::make_weak<Base>(&b);
+    mrs::Weak<Base> const null_weak;
+
+    EXPECT_TRUE(weak_a == weak_a_again);
+    EXPECT_FALSE(weak_a != weak_a_again);
+    EXPECT_TRUE(weak_a != weak_b);
+    EXPECT_TRUE(null_weak == mrs::Weak<Base>{});
+
+    EXPECT_TRUE(weak_a.is(a));
+    EXPECT_FALSE(weak_a.is(b));
+    EXPECT_FALSE(null_weak.is(a));
+}
+
+TEST(WaylandRsWeak, as_downcasts_base_to_concrete)
+{
+    Concrete object{99};
+    auto const base_weak = mrs::make_weak<Base>(&object);
+
+    auto const concrete_weak = base_weak.as<Concrete>();
+    ASSERT_TRUE(concrete_weak);
+    EXPECT_THAT(concrete_weak.value().id, Eq(99));
+    EXPECT_THAT(&concrete_weak.value(), Eq(&object));
+}
+
+TEST(WaylandRsWeak, weak_cast_downcasts_base_to_concrete)
+{
+    Concrete object{12};
+    auto const base_weak = mrs::make_weak<Base>(&object);
+
+    auto const concrete_weak = mrs::weak_cast<Concrete>(base_weak);
+    ASSERT_TRUE(concrete_weak);
+    EXPECT_THAT(concrete_weak.value().id, Eq(12));
+}
+
+TEST(WaylandRsWeak, downcast_to_wrong_type_yields_empty_weak)
+{
+    OtherConcrete object;
+    auto const base_weak = mrs::make_weak<Base>(&object);
+
+    ASSERT_TRUE(base_weak);
+    EXPECT_FALSE(base_weak.as<Concrete>());
+    EXPECT_FALSE(mrs::weak_cast<Concrete>(base_weak));
+}
+
+TEST(WaylandRsWeak, downcast_of_expired_weak_yields_empty_weak)
+{
+    auto object = std::make_unique<Concrete>(3);
+    auto const base_weak = mrs::make_weak<Base>(object.get());
+    object.reset();
+
+    EXPECT_FALSE(base_weak.as<Concrete>());
+    EXPECT_FALSE(mrs::weak_cast<Concrete>(base_weak));
+}
+
+TEST(WaylandRsWeak, from_macro_recovers_concrete_pointer)
+{
+    Concrete object{55};
+    auto const base_weak = mrs::make_weak<Base>(&object);
+
+    auto* const recovered = Concrete::from(base_weak);
+    ASSERT_THAT(recovered, Eq(&object));
+    EXPECT_THAT(recovered->id, Eq(55));
+}
+
+TEST(WaylandRsWeak, from_macro_returns_nullptr_for_wrong_type)
+{
+    OtherConcrete object;
+    auto const base_weak = mrs::make_weak<Base>(&object);
+
+    EXPECT_THAT(Concrete::from(base_weak), Eq(nullptr));
+}
+
+TEST(WaylandRsWeak, from_macro_returns_nullptr_for_expired_weak)
+{
+    auto object = std::make_unique<Concrete>(8);
+    auto const base_weak = mrs::make_weak<Base>(object.get());
+    object.reset();
+
+    EXPECT_THAT(Concrete::from(base_weak), Eq(nullptr));
+}


### PR DESCRIPTION
The goal of this work was to make storing pointers of a Wayland interfaces between each other translate better from the old C++ implementation to the new Rust-based implementation. My previous attempt at this used `std::shared_from_this`, but that was ergonomically poor and did not translate well to the existing interface. This implementation should make things much more backwards-compatible and easy to work with.

## What's new?
- `wayland_rs::Weak` now wraps a raw pointer and checks `is_destroyed` instead of wrapping a `shared_ptr`. This brings it inline with the ergonomics of the existing `wayland::Weak`, making backwards compatibility much better.
- Generating `::from<T>` methods on each Wayland class that will return a raw pointer `T*` from the `Weak` implementation. This is useful for get a `Derived` from a `wayland_rs::Weak<Base>`
- Wrote unit tests

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
