### PR TITLE
Fix documentation errors in input trigger protocols

### DIFF
--- a/wayland-protocols/ext-input-trigger-action-v1.xml
+++ b/wayland-protocols/ext-input-trigger-action-v1.xml
@@ -43,8 +43,8 @@
     </enum>
 
     <request name="destroy" type="destructor">
-      <description summary="destroy input trigger activation manager object">
-        This informs the compositor that the input trigger activation manager
+      <description summary="destroy input trigger action manager object">
+        This informs the compositor that the input trigger action manager
         object will no longer be used. Existing objects created through this
         interface remain valid.
       </description>
@@ -123,8 +123,8 @@
     </event>
 
     <request name="destroy" type="destructor">
-      <description summary="destroy the input trigger activation">
-        This informs the compositor that the input trigger activation will no
+      <description summary="destroy the input trigger action">
+        This informs the compositor that the input trigger action will no
         longer be used.
       </description>
     </request>

--- a/wayland-protocols/ext-input-trigger-registration-v1.xml
+++ b/wayland-protocols/ext-input-trigger-registration-v1.xml
@@ -221,8 +221,8 @@
     <request name="cancel" type="destructor">
       <description summary="purge the input trigger action">
         This informs the compositor that the input trigger action will no
-        longer be used. This event may be sent when the user requests to delete
-        an input trigger.
+        longer be used. This request may be made when the user requests to
+        delete an input trigger.
 
         Any ext_input_trigger_action_v1 created from the associated token
         by this or other clients will become unavailable.


### PR DESCRIPTION
Correct wording mistakes in the ext_input_trigger_action_v1 and ext_input_trigger_registration_v1 protocol descriptions:

  - ext_input_trigger_action_manager_v1.destroy and ext_input_trigger_action_v1.destroy referred to the object as an "activation" / "activation manager"; the interfaces are the input trigger "action" and "action manager". (The activation_token references elsewhere correctly refer to xdg_activation.)

  - ext_input_trigger_action_control_v1.cancel is a client request but was described as an "event" that "may be sent"; it is now described as a request that "may be made".
