### PR TITLE
Update magnifier for touch.

### DIFF
--- a/debian/libmiral8.symbols
+++ b/debian/libmiral8.symbols
@@ -247,6 +247,7 @@ libmiral.so.8 libmiral8 #MINVER#
  (c++)"miral::Magnifier::Magnifier()@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::Magnifier(miral::live_config::Store&)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::capture_size(mir::geometry::generic::Size<int> const&)@MIRAL_6.0" 6.0.0
+ (c++)"miral::Magnifier::decouple(bool)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::enable(bool)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::magnification(float)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::operator()(mir::Server&)@MIRAL_6.0" 6.0.0

--- a/debian/libmiral8.symbols
+++ b/debian/libmiral8.symbols
@@ -247,10 +247,10 @@ libmiral.so.8 libmiral8 #MINVER#
  (c++)"miral::Magnifier::Magnifier()@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::Magnifier(miral::live_config::Store&)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::capture_size(mir::geometry::generic::Size<int> const&)@MIRAL_6.0" 6.0.0
- (c++)"miral::Magnifier::decouple(bool)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::enable(bool)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::magnification(float)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::operator()(mir::Server&)@MIRAL_6.0" 6.0.0
+ (c++)"miral::Magnifier::set_behavior(miral::Magnifier::Behavior)@MIRAL_6.0" 6.0.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, MirInputEventModifier)@MIRAL_6.0" 6.0.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, MirInputEventModifier, miral::FocusStealing)@MIRAL_6.0" 6.0.0

--- a/debian/libmiral8.symbols
+++ b/debian/libmiral8.symbols
@@ -250,6 +250,7 @@ libmiral.so.8 libmiral8 #MINVER#
  (c++)"miral::Magnifier::enable(bool)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::magnification(float)@MIRAL_6.0" 6.0.0
  (c++)"miral::Magnifier::operator()(mir::Server&)@MIRAL_6.0" 6.0.0
+ (c++)"miral::Magnifier::set_behavior(miral::Magnifier::Behavior)@MIRAL_6.0" 6.0.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, MirInputEventModifier)@MIRAL_6.0" 6.0.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, MirInputEventModifier, miral::FocusStealing)@MIRAL_6.0" 6.0.0

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -223,9 +223,9 @@ int main(int argc, char const* argv[])
         {
             if (modifiers & mir_input_event_modifier_shift)
             {
-                auto const magnifier_min_magnification = 1.5f;
+                auto const magnifier_min_magnification = 1.25f;
                 auto const magnifier_max_magnification = 8.0f;
-                auto const magnifier_magnification_step = 0.5f;
+                auto const magnifier_magnification_step = 0.25f;
 
                 // Zoom the magnifier in/out on ctrl shift +/-
                 switch (mir_keyboard_event_keysym(key_event))

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -47,6 +47,7 @@
 
 #include <xkbcommon/xkbcommon-keysyms.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <linux/input-event-codes.h>
@@ -208,7 +209,11 @@ int main(int argc, char const* argv[])
         .magnification(magnification)
         .capture_size(capture_size)
         .enable(false);
-    auto magnifier_filter = [magnifier=magnifier, &magnification, &capture_size](MirKeyboardEvent const* key_event) mutable {
+    auto magnifier_filter = [magnifier = magnifier,
+                             &magnification,
+                             &capture_size,
+                             follows_cursor = true](MirKeyboardEvent const* key_event) mutable
+    {
         auto const modifiers = mir_keyboard_event_modifiers(key_event);
 
         if (mir_keyboard_event_action(key_event) != mir_keyboard_action_down)
@@ -218,31 +223,29 @@ int main(int argc, char const* argv[])
         {
             if (modifiers & mir_input_event_modifier_shift)
             {
+                auto const magnifier_min_magnification = 1.25f;
+                auto const magnifier_max_magnification = 8.0f;
+                auto const magnifier_magnification_step = 0.25f;
+
                 // Zoom the magnifier in/out on ctrl shift +/-
                 switch (mir_keyboard_event_keysym(key_event))
                 {
-                    case XKB_KEY_plus:
-                        magnification += 0.5f;
-                        if (magnification >= 5)
-                        {
-                            magnification = 5;
-                            return true;
-                        }
-
-                        magnifier.magnification(magnification);
-                        return true;
-                    case XKB_KEY_underscore:
-                        magnification -= 0.5f;
-                        if (magnification <= 1)
-                        {
-                            magnification = 1;
-                            return true;
-                        }
-
-                        magnifier.magnification(magnification);
-                        return true;
-                    default:
-                        break;
+                case XKB_KEY_plus:
+                    magnification = std::clamp(
+                        magnification + magnifier_magnification_step,
+                        magnifier_min_magnification,
+                        magnifier_max_magnification);
+                    magnifier.magnification(magnification);
+                    return true;
+                case XKB_KEY_underscore:
+                    magnification = std::clamp(
+                        magnification - magnifier_magnification_step,
+                        magnifier_min_magnification,
+                        magnifier_max_magnification);
+                    magnifier.magnification(magnification);
+                    return true;
+                default:
+                    break;
                 }
             }
             else if (modifiers & mir_input_event_modifier_alt)
@@ -250,20 +253,27 @@ int main(int argc, char const* argv[])
                 // Grow area on ctrl alt +/-
                 switch (mir_keyboard_event_keysym(key_event))
                 {
-                    case XKB_KEY_equal:
-                    {
-                        capture_size.width = Width(std::min(1000, capture_size.width.as_int() + 100));
-                        capture_size.height = Height(std::min(1000, capture_size.height.as_int() + 100));
-                        magnifier.capture_size(capture_size);
-                        return true;
-                    }
-                    case XKB_KEY_minus:
-                        capture_size.width = Width(std::max(100, capture_size.width.as_int() - 100));
-                        capture_size.height = Height(std::max(100, capture_size.height.as_int() - 100));
-                        magnifier.capture_size(capture_size);
-                        return true;
-                    default:
-                        break;
+                case XKB_KEY_equal:
+                {
+                    capture_size.width = Width(std::min(1000, capture_size.width.as_int() + 100));
+                    capture_size.height = Height(std::min(1000, capture_size.height.as_int() + 100));
+                    magnifier.capture_size(capture_size);
+                    return true;
+                }
+                case XKB_KEY_minus:
+                    capture_size.width = Width(std::max(100, capture_size.width.as_int() - 100));
+                    capture_size.height = Height(std::max(100, capture_size.height.as_int() - 100));
+                    magnifier.capture_size(capture_size);
+                    return true;
+                case XKB_KEY_m:
+                    follows_cursor = !follows_cursor;
+                    if (follows_cursor)
+                        magnifier.set_behavior(miral::Magnifier::Behavior::follow_cursor);
+                    else
+                        magnifier.set_behavior(miral::Magnifier::Behavior::freely_positioned);
+                    return true;
+                default:
+                    break;
                 }
             }
             else
@@ -271,14 +281,14 @@ int main(int argc, char const* argv[])
                 // Turn on/off the magnifier on ctrl +/-
                 switch (mir_keyboard_event_keysym(key_event))
                 {
-                    case XKB_KEY_equal:
-                        magnifier.enable(true);
-                        return true;
-                    case XKB_KEY_minus:
-                        magnifier.enable(false);
-                        return true;
-                    default:
-                        break;
+                case XKB_KEY_equal:
+                    magnifier.enable(true);
+                    return true;
+                case XKB_KEY_minus:
+                    magnifier.enable(false);
+                    return true;
+                default:
+                    break;
                 }
             }
         }

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -209,7 +209,11 @@ int main(int argc, char const* argv[])
         .magnification(magnification)
         .capture_size(capture_size)
         .enable(false);
-    auto magnifier_filter = [magnifier=magnifier, &magnification, &capture_size](MirKeyboardEvent const* key_event) mutable {
+    auto magnifier_filter = [magnifier = magnifier,
+                             &magnification,
+                             &capture_size,
+                             decoupled = false](MirKeyboardEvent const* key_event) mutable
+    {
         auto const modifiers = mir_keyboard_event_modifiers(key_event);
 
         if (mir_keyboard_event_action(key_event) != mir_keyboard_action_down)
@@ -226,22 +230,22 @@ int main(int argc, char const* argv[])
                 // Zoom the magnifier in/out on ctrl shift +/-
                 switch (mir_keyboard_event_keysym(key_event))
                 {
-                    case XKB_KEY_plus:
-                        magnification = std::clamp(
-                            magnification + magnifier_magnification_step,
-                            magnifier_min_magnification,
-                            magnifier_max_magnification);
-                        magnifier.magnification(magnification);
-                        return true;
-                    case XKB_KEY_underscore:
-                        magnification = std::clamp(
-                            magnification - magnifier_magnification_step,
-                            magnifier_min_magnification,
-                            magnifier_max_magnification);
-                        magnifier.magnification(magnification);
-                        return true;
-                    default:
-                        break;
+                case XKB_KEY_plus:
+                    magnification = std::clamp(
+                        magnification + magnifier_magnification_step,
+                        magnifier_min_magnification,
+                        magnifier_max_magnification);
+                    magnifier.magnification(magnification);
+                    return true;
+                case XKB_KEY_underscore:
+                    magnification = std::clamp(
+                        magnification - magnifier_magnification_step,
+                        magnifier_min_magnification,
+                        magnifier_max_magnification);
+                    magnifier.magnification(magnification);
+                    return true;
+                default:
+                    break;
                 }
             }
             else if (modifiers & mir_input_event_modifier_alt)
@@ -249,20 +253,24 @@ int main(int argc, char const* argv[])
                 // Grow area on ctrl alt +/-
                 switch (mir_keyboard_event_keysym(key_event))
                 {
-                    case XKB_KEY_equal:
-                    {
-                        capture_size.width = Width(std::min(1000, capture_size.width.as_int() + 100));
-                        capture_size.height = Height(std::min(1000, capture_size.height.as_int() + 100));
-                        magnifier.capture_size(capture_size);
-                        return true;
-                    }
-                    case XKB_KEY_minus:
-                        capture_size.width = Width(std::max(100, capture_size.width.as_int() - 100));
-                        capture_size.height = Height(std::max(100, capture_size.height.as_int() - 100));
-                        magnifier.capture_size(capture_size);
-                        return true;
-                    default:
-                        break;
+                case XKB_KEY_equal:
+                {
+                    capture_size.width = Width(std::min(1000, capture_size.width.as_int() + 100));
+                    capture_size.height = Height(std::min(1000, capture_size.height.as_int() + 100));
+                    magnifier.capture_size(capture_size);
+                    return true;
+                }
+                case XKB_KEY_minus:
+                    capture_size.width = Width(std::max(100, capture_size.width.as_int() - 100));
+                    capture_size.height = Height(std::max(100, capture_size.height.as_int() - 100));
+                    magnifier.capture_size(capture_size);
+                    return true;
+                case XKB_KEY_m:
+                    decoupled = !decoupled;
+                    magnifier.decouple(decoupled);
+                    return true;
+                default:
+                    break;
                 }
             }
             else
@@ -270,34 +278,16 @@ int main(int argc, char const* argv[])
                 // Turn on/off the magnifier on ctrl +/-
                 switch (mir_keyboard_event_keysym(key_event))
                 {
-                    case XKB_KEY_equal:
-                        magnifier.enable(true);
-                        return true;
-                    case XKB_KEY_minus:
-                        magnifier.enable(false);
-                        return true;
-                    default:
-                        break;
+                case XKB_KEY_equal:
+                    magnifier.enable(true);
+                    return true;
+                case XKB_KEY_minus:
+                    magnifier.enable(false);
+                    return true;
+                default:
+                    break;
                 }
             }
-        }
-
-        return false;
-    };
-
-    // Ctrl+Alt+M: toggle between cursor-follow mode and decoupled (draggable) mode
-    auto decouple_magnifier_filter = [magnifier=magnifier, decoupled=false](MirKeyboardEvent const* key_event) mutable {
-        if (mir_keyboard_event_action(key_event) != mir_keyboard_action_down)
-            return false;
-
-        auto const modifiers = mir_keyboard_event_modifiers(key_event);
-        if ((modifiers & mir_input_event_modifier_ctrl) &&
-            (modifiers & mir_input_event_modifier_alt) &&
-            mir_keyboard_event_keysym(key_event) == XKB_KEY_m)
-        {
-            decoupled = !decoupled;
-            magnifier.decouple(decoupled);
-            return true;
         }
 
         return false;
@@ -429,7 +419,6 @@ int main(int argc, char const* argv[])
             sticky_keys,
             magnifier,
             AppendKeyboardEventFilter{magnifier_filter},
-            AppendKeyboardEventFilter{decouple_magnifier_filter},
             AppendKeyboardEventFilter{sticky_keys_filter},
             cursor_scale,
             locate_pointer,

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -268,9 +268,9 @@ int main(int argc, char const* argv[])
                 case XKB_KEY_m:
                     follows_cursor = !follows_cursor;
                     if (follows_cursor)
-                        magnifier.follow_cursor();
+                        magnifier.set_behavior(miral::Magnifier::Behavior::follow_cursor);
                     else
-                        magnifier.stop_following_cursor();
+                        magnifier.set_behavior(miral::Magnifier::Behavior::freely_positioned);
                     return true;
                 default:
                     break;

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -47,6 +47,7 @@
 
 #include <xkbcommon/xkbcommon-keysyms.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <linux/input-event-codes.h>
@@ -218,27 +219,25 @@ int main(int argc, char const* argv[])
         {
             if (modifiers & mir_input_event_modifier_shift)
             {
+                auto const magnifier_min_magnification = 1.5f;
+                auto const magnifier_max_magnification = 8.0f;
+                auto const magnifier_magnification_step = 0.5f;
+
                 // Zoom the magnifier in/out on ctrl shift +/-
                 switch (mir_keyboard_event_keysym(key_event))
                 {
                     case XKB_KEY_plus:
-                        magnification += 0.5f;
-                        if (magnification >= 5)
-                        {
-                            magnification = 5;
-                            return true;
-                        }
-
+                        magnification = std::clamp(
+                            magnification + magnifier_magnification_step,
+                            magnifier_min_magnification,
+                            magnifier_max_magnification);
                         magnifier.magnification(magnification);
                         return true;
                     case XKB_KEY_underscore:
-                        magnification -= 0.5f;
-                        if (magnification <= 1)
-                        {
-                            magnification = 1;
-                            return true;
-                        }
-
+                        magnification = std::clamp(
+                            magnification - magnifier_magnification_step,
+                            magnifier_min_magnification,
+                            magnifier_max_magnification);
                         magnifier.magnification(magnification);
                         return true;
                     default:

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -212,7 +212,7 @@ int main(int argc, char const* argv[])
     auto magnifier_filter = [magnifier = magnifier,
                              &magnification,
                              &capture_size,
-                             decoupled = false](MirKeyboardEvent const* key_event) mutable
+                             follows_cursor = true](MirKeyboardEvent const* key_event) mutable
     {
         auto const modifiers = mir_keyboard_event_modifiers(key_event);
 
@@ -266,8 +266,11 @@ int main(int argc, char const* argv[])
                     magnifier.capture_size(capture_size);
                     return true;
                 case XKB_KEY_m:
-                    decoupled = !decoupled;
-                    magnifier.decouple(decoupled);
+                    follows_cursor = !follows_cursor;
+                    if (follows_cursor)
+                        magnifier.follow_cursor();
+                    else
+                        magnifier.stop_following_cursor();
                     return true;
                 default:
                     break;

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -286,6 +286,24 @@ int main(int argc, char const* argv[])
         return false;
     };
 
+    // Ctrl+Alt+M: toggle between cursor-follow mode and decoupled (draggable) mode
+    auto decouple_magnifier_filter = [magnifier=magnifier, decoupled=false](MirKeyboardEvent const* key_event) mutable {
+        if (mir_keyboard_event_action(key_event) != mir_keyboard_action_down)
+            return false;
+
+        auto const modifiers = mir_keyboard_event_modifiers(key_event);
+        if ((modifiers & mir_input_event_modifier_ctrl) &&
+            (modifiers & mir_input_event_modifier_alt) &&
+            mir_keyboard_event_keysym(key_event) == XKB_KEY_m)
+        {
+            decoupled = !decoupled;
+            magnifier.decouple(decoupled);
+            return true;
+        }
+
+        return false;
+    };
+
     StickyKeys sticky_keys = StickyKeys::disabled();
     auto const sticky_keys_filter = [sticky_keys=sticky_keys, sticky_keys_enabled=false](MirKeyboardEvent const* key_event) mutable
     {
@@ -412,6 +430,7 @@ int main(int argc, char const* argv[])
             sticky_keys,
             magnifier,
             AppendKeyboardEventFilter{magnifier_filter},
+            AppendKeyboardEventFilter{decouple_magnifier_filter},
             AppendKeyboardEventFilter{sticky_keys_filter},
             cursor_scale,
             locate_pointer,

--- a/include/miral/miral/magnifier.h
+++ b/include/miral/miral/magnifier.h
@@ -27,12 +27,20 @@ namespace miral
 namespace live_config { class Store; }
 
 /// Renders a magnified region of the scene at the cursor position.
-/// By default, the magnifier will magnify a 400x300 region below
-/// the cursor by a 2x magnitude.
+/// By default, the magnifier will magnify a 150x150 region centred on
+/// the cursor by a 1.5x magnitude.
 /// \remark Since MirAL 5.5
 class Magnifier
 {
 public:
+    /// Describes how the magnifier is positioned.
+    /// \remark Since MirAL 6.0
+    enum class Behavior
+    {
+        follow_cursor,
+        freely_positioned
+    };
+
     Magnifier();
     /// Construct a `Magnifier` instance with access to a live config store.
     ///
@@ -43,11 +51,20 @@ public:
     ///     region that will be magnified.
     ///     - {magnifier, capture_size, height}: The height of the rectangular
     ///     region that will be magnified.
+    ///     - {magnifier, follow_cursor}: Whether the magnifier follows the
+    ///     cursor.
     explicit Magnifier(live_config::Store& config_store);
 
     Magnifier& enable(bool enabled);
     Magnifier& magnification(float magnification);
     Magnifier& capture_size(mir::geometry::Size const& size);
+
+    /// Sets how the magnifier is positioned.
+    ///
+    /// When freely positioned, the magnifier can be dragged with the pointer
+    /// or a single touch contact.
+    /// \remark Since MirAL 6.0
+    Magnifier& set_behavior(Behavior behavior);
 
     void operator()(mir::Server& server);
 

--- a/include/miral/miral/magnifier.h
+++ b/include/miral/miral/magnifier.h
@@ -49,6 +49,13 @@ public:
     Magnifier& magnification(float magnification);
     Magnifier& capture_size(mir::geometry::Size const& size);
 
+    /// When \p decoupled is true, the magnifier surface is no longer tied to
+    /// the cursor position and can instead be dragged freely with the pointer
+    /// or a single touch contact.  When false (the default), the surface
+    /// follows the cursor as before.
+    /// \remark Since MirAL 6.0
+    Magnifier& decouple(bool decoupled);
+
     void operator()(mir::Server& server);
 
 private:

--- a/include/miral/miral/magnifier.h
+++ b/include/miral/miral/magnifier.h
@@ -27,8 +27,8 @@ namespace miral
 namespace live_config { class Store; }
 
 /// Renders a magnified region of the scene at the cursor position.
-/// By default, the magnifier will magnify a 400x300 region below
-/// the cursor by a 2x magnitude.
+/// By default, the magnifier will magnify a 150x150 region centred on
+/// the cursor by a 1.5x magnitude.
 /// \remark Since MirAL 5.5
 class Magnifier
 {
@@ -43,6 +43,8 @@ public:
     ///     region that will be magnified.
     ///     - {magnifier, capture_size, height}: The height of the rectangular
     ///     region that will be magnified.
+    ///     - {magnifier, decouple}: Whether the magnifier is decoupled from
+    ///     the cursor position.
     explicit Magnifier(live_config::Store& config_store);
 
     Magnifier& enable(bool enabled);

--- a/include/miral/miral/magnifier.h
+++ b/include/miral/miral/magnifier.h
@@ -33,6 +33,14 @@ namespace live_config { class Store; }
 class Magnifier
 {
 public:
+    /// Describes how the magnifier is positioned.
+    /// \remark Since MirAL 6.0
+    enum class Behavior
+    {
+        follow_cursor,
+        freely_positioned
+    };
+
     Magnifier();
     /// Construct a `Magnifier` instance with access to a live config store.
     ///
@@ -51,14 +59,12 @@ public:
     Magnifier& magnification(float magnification);
     Magnifier& capture_size(mir::geometry::Size const& size);
 
-    /// Makes the magnifier follow the cursor.
+    /// Sets how the magnifier is positioned.
+    ///
+    /// When freely positioned, the magnifier can be dragged with the pointer
+    /// or a single touch contact.
     /// \remark Since MirAL 6.0
-    Magnifier& follow_cursor();
-
-    /// Stops the magnifier following the cursor, allowing it to be dragged
-    /// freely with the pointer or a single touch contact.
-    /// \remark Since MirAL 6.0
-    Magnifier& stop_following_cursor();
+    Magnifier& set_behavior(Behavior behavior);
 
     void operator()(mir::Server& server);
 

--- a/include/miral/miral/magnifier.h
+++ b/include/miral/miral/magnifier.h
@@ -43,20 +43,22 @@ public:
     ///     region that will be magnified.
     ///     - {magnifier, capture_size, height}: The height of the rectangular
     ///     region that will be magnified.
-    ///     - {magnifier, decouple}: Whether the magnifier is decoupled from
-    ///     the cursor position.
+    ///     - {magnifier, follow_cursor}: Whether the magnifier follows the
+    ///     cursor.
     explicit Magnifier(live_config::Store& config_store);
 
     Magnifier& enable(bool enabled);
     Magnifier& magnification(float magnification);
     Magnifier& capture_size(mir::geometry::Size const& size);
 
-    /// When \p decoupled is true, the magnifier surface is no longer tied to
-    /// the cursor position and can instead be dragged freely with the pointer
-    /// or a single touch contact.  When false (the default), the surface
-    /// follows the cursor as before.
+    /// Makes the magnifier follow the cursor.
     /// \remark Since MirAL 6.0
-    Magnifier& decouple(bool decoupled);
+    Magnifier& follow_cursor();
+
+    /// Stops the magnifier following the cursor, allowing it to be dragged
+    /// freely with the pointer or a single touch contact.
+    /// \remark Since MirAL 6.0
+    Magnifier& stop_following_cursor();
 
     void operator()(mir::Server& server);
 

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(miral-internal STATIC
     live_config_overrides_list_builder.cpp    live_config_overrides_list_builder.h
     override_watcher.cpp                 override_watcher.h
     render_scene_into_surface.cpp        render_scene_into_surface.h
+    software_buffer_pool.cpp             software_buffer_pool.h
     mru_window_list.cpp                  mru_window_list.h
     open_desktop_entry.cpp               open_desktop_entry.h
     static_display_config.cpp            static_display_config.h

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(miral-internal STATIC
     live_config_ini_file_common.cpp      live_config_ini_file_common.h
     live_config_watcher.cpp               live_config_watcher.h
     version_compare.cpp                   version_compare.h
+    magnifier_layout.cpp                 magnifier_layout.h
 )
 
 # Already implied by the linker's symbol version script, but can avoid accidents

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(miral-internal STATIC
     live_config_ini_file_common.cpp      live_config_ini_file_common.h
     live_config_watcher.cpp               live_config_watcher.h
     version_compare.cpp                   version_compare.h
+    magnifier_handle_indicator.cpp       magnifier_handle_indicator.h
     magnifier_layout.cpp                 magnifier_layout.h
 )
 

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -881,13 +881,7 @@ auto miral::BasicWindowManager::window_at(geometry::Point cursor) const
 -> Window
 {
     auto surface_at = focus_controller->surface_at(cursor);
-    if (!surface_at)
-        return Window{};
-
-    // surface_at() returns any hit-testable scene surface, including internal
-    // compositor surfaces that are not managed windows.  surface_known() guards
-    // against the window_info lookup throwing for unregistered surfaces.
-    if (!surface_known(surface_at, "window_at"))
+    if (!surface_at || !window_info.contains(surface_at))
         return Window{};
 
     return info_for(surface_at).window();
@@ -1756,7 +1750,7 @@ void miral::BasicWindowManager::drag_window(miral::Window const& window, Displac
 
 auto miral::BasicWindowManager::surface_known(
     std::weak_ptr<scene::Surface> const& surface,
-    std::string const& action) const -> bool
+    std::string const& action) -> bool
 {
     if (window_info.find(surface) != window_info.end())
     {

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -881,7 +881,16 @@ auto miral::BasicWindowManager::window_at(geometry::Point cursor) const
 -> Window
 {
     auto surface_at = focus_controller->surface_at(cursor);
-    return surface_at ? info_for(surface_at).window() : Window{};
+    if (!surface_at)
+        return Window{};
+
+    // surface_at() returns any hit-testable scene surface, including internal
+    // compositor surfaces that are not managed windows.  surface_known() guards
+    // against the window_info lookup throwing for unregistered surfaces.
+    if (!surface_known(surface_at, "window_at"))
+        return Window{};
+
+    return info_for(surface_at).window();
 }
 
 auto miral::BasicWindowManager::active_output() -> geometry::Rectangle const
@@ -1747,7 +1756,7 @@ void miral::BasicWindowManager::drag_window(miral::Window const& window, Displac
 
 auto miral::BasicWindowManager::surface_known(
     std::weak_ptr<scene::Surface> const& surface,
-    std::string const& action) -> bool
+    std::string const& action) const -> bool
 {
     if (window_info.find(surface) != window_info.end())
     {

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -881,7 +881,10 @@ auto miral::BasicWindowManager::window_at(geometry::Point cursor) const
 -> Window
 {
     auto surface_at = focus_controller->surface_at(cursor);
-    return surface_at ? info_for(surface_at).window() : Window{};
+    if (!surface_at || !window_info.contains(surface_at))
+        return Window{};
+
+    return info_for(surface_at).window();
 }
 
 auto miral::BasicWindowManager::active_output() -> geometry::Rectangle const

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -272,7 +272,7 @@ private:
     void update_event_timestamp(MirTouchEvent const* tev);
     void update_event_timestamp(MirInputEvent const* iev);
 
-    auto surface_known(std::weak_ptr<mir::scene::Surface> const& surface, std::string const& action) const -> bool;
+    auto surface_known(std::weak_ptr<mir::scene::Surface> const& surface, std::string const& action) -> bool;
 
     auto can_activate_window_for_session(miral::Application const& session) -> bool;
     auto can_activate_window_for_session_in_workspace(

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -272,7 +272,7 @@ private:
     void update_event_timestamp(MirTouchEvent const* tev);
     void update_event_timestamp(MirInputEvent const* iev);
 
-    auto surface_known(std::weak_ptr<mir::scene::Surface> const& surface, std::string const& action) -> bool;
+    auto surface_known(std::weak_ptr<mir::scene::Surface> const& surface, std::string const& action) const -> bool;
 
     auto can_activate_window_for_session(miral::Application const& session) -> bool;
     auto can_activate_window_for_session_in_workspace(

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -390,6 +390,13 @@ private:
     std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
     std::shared_ptr<ms::NullSurfaceObserver> observer;
 };
+
+geom::Point surface_top_left_from_cursor(geom::Size const& window_size, geom::Point const& cursor_pos)
+{
+    return geom::Point{
+        cursor_pos.x.as_int() - window_size.width.as_int() / 2,
+        cursor_pos.y.as_int() - window_size.height.as_int() / 2};
+}
 }
 
 class miral::Magnifier::Self
@@ -506,7 +513,7 @@ public:
             if (s->decoupled)
             {
                 // Place surface at last known cursor position when enabling in decoupled mode.
-                auto const top_left = State::surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
+                auto const top_left = surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
                 surf->move_to(top_left);
                 render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
                 s->reposition_all_handles(top_left, surf->window_size(), s->magnification);
@@ -530,7 +537,7 @@ public:
     void set_capture_size(geom::Size const& size)
     {
         auto s = state.lock();
-        auto const capture_position = State::surface_top_left_from_cursor(size, s->cursor_pos);
+        auto const capture_position = surface_top_left_from_cursor(size, s->cursor_pos);
         render_scene_into_surface.capture_area({capture_position, size});
         s->reposition_all_handles(capture_position, size, s->magnification);
     }
@@ -570,7 +577,7 @@ public:
 
             if (auto const surf = s->surface.lock(); surf && s->default_enabled)
             {
-                auto const top_left = State::surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
+                auto const top_left = surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
                 surf->move_to(top_left);
                 render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
             }
@@ -585,15 +592,6 @@ private:
     {
         /// Pixel-space rectangle of signed integer coordinates.
         struct VisualBounds { int x, y, w, h; };
-
-        static geom::Point surface_top_left_from_cursor(
-            geom::Size const& window_size,
-            geom::Point const& cursor_pos)
-        {
-            return geom::Point{
-                cursor_pos.x.as_int() - window_size.width.as_int() / 2,
-                cursor_pos.y.as_int() - window_size.height.as_int() / 2};
-        }
 
         /// Returns the pixel-space top-left and size of the visual magnifier surface
         /// given its logical capture rectangle and magnification factor.
@@ -765,7 +763,7 @@ private:
             if (!surf)
                 return;
 
-            auto const capture_position = State::surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
+            auto const capture_position = surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
             surf->move_to(capture_position);
             self->render_scene_into_surface.capture_area(geom::Rectangle{capture_position, surf->window_size()});
         }

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -404,6 +404,15 @@ geom::Size logical_size_from_visual(geom::Size const& visual_size, float mag)
         geom::Width{std::max(1.0f, std::round(visual_size.width.as_value() / mag))},
         geom::Height{std::max(1.0f, std::round(visual_size.height.as_value() / mag))}};
 }
+
+/// The centre of a logical capture rectangle. The visual magnifier shares this
+/// centre, so it also fixes the away direction for handle placement.
+geom::Point center(geom::Point const& top_left, geom::Size const& size)
+{
+    return geom::Point{
+        top_left.x.as_int() + size.width.as_int() / 2,
+        top_left.y.as_int() + size.height.as_int() / 2};
+}
 }
 
 class miral::Magnifier::Self
@@ -711,9 +720,8 @@ private:
                 // The visual magnifier is scaled about the centre of its logical
                 // capture area. Keep that centre fixed so changing zoom does not
                 // shift the on-screen position.
-                geom::Point const old_visual_centre{
-                    old_logical_rect.top_left.x.as_int() + old_logical_rect.size.width.as_int() / 2,
-                    old_logical_rect.top_left.y.as_int() + old_logical_rect.size.height.as_int() / 2};
+                geom::Point const old_visual_centre =
+                    center(old_logical_rect.top_left, old_logical_rect.size);
 
                 magnification = new_magnification;
                 auto const new_logical_size = logical_size_from_visual(visual_size, magnification);

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -757,8 +757,9 @@ private:
         }
 
         /// Maps the visual magnifier's position across the screen to the logical
-        /// capture's available range. A visual edge flush with the screen maps
-        /// to the corresponding capture edge, with proportional movement between.
+        /// capture. At a flush visual edge, the capture extends far enough outside
+        /// the screen to place that screen edge just beyond the controls. Movement
+        /// between the two edges is proportional.
         geom::Point capture_position_for_surface(
             geom::Point const& surface_top_left,
             geom::Size const& logical_size,
@@ -772,25 +773,30 @@ private:
             int const screen_top = screen_bounds.top_left.y.as_int();
             int const screen_width = screen_bounds.size.width.as_int();
             int const screen_height = screen_bounds.size.height.as_int();
+            int const handle_clearance =
+                static_cast<int>(std::ceil(drag_handle_diameter / mag));
 
             auto const map_axis = [](
                 int visual_start,
                 int visual_extent,
                 int logical_extent,
                 int screen_start,
-                int screen_extent)
+                int screen_extent,
+                int max_out_of_bounds)
             {
                 int const visual_travel = screen_extent - visual_extent;
-                int const capture_travel = screen_extent - logical_extent;
 
                 if (visual_travel <= 0)
-                    return screen_start + capture_travel / 2;
+                    return screen_start + (screen_extent - logical_extent) / 2;
 
                 double const progress = std::clamp(
                     static_cast<double>(visual_start - screen_start) / visual_travel,
                     0.0,
                     1.0);
-                return screen_start + static_cast<int>(std::round(progress * capture_travel));
+                int const out_of_bounds = std::min(logical_extent / 2, max_out_of_bounds);
+                int const capture_start = screen_start - out_of_bounds;
+                int const capture_travel = screen_extent - logical_extent + 2 * out_of_bounds;
+                return capture_start + static_cast<int>(std::round(progress * capture_travel));
             };
 
             return geom::Point{
@@ -799,13 +805,15 @@ private:
                     visual.w,
                     logical_size.width.as_int(),
                     screen_left,
-                    screen_width),
+                    screen_width,
+                    handle_clearance),
                 map_axis(
                     visual.y,
                     visual.h,
                     logical_size.height.as_int(),
                     screen_top,
-                    screen_height)};
+                    screen_height,
+                    handle_clearance)};
         }
 
         /// Computes the position of the circular drag handle indicator, inset from

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -55,6 +55,9 @@ auto const max_magnification = 8.0f;
 /// Diameter in pixels of the circular drag handle shown at the corner of the magnifier.
 auto const drag_handle_diameter = 48;
 
+/// Minimum on-screen (visual) width/height of the magnifier surface, in pixels.
+auto const min_visual_dimension = 150;
+
 /// Magnification step applied by each zoom button press.
 auto const zoom_step = 0.5f;
 
@@ -405,6 +408,15 @@ geom::Size logical_size_from_visual(geom::Size const& visual_size, float mag)
         geom::Height{std::max(1.0f, std::round(visual_size.height.as_value() / mag))}};
 }
 
+/// Clamps a visual (on-screen) size so neither dimension shrinks below
+/// min_visual_dimension.
+geom::Size clamp_visual_size(geom::Size const& visual_size)
+{
+    return {
+        std::max(visual_size.width, geom::Width{min_visual_dimension}),
+        std::max(visual_size.height, geom::Height{min_visual_dimension})};
+}
+
 /// The centre of a logical capture rectangle. The visual magnifier shares this
 /// centre, so it also fixes the away direction for handle placement.
 geom::Point center(geom::Point const& top_left, geom::Size const& size)
@@ -459,7 +471,8 @@ public:
 
             s->observer = local_observer;
             s->cursor_multiplexer = server.the_cursor_observer_multiplexer();
-            s->visual_size = geom::Size{default_capture_width, default_capture_height}  * default_magnification;
+            s->visual_size = clamp_visual_size(
+                geom::Size{default_capture_width, default_capture_height} * default_magnification);
 
             s->drag.init(server, HandleKind::drag);
             s->resize.init(server, HandleKind::resize);
@@ -554,7 +567,7 @@ public:
     void set_capture_size(geom::Size const& size)
     {
         auto s = state.lock();
-        s->visual_size = size * s->magnification;
+        s->visual_size = clamp_visual_size(size * s->magnification);
         auto const logical_top_left = surface_top_left_from_cursor(size, s->cursor_pos);
 
         if (auto const surf = s->surface.lock())
@@ -998,8 +1011,17 @@ private:
             int const raw_vis_w = pin_pos.x.as_int() - ax;
             int const raw_vis_h = pin_pos.y.as_int() - ay;
 
-            auto const clamp = [](int v) { return std::clamp(v, 50, 1000); };
-            geom::Size const new_logical_size =  geom::Size{ clamp(raw_vis_w / mag), clamp(raw_vis_h / mag) };
+            // Enforce the surface's minimum on-screen footprint before converting
+            // to a logical size (rounding up so the visual size never dips below
+            // the minimum), and cap the logical size at a sane maximum.
+            auto const clamped_visual_size = clamp_visual_size(geom::Size{raw_vis_w, raw_vis_h});
+            auto const to_logical_dim = [mag](int visual_dim)
+            {
+                return std::min(static_cast<int>(std::ceil(visual_dim / mag)), 1000);
+            };
+            geom::Size const new_logical_size = geom::Size{
+                to_logical_dim(clamped_visual_size.width.as_int()),
+                to_logical_dim(clamped_visual_size.height.as_int())};
 
             // Back-solve the logical top-left from the pinned visual corner, inverting
             // the visual-edge identity above so the pinned corner stays fixed.

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -20,6 +20,10 @@
 #include "software_buffer_pool.h"
 
 #include <miral/live_config.h>
+#include <mir/events/event.h>
+#include <mir/events/input_event.h>
+#include <mir/events/pointer_event.h>
+#include <mir/events/touch_event.h>
 #include <mir/log.h>
 #include <mir/server.h>
 #include <mir/synchronised.h>
@@ -27,8 +31,10 @@
 #include <mir/graphics/display_configuration.h>
 #include <mir/graphics/display_configuration_observer.h>
 #include <mir/geometry/rectangles.h>
+#include <mir/input/composite_event_filter.h>
 #include <mir/input/cursor_observer.h>
 #include <mir/input/cursor_observer_multiplexer.h>
+#include <mir/input/event_filter.h>
 #include <mir/scene/surface.h>
 #include <mir/scene/null_surface_observer.h>
 #include <mir/scene/basic_surface.h>
@@ -494,6 +500,23 @@ private:
         mir::Synchronised<State>& state;
     };
 
+    class InputFilter : public mi::EventFilter
+    {
+    public:
+        explicit InputFilter(mir::Synchronised<State>& state) : state{state} {}
+
+        auto handle(MirEvent const& event) -> bool override;
+
+    private:
+        void reset_gestures();
+        auto handle_pointer(MirPointerEvent const& event, State const& state) -> bool;
+        auto handle_touch(MirTouchEvent const& event, State const& state) -> bool;
+
+        mir::Synchronised<State>& state;
+        std::optional<bool> pointer_gesture_consumed;
+        std::optional<bool> touch_gesture_consumed;
+    };
+
 public:
     Self()
     {
@@ -533,6 +556,8 @@ public:
             // the state lock across this call.
             server.the_display_configuration_observer_registrar()->register_interest(local_display_config_observer);
             server.the_cursor_observer_multiplexer()->register_interest(local_observer);
+            input_filter = std::make_shared<InputFilter>(state);
+            server.the_composite_event_filter()->prepend(input_filter);
 
             auto s = state.lock();
 
@@ -609,6 +634,8 @@ public:
 
             for (auto* handle : {&local_drag, &local_resize, &local_zoom_in, &local_zoom_out})
                 handle->reset();
+
+            input_filter.reset();
         });
     }
 
@@ -718,6 +745,48 @@ private:
             int const x = logical_top_left.x.as_int() - (mag - 1.0f) / 2.0f * logical_size.width.as_int();
             int const y = logical_top_left.y.as_int() - (mag - 1.0f) / 2.0f * logical_size.height.as_int();
             return {x, y, w, h};
+        }
+
+        auto point_is_on_magnifier_surface(geom::PointF const& point) const -> bool
+        {
+            if (!decoupled || !default_enabled)
+                return false;
+
+            auto const surf = surface.lock();
+            if (!surf)
+                return false;
+
+            auto const surface_top_left = surf->top_left();
+            auto const logical_size = surf->window_size();
+            auto const visual = compute_visual_bounds(surface_top_left, logical_size, magnification);
+            auto const contains = [&point](int x, int y, int width, int height)
+            {
+                return point.x.as_value() >= x && point.x.as_value() < x + width &&
+                    point.y.as_value() >= y && point.y.as_value() < y + height;
+            };
+
+            if (!contains(visual.x, visual.y, visual.w, visual.h))
+                return false;
+
+            auto const [drag_position, resize_position] =
+                compute_both_handle_positions(surface_top_left, logical_size, magnification);
+            auto const [zoom_in_position, zoom_out_position] =
+                compute_zoom_button_positions(surface_top_left, logical_size, magnification);
+
+            for (auto const& handle_position :
+                {drag_position, resize_position, zoom_in_position, zoom_out_position})
+            {
+                if (contains(
+                    handle_position.x.as_int(),
+                    handle_position.y.as_int(),
+                    drag_handle_diameter,
+                    drag_handle_diameter))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// Translates logical_top_left, if necessary, so the resulting visual
@@ -1349,7 +1418,88 @@ private:
 
     RenderSceneIntoSurface render_scene_into_surface;
     mir::Synchronised<State> state;
+    std::shared_ptr<InputFilter> input_filter;
 };
+
+auto miral::Magnifier::Self::InputFilter::handle(MirEvent const& event) -> bool
+{
+    if (event.type() != mir_event_type_input)
+        return false;
+
+    auto const s = state.lock();
+    if (!s->decoupled || !s->default_enabled)
+    {
+        reset_gestures();
+        return false;
+    }
+
+    auto const* input_event = event.to_input();
+    switch (input_event->input_type())
+    {
+    case mir_input_event_type_pointer:
+        return handle_pointer(*input_event->to_pointer(), *s);
+    case mir_input_event_type_touch:
+        return handle_touch(*input_event->to_touch(), *s);
+    default:
+        return false;
+    }
+}
+
+void miral::Magnifier::Self::InputFilter::reset_gestures()
+{
+    pointer_gesture_consumed.reset();
+    touch_gesture_consumed.reset();
+}
+
+auto miral::Magnifier::Self::InputFilter::handle_pointer(
+    MirPointerEvent const& event,
+    State const& state) -> bool
+{
+    auto const action = event.action();
+    if (action == mir_pointer_action_button_down && !pointer_gesture_consumed)
+    {
+        pointer_gesture_consumed =
+            event.position().transform([&state](auto const& position)
+                { return state.point_is_on_magnifier_surface(position); }).value_or(false);
+    }
+
+    if (pointer_gesture_consumed)
+    {
+        auto const consumed = *pointer_gesture_consumed;
+        if (action == mir_pointer_action_button_up && event.buttons() == 0)
+            pointer_gesture_consumed.reset();
+        return consumed;
+    }
+
+    return event.position().transform([&state](auto const& position)
+        { return state.point_is_on_magnifier_surface(position); }).value_or(false);
+}
+
+auto miral::Magnifier::Self::InputFilter::handle_touch(
+    MirTouchEvent const& event,
+    State const& state) -> bool
+{
+    if (!touch_gesture_consumed)
+    {
+        bool starts_on_magnifier = false;
+        for (auto i = 0u; i != event.pointer_count(); ++i)
+        {
+            starts_on_magnifier =
+                starts_on_magnifier || state.point_is_on_magnifier_surface(event.position(i));
+        }
+        touch_gesture_consumed = starts_on_magnifier;
+    }
+
+    auto const consumed = *touch_gesture_consumed;
+    bool gesture_ended = event.pointer_count() > 0;
+    for (auto i = 0u; i != event.pointer_count(); ++i)
+        gesture_ended = gesture_ended && event.action(i) == mir_touch_action_up;
+
+    if (gesture_ended)
+        touch_gesture_consumed.reset();
+
+    return consumed;
+}
 
 void miral::Magnifier::Self::DisplayConfigObserver::update_bounds(
     std::shared_ptr<mg::DisplayConfiguration const> const& config)

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -477,16 +477,92 @@ geom::Point surface_top_left_from_cursor(geom::Size const& window_size, geom::Po
             geom::as_delta(window_size.height / 2)};
 }
 
+auto rectangles_empty(geom::Rectangles const& rects) -> bool
+{
+    return rects.size() == 0 ||
+           std::ranges::any_of(
+               rects,
+               [](auto const& rect)
+               { return rect.size.width == geom::Width{0} || rect.size.height == geom::Height{0}; });
+}
+
+/// Pixel-space rectangle of signed integer coordinates.
+struct VisualBounds
+{
+    geom::X x;
+    geom::Y y;
+    geom::Width w;
+    geom::Height h;
+};
+
+auto find_current_screen(geom::Rectangles const& rects, geom::Rectangle const& visual_bounds) -> geom::Rectangle
+{
+    auto max_overlap = 0u;
+    auto max_overlap_iter = rects.begin();
+
+    for(auto iter = rects.begin(); iter != rects.end(); iter++)
+    {
+        auto const& rect = *iter;
+        auto const overlap = mir::geometry::generic::intersection_of(rect, visual_bounds);
+        auto const overlap_area = overlap.size.width.as_uint32_t() * overlap.size.height.as_uint32_t();
+
+        if (overlap_area > max_overlap)
+        {
+            max_overlap = overlap_area;
+            max_overlap_iter = iter;
+        }
+    }
+
+    return *max_overlap_iter;
+}
+
+auto overlaps_multiple_outputs(geom::Rectangles const& rects, geom::Rectangle const& visual_bounds) -> bool
+{
+    auto overlaps = 0;
+    for (auto const& rect : rects)
+    {
+        if (rect.overlaps(visual_bounds) && ++overlaps > 1)
+            return true;
+    }
+
+    return false;
+}
+
+static void clamp_visual_size_for_output(
+    geom::Size& visual_size,
+    geom::Point const& top_left,
+    geom::Rectangles const& screen_bounds)
+{
+    if (rectangles_empty(screen_bounds))
+        return;
+
+    auto const current_screen_bounds = find_current_screen(screen_bounds, {top_left, visual_size});
+    auto const max_visual_size = current_screen_bounds.size * 0.8;
+    visual_size = geom::Size{
+        std::min(max_visual_size.width, visual_size.width),
+        std::min(max_visual_size.height, visual_size.height),
+    };
+}
+
+/// Minimum on-screen (visual) width/height of the magnifier surface, in pixels.
+/// Derived so the drag handle (bottom-right corner) and the zoom button stack
+/// (right edge, vertically centred) never overlap each other: the drag handle
+/// needs a full diameter of clearance both above and below the centred stack.
+auto const min_visual_dimension = 2 * drag_handle_diameter + zoom_stack_height.as_int();
+
+geom::Size clamp_visual_size(geom::Size const& visual_size, geom::Size const& current_output_size)
+{
+    auto const max_size = current_output_size * 0.8;
+
+    return {
+        std::clamp(visual_size.width, geom::Width{min_visual_dimension}, max_size.width),
+        std::clamp(visual_size.height, geom::Height{min_visual_dimension}, max_size.height)};
+}
+
 /// Clamps a visual (on-screen) size so neither dimension shrinks below
 /// min_visual_dimension.
-geom::Size clamp_visual_size(geom::Size const& visual_size)
+auto clamp_minimum_visual_size(geom::Size const& visual_size) -> geom::Size
 {
-    /// Minimum on-screen (visual) width/height of the magnifier surface, in pixels.
-    /// Derived so the drag handle (bottom-right corner) and the zoom button stack
-    /// (right edge, vertically centred) never overlap each other: the drag handle
-    /// needs a full diameter of clearance both above and below the centred stack.
-    auto const min_visual_dimension = 2 * drag_handle_diameter + zoom_stack_height.as_int();
-
     return {
         std::max(visual_size.width, geom::Width{min_visual_dimension}),
         std::max(visual_size.height, geom::Height{min_visual_dimension})};
@@ -512,7 +588,13 @@ private:
     class DisplayConfigObserver : public mg::DisplayConfigurationObserver
     {
     public:
-        explicit DisplayConfigObserver(mir::Synchronised<State>& state) : state{state} {}
+        DisplayConfigObserver(
+            mir::Synchronised<State>& state,
+            RenderSceneIntoSurface& render_scene_into_surface)
+            : state{state},
+              render_scene_into_surface{render_scene_into_surface}
+        {
+        }
 
         void initial_configuration(
             std::shared_ptr<mg::DisplayConfiguration const> const& config) override
@@ -546,6 +628,7 @@ private:
         void update_bounds(std::shared_ptr<mg::DisplayConfiguration const> const& config);
 
         mir::Synchronised<State>& state;
+        RenderSceneIntoSurface& render_scene_into_surface;
     };
 
     class InputFilter : public mi::EventFilter
@@ -601,7 +684,8 @@ public:
                 [=, this, &server]
                 {
                     auto local_observer = std::make_shared<Observer>(this);
-                    auto local_display_config_observer = std::make_shared<DisplayConfigObserver>(state);
+                    auto local_display_config_observer =
+                        std::make_shared<DisplayConfigObserver>(state, render_scene_into_surface);
 
                     // Init `State` references under lock
                     this->post_init(server, local_observer, local_display_config_observer);
@@ -681,7 +765,7 @@ public:
         if (s->visual_size == geom::Size{})
         {
             s->visual_size =
-                clamp_visual_size(geom::Size{default_capture_width, default_capture_height} * s->magnification);
+                clamp_minimum_visual_size(geom::Size{default_capture_width, default_capture_height} * s->magnification);
         }
 
         auto const capture_compositor_id = render_scene_into_surface.capture_compositor_id();
@@ -741,12 +825,21 @@ public:
     void set_capture_size(geom::Size const& size)
     {
         auto s = state.lock();
-        s->visual_size = clamp_visual_size(size * s->magnification);
-        auto const logical_size = s->logical_size();
-        auto const logical_top_left = surface_top_left_from_cursor(logical_size, s->cursor_pos);
+        s->visual_size = clamp_minimum_visual_size(size * s->magnification);
 
         if (auto const surf = s->surface.lock())
+        {
+            if (!rectangles_empty(s->screen_bounds))
+            {
+                auto const surface_top_left = surf->top_left();
+                auto const current_output =
+                    find_current_screen(s->screen_bounds, geom::Rectangle{surface_top_left, s->visual_size});
+                s->visual_size = clamp_visual_size(s->visual_size, current_output.size);
+            }
+
+            auto const logical_top_left = surface_top_left_from_cursor(s->logical_size(), s->cursor_pos);
             apply_positioned_geometry(surf, logical_top_left, *s, render_scene_into_surface);
+        }
     }
 
     geom::Size current_size() const
@@ -796,15 +889,6 @@ public:
 private:
     struct State
     {
-        /// Pixel-space rectangle of signed integer coordinates.
-        struct VisualBounds
-        {
-            geom::X x;
-            geom::Y y;
-            geom::Width w;
-            geom::Height h;
-        };
-
         ///
         /// The visual rectangle is `mag` times larger than the logical one but
         /// shares the same centre, which is why the top-left is pulled back by
@@ -877,14 +961,20 @@ private:
             geom::Size const& logical_size,
             float mag) const
         {
-            if (screen_bounds.size == geom::Size{})
+            if (rectangles_empty(screen_bounds))
                 return logical_top_left;
 
             auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
-            auto const screen_left = screen_bounds.top_left.x;
-            auto const screen_top = screen_bounds.top_left.y;
-            auto const screen_right = screen_left + geom::as_delta(screen_bounds.size.width);
-            auto const screen_bottom = screen_top + geom::as_delta(screen_bounds.size.height);
+            auto const visual_bounds = geom::Rectangle{{vis_x, vis_y}, {vis_w, vis_h}};
+            if (overlaps_multiple_outputs(screen_bounds, visual_bounds))
+                return logical_top_left;
+
+            auto const current_screen =
+                find_current_screen(screen_bounds, visual_bounds);
+            auto const screen_left = current_screen.top_left.x;
+            auto const screen_top = current_screen.top_left.y;
+            auto const screen_right = screen_left + geom::as_delta(current_screen.size.width);
+            auto const screen_bottom = screen_top + geom::as_delta(current_screen.size.height);
 
             auto dx = geom::DeltaX{0};
             if (vis_x < screen_left)
@@ -910,14 +1000,16 @@ private:
             geom::Size const& logical_size,
             float mag) const
         {
-            if (screen_bounds.size == geom::Size{})
+            if (rectangles_empty(screen_bounds))
                 return surface_top_left;
 
             auto const visual = compute_visual_bounds(surface_top_left, logical_size, mag);
-            auto const screen_left = screen_bounds.top_left.x;
-            auto const screen_top = screen_bounds.top_left.y;
-            auto const screen_width = screen_bounds.size.width;
-            auto const screen_height = screen_bounds.size.height;
+            auto const current_screen =
+                find_current_screen(screen_bounds, geom::Rectangle{{visual.x, visual.y}, {visual.w, visual.h}});
+            auto const screen_left = current_screen.top_left.x;
+            auto const screen_top = current_screen.top_left.y;
+            auto const screen_width = current_screen.size.width;
+            auto const screen_height = current_screen.size.height;
             auto const handle_clearance = static_cast<int>(std::ceil(drag_handle_diameter / mag));
 
             struct AxisMapping
@@ -1048,14 +1140,14 @@ private:
             if (auto const surf = surface.lock())
             {
                 auto const old_logical_rect = render_scene_into_surface.capture_area();
+                magnification = new_magnification;
+                auto const new_logical_size = logical_size();
 
                 if (!follow_cursor)
                 {
                     auto const old_surface_centre =
                         center(surf->top_left(), old_logical_rect.size);
 
-                    magnification = new_magnification;
-                    auto const new_logical_size = logical_size();
                     auto const new_surface_top_left = old_surface_centre -
                         geom::Displacement{
                             geom::as_delta(new_logical_size.width / 2),
@@ -1069,8 +1161,6 @@ private:
                     auto const old_logical_centre =
                         center(old_logical_rect.top_left, old_logical_rect.size);
 
-                    magnification = new_magnification;
-                    auto const new_logical_size = logical_size();
                     auto const new_logical_top_left = old_logical_centre -
                         geom::Displacement{
                             geom::as_delta(new_logical_size.width / 2),
@@ -1134,7 +1224,7 @@ private:
         std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
 
         geom::Point cursor_pos;
-        geom::Rectangle screen_bounds;
+        geom::Rectangles screen_bounds;
         float magnification{default_magnification};
         /// The physical (screen) size of the magnifier.  When the magnification
         /// level changes the logical capture size is recalculated from this so
@@ -1150,6 +1240,7 @@ private:
         geom::Point surface_top_left;
     };
 
+
     /// Applies independent logical capture and surface presentation positions.
     static void apply_geometry(
         std::shared_ptr<ms::Surface> const& surf,
@@ -1157,6 +1248,7 @@ private:
         State& s,
         RenderSceneIntoSurface& render_scene_into_surface)
     {
+        clamp_visual_size_for_output(s.visual_size, positions.surface_top_left, s.screen_bounds);
         auto const logical_size = s.logical_size();
         render_scene_into_surface.capture_area(geom::Rectangle{positions.logical_top_left, logical_size});
         // capture_area() moves the backing surface to the capture position, so
@@ -1197,6 +1289,7 @@ private:
             return;
         }
 
+        clamp_visual_size_for_output(s.visual_size, desired_top_left, s.screen_bounds);
         auto const logical_size = s.logical_size();
         auto const surface_top_left =
             s.clamp_position_to_screen(desired_top_left, logical_size, s.magnification);
@@ -1423,7 +1516,7 @@ private:
             // Enforce the surface's minimum on-screen footprint before converting
             // to a logical size (rounding up so the visual size never dips below
             // the minimum), and cap the logical size at a sane maximum.
-            auto const clamped_visual_size = clamp_visual_size(geom::Size{raw_vis_w, raw_vis_h});
+            auto const clamped_visual_size = clamp_minimum_visual_size(geom::Size{raw_vis_w, raw_vis_h});
             auto const to_logical_dimension = [mag](auto visual_dimension)
             {
                 return decltype(visual_dimension){
@@ -1618,7 +1711,22 @@ void miral::Magnifier::Self::DisplayConfigObserver::update_bounds(
         });
 
     auto s = state.lock();
-    s->screen_bounds = rects.size() > 0 ? rects.bounding_rectangle() : geom::Rectangle{};
+    s->screen_bounds = rects;
+    if (auto const surf = s->surface.lock())
+    {
+        auto const top_left = surf->top_left();
+        auto const current_output = find_current_screen(rects, geom::Rectangle{top_left, s->visual_size});
+        auto const pre_clamp_visual_size = s->visual_size;
+        s->visual_size = clamp_visual_size(s->visual_size, current_output.size);
+
+        if (pre_clamp_visual_size == s->visual_size)
+            return;
+
+        if (s->follow_cursor)
+            Self::place_at_cursor(surf, *s, render_scene_into_surface);
+        else
+            Self::apply_positioned_geometry(surf, top_left, *s, render_scene_into_surface);
+    }
 }
 
 miral::Magnifier::Magnifier()

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -1097,6 +1097,14 @@ miral::Magnifier::Magnifier(live_config::Store& config_store)
             size.height = geom::Height(*val);
             capture_size(size);
         });
+    config_store.add_bool_attribute(
+        {"magnifier", "decouple"},
+        "Whether the magnifier is decoupled from the cursor position",
+        [this](live_config::Key const&, std::optional<bool> val)
+        {
+            if (val.has_value())
+                decouple(*val);
+        });
 }
 
 miral::Magnifier& miral::Magnifier::enable(bool enabled)

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -832,10 +832,12 @@ private:
             auto const visual = compute_visual_bounds(surface_top_left, logical_size, magnification);
             auto const contains = [&point](geom::Rectangle const& area)
             {
-                return point.x.as_value() >= area.left().as_int() &&
-                    point.x.as_value() < area.right().as_int() &&
-                    point.y.as_value() >= area.top().as_int() &&
-                    point.y.as_value() < area.bottom().as_int();
+                auto const left = static_cast<float>(area.left().as_value());
+                auto const right = static_cast<float>(area.right().as_value());
+                auto const top = static_cast<float>(area.top().as_value());
+                auto const bottom = static_cast<float>(area.bottom().as_value());
+                return point.x.as_value() >= left && point.x.as_value() < right && point.y.as_value() >= top &&
+                       point.y.as_value() < bottom;
             };
 
             if (!contains(geom::Rectangle{{visual.x, visual.y}, {visual.w, visual.h}}))

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -477,15 +477,6 @@ geom::Point surface_top_left_from_cursor(geom::Size const& window_size, geom::Po
             geom::as_delta(window_size.height / 2)};
 }
 
-geom::Size logical_size_from_visual(geom::Size const& visual_size, float mag)
-{
-    float widthf{static_cast<float>(visual_size.width.as_value())};
-    float heightf{static_cast<float>(visual_size.height.as_value())};
-    return {
-        geom::Width{std::max(1.0f, std::round(widthf/ mag))},
-        geom::Height{std::max(1.0f, std::round(heightf / mag))}};
-}
-
 /// Clamps a visual (on-screen) size so neither dimension shrinks below
 /// min_visual_dimension.
 geom::Size clamp_visual_size(geom::Size const& visual_size)
@@ -751,7 +742,7 @@ public:
     {
         auto s = state.lock();
         s->visual_size = clamp_visual_size(size * s->magnification);
-        auto const logical_size = logical_size_from_visual(s->visual_size, s->magnification);
+        auto const logical_size = s->logical_size();
         auto const logical_top_left = surface_top_left_from_cursor(logical_size, s->cursor_pos);
 
         if (auto const surf = s->surface.lock())
@@ -1064,7 +1055,7 @@ private:
                         center(surf->top_left(), old_logical_rect.size);
 
                     magnification = new_magnification;
-                    auto const new_logical_size = logical_size_from_visual(visual_size, magnification);
+                    auto const new_logical_size = logical_size();
                     auto const new_surface_top_left = old_surface_centre -
                         geom::Displacement{
                             geom::as_delta(new_logical_size.width / 2),
@@ -1079,7 +1070,7 @@ private:
                         center(old_logical_rect.top_left, old_logical_rect.size);
 
                     magnification = new_magnification;
-                    auto const new_logical_size = logical_size_from_visual(visual_size, magnification);
+                    auto const new_logical_size = logical_size();
                     auto const new_logical_top_left = old_logical_centre -
                         geom::Displacement{
                             geom::as_delta(new_logical_size.width / 2),
@@ -1123,6 +1114,15 @@ private:
             zoom_out.attach_observer<ZoomButtonObserver>(self, -zoom_step);
         }
 
+        auto logical_size() -> geom::Size
+        {
+            float widthf{static_cast<float>(visual_size.width.as_value())};
+            float heightf{static_cast<float>(visual_size.height.as_value())};
+            return {
+                geom::Width{std::max(1.0f, std::round(widthf / magnification))},
+                geom::Height{std::max(1.0f, std::round(heightf / magnification))}};
+        }
+
         std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
         std::shared_ptr<Observer> observer;
         std::shared_ptr<DisplayConfigObserver> display_config_observer;
@@ -1157,7 +1157,7 @@ private:
         State& s,
         RenderSceneIntoSurface& render_scene_into_surface)
     {
-        auto const logical_size = logical_size_from_visual(s.visual_size, s.magnification);
+        auto const logical_size = s.logical_size();
         render_scene_into_surface.capture_area(geom::Rectangle{positions.logical_top_left, logical_size});
         // capture_area() moves the backing surface to the capture position, so
         // apply the independent presentation position afterwards.
@@ -1197,7 +1197,7 @@ private:
             return;
         }
 
-        auto const logical_size = logical_size_from_visual(s.visual_size, s.magnification);
+        auto const logical_size = s.logical_size();
         auto const surface_top_left =
             s.clamp_position_to_screen(desired_top_left, logical_size, s.magnification);
         auto const logical_top_left =
@@ -1219,7 +1219,7 @@ private:
         State& s,
         RenderSceneIntoSurface& render_scene_into_surface)
     {
-        auto const logical_size = logical_size_from_visual(s.visual_size, s.magnification);
+        auto const logical_size = s.logical_size();
         auto top_left = surface_top_left_from_cursor(logical_size, s.cursor_pos);
 
         apply_positioned_geometry(surf, top_left, s, render_scene_into_surface);

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -24,7 +24,6 @@
 #include <miral/live_config.h>
 #include <mir/log.h>
 #include <mir/server.h>
-#include <mir/graphics/display_configuration.h>
 #include <mir/graphics/display.h>
 #include <mir/geometry/rectangles.h>
 #include <mir/input/cursor_observer.h>
@@ -63,11 +62,14 @@ auto const default_magnification = 1.5f;
 /// Diameter in pixels of the circular drag handle shown at the corner of the magnifier.
 auto const drag_handle_diameter = 48;
 
+enum class HandleKind { drag, resize };
+
 class DragHandleIndicator : public ms::BasicSurface
 {
 public:
     DragHandleIndicator(
         geom::Rectangle const& initial_rect,
+        HandleKind kind,
         std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
         std::shared_ptr<ms::SceneReport> const& scene_report,
         std::shared_ptr<mir::ObserverRegistrar<mg::DisplayConfigurationObserver>> const& display_config_registrar) :
@@ -85,7 +87,15 @@ public:
             1}
     {
         auto buffer = pool.claim();
-        fill_grip_buffer(*buffer);
+        switch (kind)
+        {
+        case HandleKind::drag:
+            fill_drag_buffer(*buffer);
+            break;
+        case HandleKind::resize:
+            fill_resize_buffer(*buffer);
+            break;
+        }
         auto const sz = window_size();
         get_streams().begin()->stream->submit_buffer(buffer, sz, geom::RectangleD{{0, 0}, sz});
 
@@ -95,7 +105,7 @@ public:
     }
 
 private:
-    static void fill_grip_buffer(mg::Buffer& buffer)
+    static void fill_drag_buffer(mg::Buffer& buffer)
     {
         auto const writable = mrs::as_write_mappable(std::shared_ptr<mg::Buffer>(&buffer, [](mg::Buffer*) {}));
         auto const mapping  = writable->map_writeable();
@@ -188,6 +198,58 @@ private:
                     set_pixel(x, y, 210, 230);
     }
 
+    static void fill_resize_buffer(mg::Buffer& buffer)
+    {
+        auto const writable = mrs::as_write_mappable(std::shared_ptr<mg::Buffer>(&buffer, [](mg::Buffer*) {}));
+        auto const mapping  = writable->map_writeable();
+        auto* const pixels  = reinterpret_cast<uint8_t*>(mapping->data());
+        int const stride    = mapping->stride().as_int();
+        int const w         = buffer.size().width.as_int();
+        int const h         = buffer.size().height.as_int();
+
+        auto const set_pixel = [&](int x, int y, uint8_t grey, uint8_t alpha)
+        {
+            if (x < 0 || x >= w || y < 0 || y >= h) return;
+            uint8_t* p = pixels + y * stride + x * 4;
+            p[0] = grey; p[1] = grey; p[2] = grey; p[3] = alpha;
+        };
+
+        // Start fully transparent.
+        for (int y = 0; y < h; ++y)
+            for (int x = 0; x < w; ++x)
+                set_pixel(x, y, 0, 0);
+
+        // Draw a filled circle with a semi-transparent dark background.
+        float const cx_f  = (w - 1) / 2.0f;
+        float const cy_f  = (h - 1) / 2.0f;
+        float const r     = std::min(cx_f, cy_f);
+        float const r_sq  = r * r;
+        for (int y = 0; y < h; ++y)
+            for (int x = 0; x < w; ++x)
+            {
+                float const dx = x - cx_f, dy = y - cy_f;
+                if (dx * dx + dy * dy <= r_sq)
+                    set_pixel(x, y, 40, 200);
+            }
+
+        // Corner bracket: two 2-px arms meeting at the top-left corner, which is
+        // where the resize handle always sits within the magnifier surface.
+        static int constexpr arm_len   = 12;
+        static int constexpr thickness = 2;
+        int const corner_x = w / 4 ;
+        int const corner_y = h / 4;
+
+        // Horizontal arm
+        for (int t = 0; t < thickness; ++t)
+            for (int i = 0; i <= arm_len; ++i)
+                set_pixel(corner_x + i, corner_y + t, 210, 230);
+
+        // Vertical arm (skip corner pixel to avoid double-draw)
+        for (int t = 0; t < thickness; ++t)
+            for (int i = 1; i <= arm_len; ++i)
+                set_pixel(corner_x + t, corner_y + i, 210, 230);
+    }
+
     SoftwareBufferPool mutable pool;
 };
 }
@@ -200,6 +262,25 @@ public:
         render_scene_into_surface
             .capture_area(geom::Rectangle{{300, 300}, geom::Size(default_capture_width, default_capture_height)})
             .overlay_cursor(false);
+    }
+
+    /// Creates a handle indicator surface, adds it to the surface stack and
+    /// gives it the default cursor image.
+    auto create_handle_indicator(
+        mir::Server& server,
+        HandleKind kind,
+        geom::Rectangle const& rect) -> std::shared_ptr<DragHandleIndicator>
+    {
+        auto indicator = std::make_shared<DragHandleIndicator>(
+            rect,
+            kind,
+            server.the_buffer_allocator(),
+            server.the_scene_report(),
+            server.the_display_configuration_observer_registrar());
+
+        server.the_surface_stack()->add_surface(indicator, mi::InputReceptionMode::normal);
+        indicator->set_cursor_image(server.the_default_cursor_image());
+        return indicator;
     }
 
     void init(mir::Server& server)
@@ -232,27 +313,28 @@ public:
                 {0, 0},
                 {geom::Width{drag_handle_diameter}, geom::Height{drag_handle_diameter}}};
 
-            drag_handle_indicator = std::make_shared<DragHandleIndicator>(
-                handle_rect,
-                server.the_buffer_allocator(),
-                server.the_scene_report(),
-                server.the_display_configuration_observer_registrar());
-
-            server.the_surface_stack()->add_surface(
-                drag_handle_indicator, mi::InputReceptionMode::normal);
-            drag_handle_indicator->set_cursor_image(server.the_default_cursor_image());
-            drag_handle_surface_stack = server.the_surface_stack();
+            drag_handle_indicator   = create_handle_indicator(server, HandleKind::drag, handle_rect);
+            resize_handle_indicator = create_handle_indicator(server, HandleKind::resize, handle_rect);
+            handle_surface_stack    = server.the_surface_stack();
 
             if (decoupled)
             {
                 drag_handle_observer = std::make_shared<DragHandleObserver>(this);
                 drag_handle_indicator->register_interest(drag_handle_observer);
 
+                resize_drag_observer = std::make_shared<ResizeDragObserver>(this);
+                resize_handle_indicator->register_interest(resize_drag_observer);
+
                 if (auto const surf = surface.lock(); surf && default_enabled)
                 {
-                    auto const dp = compute_drag_handle_position(surf->top_left(), surf->window_size(), magnification);
+                    auto const [dp, rp] = compute_both_handle_positions(
+                        surf->top_left(), surf->window_size(), magnification);
+
                     drag_handle_indicator->move_to(dp);
                     drag_handle_indicator->show();
+
+                    resize_handle_indicator->move_to(rp);
+                    resize_handle_indicator->show();
                 }
             }
         });
@@ -269,11 +351,21 @@ public:
                 drag_handle_observer.reset();
             }
 
-            if (auto const locked = drag_handle_surface_stack.lock())
+
+            if (resize_drag_observer)
+            {
+                resize_handle_indicator->unregister_interest(*resize_drag_observer);
+                resize_drag_observer.reset();
+            }
+
+            if (auto const locked = handle_surface_stack.lock())
+            {
                 locked->remove_surface(drag_handle_indicator);
+                locked->remove_surface(resize_handle_indicator);
+            }
 
             drag_handle_indicator.reset();
-
+            resize_handle_indicator.reset();
         });
     }
 
@@ -293,11 +385,16 @@ public:
                 auto const top_left = surface_top_left_from_cursor(surf->window_size(), cursor_pos);
                 surf->move_to(top_left);
                 render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
+                auto [dp, rp] = compute_both_handle_positions(top_left, surf->window_size(), magnification);
                 if (drag_handle_indicator)
                 {
-                    drag_handle_indicator->move_to(
-                        compute_drag_handle_position(top_left, surf->window_size(), magnification));
+                    drag_handle_indicator->move_to(dp);
                     drag_handle_indicator->show();
+                }
+                if (resize_handle_indicator)
+                {
+                    resize_handle_indicator->move_to(rp);
+                    resize_handle_indicator->show();
                 }
             }
             surf->show();
@@ -307,6 +404,8 @@ public:
             surf->hide();
             if (drag_handle_indicator)
                 drag_handle_indicator->hide();
+            if (resize_handle_indicator)
+                resize_handle_indicator->hide();
         }
     }
 
@@ -317,10 +416,13 @@ public:
         if (auto const surf = surface.lock())
         {
             surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
-            if (decoupled && drag_handle_indicator)
+            if (decoupled && (drag_handle_indicator || resize_handle_indicator))
             {
-                drag_handle_indicator->move_to(
-                    compute_drag_handle_position(surf->top_left(), surf->window_size(), magnification));
+                auto [dp, rp] = compute_both_handle_positions(surf->top_left(), surf->window_size(), magnification);
+                if (drag_handle_indicator)
+                    drag_handle_indicator->move_to(dp);
+                if (resize_handle_indicator)
+                    resize_handle_indicator->move_to(rp);
             }
         }
     }
@@ -330,9 +432,13 @@ public:
         std::lock_guard lock(mutex);
         auto const capture_position = surface_top_left_from_cursor(size, cursor_pos);
         render_scene_into_surface.capture_area({ capture_position, size });
-        if (decoupled && drag_handle_indicator)
+        if (decoupled &&  (drag_handle_indicator || resize_handle_indicator))
         {
-            drag_handle_indicator->move_to(compute_drag_handle_position(capture_position, size, magnification));
+            auto [dp, rp] = compute_both_handle_positions(capture_position, size, magnification);
+            if (drag_handle_indicator)
+                drag_handle_indicator->move_to(dp);
+            if (resize_handle_indicator)
+                resize_handle_indicator->move_to(rp);
         }
     }
 
@@ -351,17 +457,32 @@ public:
 
         if (new_decoupled)
         {
-            if (auto const surf = surface.lock(); surf && drag_handle_indicator)
+            if (auto const surf = surface.lock())
             {
-                drag_handle_observer = std::make_shared<DragHandleObserver>(this);
-                drag_handle_indicator->register_interest(drag_handle_observer);
-
-                // Only show the handle if the magnifier is currently active.
-                if (default_enabled)
+                if (drag_handle_indicator)
                 {
-                    auto const dp = compute_drag_handle_position(surf->top_left(), surf->window_size(), magnification);
-                    drag_handle_indicator->move_to(dp);
-                    drag_handle_indicator->show();
+                    drag_handle_observer = std::make_shared<DragHandleObserver>(this);
+                    drag_handle_indicator->register_interest(drag_handle_observer);
+                }
+                if (resize_handle_indicator)
+                {
+                    resize_drag_observer = std::make_shared<ResizeDragObserver>(this);
+                    resize_handle_indicator->register_interest(resize_drag_observer);
+                }
+                if (default_enabled && (drag_handle_indicator || resize_handle_indicator))
+                {
+                    auto [dp, rp] = compute_both_handle_positions(
+                        surf->top_left(), surf->window_size(), magnification);
+                    if (drag_handle_indicator)
+                    {
+                        drag_handle_indicator->move_to(dp);
+                        drag_handle_indicator->show();
+                    }
+                    if (resize_handle_indicator)
+                    {
+                        resize_handle_indicator->move_to(rp);
+                        resize_handle_indicator->show();
+                    }
                 }
             }
         }
@@ -375,6 +496,15 @@ public:
                     drag_handle_observer.reset();
                 }
                 drag_handle_indicator->hide();
+            }
+            if (resize_handle_indicator)
+            {
+                if (resize_drag_observer)
+                {
+                    resize_handle_indicator->unregister_interest(*resize_drag_observer);
+                    resize_drag_observer.reset();
+                }
+                resize_handle_indicator->hide();
             }
 
             if (auto const surf = surface.lock(); surf && default_enabled)
@@ -508,12 +638,12 @@ private:
                 surf->move_to(new_pos);
                 self->render_scene_into_surface.capture_area(
                     geom::Rectangle{new_pos, surf->window_size()});
+                auto [dp, rp] = self->compute_both_handle_positions(
+                    new_pos, surf->window_size(), self->magnification);
                 if (self->drag_handle_indicator)
-                {
-                    self->drag_handle_indicator->move_to(
-                        self->compute_drag_handle_position(
-                            new_pos, surf->window_size(), self->magnification));
-                }
+                    self->drag_handle_indicator->move_to(dp);
+                if (self->resize_handle_indicator)
+                    self->resize_handle_indicator->move_to(rp);
             }
         }
 
@@ -521,6 +651,152 @@ private:
         bool drag_active{false};
         geom::Displacement grab_abs{};
         geom::Point drag_start_magnifier_pos{};
+    };
+
+    /// Observes input on the resize handle indicator and changes the magnifier capture size.
+    class ResizeDragObserver : public ms::NullSurfaceObserver
+    {
+    public:
+        explicit ResizeDragObserver(Self* self) : self(self) {}
+
+        void input_consumed(
+            ms::Surface const*,
+            std::shared_ptr<MirEvent const> const& event) override
+        {
+            if (mir_event_get_type(event.get()) != mir_event_type_input)
+                return;
+            auto const* input_ev = mir_event_get_input_event(event.get());
+            switch (mir_input_event_get_type(input_ev))
+            {
+            case mir_input_event_type_pointer:
+                handle_pointer(mir_input_event_get_pointer_event(input_ev));
+                break;
+            case mir_input_event_type_touch:
+                handle_touch(mir_input_event_get_touch_event(input_ev));
+                break;
+            default:
+                break;
+            }
+        }
+
+    private:
+        void handle_pointer(MirPointerEvent const* pev)
+        {
+            auto const action = mir_pointer_event_action(pev);
+            auto const ax = static_cast<int>(
+                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_x)));
+            auto const ay = static_cast<int>(
+                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_y)));
+
+            std::lock_guard lock(self->mutex);
+            if (action == mir_pointer_action_button_down &&
+                mir_pointer_event_button_state(pev, mir_pointer_button_primary))
+                start_drag(ax, ay);
+            else if (action == mir_pointer_action_motion && drag_active &&
+                     mir_pointer_event_button_state(pev, mir_pointer_button_primary))
+                apply_drag(ax, ay);
+            else if (action == mir_pointer_action_button_up)
+                drag_active = false;
+        }
+
+        void handle_touch(MirTouchEvent const* tev)
+        {
+            if (mir_touch_event_point_count(tev) != 1)
+                return;
+            auto const action = mir_touch_event_action(tev, 0);
+            auto const ax = static_cast<int>(
+                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_x)));
+            auto const ay = static_cast<int>(
+                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_y)));
+
+            std::lock_guard lock(self->mutex);
+            if (action == mir_touch_action_down)
+                start_drag(ax, ay);
+            else if (action == mir_touch_action_change && drag_active)
+                apply_drag(ax, ay);
+            else if (action == mir_touch_action_up)
+                drag_active = false;
+        }
+
+        void start_drag(int ax, int ay)
+        {
+            drag_active = true;
+            grab_abs = {geom::DeltaX{ax}, geom::DeltaY{ay}};
+
+            auto const surf = self->surface.lock();
+            if (!surf) return;
+            auto const tl   = surf->top_left();
+            auto const sz   = self->render_scene_into_surface.capture_area().size;
+            float const mag = self->magnification;
+
+            // Determine which corner the handle is currently at
+            auto const resize_pos        = self->compute_resize_handle_position(tl, sz, mag);
+            auto const [left, top]       = self->determine_resize_corner(resize_pos, tl, sz);
+
+            // The pinned corner is diagonally opposite the active handle corner
+            pin_left  = !left;
+            pin_above = !top;
+
+            float const inner = (mag - 1.0f) / 2.0f;
+            float const outer = (mag + 1.0f) / 2.0f;
+            pin_pos = geom::Point{
+                pin_left
+                    ? static_cast<int>(tl.x.as_int() - inner * sz.width.as_int())
+                    : static_cast<int>(tl.x.as_int() + outer * sz.width.as_int()),
+                pin_above
+                    ? static_cast<int>(tl.y.as_int() - inner * sz.height.as_int())
+                    : static_cast<int>(tl.y.as_int() + outer * sz.height.as_int())};
+        }
+
+        void apply_drag(int ax, int ay)
+        {
+            float const mag = self->magnification;
+
+            // Visual size from the finger position to the pinned corner
+            int const raw_vis_w = pin_left
+                ? (ax - pin_pos.x.as_int())
+                : (pin_pos.x.as_int() - ax);
+            int const raw_vis_h = pin_above
+                ? (ay - pin_pos.y.as_int())
+                : (pin_pos.y.as_int() - ay);
+
+            auto const clamp = [](int v) { return std::clamp(v, 50, 1000); };
+            geom::Size const new_logical_size{
+                geom::Width{ clamp(static_cast<int>(std::round(raw_vis_w / mag)))},
+                geom::Height{clamp(static_cast<int>(std::round(raw_vis_h / mag)))}};
+
+            float const inner = (mag - 1.0f) / 2.0f;
+            float const outer = (mag + 1.0f) / 2.0f;
+            int const w = new_logical_size.width.as_int();
+            int const h = new_logical_size.height.as_int();
+
+            geom::Point const new_logical_tl{
+                pin_left
+                    ? static_cast<int>(pin_pos.x.as_int() + inner * w)
+                    : static_cast<int>(pin_pos.x.as_int() - outer * w),
+                pin_above
+                    ? static_cast<int>(pin_pos.y.as_int() + inner * h)
+                    : static_cast<int>(pin_pos.y.as_int() - outer * h)};
+
+            auto const surf = self->surface.lock();
+            if (!surf) return;
+
+            surf->move_to(new_logical_tl);
+            self->render_scene_into_surface.capture_area({new_logical_tl, new_logical_size});
+
+            auto const [dp, rp] = self->compute_both_handle_positions(new_logical_tl, new_logical_size, mag);
+            if (self->drag_handle_indicator)
+                self->drag_handle_indicator->move_to(dp);
+            if (self->resize_handle_indicator)
+                self->resize_handle_indicator->move_to(rp);
+        }
+
+        Self* self;
+        bool drag_active{false};
+        geom::Displacement grab_abs{};
+        geom::Point pin_pos{};
+        bool pin_left{false};
+        bool pin_above{false};
     };
 
     static geom::Point surface_top_left_from_cursor(
@@ -553,14 +829,61 @@ private:
         return geom::Point{hx, hy};
     }
 
+    /// Computes the position of the circular resize handle indicator.
+    ///
+    /// The handle is placed at the visual top-left corner of the magnifier.
+    geom::Point compute_resize_handle_position(
+        geom::Point const& logical_top_left,
+        geom::Size const& logical_size,
+        float mag) const
+    {
+        // Visual top-left of the magnifier.
+        int const vis_x = logical_top_left.x.as_int() - (mag - 1.0f) / 2.0f * logical_size.width.as_int();
+        int const vis_y = logical_top_left.y.as_int() - (mag - 1.0f) / 2.0f * logical_size.height.as_int();
+
+        // Default: circle centred on the top-left corner of the visual magnifier,
+        // so it sits half outside the content area.
+        int hx = vis_x;
+        int hy = vis_y;
+
+        return geom::Point{hx, hy};
+    }
+
+    std::pair<geom::Point, geom::Point> compute_both_handle_positions(
+        geom::Point const& logical_top_left,
+        geom::Size const& logical_size,
+        float mag) const
+    {
+        return {
+            compute_drag_handle_position(logical_top_left, logical_size, mag),
+            compute_resize_handle_position(logical_top_left, logical_size, mag)};
+    }
+
+    /// Returns which corner the resize handle is at as (corner_left, corner_top).
+    std::pair<bool, bool> determine_resize_corner(
+        geom::Point const& handle_pos,
+        geom::Point const& logical_top_left,
+        geom::Size const& logical_size) const
+    {
+        int const vis_cx = logical_top_left.x.as_int() + logical_size.width.as_int()  / 2;
+        int const vis_cy = logical_top_left.y.as_int() + logical_size.height.as_int() / 2;
+
+        int const hx = handle_pos.x.as_int() + drag_handle_diameter / 2;
+        int const hy = handle_pos.y.as_int() + drag_handle_diameter / 2;
+
+        return {hx < vis_cx, hy < vis_cy};
+    }
+
     std::mutex mutex;
     RenderSceneIntoSurface render_scene_into_surface;
     std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
     std::shared_ptr<Observer> observer;
     std::weak_ptr<ms::Surface> surface;
     std::shared_ptr<DragHandleIndicator> drag_handle_indicator;
-    std::weak_ptr<msh::SurfaceStack> drag_handle_surface_stack;
+    std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
     std::shared_ptr<DragHandleObserver> drag_handle_observer;
+    std::shared_ptr<DragHandleIndicator> resize_handle_indicator;
+    std::shared_ptr<ResizeDragObserver> resize_drag_observer;
     geom::Point cursor_pos;
     float magnification{default_magnification};
     bool default_enabled{false};

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -593,8 +593,10 @@ private:
         /// Pixel-space rectangle of signed integer coordinates.
         struct VisualBounds { int x, y, w, h; };
 
-        /// Returns the pixel-space top-left and size of the visual magnifier surface
-        /// given its logical capture rectangle and magnification factor.
+        ///
+        /// The visual rectangle is `mag` times larger than the logical one but
+        /// shares the same centre, which is why the top-left is pulled back by
+        /// (mag-1)/2 * size.
         VisualBounds compute_visual_bounds(
             geom::Point const& logical_top_left,
             geom::Size const& logical_size,
@@ -894,6 +896,26 @@ private:
 
     /// Observes input on the resize handle indicator and changes the magnifier capture size.
     /// Resizes the magnifier capture area when its resize handle is dragged.
+    ///
+    /// Resizing model
+    /// --------------
+    /// The magnifier draws a *logical* capture rectangle (top-left L, size sw x sh)
+    /// scaled by `mag` into a larger *visual* rectangle on screen. Both share the same
+    /// centre, so (with inner = (mag-1)/2, outer = (mag+1)/2) the visual edges are:
+    ///     visual left/top    = L - inner * size
+    ///     visual right/bottom = L + outer * size
+    ///
+    /// A resize drag keeps the visual corner *opposite* the grabbed handle pinned and
+    /// lets the grabbed corner follow the finger:
+    ///
+    ///     pin +-----------+
+    ///         |  visual   |
+    ///         |   rect    |
+    ///         +-----------X  <- grabbed corner follows the finger (ax, ay)
+    ///
+    /// on_drag_start records the pinned visual corner. on_drag_move measures the visual
+    /// extent from pin to finger, converts it back to a logical size (/ mag), then
+    /// back-solves the logical top-left so the pinned visual corner stays put.
     class ResizeDragObserver : public HandleObserver
     {
     public:
@@ -929,6 +951,8 @@ private:
                 geom::Width{clamp(static_cast<int>(std::round(raw_vis_w / mag)))},
                 geom::Height{clamp(static_cast<int>(std::round(raw_vis_h / mag)))}};
 
+            // Back-solve the logical top-left from the pinned visual corner, inverting
+            // the visual-edge identity above so the pinned corner stays fixed.
             float const outer = (mag + 1.0f) / 2.0f;
 
             int const w = new_logical_size.width.as_int();

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "render_scene_into_surface.h"
+#include "software_buffer_pool.h"
 #include <miral/magnifier.h>
 
 #include <input-method-unstable-v2_wrapper.h>
@@ -23,22 +24,172 @@
 #include <miral/live_config.h>
 #include <mir/log.h>
 #include <mir/server.h>
+#include <mir/graphics/display_configuration.h>
+#include <mir/graphics/display.h>
+#include <mir/geometry/rectangles.h>
 #include <mir/input/cursor_observer.h>
 #include <mir/input/cursor_observer_multiplexer.h>
 #include <mir/scene/surface.h>
+#include <mir/scene/null_surface_observer.h>
+#include <mir/scene/basic_surface.h>
+#include <mir/scene/scene_report.h>
+#include <mir/compositor/stream.h>
+#include <mir/graphics/graphic_buffer_allocator.h>
+#include <mir/renderer/sw/pixel_source.h>
+#include <mir/shell/surface_stack.h>
+#include <mir/observer_registrar.h>
 
 #include <glm/gtc/matrix_transform.hpp>
+
+#include <cmath>
+#include <algorithm>
 
 namespace mi = mir::input;
 namespace ms = mir::scene;
 namespace geom = mir::geometry;
 namespace mg = mir::graphics;
+namespace mrs = mir::renderer::software;
+namespace msh = mir::shell;
 
 namespace
 {
+using miral::SoftwareBufferPool;
+using miral::create_stream_info;
+
 auto const default_capture_width = 150;
 auto const default_capture_height = 150;
 auto const default_magnification = 1.5f;
+
+/// Diameter in pixels of the circular drag handle shown at the corner of the magnifier.
+auto const drag_handle_diameter = 48;
+
+class DragHandleIndicator : public ms::BasicSurface
+{
+public:
+    DragHandleIndicator(
+        geom::Rectangle const& initial_rect,
+        std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
+        std::shared_ptr<ms::SceneReport> const& scene_report,
+        std::shared_ptr<mir::ObserverRegistrar<mg::DisplayConfigurationObserver>> const& display_config_registrar) :
+        BasicSurface{
+            "magnifier-drag-handle",
+            initial_rect,
+            mir_pointer_unconfined,
+            create_stream_info(),
+            nullptr,
+            scene_report,
+            display_config_registrar},
+        pool{
+            [allocator, initial_rect]
+            { return allocator->alloc_software_buffer(initial_rect.size, mir_pixel_format_argb_8888); },
+            1}
+    {
+        auto buffer = pool.claim();
+        fill_grip_buffer(*buffer);
+        auto const sz = window_size();
+        get_streams().begin()->stream->submit_buffer(buffer, sz, geom::RectangleD{{0, 0}, sz});
+
+        set_depth_layer(mir_depth_layer_always_on_top);
+        set_focus_mode(mir_focus_mode_disabled);
+        hide();
+    }
+
+private:
+    static void fill_grip_buffer(mg::Buffer& buffer)
+    {
+        auto const writable = mrs::as_write_mappable(std::shared_ptr<mg::Buffer>(&buffer, [](mg::Buffer*) {}));
+        auto const mapping  = writable->map_writeable();
+        auto* const pixels  = reinterpret_cast<uint8_t*>(mapping->data());
+        int const stride    = mapping->stride().as_int();
+        int const w         = buffer.size().width.as_int();
+        int const h         = buffer.size().height.as_int();
+
+        // For mir_pixel_format_argb_8888 on little-endian: memory layout [B, G, R, A].
+        auto const set_pixel = [&](int x, int y, uint8_t grey, uint8_t alpha)
+        {
+            uint8_t* p = pixels + y * stride + x * 4;
+            p[0] = grey; p[1] = grey; p[2] = grey; p[3] = alpha;
+        };
+
+        // Start fully transparent.
+        for (int y = 0; y < h; ++y)
+            for (int x = 0; x < w; ++x)
+                set_pixel(x, y, 0, 0);
+
+        // Draw a filled circle with a semi-transparent dark background.
+        float const cx   = (w - 1) / 2.0f;
+        float const cy   = (h - 1) / 2.0f;
+        float const r    = std::min(cx, cy);
+        float const r_sq = r * r;
+
+        for (int y = 0; y < h; ++y)
+        {
+            for (int x = 0; x < w; ++x)
+            {
+                float const dx = x - cx;
+                float const dy = y - cy;
+                if (dx * dx + dy * dy <= r_sq)
+                    set_pixel(x, y, 40, 200);
+            }
+        }
+
+        // Draw a drag-pan icon: four arrowheads (N/S/E/W) connected by slim stems.
+        // head_half == head_len so the half-width grows by exactly 1 px per row, with
+        // no isolated single-pixel tip rows (the tip row itself is skipped).
+        static int constexpr tip_dist  = 15; // distance from centre to arrow tip
+        static int constexpr head_len  = 5;  // rows from stem junction to tip (== head_half)
+        static int constexpr stem_half = 1;  // half-width of connecting stems (3 px total)
+
+        int const ci     = static_cast<int>(cx);
+        int const cj     = static_cast<int>(cy);
+        int const tip_n  = cj - tip_dist;
+        int const tip_s  = cj + tip_dist;
+        int const tip_w  = ci - tip_dist;
+        int const tip_e  = ci + tip_dist;
+        int const base_n = cj - (tip_dist - head_len);
+        int const base_s = cj + (tip_dist - head_len);
+        int const base_w = ci - (tip_dist - head_len);
+        int const base_e = ci + (tip_dist - head_len);
+
+        auto const in_icon = [&](int x, int y) -> bool
+        {
+            // Vertical stem
+            if (std::abs(x - ci) <= stem_half && y >= base_n && y <= base_s)
+                return true;
+            // Horizontal stem
+            if (std::abs(y - cj) <= stem_half && x >= base_w && x <= base_e)
+                return true;
+            // North arrowhead — skip y==tip_n so the tip starts at 3 px wide, not 1
+            if (y > tip_n && y <= base_n)
+            {
+                if (std::abs(x - ci) <= y - tip_n) return true;
+            }
+            // South arrowhead
+            if (y >= base_s && y < tip_s)
+            {
+                if (std::abs(x - ci) <= tip_s - y) return true;
+            }
+            // West arrowhead
+            if (x > tip_w && x <= base_w)
+            {
+                if (std::abs(y - cj) <= x - tip_w) return true;
+            }
+            // East arrowhead
+            if (x >= base_e && x < tip_e)
+            {
+                if (std::abs(y - cj) <= tip_e - x) return true;
+            }
+            return false;
+        };
+
+        for (int y = 0; y < h; ++y)
+            for (int x = 0; x < w; ++x)
+                if (in_icon(x, y))
+                    set_pixel(x, y, 210, 230);
+    }
+
+    SoftwareBufferPool mutable pool;
+};
 }
 
 class miral::Magnifier::Self
@@ -75,6 +226,35 @@ public:
             observer = std::make_shared<Observer>(this);
             server.the_cursor_observer_multiplexer()->register_interest(observer);
             cursor_multiplexer = server.the_cursor_observer_multiplexer();
+
+            // Create the drag handle indicator.
+            geom::Rectangle const handle_rect{
+                {0, 0},
+                {geom::Width{drag_handle_diameter}, geom::Height{drag_handle_diameter}}};
+
+            drag_handle_indicator = std::make_shared<DragHandleIndicator>(
+                handle_rect,
+                server.the_buffer_allocator(),
+                server.the_scene_report(),
+                server.the_display_configuration_observer_registrar());
+
+            server.the_surface_stack()->add_surface(
+                drag_handle_indicator, mi::InputReceptionMode::normal);
+            drag_handle_indicator->set_cursor_image(server.the_default_cursor_image());
+            drag_handle_surface_stack = server.the_surface_stack();
+
+            if (decoupled)
+            {
+                drag_handle_observer = std::make_shared<DragHandleObserver>(this);
+                drag_handle_indicator->register_interest(drag_handle_observer);
+
+                if (auto const surf = surface.lock(); surf && default_enabled)
+                {
+                    auto const dp = compute_drag_handle_position(surf->top_left(), surf->window_size(), magnification);
+                    drag_handle_indicator->move_to(dp);
+                    drag_handle_indicator->show();
+                }
+            }
         });
 
         server.add_stop_callback([&]
@@ -82,6 +262,18 @@ public:
             std::lock_guard lock(mutex);
             if (auto const locked = cursor_multiplexer.lock())
                 locked->unregister_interest(*observer);
+
+            if (drag_handle_observer)
+            {
+                drag_handle_indicator->unregister_interest(*drag_handle_observer);
+                drag_handle_observer.reset();
+            }
+
+            if (auto const locked = drag_handle_surface_stack.lock())
+                locked->remove_surface(drag_handle_indicator);
+
+            drag_handle_indicator.reset();
+
         });
     }
 
@@ -101,12 +293,20 @@ public:
                 auto const top_left = surface_top_left_from_cursor(surf->window_size(), cursor_pos);
                 surf->move_to(top_left);
                 render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
+                if (drag_handle_indicator)
+                {
+                    drag_handle_indicator->move_to(
+                        compute_drag_handle_position(top_left, surf->window_size(), magnification));
+                    drag_handle_indicator->show();
+                }
             }
             surf->show();
         }
         else
         {
             surf->hide();
+            if (drag_handle_indicator)
+                drag_handle_indicator->hide();
         }
     }
 
@@ -115,15 +315,25 @@ public:
         std::lock_guard lock(mutex);
         magnification = new_magnification;
         if (auto const surf = surface.lock())
+        {
             surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
+            if (decoupled && drag_handle_indicator)
+            {
+                drag_handle_indicator->move_to(
+                    compute_drag_handle_position(surf->top_left(), surf->window_size(), magnification));
+            }
+        }
     }
 
     void set_capture_size(geom::Size const& size)
     {
         std::lock_guard lock(mutex);
-        auto const surf = surface.lock();
-        auto const capture_position = surf ? surf->top_left() : surface_top_left_from_cursor(size, cursor_pos);
+        auto const capture_position = surface_top_left_from_cursor(size, cursor_pos);
         render_scene_into_surface.capture_area({ capture_position, size });
+        if (decoupled && drag_handle_indicator)
+        {
+            drag_handle_indicator->move_to(compute_drag_handle_position(capture_position, size, magnification));
+        }
     }
 
     geom::Size current_size() const
@@ -138,9 +348,35 @@ public:
             return;
 
         decoupled = new_decoupled;
+
         if (new_decoupled)
         {
-            // Re-couple: snap surface back to current cursor position.
+            if (auto const surf = surface.lock(); surf && drag_handle_indicator)
+            {
+                drag_handle_observer = std::make_shared<DragHandleObserver>(this);
+                drag_handle_indicator->register_interest(drag_handle_observer);
+
+                // Only show the handle if the magnifier is currently active.
+                if (default_enabled)
+                {
+                    auto const dp = compute_drag_handle_position(surf->top_left(), surf->window_size(), magnification);
+                    drag_handle_indicator->move_to(dp);
+                    drag_handle_indicator->show();
+                }
+            }
+        }
+        else
+        {
+            if (drag_handle_indicator)
+            {
+                if (drag_handle_observer)
+                {
+                    drag_handle_indicator->unregister_interest(*drag_handle_observer);
+                    drag_handle_observer.reset();
+                }
+                drag_handle_indicator->hide();
+            }
+
             if (auto const surf = surface.lock(); surf && default_enabled)
             {
                 auto const top_left = surface_top_left_from_cursor(surf->window_size(), cursor_pos);
@@ -169,7 +405,9 @@ private:
             if (!surf)
                 return;
 
-            auto const capture_position = surface_top_left_from_cursor(surf->window_size(), self->cursor_pos);
+            auto const capture_position = surface_top_left_from_cursor(
+                surf->window_size(),
+                self->cursor_pos);
             surf->move_to(capture_position);
             self->render_scene_into_surface.capture_area(
                 geom::Rectangle{capture_position, surf->window_size()});
@@ -183,6 +421,108 @@ private:
         Self* self;
     };
 
+    /// Observes input on the drag handle indicator and moves both surfaces.
+    class DragHandleObserver : public ms::NullSurfaceObserver
+    {
+    public:
+        explicit DragHandleObserver(Self* self) : self(self) {}
+
+        void input_consumed(
+            ms::Surface const*,
+            std::shared_ptr<MirEvent const> const& event) override
+        {
+            if (mir_event_get_type(event.get()) != mir_event_type_input)
+                return;
+            auto const* input_ev = mir_event_get_input_event(event.get());
+            switch (mir_input_event_get_type(input_ev))
+            {
+            case mir_input_event_type_pointer:
+                handle_pointer(mir_input_event_get_pointer_event(input_ev));
+                break;
+            case mir_input_event_type_touch:
+                handle_touch(mir_input_event_get_touch_event(input_ev));
+                break;
+            default:
+                break;
+            }
+        }
+
+    private:
+        void handle_pointer(MirPointerEvent const* pev)
+        {
+            auto const action = mir_pointer_event_action(pev);
+            auto const ax = static_cast<int>(
+                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_x)));
+            auto const ay = static_cast<int>(
+                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_y)));
+
+            std::lock_guard lock(self->mutex);
+            if (action == mir_pointer_action_button_down &&
+                mir_pointer_event_button_state(pev, mir_pointer_button_primary))
+                start_drag(ax, ay);
+            else if (action == mir_pointer_action_motion && drag_active &&
+                     mir_pointer_event_button_state(pev, mir_pointer_button_primary))
+                apply_drag(ax, ay);
+            else if (action == mir_pointer_action_button_up)
+                drag_active = false;
+        }
+
+        void handle_touch(MirTouchEvent const* tev)
+        {
+            if (mir_touch_event_point_count(tev) != 1)
+                return;
+            auto const action = mir_touch_event_action(tev, 0);
+            auto const ax = static_cast<int>(
+                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_x)));
+            auto const ay = static_cast<int>(
+                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_y)));
+
+            std::lock_guard lock(self->mutex);
+            if (action == mir_touch_action_down)
+                start_drag(ax, ay);
+            else if (action == mir_touch_action_change && drag_active)
+                apply_drag(ax, ay);
+            else if (action == mir_touch_action_up)
+                drag_active = false;
+        }
+
+        void start_drag(int ax, int ay)
+        {
+            drag_active = true;
+            grab_abs = {geom::DeltaX{ax}, geom::DeltaY{ay}};
+            if (auto const surf = self->surface.lock())
+                drag_start_magnifier_pos = surf->top_left();
+        }
+
+        void apply_drag(int ax, int ay)
+        {
+            geom::Displacement const delta{
+                geom::DeltaX{ax} - grab_abs.dx,
+                geom::DeltaY{ay} - grab_abs.dy};
+            geom::Point const new_pos{
+                drag_start_magnifier_pos.x + delta.dx,
+                drag_start_magnifier_pos.y + delta.dy};
+
+            if (auto const surf = self->surface.lock())
+            {
+                surf->move_to(new_pos);
+                self->render_scene_into_surface.capture_area(
+                    geom::Rectangle{new_pos, surf->window_size()});
+                if (self->drag_handle_indicator)
+                {
+                    self->drag_handle_indicator->move_to(
+                        self->compute_drag_handle_position(
+                            new_pos, surf->window_size(), self->magnification));
+                }
+            }
+        }
+
+        Self* self;
+        bool drag_active{false};
+        geom::Displacement grab_abs{};
+        geom::Point drag_start_magnifier_pos{};
+    };
+
     static geom::Point surface_top_left_from_cursor(
         geom::Size const& window_size,
         geom::Point const& cursor_pos)
@@ -192,13 +532,35 @@ private:
             cursor_pos.y.as_int() - window_size.height.as_int() / 2};
     }
 
-    friend Observer;
+    /// Computes the position of the circular drag handle indicator.
+    ///
+    /// The handle is placed at the visual bottom-right corner of the magnifier.
+    geom::Point compute_drag_handle_position(
+        geom::Point const& logical_top_left,
+        geom::Size const& logical_size,
+        float mag) const
+    {
+        int const vis_w = mag * logical_size.width.as_int();
+        int const vis_h = mag * logical_size.height.as_int();
+
+        // Visual top-left of the magnifier.
+        int const vis_x = logical_top_left.x.as_int() - (mag - 1.0f) / 2.0f * logical_size.width.as_int();
+        int const vis_y = logical_top_left.y.as_int() - (mag - 1.0f) / 2.0f * logical_size.height.as_int();
+
+        int hx = vis_x + vis_w - drag_handle_diameter;
+        int hy = vis_y + vis_h - drag_handle_diameter;
+
+        return geom::Point{hx, hy};
+    }
 
     std::mutex mutex;
     RenderSceneIntoSurface render_scene_into_surface;
     std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
     std::shared_ptr<Observer> observer;
     std::weak_ptr<ms::Surface> surface;
+    std::shared_ptr<DragHandleIndicator> drag_handle_indicator;
+    std::weak_ptr<msh::SurfaceStack> drag_handle_surface_stack;
+    std::shared_ptr<DragHandleObserver> drag_handle_observer;
     geom::Point cursor_pos;
     float magnification{default_magnification};
     bool default_enabled{false};

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -71,19 +71,8 @@ auto const zoom_stack_padding = 8;
 /// Height of the vertical zoom-in/zoom-out button stack.
 geom::Height const zoom_stack_height{2 * drag_handle_diameter + zoom_stack_padding};
 
-/// Minimum on-screen (visual) width/height of the magnifier surface, in pixels.
-/// Derived so the drag handle (bottom-right corner) and the zoom button stack
-/// (right edge, vertically centred) never overlap each other: the drag handle
-/// needs a full diameter of clearance both above and below the centred stack.
-auto const min_visual_dimension = 2 * drag_handle_diameter + zoom_stack_height.as_int();
-
 /// Magnification step applied by each zoom button press.
 auto const zoom_step = 0.25f;
-
-/// Painter colour/alpha constants for handle indicator graphics.
-uint8_t constexpr disc_grey  = 40;
-uint8_t constexpr icon_grey  = 210;
-uint8_t constexpr background_alpha = 150;
 
 enum class HandleKind { drag, resize, zoom_in, zoom_out };
 
@@ -187,7 +176,7 @@ private:
             std::memset(mapping->data(), 0, mapping->len());
         }
 
-        void fill_circle(uint8_t grey)
+        void fill_circle()
         {
             auto const cx = geom::as_x((size.width - geom::DeltaX{1}) / 2.0f);
             auto const cy = geom::as_y((size.height - geom::DeltaY{1}) / 2.0f);
@@ -203,27 +192,27 @@ private:
                     auto const delta = dx.as_value() * dx.as_value() + dy.as_value() * dy.as_value();
 
                     if (delta <= r_sq)
-                        set_pixel(geom::Point{x, y}, grey);
+                        set_pixel(geom::Point{x, y}, disc_grey);
                 }
             }
         }
 
-        void draw_horizontal_line(HorizontalLine const& line, uint8_t grey)
+        void draw_horizontal_line(HorizontalLine const& line)
         {
             auto const true_start = std::min<geom::X>(line.start, line.end);
             auto const true_end = std::max<geom::X>(line.start, line.end);
             for (int t = 0; t < line.thickness.as_value(); ++t)
                 for (auto x = true_start; x <= true_end; x = x + geom::DeltaX{1})
-                    set_pixel(geom::Point{x, line.y + geom::DeltaY{t}}, grey);
+                    set_pixel(geom::Point{x, line.y + geom::DeltaY{t}}, icon_grey);
         }
 
-        void draw_vertical_line(VerticalLine const& line, uint8_t grey)
+        void draw_vertical_line(VerticalLine const& line)
         {
             auto const true_start = std::min<geom::Y>(line.start, line.end);
             auto const true_end = std::max<geom::Y>(line.start, line.end);
             for (int t = 0; t < line.thickness.as_value(); ++t)
                 for (auto y = true_start; y <= true_end; y = y + geom::DeltaY{1})
-                    set_pixel(geom::Point{line.x + geom::DeltaX{t}, y}, grey);
+                    set_pixel(geom::Point{line.x + geom::DeltaX{t}, y}, icon_grey);
         }
 
         auto buffer_size() const -> geom::Size
@@ -248,6 +237,11 @@ private:
             pixel[3] = background_alpha;
         }
 
+        /// Painter colour/alpha constants for handle indicator graphics.
+        inline uint8_t static disc_grey = 40;
+        inline uint8_t static icon_grey = 210;
+        inline uint8_t static background_alpha = 150;
+
         static auto constexpr format = mir_pixel_format_argb_8888;
         std::shared_ptr<mrs::WriteMappable> const writable;
         std::unique_ptr<mrs::Mapping<std::byte>> const mapping;
@@ -259,7 +253,7 @@ private:
     {
         BufferPainter painter{buffer};
         painter.clear();
-        painter.fill_circle(disc_grey);
+        painter.fill_circle();
 
         // Draw a drag-pan icon: four arrowheads (N/S/E/W) connected by slim stems.
         static int constexpr tip_dist  = 15;
@@ -286,16 +280,14 @@ private:
                 .start = base_n,
                 .end = base_s,
                 .thickness = geom::Width{stem_thickness},
-            },
-            icon_grey);
+            });
         painter.draw_horizontal_line(
             {
                 .start = base_w,
                 .end = base_e,
                 .y = center_y - geom::DeltaY{stem_thickness / 2},
                 .thickness = geom::Height{stem_thickness},
-            },
-            icon_grey);
+            });
 
         // North arrowhead — rows from tip_n+1 to base_n, width grows by 1 px per row
         for (auto y = tip_n + geom::DeltaY{1}; y <= base_n; y = y + geom::DeltaY{1})
@@ -305,8 +297,7 @@ private:
                     .end = center_x + geom::DeltaX((y - tip_n).as_value()),
                     .y = y,
                     .thickness = geom::Height{1},
-                },
-                icon_grey);
+                });
 
         // South arrowhead
         for (auto y = base_s; y < tip_s; y = y + geom::DeltaY{1})
@@ -316,8 +307,7 @@ private:
                     .end = center_x + geom::DeltaX((tip_s - y).as_value()),
                     .y = y,
                     .thickness = geom::Height{1},
-                },
-                icon_grey);
+                });
 
         // West arrowhead — columns from tip_w+1 to base_w
         for (auto x = tip_w + geom::DeltaX{1}; x <= base_w; x = x + geom::DeltaX{1})
@@ -327,8 +317,7 @@ private:
                     .start = center_y - geom::DeltaY((x - tip_w).as_value()),
                     .end = center_y + geom::DeltaY((x - tip_w).as_value()),
                     .thickness = geom::Width{1},
-                },
-                icon_grey);
+                });
 
         // East arrowhead
         for (auto x = base_e; x < tip_e; x = x + geom::DeltaX{1})
@@ -338,15 +327,14 @@ private:
                     .start = center_y - geom::DeltaY((tip_e - x).as_value()),
                     .end = center_y + geom::DeltaY((tip_e - x).as_value()),
                     .thickness = geom::Width{1},
-                },
-                icon_grey);
+                });
     }
 
     static void fill_resize_buffer(mg::Buffer& buffer)
     {
         BufferPainter painter{buffer};
         painter.clear();
-        painter.fill_circle(disc_grey);
+        painter.fill_circle();
 
         // Corner bracket: two 2-px arms meeting at the top-left corner, which is
         // where the resize handle always sits within the magnifier surface.
@@ -362,23 +350,21 @@ private:
                 .end = corner_x + geom::DeltaX{arm_len},
                 .y = corner_y,
                 .thickness = geom::Height{thickness},
-            },
-            icon_grey);
+            });
         painter.draw_vertical_line(
             {
                 .x = corner_x,
                 .start = corner_y,
                 .end = corner_y + geom::DeltaY{arm_len},
                 .thickness = geom::Width{thickness},
-            },
-            icon_grey);
+            });
     }
 
     static void fill_zoom_buffer(mg::Buffer& buffer, bool zoom_in)
     {
         BufferPainter painter{buffer};
         painter.clear();
-        painter.fill_circle(disc_grey);
+        painter.fill_circle();
 
         // Draw + (zoom in) or – (zoom out) symbol.
         auto const [w, h] = painter.buffer_size();
@@ -391,8 +377,7 @@ private:
                 .end = geom::as_x((w + geom::Width{bar_len}) / 2 - geom::DeltaX{1}),
                 .y = geom::as_y((h - geom::Height{bar_thickness}) / 2),
                 .thickness = geom::Height{bar_thickness},
-            },
-            icon_grey);
+            });
 
         if (zoom_in)
             painter.draw_vertical_line(
@@ -401,8 +386,7 @@ private:
                     .start = geom::as_y((h - geom::Height{bar_len}) / 2),
                     .end = geom::as_y((h + geom::Height{bar_len}) / 2 - geom::DeltaY{1}),
                     .thickness = geom::Width{bar_thickness},
-                },
-                icon_grey);
+                });
     }
 
     miral::SoftwareBufferPool mutable pool;
@@ -505,6 +489,12 @@ geom::Size logical_size_from_visual(geom::Size const& visual_size, float mag)
 /// min_visual_dimension.
 geom::Size clamp_visual_size(geom::Size const& visual_size)
 {
+    /// Minimum on-screen (visual) width/height of the magnifier surface, in pixels.
+    /// Derived so the drag handle (bottom-right corner) and the zoom button stack
+    /// (right edge, vertically centred) never overlap each other: the drag handle
+    /// needs a full diameter of clearance both above and below the centred stack.
+    auto const min_visual_dimension = 2 * drag_handle_diameter + zoom_stack_height.as_int();
+
     return {
         std::max(visual_size.width, geom::Width{min_visual_dimension}),
         std::max(visual_size.height, geom::Height{min_visual_dimension})};

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -82,9 +82,8 @@ auto const zoom_step = 0.25f;
 
 /// Painter colour/alpha constants for handle indicator graphics.
 uint8_t constexpr disc_grey  = 40;
-uint8_t constexpr disc_alpha = 200;
 uint8_t constexpr icon_grey  = 210;
-uint8_t constexpr icon_alpha = 230;
+uint8_t constexpr background_alpha = 150;
 
 enum class HandleKind { drag, resize, zoom_in, zoom_out };
 
@@ -188,7 +187,7 @@ private:
             std::memset(mapping->data(), 0, mapping->len());
         }
 
-        void fill_circle(uint8_t grey, uint8_t alpha)
+        void fill_circle(uint8_t grey)
         {
             auto const cx = geom::as_x((size.width - geom::DeltaX{1}) / 2.0f);
             auto const cy = geom::as_y((size.height - geom::DeltaY{1}) / 2.0f);
@@ -204,33 +203,27 @@ private:
                     auto const delta = dx.as_value() * dx.as_value() + dy.as_value() * dy.as_value();
 
                     if (delta <= r_sq)
-                        set_pixel(geom::Point{x, y}, grey, alpha);
+                        set_pixel(geom::Point{x, y}, grey);
                 }
             }
         }
 
-        void draw_horizontal_line(
-            HorizontalLine const& line,
-            uint8_t grey,
-            uint8_t alpha)
+        void draw_horizontal_line(HorizontalLine const& line, uint8_t grey)
         {
             auto const true_start = std::min<geom::X>(line.start, line.end);
             auto const true_end = std::max<geom::X>(line.start, line.end);
             for (int t = 0; t < line.thickness.as_value(); ++t)
                 for (auto x = true_start; x <= true_end; x = x + geom::DeltaX{1})
-                    set_pixel(geom::Point{x, line.y + geom::DeltaY{t}}, grey, alpha);
+                    set_pixel(geom::Point{x, line.y + geom::DeltaY{t}}, grey);
         }
 
-        void draw_vertical_line(
-            VerticalLine const& line,
-            uint8_t grey,
-            uint8_t alpha)
+        void draw_vertical_line(VerticalLine const& line, uint8_t grey)
         {
             auto const true_start = std::min<geom::Y>(line.start, line.end);
             auto const true_end = std::max<geom::Y>(line.start, line.end);
             for (int t = 0; t < line.thickness.as_value(); ++t)
                 for (auto y = true_start; y <= true_end; y = y + geom::DeltaY{1})
-                    set_pixel(geom::Point{line.x + geom::DeltaX{t}, y}, grey, alpha);
+                    set_pixel(geom::Point{line.x + geom::DeltaX{t}, y}, grey);
         }
 
         auto buffer_size() const -> geom::Size
@@ -239,7 +232,7 @@ private:
         }
 
     private:
-        void set_pixel(geom::Point const& point, uint8_t grey, uint8_t alpha)
+        void set_pixel(geom::Point const& point, uint8_t grey)
         {
             auto const x = point.x.as_value();
             auto const y = point.y.as_value();
@@ -254,7 +247,7 @@ private:
             auto const offset = y * stride.as_value() + x * MIR_BYTES_PER_PIXEL(format);
             auto const pixel = pixels.subspan(offset, MIR_BYTES_PER_PIXEL(format));
             pixel[0] = pixel[1] = pixel[2] = grey;
-            pixel[3] = alpha;
+            pixel[3] = background_alpha;
         }
 
         static auto constexpr format = mir_pixel_format_argb_8888;
@@ -268,7 +261,7 @@ private:
     {
         BufferPainter painter{buffer};
         painter.clear();
-        painter.fill_circle(disc_grey, disc_alpha);
+        painter.fill_circle(disc_grey);
 
         // Draw a drag-pan icon: four arrowheads (N/S/E/W) connected by slim stems.
         static int constexpr tip_dist  = 15;
@@ -296,8 +289,7 @@ private:
                 .end = base_s,
                 .thickness = geom::Width{stem_thickness},
             },
-            icon_grey,
-            icon_alpha);
+            icon_grey);
         painter.draw_horizontal_line(
             {
                 .start = base_w,
@@ -305,8 +297,7 @@ private:
                 .y = center_y - geom::DeltaY{stem_thickness / 2},
                 .thickness = geom::Height{stem_thickness},
             },
-            icon_grey,
-            icon_alpha);
+            icon_grey);
 
         // North arrowhead — rows from tip_n+1 to base_n, width grows by 1 px per row
         for (auto y = tip_n + geom::DeltaY{1}; y <= base_n; y = y + geom::DeltaY{1})
@@ -317,8 +308,7 @@ private:
                     .y = y,
                     .thickness = geom::Height{1},
                 },
-                icon_grey,
-                icon_alpha);
+                icon_grey);
 
         // South arrowhead
         for (auto y = base_s; y < tip_s; y = y + geom::DeltaY{1})
@@ -329,8 +319,7 @@ private:
                     .y = y,
                     .thickness = geom::Height{1},
                 },
-                icon_grey,
-                icon_alpha);
+                icon_grey);
 
         // West arrowhead — columns from tip_w+1 to base_w
         for (auto x = tip_w + geom::DeltaX{1}; x <= base_w; x = x + geom::DeltaX{1})
@@ -341,8 +330,7 @@ private:
                     .end = center_y + geom::DeltaY((x - tip_w).as_value()),
                     .thickness = geom::Width{1},
                 },
-                icon_grey,
-                icon_alpha);
+                icon_grey);
 
         // East arrowhead
         for (auto x = base_e; x < tip_e; x = x + geom::DeltaX{1})
@@ -353,15 +341,14 @@ private:
                     .end = center_y + geom::DeltaY((tip_e - x).as_value()),
                     .thickness = geom::Width{1},
                 },
-                icon_grey,
-                icon_alpha);
+                icon_grey);
     }
 
     static void fill_resize_buffer(mg::Buffer& buffer)
     {
         BufferPainter painter{buffer};
         painter.clear();
-        painter.fill_circle(disc_grey, disc_alpha);
+        painter.fill_circle(disc_grey);
 
         // Corner bracket: two 2-px arms meeting at the top-left corner, which is
         // where the resize handle always sits within the magnifier surface.
@@ -378,8 +365,7 @@ private:
                 .y = corner_y,
                 .thickness = geom::Height{thickness},
             },
-            icon_grey,
-            icon_alpha);
+            icon_grey);
         painter.draw_vertical_line(
             {
                 .x = corner_x,
@@ -387,15 +373,14 @@ private:
                 .end = corner_y + geom::DeltaY{arm_len},
                 .thickness = geom::Width{thickness},
             },
-            icon_grey,
-            icon_alpha);
+            icon_grey);
     }
 
     static void fill_zoom_buffer(mg::Buffer& buffer, bool zoom_in)
     {
         BufferPainter painter{buffer};
         painter.clear();
-        painter.fill_circle(disc_grey, disc_alpha);
+        painter.fill_circle(disc_grey);
 
         // Draw + (zoom in) or – (zoom out) symbol.
         auto const [w, h] = painter.buffer_size();
@@ -409,8 +394,7 @@ private:
                 .y = geom::as_y((h - geom::Height{bar_thickness}) / 2),
                 .thickness = geom::Height{bar_thickness},
             },
-            icon_grey,
-            icon_alpha);
+            icon_grey);
 
         if (zoom_in)
             painter.draw_vertical_line(
@@ -420,8 +404,7 @@ private:
                     .end = geom::as_y((h + geom::Height{bar_len}) / 2 - geom::DeltaY{1}),
                     .thickness = geom::Width{bar_thickness},
                 },
-                icon_grey,
-                icon_alpha);
+                icon_grey);
     }
 
     miral::SoftwareBufferPool mutable pool;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -544,9 +544,7 @@ public:
             if (s->decoupled)
             {
                 // Place surface at last known cursor position when enabling in decoupled mode.
-                auto const logical_size = logical_size_from_visual(s->visual_size, s->magnification);
-                auto const top_left = surface_top_left_from_cursor(logical_size, s->cursor_pos);
-                apply_visual_geometry(surf, top_left, *s, render_scene_into_surface);
+                place_at_cursor(surf, *s, render_scene_into_surface);
                 s->show_all_handles();
             }
             surf->show();
@@ -610,9 +608,7 @@ public:
 
             if (auto const surf = s->surface.lock(); surf && s->default_enabled)
             {
-                auto const logical_size = logical_size_from_visual(s->visual_size, s->magnification);
-                auto const top_left = surface_top_left_from_cursor(logical_size, s->cursor_pos);
-                apply_visual_geometry(surf, top_left, *s, render_scene_into_surface);
+                place_at_cursor(surf, *s, render_scene_into_surface);
             }
         }
     }
@@ -816,6 +812,18 @@ private:
         s.reposition_all_handles(logical_top_left, logical_size, s.magnification);
     }
 
+    /// Applies visual geometry with the magnifier's logical top-left computed
+    /// from its current visual size so the surface is centred on the cursor.
+    static void place_at_cursor(
+        std::shared_ptr<ms::Surface> const& surf,
+        State& s,
+        RenderSceneIntoSurface& render_scene_into_surface)
+    {
+        auto const logical_size = logical_size_from_visual(s.visual_size, s.magnification);
+        auto const top_left = surface_top_left_from_cursor(logical_size, s.cursor_pos);
+        apply_visual_geometry(surf, top_left, s, render_scene_into_surface);
+    }
+
     class Observer : public mi::CursorObserver
     {
     public:
@@ -834,9 +842,7 @@ private:
             if (!surf)
                 return;
 
-            auto const logical_size = logical_size_from_visual(s->visual_size, s->magnification);
-            auto const capture_position = surface_top_left_from_cursor(logical_size, s->cursor_pos);
-            self->apply_visual_geometry(surf, capture_position, *s, self->render_scene_into_surface);
+            self->place_at_cursor(surf, *s, self->render_scene_into_surface);
         }
 
         void pointer_usable() override {}
@@ -1081,9 +1087,7 @@ private:
             if (action == mir_pointer_action_button_down &&
                 mir_pointer_event_button_state(pev, mir_pointer_button_primary))
             {
-                s->set_magnification(
-                    std::clamp(s->magnification + delta, min_magnification + zoom_step, max_magnification),
-                    self->render_scene_into_surface);
+                apply_zoom(*s);
             }
         }
 
@@ -1095,10 +1099,16 @@ private:
             auto s = self->state.lock();
             if (action == mir_touch_action_down)
             {
-                s->set_magnification(
-                    std::clamp(s->magnification + delta, min_magnification + zoom_step, max_magnification),
-                    self->render_scene_into_surface);
+                apply_zoom(*s);
             }
+        }
+
+        /// Clamps and applies the zoom step. Caller must hold self->state.
+        void apply_zoom(State& s)
+        {
+            s.set_magnification(
+                std::clamp(s.magnification + delta, min_magnification + zoom_step, max_magnification),
+                self->render_scene_into_surface);
         }
 
         Self* self;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -75,6 +75,18 @@ uint8_t constexpr icon_alpha = 230;
 
 enum class HandleKind { drag, resize, zoom_in, zoom_out };
 
+static std::string name_for_kind(HandleKind kind)
+{
+    switch (kind)
+    {
+    case HandleKind::drag:     return "magnifier-drag-handle";
+    case HandleKind::resize:   return "magnifier-resize-handle";
+    case HandleKind::zoom_in:  return "magnifier-zoom-in-handle";
+    case HandleKind::zoom_out: return "magnifier-zoom-out-handle";
+    }
+    return "magnifier-handle";
+}
+
 class HandleIndicator : public ms::BasicSurface
 {
 public:
@@ -85,7 +97,7 @@ public:
         std::shared_ptr<ms::SceneReport> const& scene_report,
         std::shared_ptr<mir::ObserverRegistrar<mg::DisplayConfigurationObserver>> const& display_config_registrar) :
         BasicSurface{
-            "magnifier-drag-handle",
+            name_for_kind(kind),
             initial_rect,
             mir_pointer_unconfined,
             create_stream_info(),

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -691,15 +691,18 @@ public:
         s->zoom_in.init(server, HandleKind::zoom_in, capture_compositor_id);
         s->zoom_out.init(server, HandleKind::zoom_out, capture_compositor_id);
 
-        if (!s->follow_cursor)
+        if (auto const surf = s->surface.lock(); surf && s->default_enabled)
         {
-            s->attach_observers(this);
-
-            if (auto const surf = s->surface.lock(); surf && s->default_enabled)
+            if (!s->follow_cursor)
             {
+                s->attach_observers(this);
                 auto const logical_rect = render_scene_into_surface.capture_area();
                 apply_positioned_geometry(surf, logical_rect.top_left, *s, render_scene_into_surface);
                 s->show_all_handles();
+            }
+            else
+            {
+                place_at_cursor(surf, *s, render_scene_into_surface);
             }
         }
     }

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -421,6 +421,7 @@ public:
             server.the_cursor_observer_multiplexer()->register_interest(observer);
             cursor_multiplexer = server.the_cursor_observer_multiplexer();
 
+            std::lock_guard lock(mutex);
             drag.init(server, HandleKind::drag);
             resize.init(server, HandleKind::resize);
             zoom_in.init(server, HandleKind::zoom_in);

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -89,12 +89,24 @@ public:
     {
         std::lock_guard lock(mutex);
         default_enabled = enable;
-        if (auto const surf = surface.lock())
+        auto const surf = surface.lock();
+        if (!surf)
+            return;
+
+        if (enable)
         {
-            if (enable)
-                surf->show();
-            else
-                surf->hide();
+            if (decoupled)
+            {
+                // Place surface at last known cursor position when enabling in decoupled mode.
+                auto const top_left = surface_top_left_from_cursor(surf->window_size(), cursor_pos);
+                surf->move_to(top_left);
+                render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
+            }
+            surf->show();
+        }
+        else
+        {
+            surf->hide();
         }
     }
 
@@ -109,13 +121,33 @@ public:
     void set_capture_size(geom::Size const& size)
     {
         std::lock_guard lock(mutex);
-        auto const capture_position = Observer::cursor_position_to_capture_position(size, cursor_pos);
+        auto const surf = surface.lock();
+        auto const capture_position = surf ? surf->top_left() : surface_top_left_from_cursor(size, cursor_pos);
         render_scene_into_surface.capture_area({ capture_position, size });
     }
 
     geom::Size current_size() const
     {
         return render_scene_into_surface.capture_area().size;
+    }
+
+    void set_decoupled(bool new_decoupled)
+    {
+        std::lock_guard lock(mutex);
+        if (decoupled == new_decoupled)
+            return;
+
+        decoupled = new_decoupled;
+        if (new_decoupled)
+        {
+            // Re-couple: snap surface back to current cursor position.
+            if (auto const surf = surface.lock(); surf && default_enabled)
+            {
+                auto const top_left = surface_top_left_from_cursor(surf->window_size(), cursor_pos);
+                surf->move_to(top_left);
+                render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
+            }
+        }
     }
 
 private:
@@ -128,13 +160,16 @@ private:
         {
             std::lock_guard lock(self->mutex);
             self->cursor_pos = geom::Point{abs_x, abs_y};
+
+            // In decoupled mode the surface stays put; only update when coupled.
+            if (self->decoupled)
+                return;
+
             auto const surf = self->surface.lock();
             if (!surf)
                 return;
 
-            auto const capture_position = cursor_position_to_capture_position(
-                surf->window_size(),
-                self->cursor_pos);
+            auto const capture_position = surface_top_left_from_cursor(surf->window_size(), self->cursor_pos);
             surf->move_to(capture_position);
             self->render_scene_into_surface.capture_area(
                 geom::Rectangle{capture_position, surf->window_size()});
@@ -144,19 +179,18 @@ private:
         void pointer_unusable() override {}
         void image_set_to(std::shared_ptr<mg::CursorImage>) override {}
 
-        static geom::Point cursor_position_to_capture_position(
-            geom::Size const& window_size,
-            geom::Point const& cursor_pos)
-        {
-            return geom::Point{
-                cursor_pos.x.as_value() - window_size.width.as_value() / 2,
-                cursor_pos.y.as_value() - window_size.height.as_value() / 2
-            };
-        }
-
     private:
         Self* self;
     };
+
+    static geom::Point surface_top_left_from_cursor(
+        geom::Size const& window_size,
+        geom::Point const& cursor_pos)
+    {
+        return geom::Point{
+            cursor_pos.x.as_int() - window_size.width.as_int() / 2,
+            cursor_pos.y.as_int() - window_size.height.as_int() / 2};
+    }
 
     friend Observer;
 
@@ -166,8 +200,9 @@ private:
     std::shared_ptr<Observer> observer;
     std::weak_ptr<ms::Surface> surface;
     geom::Point cursor_pos;
-    float magnification = default_magnification;
-    bool default_enabled = false;
+    float magnification{default_magnification};
+    bool default_enabled{false};
+    bool decoupled{false};
 };
 
 miral::Magnifier::Magnifier()
@@ -270,6 +305,12 @@ miral::Magnifier& miral::Magnifier::magnification(float magnification)
 miral::Magnifier& miral::Magnifier::capture_size(mir::geometry::Size const& size)
 {
     self->set_capture_size(size);
+    return *this;
+}
+
+miral::Magnifier& miral::Magnifier::decouple(bool decoupled)
+{
+    self->set_decoupled(decoupled);
     return *this;
 }
 

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -603,21 +603,29 @@ public:
 
         server.add_init_callback([&]
         {
-            auto local_observer = std::make_shared<Observer>(this);
-            auto local_display_config_observer = std::make_shared<DisplayConfigObserver>(state);
-
-            // Keep screen bounds up to date to respond to display
-            // (re)configuration, e.g. resizing a nested window.
-            // Note: register_interest may call initial_configuration() synchronously,
-            // which calls update_bounds(), which locks state — so we must not hold
-            // the state lock across this call.
-            server.the_display_configuration_observer_registrar()->register_interest(local_display_config_observer);
-            server.the_cursor_observer_multiplexer()->register_interest(local_observer);
             input_filter = std::make_shared<InputFilter>(state);
             server.the_composite_event_filter()->prepend(input_filter);
 
-            server.the_main_loop()->spawn([=, this, &server]
-                                          { this->post_init(server, local_observer, local_display_config_observer); });
+            server.the_main_loop()->spawn(
+                [=, this, &server]
+                {
+                    auto local_observer = std::make_shared<Observer>(this);
+                    auto local_display_config_observer = std::make_shared<DisplayConfigObserver>(state);
+
+                    // Init `State` references under lock
+                    this->post_init(server, local_observer, local_display_config_observer);
+
+                    // Keep screen bounds up to date to respond to display
+                    // (re)configuration, e.g. resizing a nested window.
+                    //
+                    // Note: register_interest may call initial_configuration()
+                    // synchronously, which calls update_bounds(), which locks
+                    // state — so we must not hold the state lock across this
+                    // call. Hence why we're calling after `post_init()`.
+                    server.the_display_configuration_observer_registrar()->register_interest(
+                        local_display_config_observer);
+                    server.the_cursor_observer_multiplexer()->register_interest(local_observer);
+                });
         });
 
         server.add_stop_callback([&]

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -58,7 +58,7 @@ namespace
 auto const default_capture_width = 150;
 auto const default_capture_height = 150;
 auto const min_magnification = 1.0f;
-auto const default_magnification = 1.5f;
+auto const default_magnification = 1.25f;
 auto const max_magnification = 8.0f;
 
 /// Diameter in pixels of the circular drag handle shown at the corner of the magnifier.
@@ -77,7 +77,7 @@ auto const zoom_stack_height = 2 * drag_handle_diameter + zoom_stack_padding;
 auto const min_visual_dimension = 2 * drag_handle_diameter + zoom_stack_height;
 
 /// Magnification step applied by each zoom button press.
-auto const zoom_step = 0.5f;
+auto const zoom_step = 0.25f;
 
 /// Painter colour/alpha constants for handle indicator graphics.
 uint8_t constexpr disc_grey  = 40;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -494,9 +494,11 @@ geom::Point surface_top_left_from_cursor(geom::Size const& window_size, geom::Po
 
 geom::Size logical_size_from_visual(geom::Size const& visual_size, float mag)
 {
+    float widthf{static_cast<float>(visual_size.width.as_value())};
+    float heightf{static_cast<float>(visual_size.height.as_value())};
     return {
-        geom::Width{std::max(1.0f, std::round(visual_size.width.as_value() / mag))},
-        geom::Height{std::max(1.0f, std::round(visual_size.height.as_value() / mag))}};
+        geom::Width{std::max(1.0f, std::round(widthf/ mag))},
+        geom::Height{std::max(1.0f, std::round(heightf / mag))}};
 }
 
 /// Clamps a visual (on-screen) size so neither dimension shrinks below

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -483,8 +483,11 @@ public:
 
             s->observer = local_observer;
             s->cursor_multiplexer = server.the_cursor_observer_multiplexer();
-            s->visual_size = clamp_visual_size(
-                geom::Size{default_capture_width, default_capture_height} * default_magnification);
+            if (s->visual_size == geom::Size{})
+            {
+                s->visual_size = clamp_visual_size(
+                    geom::Size{default_capture_width, default_capture_height} * s->magnification);
+            }
 
             auto const capture_compositor_id = render_scene_into_surface.capture_compositor_id();
             s->drag.init(server, HandleKind::drag, capture_compositor_id);

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -149,7 +149,7 @@ private:
         {
             for (int y = 0; y < height; ++y)
                 for (int x = 0; x < width; ++x)
-                set_pixel(x, y, 0, 0);
+                    set_pixel(x, y, 0, 0);
         }
 
         void fill_circle(uint8_t grey, uint8_t alpha)

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -43,6 +43,7 @@ namespace geom = mir::geometry;
 namespace mg = mir::graphics;
 namespace mrs = mir::renderer::software;
 namespace msh = mir::shell;
+namespace mc = mir::compositor;
 
 namespace
 {
@@ -88,6 +89,7 @@ public:
     HandleIndicator(
         geom::Rectangle const& initial_rect,
         HandleKind kind,
+        mc::CompositorID capture_compositor_id,
         std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
         std::shared_ptr<ms::SceneReport> const& scene_report,
         std::shared_ptr<mir::ObserverRegistrar<mg::DisplayConfigurationObserver>> const& display_config_registrar) :
@@ -102,7 +104,8 @@ public:
         pool{
             [allocator, initial_rect]
             { return allocator->alloc_software_buffer(initial_rect.size, mir_pixel_format_argb_8888); },
-            1}
+            1},
+        capture_compositor_id{capture_compositor_id}
     {
         auto buffer = pool.claim();
         switch (kind)
@@ -124,6 +127,13 @@ public:
         set_depth_layer(mir_depth_layer_always_on_top);
         set_focus_mode(mir_focus_mode_disabled);
         hide();
+    }
+
+    auto generate_renderables(mc::CompositorID id) const -> mg::RenderableList override
+    {
+        if (id == capture_compositor_id)
+            return {};
+        return BasicSurface::generate_renderables(id);
     }
 
 private:
@@ -318,6 +328,7 @@ private:
     }
 
     miral::SoftwareBufferPool mutable pool;
+    mc::CompositorID capture_compositor_id;
 };
 
 class Handle
@@ -325,11 +336,12 @@ class Handle
 public:
     Handle() = default;
 
-    void init(mir::Server& server, HandleKind kind)
+    void init(mir::Server& server, HandleKind kind, mc::CompositorID capture_compositor_id)
     {
         indicator = std::make_shared<HandleIndicator>(
             handle_rect,
             kind,
+            capture_compositor_id,
             server.the_buffer_allocator(),
             server.the_scene_report(),
             server.the_display_configuration_observer_registrar());
@@ -474,10 +486,11 @@ public:
             s->visual_size = clamp_visual_size(
                 geom::Size{default_capture_width, default_capture_height} * default_magnification);
 
-            s->drag.init(server, HandleKind::drag);
-            s->resize.init(server, HandleKind::resize);
-            s->zoom_in.init(server, HandleKind::zoom_in);
-            s->zoom_out.init(server, HandleKind::zoom_out);
+            auto const capture_compositor_id = render_scene_into_surface.capture_compositor_id();
+            s->drag.init(server, HandleKind::drag, capture_compositor_id);
+            s->resize.init(server, HandleKind::resize, capture_compositor_id);
+            s->zoom_in.init(server, HandleKind::zoom_in, capture_compositor_id);
+            s->zoom_out.init(server, HandleKind::zoom_out, capture_compositor_id);
 
             if (s->decoupled)
             {

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -551,11 +551,13 @@ private:
         Self* self;
     };
 
-    /// Observes input on the drag handle indicator and moves both surfaces.
-    class DragHandleObserver : public ms::NullSurfaceObserver
+    /// Base for observers that turn a pointer/touch drag on a handle surface
+    /// into on_drag_start()/on_drag_move() callbacks. Both callbacks are invoked
+    /// with the magnifier mutex held; grab_abs holds the drag's grab position.
+    class HandleObserver : public ms::NullSurfaceObserver
     {
     public:
-        explicit DragHandleObserver(Self* self) : self(self) {}
+        explicit HandleObserver(Self* self) : self(self) {}
 
         void input_consumed(
             ms::Surface const*,
@@ -577,7 +579,22 @@ private:
             }
         }
 
+    protected:
+        virtual void on_drag_start(int ax, int ay) = 0;
+        virtual void on_drag_move(int ax, int ay) = 0;
+
+        Self* self;
+        bool drag_active{false};
+        geom::Displacement grab_abs{};
+
     private:
+        void begin_drag(int ax, int ay)
+        {
+            drag_active = true;
+            grab_abs = {geom::DeltaX{ax}, geom::DeltaY{ay}};
+            on_drag_start(ax, ay);
+        }
+
         void handle_pointer(MirPointerEvent const* pev)
         {
             auto const action = mir_pointer_event_action(pev);
@@ -589,10 +606,10 @@ private:
             std::lock_guard lock(self->mutex);
             if (action == mir_pointer_action_button_down &&
                 mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                start_drag(ax, ay);
+                begin_drag(ax, ay);
             else if (action == mir_pointer_action_motion && drag_active &&
                      mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                apply_drag(ax, ay);
+                on_drag_move(ax, ay);
             else if (action == mir_pointer_action_button_up)
                 drag_active = false;
         }
@@ -609,22 +626,28 @@ private:
 
             std::lock_guard lock(self->mutex);
             if (action == mir_touch_action_down)
-                start_drag(ax, ay);
+                begin_drag(ax, ay);
             else if (action == mir_touch_action_change && drag_active)
-                apply_drag(ax, ay);
+                on_drag_move(ax, ay);
             else if (action == mir_touch_action_up)
                 drag_active = false;
         }
+    };
 
-        void start_drag(int ax, int ay)
+    /// Moves the magnifier when its drag handle is dragged.
+    class DragHandleObserver : public HandleObserver
+    {
+    public:
+        using HandleObserver::HandleObserver;
+
+    protected:
+        void on_drag_start(int, int) override
         {
-            drag_active = true;
-            grab_abs = {geom::DeltaX{ax}, geom::DeltaY{ay}};
             if (auto const surf = self->surface.lock())
                 drag_start_magnifier_pos = surf->top_left();
         }
 
-        void apply_drag(int ax, int ay)
+        void on_drag_move(int ax, int ay) override
         {
             geom::Displacement const delta{
                 geom::DeltaX{ax} - grab_abs.dx,
@@ -647,82 +670,19 @@ private:
             }
         }
 
-        Self* self;
-        bool drag_active{false};
-        geom::Displacement grab_abs{};
         geom::Point drag_start_magnifier_pos{};
     };
 
     /// Observes input on the resize handle indicator and changes the magnifier capture size.
-    class ResizeDragObserver : public ms::NullSurfaceObserver
+    /// Resizes the magnifier capture area when its resize handle is dragged.
+    class ResizeDragObserver : public HandleObserver
     {
     public:
-        explicit ResizeDragObserver(Self* self) : self(self) {}
+        using HandleObserver::HandleObserver;
 
-        void input_consumed(
-            ms::Surface const*,
-            std::shared_ptr<MirEvent const> const& event) override
+    protected:
+        void on_drag_start(int, int) override
         {
-            if (mir_event_get_type(event.get()) != mir_event_type_input)
-                return;
-            auto const* input_ev = mir_event_get_input_event(event.get());
-            switch (mir_input_event_get_type(input_ev))
-            {
-            case mir_input_event_type_pointer:
-                handle_pointer(mir_input_event_get_pointer_event(input_ev));
-                break;
-            case mir_input_event_type_touch:
-                handle_touch(mir_input_event_get_touch_event(input_ev));
-                break;
-            default:
-                break;
-            }
-        }
-
-    private:
-        void handle_pointer(MirPointerEvent const* pev)
-        {
-            auto const action = mir_pointer_event_action(pev);
-            auto const ax = static_cast<int>(
-                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_x)));
-            auto const ay = static_cast<int>(
-                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_y)));
-
-            std::lock_guard lock(self->mutex);
-            if (action == mir_pointer_action_button_down &&
-                mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                start_drag(ax, ay);
-            else if (action == mir_pointer_action_motion && drag_active &&
-                     mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                apply_drag(ax, ay);
-            else if (action == mir_pointer_action_button_up)
-                drag_active = false;
-        }
-
-        void handle_touch(MirTouchEvent const* tev)
-        {
-            if (mir_touch_event_point_count(tev) != 1)
-                return;
-            auto const action = mir_touch_event_action(tev, 0);
-            auto const ax = static_cast<int>(
-                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_x)));
-            auto const ay = static_cast<int>(
-                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_y)));
-
-            std::lock_guard lock(self->mutex);
-            if (action == mir_touch_action_down)
-                start_drag(ax, ay);
-            else if (action == mir_touch_action_change && drag_active)
-                apply_drag(ax, ay);
-            else if (action == mir_touch_action_up)
-                drag_active = false;
-        }
-
-        void start_drag(int ax, int ay)
-        {
-            drag_active = true;
-            grab_abs = {geom::DeltaX{ax}, geom::DeltaY{ay}};
-
             auto const surf = self->surface.lock();
             if (!surf) return;
             auto const tl   = surf->top_left();
@@ -748,7 +708,7 @@ private:
                     : static_cast<int>(tl.y.as_int() + outer * sz.height.as_int())};
         }
 
-        void apply_drag(int ax, int ay)
+        void on_drag_move(int ax, int ay) override
         {
             float const mag = self->magnification;
 
@@ -791,9 +751,6 @@ private:
                 self->resize_handle_indicator->move_to(rp);
         }
 
-        Self* self;
-        bool drag_active{false};
-        geom::Displacement grab_abs{};
         geom::Point pin_pos{};
         bool pin_left{false};
         bool pin_above{false};

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -397,6 +397,13 @@ geom::Point surface_top_left_from_cursor(geom::Size const& window_size, geom::Po
         cursor_pos.x.as_int() - window_size.width.as_int() / 2,
         cursor_pos.y.as_int() - window_size.height.as_int() / 2};
 }
+
+geom::Size logical_size_from_visual(geom::Size const& visual_size, float mag)
+{
+    return {
+        geom::Width{std::max(1.0f, std::round(visual_size.width.as_value() / mag))},
+        geom::Height{std::max(1.0f, std::round(visual_size.height.as_value() / mag))}};
+}
 }
 
 class miral::Magnifier::Self
@@ -411,20 +418,20 @@ public:
 
     void init(mir::Server& server)
     {
-        render_scene_into_surface.on_surface_ready([this](auto const& surf)
-        {
-            auto s = state.lock();
-            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(s->magnification, s->magnification, 1)));
-            surf->set_depth_layer(mir_depth_layer_always_on_top);
-            surf->set_focus_mode(mir_focus_mode_disabled);
+        render_scene_into_surface.on_surface_ready(
+            [this](auto const& surf)
+            {
+                surf->set_depth_layer(mir_depth_layer_always_on_top);
+                surf->set_focus_mode(mir_focus_mode_disabled);
+                auto s = state.lock();
 
-            if (s->default_enabled)
-                surf->show();
-            else
-                surf->hide();
+                if (s->default_enabled)
+                    surf->show();
+                else
+                    surf->hide();
 
-            s->surface = surf;
-        });
+                s->surface = surf;
+            });
 
         render_scene_into_surface(server);
 
@@ -443,6 +450,7 @@ public:
 
             s->observer = local_observer;
             s->cursor_multiplexer = server.the_cursor_observer_multiplexer();
+            s->visual_size = geom::Size{default_capture_width, default_capture_height}  * default_magnification;
 
             s->drag.init(server, HandleKind::drag);
             s->resize.init(server, HandleKind::resize);
@@ -455,7 +463,8 @@ public:
 
                 if (auto const surf = s->surface.lock(); surf && s->default_enabled)
                 {
-                    s->reposition_all_handles(surf->top_left(), surf->window_size(), s->magnification);
+                    auto const logical_rect = render_scene_into_surface.capture_area();
+                    apply_visual_geometry(surf, logical_rect.top_left, *s, render_scene_into_surface);
                     s->show_all_handles();
                 }
             }
@@ -513,10 +522,9 @@ public:
             if (s->decoupled)
             {
                 // Place surface at last known cursor position when enabling in decoupled mode.
-                auto const top_left = surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
-                surf->move_to(top_left);
-                render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
-                s->reposition_all_handles(top_left, surf->window_size(), s->magnification);
+                auto const logical_size = logical_size_from_visual(s->visual_size, s->magnification);
+                auto const top_left = surface_top_left_from_cursor(logical_size, s->cursor_pos);
+                apply_visual_geometry(surf, top_left, *s, render_scene_into_surface);
                 s->show_all_handles();
             }
             surf->show();
@@ -531,15 +539,17 @@ public:
     void set_magnification(float new_magnification)
     {
         auto s = state.lock();
-        s->set_magnification(new_magnification);
+        s->set_magnification(new_magnification, render_scene_into_surface);
     }
 
     void set_capture_size(geom::Size const& size)
     {
         auto s = state.lock();
-        auto const capture_position = surface_top_left_from_cursor(size, s->cursor_pos);
-        render_scene_into_surface.capture_area({capture_position, size});
-        s->reposition_all_handles(capture_position, size, s->magnification);
+        s->visual_size = size * s->magnification;
+        auto const logical_top_left = surface_top_left_from_cursor(size, s->cursor_pos);
+
+        if (auto const surf = s->surface.lock())
+            apply_visual_geometry(surf, logical_top_left, *s, render_scene_into_surface);
     }
 
     geom::Size current_size() const
@@ -555,14 +565,15 @@ public:
 
         s->decoupled = new_decoupled;
 
-        if (new_decoupled)
+        if (s->decoupled)
         {
             if (auto const surf = s->surface.lock())
             {
                 s->attach_observers(this);
                 if (s->default_enabled)
                 {
-                    s->reposition_all_handles(surf->top_left(), surf->window_size(), s->magnification);
+                    auto const logical_rect = render_scene_into_surface.capture_area();
+                    s->reposition_all_handles(logical_rect.top_left, logical_rect.size, s->magnification);
                     s->show_all_handles();
                 }
             }
@@ -577,9 +588,9 @@ public:
 
             if (auto const surf = s->surface.lock(); surf && s->default_enabled)
             {
-                auto const top_left = surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
-                surf->move_to(top_left);
-                render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
+                auto const logical_size = logical_size_from_visual(s->visual_size, s->magnification);
+                auto const top_left = surface_top_left_from_cursor(logical_size, s->cursor_pos);
+                apply_visual_geometry(surf, top_left, *s, render_scene_into_surface);
             }
         }
     }
@@ -691,14 +702,31 @@ private:
             zoom_out.move_to(zm);
         }
 
-        void set_magnification(float new_magnification)
+        void set_magnification(float new_magnification, RenderSceneIntoSurface& render_scene_into_surface)
         {
-            magnification = new_magnification;
             if (auto const surf = surface.lock())
             {
-                surf->set_transformation(
-                    glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
-                reposition_all_handles(surf->top_left(), surf->window_size(), magnification);
+                auto const old_logical_rect = render_scene_into_surface.capture_area();
+
+                // The visual magnifier is scaled about the centre of its logical
+                // capture area. Keep that centre fixed so changing zoom does not
+                // shift the on-screen position.
+                geom::Point const old_visual_centre{
+                    old_logical_rect.top_left.x.as_int() + old_logical_rect.size.width.as_int() / 2,
+                    old_logical_rect.top_left.y.as_int() + old_logical_rect.size.height.as_int() / 2};
+
+                magnification = new_magnification;
+                auto const new_logical_size = logical_size_from_visual(visual_size, magnification);
+
+                geom::Point const new_logical_top_left{
+                    old_visual_centre.x.as_int() - new_logical_size.width.as_int() / 2,
+                    old_visual_centre.y.as_int() - new_logical_size.height.as_int() / 2};
+
+                apply_visual_geometry(surf, new_logical_top_left, *this, render_scene_into_surface);
+            }
+            else
+            {
+                magnification = new_magnification;
             }
         }
 
@@ -743,9 +771,29 @@ private:
 
         geom::Point cursor_pos;
         float magnification{default_magnification};
+        /// The physical (screen) size of the magnifier.  When the magnification
+        /// level changes the logical capture size is recalculated from this so
+        /// that the magnifier's on-screen footprint stays the same.
+        geom::Size visual_size;
         bool default_enabled{false};
         bool decoupled{false};
     };
+
+    /// Sets the logical capture area and transform so that the magnifier
+    /// renders with the supplied logical top-left and keeps the same physical
+    /// (visual) footprint.  The current visual size is taken from the state.
+    static void apply_visual_geometry(
+        std::shared_ptr<ms::Surface> const& surf,
+        geom::Point const& logical_top_left,
+        State& s,
+        RenderSceneIntoSurface& render_scene_into_surface)
+    {
+        auto const logical_size = logical_size_from_visual(s.visual_size, s.magnification);
+        surf->move_to(logical_top_left);
+        render_scene_into_surface.capture_area(geom::Rectangle{logical_top_left, logical_size});
+        surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(s.magnification, s.magnification, 1)));
+        s.reposition_all_handles(logical_top_left, logical_size, s.magnification);
+    }
 
     class Observer : public mi::CursorObserver
     {
@@ -765,9 +813,9 @@ private:
             if (!surf)
                 return;
 
-            auto const capture_position = surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
-            surf->move_to(capture_position);
-            self->render_scene_into_surface.capture_area(geom::Rectangle{capture_position, surf->window_size()});
+            auto const logical_size = logical_size_from_visual(s->visual_size, s->magnification);
+            auto const capture_position = surface_top_left_from_cursor(logical_size, s->cursor_pos);
+            self->apply_visual_geometry(surf, capture_position, *s, self->render_scene_into_surface);
         }
 
         void pointer_usable() override {}
@@ -879,16 +927,12 @@ private:
             geom::Displacement const delta{
                 geom::DeltaX{ax} - grab_abs.dx,
                 geom::DeltaY{ay} - grab_abs.dy};
-            geom::Point const new_pos{
+            geom::Point const new_logical_tl{
                 drag_start_magnifier_pos.x + delta.dx,
                 drag_start_magnifier_pos.y + delta.dy};
 
             if (auto const surf = s.surface.lock())
-            {
-                surf->move_to(new_pos);
-                self->render_scene_into_surface.capture_area(geom::Rectangle{new_pos, surf->window_size()});
-                s.reposition_all_handles(new_pos, surf->window_size(), s.magnification);
-            }
+                self->apply_visual_geometry(surf, new_logical_tl, s, self->render_scene_into_surface);
         }
 
         geom::Point drag_start_magnifier_pos{};
@@ -947,9 +991,7 @@ private:
             int const raw_vis_h = pin_pos.y.as_int() - ay;
 
             auto const clamp = [](int v) { return std::clamp(v, 50, 1000); };
-            geom::Size const new_logical_size{
-                geom::Width{clamp(static_cast<int>(std::round(raw_vis_w / mag)))},
-                geom::Height{clamp(static_cast<int>(std::round(raw_vis_h / mag)))}};
+            geom::Size const new_logical_size =  geom::Size{ clamp(raw_vis_w / mag), clamp(raw_vis_h / mag) };
 
             // Back-solve the logical top-left from the pinned visual corner, inverting
             // the visual-edge identity above so the pinned corner stays fixed.
@@ -967,9 +1009,9 @@ private:
             if (!surf)
                 return;
 
-            surf->move_to(new_logical_tl);
-            self->render_scene_into_surface.capture_area({new_logical_tl, new_logical_size});
-            s.reposition_all_handles(new_logical_tl, new_logical_size, mag);
+            s.visual_size = new_logical_size * mag;
+
+            self->apply_visual_geometry(surf, new_logical_tl, s, self->render_scene_into_surface);
         }
 
         geom::Point pin_pos{};
@@ -1010,7 +1052,8 @@ private:
                 mir_pointer_event_button_state(pev, mir_pointer_button_primary))
             {
                 s->set_magnification(
-                    std::clamp(s->magnification + delta, min_magnification + zoom_step, max_magnification));
+                    std::clamp(s->magnification + delta, min_magnification + zoom_step, max_magnification),
+                    self->render_scene_into_surface);
             }
         }
 
@@ -1023,7 +1066,8 @@ private:
             if (action == mir_touch_action_down)
             {
                 s->set_magnification(
-                    std::clamp(s->magnification + delta, min_magnification + zoom_step, max_magnification));
+                    std::clamp(s->magnification + delta, min_magnification + zoom_step, max_magnification),
+                    self->render_scene_into_surface);
             }
         }
 

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -57,12 +57,17 @@ using miral::create_stream_info;
 
 auto const default_capture_width = 150;
 auto const default_capture_height = 150;
+auto const min_magnification = 1.0f;
 auto const default_magnification = 1.5f;
+auto const max_magnification = 8.0f;
 
 /// Diameter in pixels of the circular drag handle shown at the corner of the magnifier.
 auto const drag_handle_diameter = 48;
 
-enum class HandleKind { drag, resize };
+/// Magnification step applied by each zoom button press.
+auto const zoom_step = 0.5f;
+
+enum class HandleKind { drag, resize, zoom_in, zoom_out };
 
 class DragHandleIndicator : public ms::BasicSurface
 {
@@ -94,6 +99,10 @@ public:
             break;
         case HandleKind::resize:
             fill_resize_buffer(*buffer);
+            break;
+        case HandleKind::zoom_in:
+        case HandleKind::zoom_out:
+            fill_zoom_buffer(*buffer, kind == HandleKind::zoom_in);
             break;
         }
         auto const sz = window_size();
@@ -263,6 +272,36 @@ private:
         painter.draw_vertical_line(corner_x, corner_y, corner_y + arm_len, thickness, 210, 230);
     }
 
+    static void fill_zoom_buffer(mg::Buffer& buffer, bool zoom_in)
+    {
+        BufferPainter painter{buffer};
+        painter.clear();
+        painter.fill_circle(40, 200);
+
+        // Draw + (zoom in) or – (zoom out) symbol.
+        int const w = painter.buffer_width();
+        int const h = painter.buffer_height();
+        int const bar_thickness = std::max(2, w / 12);
+        int const bar_len       = w * 5 / 8;
+
+        painter.draw_horizontal_line(
+            (w - bar_len) / 2,
+            (w + bar_len) / 2 - 1,
+            (h - bar_thickness) / 2,
+            bar_thickness,
+            210,
+            230);
+
+        if (zoom_in)
+            painter.draw_vertical_line(
+                (w - bar_thickness) / 2,
+                (h - bar_len) / 2,
+                (h + bar_len) / 2 - 1,
+                bar_thickness,
+                210,
+                230);
+    }
+
     SoftwareBufferPool mutable pool;
 };
 }
@@ -328,6 +367,8 @@ public:
 
             drag_handle_indicator   = create_handle_indicator(server, HandleKind::drag, handle_rect);
             resize_handle_indicator = create_handle_indicator(server, HandleKind::resize, handle_rect);
+            zoom_in_indicator       = create_handle_indicator(server, HandleKind::zoom_in, handle_rect);
+            zoom_out_indicator      = create_handle_indicator(server, HandleKind::zoom_out, handle_rect);
             handle_surface_stack    = server.the_surface_stack();
 
             if (decoupled)
@@ -338,16 +379,16 @@ public:
                 resize_drag_observer = std::make_shared<ResizeDragObserver>(this);
                 resize_handle_indicator->register_interest(resize_drag_observer);
 
+                zoom_in_observer = std::make_shared<ZoomButtonObserver>(this, +zoom_step);
+                zoom_in_indicator->register_interest(zoom_in_observer);
+
+                zoom_out_observer = std::make_shared<ZoomButtonObserver>(this, -zoom_step);
+                zoom_out_indicator->register_interest(zoom_out_observer);
+
                 if (auto const surf = surface.lock(); surf && default_enabled)
                 {
-                    auto const [dp, rp] = compute_both_handle_positions(
-                        surf->top_left(), surf->window_size(), magnification);
-
-                    drag_handle_indicator->move_to(dp);
-                    drag_handle_indicator->show();
-
-                    resize_handle_indicator->move_to(rp);
-                    resize_handle_indicator->show();
+                    reposition_all_handles_locked(surf->top_left(), surf->window_size(), magnification);
+                    show_all_handles_locked();
                 }
             }
         });
@@ -371,14 +412,30 @@ public:
                 resize_drag_observer.reset();
             }
 
+            if (zoom_in_observer)
+            {
+                zoom_in_indicator->unregister_interest(*zoom_in_observer);
+                zoom_in_observer.reset();
+            }
+
+            if (zoom_out_observer)
+            {
+                zoom_out_indicator->unregister_interest(*zoom_out_observer);
+                zoom_out_observer.reset();
+            }
+
             if (auto const locked = handle_surface_stack.lock())
             {
                 locked->remove_surface(drag_handle_indicator);
                 locked->remove_surface(resize_handle_indicator);
+                locked->remove_surface(zoom_in_indicator);
+                locked->remove_surface(zoom_out_indicator);
             }
 
             drag_handle_indicator.reset();
             resize_handle_indicator.reset();
+            zoom_in_indicator.reset();
+            zoom_out_indicator.reset();
         });
     }
 
@@ -398,46 +455,22 @@ public:
                 auto const top_left = surface_top_left_from_cursor(surf->window_size(), cursor_pos);
                 surf->move_to(top_left);
                 render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
-                auto [dp, rp] = compute_both_handle_positions(top_left, surf->window_size(), magnification);
-                if (drag_handle_indicator)
-                {
-                    drag_handle_indicator->move_to(dp);
-                    drag_handle_indicator->show();
-                }
-                if (resize_handle_indicator)
-                {
-                    resize_handle_indicator->move_to(rp);
-                    resize_handle_indicator->show();
-                }
+                reposition_all_handles_locked(top_left, surf->window_size(), magnification);
+                show_all_handles_locked();
             }
             surf->show();
         }
         else
         {
             surf->hide();
-            if (drag_handle_indicator)
-                drag_handle_indicator->hide();
-            if (resize_handle_indicator)
-                resize_handle_indicator->hide();
+            hide_all_handles_locked();
         }
     }
 
     void set_magnification(float new_magnification)
     {
         std::lock_guard lock(mutex);
-        magnification = new_magnification;
-        if (auto const surf = surface.lock())
-        {
-            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
-            if (decoupled && (drag_handle_indicator || resize_handle_indicator))
-            {
-                auto [dp, rp] = compute_both_handle_positions(surf->top_left(), surf->window_size(), magnification);
-                if (drag_handle_indicator)
-                    drag_handle_indicator->move_to(dp);
-                if (resize_handle_indicator)
-                    resize_handle_indicator->move_to(rp);
-            }
-        }
+        set_magnification_locked(new_magnification);
     }
 
     void set_capture_size(geom::Size const& size)
@@ -445,14 +478,7 @@ public:
         std::lock_guard lock(mutex);
         auto const capture_position = surface_top_left_from_cursor(size, cursor_pos);
         render_scene_into_surface.capture_area({ capture_position, size });
-        if (decoupled &&  (drag_handle_indicator || resize_handle_indicator))
-        {
-            auto [dp, rp] = compute_both_handle_positions(capture_position, size, magnification);
-            if (drag_handle_indicator)
-                drag_handle_indicator->move_to(dp);
-            if (resize_handle_indicator)
-                resize_handle_indicator->move_to(rp);
-        }
+        reposition_all_handles_locked(capture_position, size, magnification);
     }
 
     geom::Size current_size() const
@@ -482,20 +508,20 @@ public:
                     resize_drag_observer = std::make_shared<ResizeDragObserver>(this);
                     resize_handle_indicator->register_interest(resize_drag_observer);
                 }
-                if (default_enabled && (drag_handle_indicator || resize_handle_indicator))
+                if (zoom_in_indicator)
                 {
-                    auto [dp, rp] = compute_both_handle_positions(
-                        surf->top_left(), surf->window_size(), magnification);
-                    if (drag_handle_indicator)
-                    {
-                        drag_handle_indicator->move_to(dp);
-                        drag_handle_indicator->show();
-                    }
-                    if (resize_handle_indicator)
-                    {
-                        resize_handle_indicator->move_to(rp);
-                        resize_handle_indicator->show();
-                    }
+                    zoom_in_observer = std::make_shared<ZoomButtonObserver>(this, +zoom_step);
+                    zoom_in_indicator->register_interest(zoom_in_observer);
+                }
+                if (zoom_out_indicator)
+                {
+                    zoom_out_observer = std::make_shared<ZoomButtonObserver>(this, -zoom_step);
+                    zoom_out_indicator->register_interest(zoom_out_observer);
+                }
+                if (default_enabled)
+                {
+                    reposition_all_handles_locked(surf->top_left(), surf->window_size(), magnification);
+                    show_all_handles_locked();
                 }
             }
         }
@@ -518,6 +544,24 @@ public:
                     resize_drag_observer.reset();
                 }
                 resize_handle_indicator->hide();
+            }
+            if (zoom_in_indicator)
+            {
+                if (zoom_in_observer)
+                {
+                    zoom_in_indicator->unregister_interest(*zoom_in_observer);
+                    zoom_in_observer.reset();
+                }
+                zoom_in_indicator->hide();
+            }
+            if (zoom_out_indicator)
+            {
+                if (zoom_out_observer)
+                {
+                    zoom_out_indicator->unregister_interest(*zoom_out_observer);
+                    zoom_out_observer.reset();
+                }
+                zoom_out_indicator->hide();
             }
 
             if (auto const surf = surface.lock(); surf && default_enabled)
@@ -674,12 +718,7 @@ private:
                 surf->move_to(new_pos);
                 self->render_scene_into_surface.capture_area(
                     geom::Rectangle{new_pos, surf->window_size()});
-                auto [dp, rp] = self->compute_both_handle_positions(
-                    new_pos, surf->window_size(), self->magnification);
-                if (self->drag_handle_indicator)
-                    self->drag_handle_indicator->move_to(dp);
-                if (self->resize_handle_indicator)
-                    self->resize_handle_indicator->move_to(rp);
+                self->reposition_all_handles_locked(new_pos, surf->window_size(), self->magnification);
             }
         }
 
@@ -756,17 +795,66 @@ private:
 
             surf->move_to(new_logical_tl);
             self->render_scene_into_surface.capture_area({new_logical_tl, new_logical_size});
-
-            auto const [dp, rp] = self->compute_both_handle_positions(new_logical_tl, new_logical_size, mag);
-            if (self->drag_handle_indicator)
-                self->drag_handle_indicator->move_to(dp);
-            if (self->resize_handle_indicator)
-                self->resize_handle_indicator->move_to(rp);
+            self->reposition_all_handles_locked(new_logical_tl, new_logical_size, mag);
         }
 
         geom::Point pin_pos{};
         bool pin_left{false};
         bool pin_above{false};
+    };
+
+    /// Adjusts the magnification level when a zoom button is tapped or touched.
+    class ZoomButtonObserver : public ms::NullSurfaceObserver
+    {
+    public:
+        ZoomButtonObserver(Self* self, float delta) : self{self}, delta{delta} {}
+
+        void input_consumed(
+            ms::Surface const*,
+            std::shared_ptr<MirEvent const> const& event) override
+        {
+            if (mir_event_get_type(event.get()) != mir_event_type_input)
+                return;
+            auto const* input_ev = mir_event_get_input_event(event.get());
+            switch (mir_input_event_get_type(input_ev))
+            {
+            case mir_input_event_type_pointer:
+                handle_pointer(mir_input_event_get_pointer_event(input_ev));
+                break;
+            case mir_input_event_type_touch:
+                handle_touch(mir_input_event_get_touch_event(input_ev));
+                break;
+            default:
+                break;
+            }
+        }
+
+    private:
+        void handle_pointer(MirPointerEvent const* pev)
+        {
+            auto const action = mir_pointer_event_action(pev);
+
+            std::lock_guard lock(self->mutex);
+            if (action == mir_pointer_action_button_down &&
+                mir_pointer_event_button_state(pev, mir_pointer_button_primary))
+                self->set_magnification_locked(
+                    std::clamp(self->magnification + delta, min_magnification + zoom_step, max_magnification));
+        }
+
+        void handle_touch(MirTouchEvent const* tev)
+        {
+            if (mir_touch_event_point_count(tev) != 1)
+                return;
+            auto const action = mir_touch_event_action(tev, 0);
+
+            std::lock_guard lock(self->mutex);
+            if (action == mir_touch_action_down)
+                self->set_magnification_locked(
+                    std::clamp(self->magnification + delta, min_magnification + zoom_step, max_magnification));
+        }
+
+        Self* self;
+        float delta;
     };
 
     static geom::Point surface_top_left_from_cursor(
@@ -854,6 +942,73 @@ private:
         return {hx < vis_cx, hy < vis_cy};
     }
 
+    /// Computes positions for the zoom-in and zoom-out button indicators.
+    ///
+    /// Returns {zoom_in_pos, zoom_out_pos}.
+    std::pair<geom::Point, geom::Point> compute_zoom_button_positions(
+        geom::Point const& logical_top_left,
+        geom::Size const& logical_size,
+        float mag) const
+    {
+        auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
+
+        int const vertical_padding = 8;
+        int const stack_width = drag_handle_diameter;
+        int const stack_height = 2 * drag_handle_diameter + vertical_padding;
+
+        int const x = vis_x + vis_w - stack_width;
+        int const y = vis_y + vis_h / 2 - stack_height / 2;
+
+        return {geom::Point{x, y}, geom::Point{x, y + drag_handle_diameter + vertical_padding}};
+    }
+
+    /// Repositions all handle and button indicators for the given capture geometry.
+    /// No-op when not in decoupled mode.  Must be called with `mutex` held.
+    void reposition_all_handles_locked(
+        geom::Point const& tl,
+        geom::Size const& sz,
+        float mag)
+    {
+        if (!decoupled)
+            return;
+
+        auto const [dp, rp] = compute_both_handle_positions(tl, sz, mag);
+        if (drag_handle_indicator)   drag_handle_indicator->move_to(dp);
+        if (resize_handle_indicator) resize_handle_indicator->move_to(rp);
+
+        auto const [zp, zm] = compute_zoom_button_positions(tl, sz, mag);
+        if (zoom_in_indicator)  zoom_in_indicator->move_to(zp);
+        if (zoom_out_indicator) zoom_out_indicator->move_to(zm);
+    }
+
+    /// Updates the magnification without acquiring the mutex (caller must hold it).
+    void set_magnification_locked(float new_magnification)
+    {
+        magnification = new_magnification;
+        if (auto const surf = surface.lock())
+        {
+            surf->set_transformation(
+                glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
+            reposition_all_handles_locked(surf->top_left(), surf->window_size(), magnification);
+        }
+    }
+
+    void show_all_handles_locked()
+    {
+        if (drag_handle_indicator)   drag_handle_indicator->show();
+        if (resize_handle_indicator) resize_handle_indicator->show();
+        if (zoom_in_indicator)  zoom_in_indicator->show();
+        if (zoom_out_indicator) zoom_out_indicator->show();
+    }
+
+    void hide_all_handles_locked()
+    {
+        if (drag_handle_indicator)   drag_handle_indicator->hide();
+        if (resize_handle_indicator) resize_handle_indicator->hide();
+        if (zoom_in_indicator)  zoom_in_indicator->hide();
+        if (zoom_out_indicator) zoom_out_indicator->hide();
+    }
+
     std::mutex mutex;
     RenderSceneIntoSurface render_scene_into_surface;
     std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
@@ -864,6 +1019,10 @@ private:
     std::shared_ptr<DragHandleObserver> drag_handle_observer;
     std::shared_ptr<DragHandleIndicator> resize_handle_indicator;
     std::shared_ptr<ResizeDragObserver> resize_drag_observer;
+    std::shared_ptr<DragHandleIndicator> zoom_in_indicator;
+    std::shared_ptr<DragHandleIndicator> zoom_out_indicator;
+    std::shared_ptr<ZoomButtonObserver> zoom_in_observer;
+    std::shared_ptr<ZoomButtonObserver> zoom_out_observer;
     geom::Point cursor_pos;
     float magnification{default_magnification};
     bool default_enabled{false};
@@ -892,16 +1051,8 @@ miral::Magnifier::Magnifier(live_config::Store& config_store)
         {"magnifier", "magnification"},
         "The magnification scale ",
         default_magnification,
-        [this](live_config::Key const& key, std::optional<float> val)
+        [this](live_config::Key const&, std::optional<float> val)
         {
-            if (val.has_value() && *val <= 1.f)
-            {
-                mir::log_warning(
-                    "Config key '%s' should be greater than or equal to 1",
-                    key.to_string().c_str());
-                return;
-            }
-
             magnification(val.value_or(default_magnification));
         });
     config_store.add_int_attribute(
@@ -956,14 +1107,18 @@ miral::Magnifier& miral::Magnifier::enable(bool enabled)
 
 miral::Magnifier& miral::Magnifier::magnification(float magnification)
 {
-    if (magnification <= 1.f)
+    auto const clamped_magnification = std::clamp(magnification, min_magnification, max_magnification);
+    if (magnification != clamped_magnification)
     {
         mir::log_warning(
-            "Magnification should be greater than or equal to 1");
+            "Magnification should be between %.2f and %.2f",
+            min_magnification,
+            max_magnification);
+
         return *this;
     }
 
-    self->set_magnification(magnification);
+    self->set_magnification(clamped_magnification);
     return *this;
 }
 

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -22,6 +22,7 @@
 #include <miral/live_config.h>
 #include <mir/log.h>
 #include <mir/server.h>
+#include <mir/synchronised.h>
 #include <mir/graphics/display.h>
 #include <mir/geometry/rectangles.h>
 #include <mir/input/cursor_observer.h>
@@ -405,41 +406,50 @@ public:
     {
         render_scene_into_surface.on_surface_ready([this](auto const& surf)
         {
-            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
+            auto s = state.lock();
+            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(s->magnification, s->magnification, 1)));
             surf->set_depth_layer(mir_depth_layer_always_on_top);
             surf->set_focus_mode(mir_focus_mode_disabled);
 
-            if (default_enabled)
+            if (s->default_enabled)
                 surf->show();
             else
                 surf->hide();
 
-            std::lock_guard lock(mutex);
-            surface = surf;
+            s->surface = surf;
         });
 
         render_scene_into_surface(server);
 
         server.add_init_callback([&]
         {
-            observer = std::make_shared<Observer>(this);
-            server.the_cursor_observer_multiplexer()->register_interest(observer);
-            cursor_multiplexer = server.the_cursor_observer_multiplexer();
+            auto local_observer = std::make_shared<Observer>(this);
 
-            std::lock_guard lock(mutex);
-            drag.init(server, HandleKind::drag);
-            resize.init(server, HandleKind::resize);
-            zoom_in.init(server, HandleKind::zoom_in);
-            zoom_out.init(server, HandleKind::zoom_out);
+            // Keep screen bounds up to date to respond to display
+            // (re)configuration, e.g. resizing a nested window.
+            // Note: register_interest may call initial_configuration() synchronously,
+            // which calls update_bounds(), which locks state — so we must not hold
+            // the state lock across this call.
+            server.the_cursor_observer_multiplexer()->register_interest(local_observer);
 
-            if (decoupled)
+            auto s = state.lock();
+
+            s->observer = local_observer;
+            s->cursor_multiplexer = server.the_cursor_observer_multiplexer();
+
+            s->drag.init(server, HandleKind::drag);
+            s->resize.init(server, HandleKind::resize);
+            s->zoom_in.init(server, HandleKind::zoom_in);
+            s->zoom_out.init(server, HandleKind::zoom_out);
+
+            if (s->decoupled)
             {
-                attach_observers_locked();
+                s->attach_observers(this);
 
-                if (auto const surf = surface.lock(); surf && default_enabled)
+                if (auto const surf = s->surface.lock(); surf && s->default_enabled)
                 {
-                    reposition_all_handles_locked(surf->top_left(), surf->window_size(), magnification);
-                    show_all_handles_locked();
+                    s->reposition_all_handles(surf->top_left(), surf->window_size(), s->magnification);
+                    s->show_all_handles();
                 }
             }
         });
@@ -447,13 +457,14 @@ public:
         server.add_stop_callback([&]
         {
             // The naive way to do this would be:
-            //  - lock self->mutex
+            //  - lock self->state
             //  - unregister observers
             //
             // This may cause a deadlock in the following case:
-            //  - lock self->mutex
-            //  - on another thread, the observer gets called into, attempts to lock self->mutex and blocks
-            //  - unregistering the observer waits until the observer returns, which it will not since its waiting on the lock
+            //  - lock self->state
+            //  - on another thread, the observer gets called into, attempts to lock self->state and blocks
+            //  - unregistering the observer waits until the observer returns,
+            //    which it will not since its waiting on the lock
             //  - deadlock: unregister waiting on observer, observer waiting on lock held to unregister
             //
             //  The lock is only required to grab references to the observers
@@ -464,14 +475,14 @@ public:
             std::shared_ptr<Observer> local_observer;
             Handle local_drag, local_resize, local_zoom_in, local_zoom_out;
             {
-                std::lock_guard lock(mutex);
+                auto s = state.lock();
 
-                local_cursor_mux = cursor_multiplexer.lock();
-                local_observer = observer;
-                local_drag = std::exchange(drag, {});
-                local_resize = std::exchange(resize, {});
-                local_zoom_in = std::exchange(zoom_in, {});
-                local_zoom_out = std::exchange(zoom_out, {});
+                local_cursor_mux = s->cursor_multiplexer.lock();
+                local_observer = s->observer;
+                local_drag = std::exchange(s->drag, {});
+                local_resize = std::exchange(s->resize, {});
+                local_zoom_in = std::exchange(s->zoom_in, {});
+                local_zoom_out = std::exchange(s->zoom_out, {});
             }
 
             if (local_cursor_mux && local_observer)
@@ -484,44 +495,44 @@ public:
 
     void set_enable(bool enable)
     {
-        std::lock_guard lock(mutex);
-        default_enabled = enable;
-        auto const surf = surface.lock();
+        auto s = state.lock();
+        s->default_enabled = enable;
+        auto const surf = s->surface.lock();
         if (!surf)
             return;
 
         if (enable)
         {
-            if (decoupled)
+            if (s->decoupled)
             {
                 // Place surface at last known cursor position when enabling in decoupled mode.
-                auto const top_left = surface_top_left_from_cursor(surf->window_size(), cursor_pos);
+                auto const top_left = State::surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
                 surf->move_to(top_left);
                 render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
-                reposition_all_handles_locked(top_left, surf->window_size(), magnification);
-                show_all_handles_locked();
+                s->reposition_all_handles(top_left, surf->window_size(), s->magnification);
+                s->show_all_handles();
             }
             surf->show();
         }
         else
         {
             surf->hide();
-            hide_all_handles_locked();
+            s->hide_all_handles();
         }
     }
 
     void set_magnification(float new_magnification)
     {
-        std::lock_guard lock(mutex);
-        set_magnification_locked(new_magnification);
+        auto s = state.lock();
+        s->set_magnification(new_magnification);
     }
 
     void set_capture_size(geom::Size const& size)
     {
-        std::lock_guard lock(mutex);
-        auto const capture_position = surface_top_left_from_cursor(size, cursor_pos);
-        render_scene_into_surface.capture_area({ capture_position, size });
-        reposition_all_handles_locked(capture_position, size, magnification);
+        auto s = state.lock();
+        auto const capture_position = State::surface_top_left_from_cursor(size, s->cursor_pos);
+        render_scene_into_surface.capture_area({capture_position, size});
+        s->reposition_all_handles(capture_position, size, s->magnification);
     }
 
     geom::Size current_size() const
@@ -531,35 +542,35 @@ public:
 
     void set_decoupled(bool new_decoupled)
     {
-        std::lock_guard lock(mutex);
-        if (decoupled == new_decoupled)
+        auto s = state.lock();
+        if (s->decoupled == new_decoupled)
             return;
 
-        decoupled = new_decoupled;
+        s->decoupled = new_decoupled;
 
         if (new_decoupled)
         {
-            if (auto const surf = surface.lock())
+            if (auto const surf = s->surface.lock())
             {
-                attach_observers_locked();
-                if (default_enabled)
+                s->attach_observers(this);
+                if (s->default_enabled)
                 {
-                    reposition_all_handles_locked(surf->top_left(), surf->window_size(), magnification);
-                    show_all_handles_locked();
+                    s->reposition_all_handles(surf->top_left(), surf->window_size(), s->magnification);
+                    s->show_all_handles();
                 }
             }
         }
         else
         {
-            for (auto* handle : {&drag, &resize, &zoom_in, &zoom_out})
+            for (auto* handle : {&s->drag, &s->resize, &s->zoom_in, &s->zoom_out})
             {
                 handle->detach_observer();
                 handle->hide();
             }
 
-            if (auto const surf = surface.lock(); surf && default_enabled)
+            if (auto const surf = s->surface.lock(); surf && s->default_enabled)
             {
-                auto const top_left = surface_top_left_from_cursor(surf->window_size(), cursor_pos);
+                auto const top_left = State::surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
                 surf->move_to(top_left);
                 render_scene_into_surface.capture_area(geom::Rectangle{top_left, surf->window_size()});
             }
@@ -567,6 +578,175 @@ public:
     }
 
 private:
+    class Observer;
+    class DisplayConfigObserver;
+
+    struct State
+    {
+        /// Pixel-space rectangle of signed integer coordinates.
+        struct VisualBounds { int x, y, w, h; };
+
+        static geom::Point surface_top_left_from_cursor(
+            geom::Size const& window_size,
+            geom::Point const& cursor_pos)
+        {
+            return geom::Point{
+                cursor_pos.x.as_int() - window_size.width.as_int() / 2,
+                cursor_pos.y.as_int() - window_size.height.as_int() / 2};
+        }
+
+        /// Returns the pixel-space top-left and size of the visual magnifier surface
+        /// given its logical capture rectangle and magnification factor.
+        VisualBounds compute_visual_bounds(
+            geom::Point const& logical_top_left,
+            geom::Size const& logical_size,
+            float mag) const
+        {
+            int const w = mag * logical_size.width.as_int();
+            int const h = mag * logical_size.height.as_int();
+            int const x = logical_top_left.x.as_int() - (mag - 1.0f) / 2.0f * logical_size.width.as_int();
+            int const y = logical_top_left.y.as_int() - (mag - 1.0f) / 2.0f * logical_size.height.as_int();
+            return {x, y, w, h};
+        }
+
+        /// Computes the position of the circular drag handle indicator.
+        ///
+        /// The handle is placed at the visual bottom-right corner of the magnifier.
+        geom::Point compute_drag_handle_position(
+            geom::Point const& logical_top_left,
+            geom::Size const& logical_size,
+            float mag) const
+        {
+            auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
+
+            int hx = vis_x + vis_w - drag_handle_diameter;
+            int hy = vis_y + vis_h - drag_handle_diameter;
+
+            return geom::Point{hx, hy};
+        }
+
+        /// Computes the position of the circular resize handle indicator.
+        ///
+        /// The handle is placed at the visual top-left corner of the magnifier.
+        geom::Point compute_resize_handle_position(
+            geom::Point const& logical_top_left,
+            geom::Size const& logical_size,
+            float mag) const
+        {
+            auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
+
+            // Default: circle centred on the top-left corner of the visual magnifier,
+            // so it sits half outside the content area.
+            int hx = vis_x;
+            int hy = vis_y;
+
+            return geom::Point{hx, hy};
+        }
+
+        std::pair<geom::Point, geom::Point> compute_both_handle_positions(
+            geom::Point const& logical_top_left,
+            geom::Size const& logical_size,
+            float mag) const
+        {
+            return {
+                compute_drag_handle_position(logical_top_left, logical_size, mag),
+                compute_resize_handle_position(logical_top_left, logical_size, mag)};
+        }
+
+        /// Computes positions for the zoom-in and zoom-out button indicators.
+        ///
+        /// Returns {zoom_in_pos, zoom_out_pos}.
+        std::pair<geom::Point, geom::Point> compute_zoom_button_positions(
+            geom::Point const& logical_top_left,
+            geom::Size const& logical_size,
+            float mag) const
+        {
+            auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
+
+            int const vertical_padding = 8;
+            int const stack_width = drag_handle_diameter;
+            int const stack_height = 2 * drag_handle_diameter + vertical_padding;
+
+            int const x = vis_x + vis_w - stack_width;
+            int const y = vis_y + vis_h / 2 - stack_height / 2;
+
+            return {geom::Point{x, y}, geom::Point{x, y + drag_handle_diameter + vertical_padding}};
+        }
+
+        /// Repositions all handle and button indicators for the given capture geometry.
+        /// No-op when not in decoupled mode.
+        void reposition_all_handles(
+            geom::Point const& tl,
+            geom::Size const& sz,
+            float mag)
+        {
+            if (!decoupled)
+                return;
+
+            auto const [dp, rp] = compute_both_handle_positions(tl, sz, mag);
+            auto const [zp, zm] = compute_zoom_button_positions(tl, sz, mag);
+            drag.move_to(dp);
+            resize.move_to(rp);
+            zoom_in.move_to(zp);
+            zoom_out.move_to(zm);
+        }
+
+        void set_magnification(float new_magnification)
+        {
+            magnification = new_magnification;
+            if (auto const surf = surface.lock())
+            {
+                surf->set_transformation(
+                    glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
+                reposition_all_handles(surf->top_left(), surf->window_size(), magnification);
+            }
+        }
+
+        void show_all_handles()
+        {
+            for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
+                h->show();
+        }
+
+        void hide_all_handles()
+        {
+            for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
+                h->hide();
+        }
+
+        /// Unregisters and discards the observer on each handle that has one.
+        void detach_observers()
+        {
+            for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
+                h->detach_observer();
+        }
+
+        /// Creates and registers concrete observers on each handle. Guards against
+        /// missing indicators.
+        void attach_observers(Self* self)
+        {
+            drag.attach_observer<DragHandleObserver>(self);
+            resize.attach_observer<ResizeDragObserver>(self);
+            zoom_in.attach_observer<ZoomButtonObserver>(self, +zoom_step);
+            zoom_out.attach_observer<ZoomButtonObserver>(self, -zoom_step);
+        }
+
+        std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
+        std::shared_ptr<Observer> observer;
+        std::shared_ptr<DisplayConfigObserver> display_config_observer;
+        std::weak_ptr<ms::Surface> surface;
+        Handle drag;
+        Handle resize;
+        Handle zoom_in;
+        Handle zoom_out;
+        std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
+
+        geom::Point cursor_pos;
+        float magnification{default_magnification};
+        bool default_enabled{false};
+        bool decoupled{false};
+    };
+
     class Observer : public mi::CursorObserver
     {
     public:
@@ -574,23 +754,20 @@ private:
 
         void cursor_moved_to(float abs_x, float abs_y) override
         {
-            std::lock_guard lock(self->mutex);
-            self->cursor_pos = geom::Point{abs_x, abs_y};
+            auto s = self->state.lock();
+            s->cursor_pos = geom::Point{abs_x, abs_y};
 
             // In decoupled mode the surface stays put; only update when coupled.
-            if (self->decoupled)
+            if (s->decoupled)
                 return;
 
-            auto const surf = self->surface.lock();
+            auto const surf = s->surface.lock();
             if (!surf)
                 return;
 
-            auto const capture_position = surface_top_left_from_cursor(
-                surf->window_size(),
-                self->cursor_pos);
+            auto const capture_position = State::surface_top_left_from_cursor(surf->window_size(), s->cursor_pos);
             surf->move_to(capture_position);
-            self->render_scene_into_surface.capture_area(
-                geom::Rectangle{capture_position, surf->window_size()});
+            self->render_scene_into_surface.capture_area(geom::Rectangle{capture_position, surf->window_size()});
         }
 
         void pointer_usable() override {}
@@ -630,19 +807,19 @@ private:
         }
 
     protected:
-        virtual void on_drag_start(int ax, int ay) = 0;
-        virtual void on_drag_move(int ax, int ay) = 0;
+        virtual void on_drag_start(State& s, int ax, int ay) = 0;
+        virtual void on_drag_move(State& s, int ax, int ay) = 0;
 
         Self* self;
         bool drag_active{false};
         geom::Displacement grab_abs{};
 
     private:
-        void begin_drag(int ax, int ay)
+        void begin_drag(State& s, int ax, int ay)
         {
             drag_active = true;
             grab_abs = {geom::DeltaX{ax}, geom::DeltaY{ay}};
-            on_drag_start(ax, ay);
+            on_drag_start(s, ax, ay);
         }
 
         void handle_pointer(MirPointerEvent const* pev)
@@ -653,13 +830,13 @@ private:
             auto const ay = static_cast<int>(
                 std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_y)));
 
-            std::lock_guard lock(self->mutex);
+            auto s = self->state.lock();
             if (action == mir_pointer_action_button_down &&
                 mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                begin_drag(ax, ay);
+                begin_drag(*s, ax, ay);
             else if (action == mir_pointer_action_motion && drag_active &&
                      mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                on_drag_move(ax, ay);
+                on_drag_move(*s, ax, ay);
             else if (action == mir_pointer_action_button_up)
                 drag_active = false;
         }
@@ -674,11 +851,11 @@ private:
             auto const ay = static_cast<int>(
                 std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_y)));
 
-            std::lock_guard lock(self->mutex);
+            auto s = self->state.lock();
             if (action == mir_touch_action_down)
-                begin_drag(ax, ay);
+                begin_drag(*s, ax, ay);
             else if (action == mir_touch_action_change && drag_active)
-                on_drag_move(ax, ay);
+                on_drag_move(*s, ax, ay);
             else if (action == mir_touch_action_up)
                 drag_active = false;
         }
@@ -691,13 +868,13 @@ private:
         using HandleObserver::HandleObserver;
 
     protected:
-        void on_drag_start(int, int) override
+        void on_drag_start(State& s, int, int) override
         {
-            if (auto const surf = self->surface.lock())
+            if (auto const surf = s.surface.lock())
                 drag_start_magnifier_pos = surf->top_left();
         }
 
-        void on_drag_move(int ax, int ay) override
+        void on_drag_move(State& s, int ax, int ay) override
         {
             geom::Displacement const delta{
                 geom::DeltaX{ax} - grab_abs.dx,
@@ -706,12 +883,11 @@ private:
                 drag_start_magnifier_pos.x + delta.dx,
                 drag_start_magnifier_pos.y + delta.dy};
 
-            if (auto const surf = self->surface.lock())
+            if (auto const surf = s.surface.lock())
             {
                 surf->move_to(new_pos);
-                self->render_scene_into_surface.capture_area(
-                    geom::Rectangle{new_pos, surf->window_size()});
-                self->reposition_all_handles_locked(new_pos, surf->window_size(), self->magnification);
+                self->render_scene_into_surface.capture_area(geom::Rectangle{new_pos, surf->window_size()});
+                s.reposition_all_handles(new_pos, surf->window_size(), s.magnification);
             }
         }
 
@@ -726,74 +902,55 @@ private:
         using HandleObserver::HandleObserver;
 
     protected:
-        void on_drag_start(int, int) override
+        void on_drag_start(State& s, int, int) override
         {
-            auto const surf = self->surface.lock();
-            if (!surf) return;
-            auto const tl   = surf->top_left();
-            auto const sz   = self->render_scene_into_surface.capture_area().size;
-            float const mag = self->magnification;
+            auto const surf = s.surface.lock();
+            if (!surf)
+                return;
+            auto const tl = surf->top_left();
+            auto const sz = self->render_scene_into_surface.capture_area().size;
+            float const mag = s.magnification;
 
-            // Determine which corner the handle is currently at
-            auto const resize_pos        = self->compute_resize_handle_position(tl, sz, mag);
-            auto const [left, top]       = self->determine_resize_corner(resize_pos, tl, sz);
-
-            // The pinned corner is diagonally opposite the active handle corner
-            pin_left  = !left;
-            pin_above = !top;
-
-            float const inner = (mag - 1.0f) / 2.0f;
             float const outer = (mag + 1.0f) / 2.0f;
             pin_pos = geom::Point{
-                pin_left
-                    ? static_cast<int>(tl.x.as_int() - inner * sz.width.as_int())
-                    : static_cast<int>(tl.x.as_int() + outer * sz.width.as_int()),
-                pin_above
-                    ? static_cast<int>(tl.y.as_int() - inner * sz.height.as_int())
-                    : static_cast<int>(tl.y.as_int() + outer * sz.height.as_int())};
+                tl.x.as_int() + outer * sz.width.as_int(),
+                tl.y.as_int() + outer * sz.height.as_int(),
+            };
         }
 
-        void on_drag_move(int ax, int ay) override
+        void on_drag_move(State& s, int ax, int ay) override
         {
-            float const mag = self->magnification;
+            float const mag = s.magnification;
 
             // Visual size from the finger position to the pinned corner
-            int const raw_vis_w = pin_left
-                ? (ax - pin_pos.x.as_int())
-                : (pin_pos.x.as_int() - ax);
-            int const raw_vis_h = pin_above
-                ? (ay - pin_pos.y.as_int())
-                : (pin_pos.y.as_int() - ay);
+            int const raw_vis_w = pin_pos.x.as_int() - ax;
+            int const raw_vis_h = pin_pos.y.as_int() - ay;
 
             auto const clamp = [](int v) { return std::clamp(v, 50, 1000); };
             geom::Size const new_logical_size{
-                geom::Width{ clamp(static_cast<int>(std::round(raw_vis_w / mag)))},
+                geom::Width{clamp(static_cast<int>(std::round(raw_vis_w / mag)))},
                 geom::Height{clamp(static_cast<int>(std::round(raw_vis_h / mag)))}};
 
-            float const inner = (mag - 1.0f) / 2.0f;
             float const outer = (mag + 1.0f) / 2.0f;
+
             int const w = new_logical_size.width.as_int();
             int const h = new_logical_size.height.as_int();
 
             geom::Point const new_logical_tl{
-                pin_left
-                    ? static_cast<int>(pin_pos.x.as_int() + inner * w)
-                    : static_cast<int>(pin_pos.x.as_int() - outer * w),
-                pin_above
-                    ? static_cast<int>(pin_pos.y.as_int() + inner * h)
-                    : static_cast<int>(pin_pos.y.as_int() - outer * h)};
+                pin_pos.x.as_int() - outer * w,
+                pin_pos.y.as_int() - outer * h,
+            };
 
-            auto const surf = self->surface.lock();
-            if (!surf) return;
+            auto const surf = s.surface.lock();
+            if (!surf)
+                return;
 
             surf->move_to(new_logical_tl);
             self->render_scene_into_surface.capture_area({new_logical_tl, new_logical_size});
-            self->reposition_all_handles_locked(new_logical_tl, new_logical_size, mag);
+            s.reposition_all_handles(new_logical_tl, new_logical_size, mag);
         }
 
         geom::Point pin_pos{};
-        bool pin_left{false};
-        bool pin_above{false};
     };
 
     /// Adjusts the magnification level when a zoom button is tapped or touched.
@@ -826,11 +983,13 @@ private:
         void handle_pointer(MirPointerEvent const* pev)
         {
             auto const action = mir_pointer_event_action(pev);
-
-            std::lock_guard lock(self->mutex);
+            auto s = self->state.lock();
             if (action == mir_pointer_action_button_down &&
                 mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                apply_zoom_locked();
+            {
+                s->set_magnification(
+                    std::clamp(s->magnification + delta, min_magnification + zoom_step, max_magnification));
+            }
         }
 
         void handle_touch(MirTouchEvent const* tev)
@@ -838,270 +997,20 @@ private:
             if (mir_touch_event_point_count(tev) != 1)
                 return;
             auto const action = mir_touch_event_action(tev, 0);
-
-            std::lock_guard lock(self->mutex);
+            auto s = self->state.lock();
             if (action == mir_touch_action_down)
-                apply_zoom_locked();
-        }
-
-        /// Clamps and applies the zoom step. Callers must hold self->mutex.
-        void apply_zoom_locked()
-        {
-            self->set_magnification_locked(
-                std::clamp(self->magnification + delta, min_magnification + zoom_step, max_magnification));
+            {
+                s->set_magnification(
+                    std::clamp(s->magnification + delta, min_magnification + zoom_step, max_magnification));
+            }
         }
 
         Self* self;
         float delta;
     };
 
-    static geom::Point surface_top_left_from_cursor(
-        geom::Size const& window_size,
-        geom::Point const& cursor_pos)
-    {
-        return geom::Point{
-            cursor_pos.x.as_int() - window_size.width.as_int() / 2,
-            cursor_pos.y.as_int() - window_size.height.as_int() / 2};
-    }
-
-    /// Pixel-space bounds of the magnified visual surface.
-    struct VisualBounds { int x, y, w, h; };
-
-    /// Returns the pixel-space top-left and size of the visual magnifier surface
-    /// given its logical capture rectangle and magnification factor.
-    VisualBounds compute_visual_bounds(
-        geom::Point const& logical_top_left,
-        geom::Size const& logical_size,
-        float mag) const
-    {
-        int const w = mag * logical_size.width.as_int();
-        int const h = mag * logical_size.height.as_int();
-        int const x = logical_top_left.x.as_int() - (mag - 1.0f) / 2.0f * logical_size.width.as_int();
-        int const y = logical_top_left.y.as_int() - (mag - 1.0f) / 2.0f * logical_size.height.as_int();
-        return {x, y, w, h};
-    }
-
-    /// Computes the position of the circular drag handle indicator.
-    ///
-    /// The handle is placed at the visual bottom-right corner of the magnifier.
-    geom::Point compute_drag_handle_position(
-        geom::Point const& logical_top_left,
-        geom::Size const& logical_size,
-        float mag) const
-    {
-        auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
-
-        int hx = vis_x + vis_w - drag_handle_diameter;
-        int hy = vis_y + vis_h - drag_handle_diameter;
-
-        return geom::Point{hx, hy};
-    }
-
-    /// Computes the position of the circular resize handle indicator.
-    ///
-    /// The handle is placed at the visual top-left corner of the magnifier.
-    geom::Point compute_resize_handle_position(
-        geom::Point const& logical_top_left,
-        geom::Size const& logical_size,
-        float mag) const
-    {
-        auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
-
-        // Default: circle centred on the top-left corner of the visual magnifier,
-        // so it sits half outside the content area.
-        int hx = vis_x;
-        int hy = vis_y;
-
-        return geom::Point{hx, hy};
-    }
-
-    std::pair<geom::Point, geom::Point> compute_both_handle_positions(
-        geom::Point const& logical_top_left,
-        geom::Size const& logical_size,
-        float mag) const
-    {
-        return {
-            compute_drag_handle_position(logical_top_left, logical_size, mag),
-            compute_resize_handle_position(logical_top_left, logical_size, mag)};
-    }
-
-    /// Returns which corner the resize handle is at as (corner_left, corner_top).
-    std::pair<bool, bool> determine_resize_corner(
-        geom::Point const& handle_pos,
-        geom::Point const& logical_top_left,
-        geom::Size const& logical_size) const
-    {
-        int const vis_cx = logical_top_left.x.as_int() + logical_size.width.as_int()  / 2;
-        int const vis_cy = logical_top_left.y.as_int() + logical_size.height.as_int() / 2;
-
-        int const hx = handle_pos.x.as_int() + drag_handle_diameter / 2;
-        int const hy = handle_pos.y.as_int() + drag_handle_diameter / 2;
-
-        return {hx < vis_cx, hy < vis_cy};
-    }
-
-    /// Computes positions for the zoom-in and zoom-out button indicators.
-    ///
-    /// Returns {zoom_in_pos, zoom_out_pos}.
-    std::pair<geom::Point, geom::Point> compute_zoom_button_positions(
-        geom::Point const& logical_top_left,
-        geom::Size const& logical_size,
-        float mag) const
-    {
-        auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
-
-        int const vertical_padding = 8;
-        int const stack_width = drag_handle_diameter;
-        int const stack_height = 2 * drag_handle_diameter + vertical_padding;
-
-        int const x = vis_x + vis_w - stack_width;
-        int const y = vis_y + vis_h / 2 - stack_height / 2;
-
-        return {geom::Point{x, y}, geom::Point{x, y + drag_handle_diameter + vertical_padding}};
-    }
-
-    /// Repositions all handle and button indicators for the given capture geometry.
-    /// No-op when not in decoupled mode.  Must be called with `mutex` held.
-    void reposition_all_handles_locked(
-        geom::Point const& tl,
-        geom::Size const& sz,
-        float mag)
-    {
-        if (!decoupled)
-            return;
-
-        auto const [dp, rp] = compute_both_handle_positions(tl, sz, mag);
-        auto const [zp, zm] = compute_zoom_button_positions(tl, sz, mag);
-        drag.move_to(dp);
-        resize.move_to(rp);
-        zoom_in.move_to(zp);
-        zoom_out.move_to(zm);
-    }
-
-    /// Updates the magnification without acquiring the mutex (caller must hold it).
-    void set_magnification_locked(float new_magnification)
-    {
-        magnification = new_magnification;
-        if (auto const surf = surface.lock())
-        {
-            surf->set_transformation(
-                glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
-            reposition_all_handles_locked(surf->top_left(), surf->window_size(), magnification);
-        }
-    }
-
-    void show_all_handles_locked()
-    {
-        for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
-            h->show();
-    }
-
-    void hide_all_handles_locked()
-    {
-        for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
-            h->hide();
-    }
-
-    /// Creates and registers concrete observers on each handle. Guards against
-    /// missing indicators. Callers must hold mutex.
-    void attach_observers_locked()
-    {
-        drag.attach_observer<DragHandleObserver>(this);
-        resize.attach_observer<ResizeDragObserver>(this);
-        zoom_in.attach_observer<ZoomButtonObserver>(this, +zoom_step);
-        zoom_out.attach_observer<ZoomButtonObserver>(this, -zoom_step);
-    }
-
-    std::mutex mutex;
     RenderSceneIntoSurface render_scene_into_surface;
-    std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
-    std::shared_ptr<Observer> observer;
-    std::weak_ptr<ms::Surface> surface;
-    geom::Rectangle screen_bounds;
-
-    class Handle
-    {
-    public:
-        Handle() = default;
-
-        void init(mir::Server& server, HandleKind kind)
-        {
-            indicator = std::make_shared<HandleIndicator>(
-                handle_rect,
-                kind,
-                server.the_buffer_allocator(),
-                server.the_scene_report(),
-                server.the_display_configuration_observer_registrar());
-            handle_surface_stack = server.the_surface_stack();
-
-            server.the_surface_stack()->add_surface(indicator, mi::InputReceptionMode::normal);
-            indicator->set_cursor_image(server.the_default_cursor_image());
-        }
-
-        void reset()
-        {
-            detach_observer();
-            if(auto const surface_stack = handle_surface_stack.lock())
-                surface_stack->remove_surface(indicator);
-            indicator.reset();
-        }
-
-        template<typename ObserverType, typename... Args>
-        void attach_observer(Args&&... args)
-        {
-            if(!indicator)
-                return;
-
-            observer = std::make_shared<ObserverType>(std::forward<Args>(args)...);
-            indicator->register_interest(observer);
-        }
-
-        void detach_observer()
-        {
-            if (!observer)
-                return;
-
-            indicator->unregister_interest(*observer);
-            observer.reset();
-        }
-
-        void move_to(geom::Point const& pos)
-        {
-            if (indicator)
-                indicator->move_to(pos);
-        }
-
-        void show()
-        {
-            if (indicator)
-                indicator->show();
-        }
-
-        void hide()
-        {
-            if (indicator)
-                indicator->hide();
-        }
-
-    private:
-        static constexpr geom::Rectangle handle_rect{
-            {0, 0},
-            {geom::Width{drag_handle_diameter}, geom::Height{drag_handle_diameter}}};
-
-        std::shared_ptr<HandleIndicator> indicator;
-        std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
-        std::shared_ptr<ms::NullSurfaceObserver> observer;
-    };
-
-    Handle drag;
-    Handle resize;
-    Handle zoom_in;
-    Handle zoom_out;
-
-    geom::Point cursor_pos;
-    float magnification{default_magnification};
-    bool default_enabled{false};
-    bool decoupled{false};
+    mir::Synchronised<State> state;
 };
 
 miral::Magnifier::Magnifier()

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -41,6 +41,7 @@
 #include <mir/graphics/graphic_buffer_allocator.h>
 #include <mir/shell/surface_stack.h>
 #include <mir/observer_registrar.h>
+#include <mir/main_loop.h>
 
 #include <glm/gtc/matrix_transform.hpp>
 
@@ -515,6 +516,7 @@ class miral::Magnifier::Self
 {
 private:
     struct State;
+    class Observer;
 
     class DisplayConfigObserver : public mg::DisplayConfigurationObserver
     {
@@ -614,35 +616,8 @@ public:
             input_filter = std::make_shared<InputFilter>(state);
             server.the_composite_event_filter()->prepend(input_filter);
 
-            auto s = state.lock();
-
-            s->observer = local_observer;
-            s->display_config_observer = local_display_config_observer;
-            s->cursor_multiplexer = server.the_cursor_observer_multiplexer();
-            if (s->visual_size == geom::Size{})
-            {
-                s->visual_size = clamp_visual_size(
-                    geom::Size{default_capture_width, default_capture_height} * s->magnification);
-            }
-
-            auto const capture_compositor_id = render_scene_into_surface.capture_compositor_id();
-            s->drag.init(server, HandleKind::drag, capture_compositor_id);
-            s->resize.init(server, HandleKind::resize, capture_compositor_id);
-            s->zoom_in.init(server, HandleKind::zoom_in, capture_compositor_id);
-            s->zoom_out.init(server, HandleKind::zoom_out, capture_compositor_id);
-
-            if (!s->follow_cursor)
-            {
-                s->attach_observers(this);
-
-                if (auto const surf = s->surface.lock(); surf && s->default_enabled)
-                {
-                    auto const logical_rect = render_scene_into_surface.capture_area();
-                    apply_positioned_geometry(
-                        surf, logical_rect.top_left, *s, render_scene_into_surface);
-                    s->show_all_handles();
-                }
-            }
+            server.the_main_loop()->spawn([=, this, &server]
+                                          { this->post_init(server, local_observer, local_display_config_observer); });
         });
 
         server.add_stop_callback([&]
@@ -692,6 +667,41 @@ public:
 
             input_filter.reset();
         });
+    }
+
+    void post_init(
+        mir::Server& server,
+        std::shared_ptr<Observer> const& local_observer,
+        std::shared_ptr<DisplayConfigObserver> const& local_display_config_observer)
+    {
+        auto s = state.lock();
+
+        s->observer = local_observer;
+        s->display_config_observer = local_display_config_observer;
+        s->cursor_multiplexer = server.the_cursor_observer_multiplexer();
+        if (s->visual_size == geom::Size{})
+        {
+            s->visual_size =
+                clamp_visual_size(geom::Size{default_capture_width, default_capture_height} * s->magnification);
+        }
+
+        auto const capture_compositor_id = render_scene_into_surface.capture_compositor_id();
+        s->drag.init(server, HandleKind::drag, capture_compositor_id);
+        s->resize.init(server, HandleKind::resize, capture_compositor_id);
+        s->zoom_in.init(server, HandleKind::zoom_in, capture_compositor_id);
+        s->zoom_out.init(server, HandleKind::zoom_out, capture_compositor_id);
+
+        if (!s->follow_cursor)
+        {
+            s->attach_observers(this);
+
+            if (auto const surf = s->surface.lock(); surf && s->default_enabled)
+            {
+                auto const logical_rect = render_scene_into_surface.capture_area();
+                apply_positioned_geometry(surf, logical_rect.top_left, *s, render_scene_into_surface);
+                s->show_all_handles();
+            }
+        }
     }
 
     void set_enable(bool enable)
@@ -782,8 +792,6 @@ public:
     }
 
 private:
-    class Observer;
-
     struct State
     {
         /// Pixel-space rectangle of signed integer coordinates.

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -24,6 +24,8 @@
 #include <mir/server.h>
 #include <mir/synchronised.h>
 #include <mir/graphics/display.h>
+#include <mir/graphics/display_configuration.h>
+#include <mir/graphics/display_configuration_observer.h>
 #include <mir/geometry/rectangles.h>
 #include <mir/input/cursor_observer.h>
 #include <mir/input/cursor_observer_multiplexer.h>
@@ -56,8 +58,17 @@ auto const max_magnification = 8.0f;
 /// Diameter in pixels of the circular drag handle shown at the corner of the magnifier.
 auto const drag_handle_diameter = 48;
 
+/// Vertical gap between the zoom-in and zoom-out buttons in their stack.
+auto const zoom_stack_padding = 8;
+
+/// Height of the vertical zoom-in/zoom-out button stack.
+auto const zoom_stack_height = 2 * drag_handle_diameter + zoom_stack_padding;
+
 /// Minimum on-screen (visual) width/height of the magnifier surface, in pixels.
-auto const min_visual_dimension = 150;
+/// Derived so the drag handle (bottom-right corner) and the zoom button stack
+/// (right edge, vertically centred) never overlap each other: the drag handle
+/// needs a full diameter of clearance both above and below the centred stack.
+auto const min_visual_dimension = 2 * drag_handle_diameter + zoom_stack_height;
 
 /// Magnification step applied by each zoom button press.
 auto const zoom_step = 0.5f;
@@ -441,6 +452,48 @@ geom::Point center(geom::Point const& top_left, geom::Size const& size)
 
 class miral::Magnifier::Self
 {
+private:
+    struct State;
+
+    class DisplayConfigObserver : public mg::DisplayConfigurationObserver
+    {
+    public:
+        explicit DisplayConfigObserver(mir::Synchronised<State>& state) : state{state} {}
+
+        void initial_configuration(
+            std::shared_ptr<mg::DisplayConfiguration const> const& config) override
+        {
+            update_bounds(config);
+        }
+
+        void configuration_applied(
+            std::shared_ptr<mg::DisplayConfiguration const> const& config) override
+        {
+            update_bounds(config);
+        }
+
+        void base_configuration_updated(
+            std::shared_ptr<mg::DisplayConfiguration const> const&) override {}
+        void session_configuration_applied(
+            std::shared_ptr<ms::Session> const&,
+            std::shared_ptr<mg::DisplayConfiguration> const&) override {}
+        void session_configuration_removed(std::shared_ptr<ms::Session> const&) override {}
+        void configuration_failed(
+            std::shared_ptr<mg::DisplayConfiguration const> const&,
+            std::exception const&) override {}
+        void catastrophic_configuration_error(
+            std::shared_ptr<mg::DisplayConfiguration const> const&,
+            std::exception const&) override {}
+        void configuration_updated_for_session(
+            std::shared_ptr<ms::Session> const&,
+            std::shared_ptr<mg::DisplayConfiguration const> const&) override {}
+
+    private:
+        void update_bounds(std::shared_ptr<mg::DisplayConfiguration const> const& config);
+
+        mir::Synchronised<State>& state;
+    };
+
 public:
     Self()
     {
@@ -471,17 +524,20 @@ public:
         server.add_init_callback([&]
         {
             auto local_observer = std::make_shared<Observer>(this);
+            auto local_display_config_observer = std::make_shared<DisplayConfigObserver>(state);
 
             // Keep screen bounds up to date to respond to display
             // (re)configuration, e.g. resizing a nested window.
             // Note: register_interest may call initial_configuration() synchronously,
             // which calls update_bounds(), which locks state — so we must not hold
             // the state lock across this call.
+            server.the_display_configuration_observer_registrar()->register_interest(local_display_config_observer);
             server.the_cursor_observer_multiplexer()->register_interest(local_observer);
 
             auto s = state.lock();
 
             s->observer = local_observer;
+            s->display_config_observer = local_display_config_observer;
             s->cursor_multiplexer = server.the_cursor_observer_multiplexer();
             if (s->visual_size == geom::Size{})
             {
@@ -502,7 +558,8 @@ public:
                 if (auto const surf = s->surface.lock(); surf && s->default_enabled)
                 {
                     auto const logical_rect = render_scene_into_surface.capture_area();
-                    apply_visual_geometry(surf, logical_rect.top_left, *s, render_scene_into_surface);
+                    apply_positioned_geometry(
+                        surf, logical_rect.top_left, *s, render_scene_into_surface);
                     s->show_all_handles();
                 }
             }
@@ -527,12 +584,14 @@ public:
 
             std::shared_ptr<mi::CursorObserverMultiplexer> local_cursor_mux;
             std::shared_ptr<Observer> local_observer;
+            std::shared_ptr<DisplayConfigObserver> local_display_config_observer;
             Handle local_drag, local_resize, local_zoom_in, local_zoom_out;
             {
                 auto s = state.lock();
 
                 local_cursor_mux = s->cursor_multiplexer.lock();
                 local_observer = s->observer;
+                local_display_config_observer = std::exchange(s->display_config_observer, {});
                 local_drag = std::exchange(s->drag, {});
                 local_resize = std::exchange(s->resize, {});
                 local_zoom_in = std::exchange(s->zoom_in, {});
@@ -541,6 +600,12 @@ public:
 
             if (local_cursor_mux && local_observer)
                 local_cursor_mux->unregister_interest(*local_observer);
+
+            if (local_display_config_observer)
+            {
+                server.the_display_configuration_observer_registrar()->unregister_interest(
+                    *local_display_config_observer);
+            }
 
             for (auto* handle : {&local_drag, &local_resize, &local_zoom_in, &local_zoom_out})
                 handle->reset();
@@ -582,10 +647,11 @@ public:
     {
         auto s = state.lock();
         s->visual_size = clamp_visual_size(size * s->magnification);
-        auto const logical_top_left = surface_top_left_from_cursor(size, s->cursor_pos);
+        auto const logical_size = logical_size_from_visual(s->visual_size, s->magnification);
+        auto const logical_top_left = surface_top_left_from_cursor(logical_size, s->cursor_pos);
 
         if (auto const surf = s->surface.lock())
-            apply_visual_geometry(surf, logical_top_left, *s, render_scene_into_surface);
+            apply_positioned_geometry(surf, logical_top_left, *s, render_scene_into_surface);
     }
 
     geom::Size current_size() const
@@ -609,7 +675,8 @@ public:
                 if (s->default_enabled)
                 {
                     auto const logical_rect = render_scene_into_surface.capture_area();
-                    s->reposition_all_handles(logical_rect.top_left, logical_rect.size, s->magnification);
+                    apply_positioned_geometry(
+                        surf, logical_rect.top_left, *s, render_scene_into_surface);
                     s->show_all_handles();
                 }
             }
@@ -631,7 +698,6 @@ public:
 
 private:
     class Observer;
-    class DisplayConfigObserver;
 
     struct State
     {
@@ -654,9 +720,97 @@ private:
             return {x, y, w, h};
         }
 
-        /// Computes the position of the circular drag handle indicator.
-        ///
-        /// The handle is placed at the visual bottom-right corner of the magnifier.
+        /// Translates logical_top_left, if necessary, so the resulting visual
+        /// rect fits within screen_bounds (preferring to keep the top-left edge
+        /// on-screen if the rect is bigger than the screen in some dimension).
+        /// Used when placing the magnifier so its handles don't end up
+        /// off-screen and unreachable, e.g. after enabling/decoupling while the
+        /// cursor was near a screen edge. Returns logical_top_left unchanged if
+        /// screen bounds aren't known yet.
+        geom::Point clamp_position_to_screen(
+            geom::Point const& logical_top_left,
+            geom::Size const& logical_size,
+            float mag) const
+        {
+            if (screen_bounds.size == geom::Size{})
+                return logical_top_left;
+
+            auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
+            int const screen_left = screen_bounds.top_left.x.as_int();
+            int const screen_top = screen_bounds.top_left.y.as_int();
+            int const screen_right = screen_left + screen_bounds.size.width.as_int();
+            int const screen_bottom = screen_top + screen_bounds.size.height.as_int();
+
+            int dx = 0;
+            if (vis_x < screen_left)
+                dx = screen_left - vis_x;
+            else if (vis_x + vis_w > screen_right)
+                dx = screen_right - (vis_x + vis_w);
+
+            int dy = 0;
+            if (vis_y < screen_top)
+                dy = screen_top - vis_y;
+            else if (vis_y + vis_h > screen_bottom)
+                dy = screen_bottom - (vis_y + vis_h);
+
+            return logical_top_left + geom::Displacement{geom::DeltaX{dx}, geom::DeltaY{dy}};
+        }
+
+        /// Maps the visual magnifier's position across the screen to the logical
+        /// capture's available range. A visual edge flush with the screen maps
+        /// to the corresponding capture edge, with proportional movement between.
+        geom::Point capture_position_for_surface(
+            geom::Point const& surface_top_left,
+            geom::Size const& logical_size,
+            float mag) const
+        {
+            if (screen_bounds.size == geom::Size{})
+                return surface_top_left;
+
+            auto const visual = compute_visual_bounds(surface_top_left, logical_size, mag);
+            int const screen_left = screen_bounds.top_left.x.as_int();
+            int const screen_top = screen_bounds.top_left.y.as_int();
+            int const screen_width = screen_bounds.size.width.as_int();
+            int const screen_height = screen_bounds.size.height.as_int();
+
+            auto const map_axis = [](
+                int visual_start,
+                int visual_extent,
+                int logical_extent,
+                int screen_start,
+                int screen_extent)
+            {
+                int const visual_travel = screen_extent - visual_extent;
+                int const capture_travel = screen_extent - logical_extent;
+
+                if (visual_travel <= 0)
+                    return screen_start + capture_travel / 2;
+
+                double const progress = std::clamp(
+                    static_cast<double>(visual_start - screen_start) / visual_travel,
+                    0.0,
+                    1.0);
+                return screen_start + static_cast<int>(std::round(progress * capture_travel));
+            };
+
+            return geom::Point{
+                map_axis(
+                    visual.x,
+                    visual.w,
+                    logical_size.width.as_int(),
+                    screen_left,
+                    screen_width),
+                map_axis(
+                    visual.y,
+                    visual.h,
+                    logical_size.height.as_int(),
+                    screen_top,
+                    screen_height)};
+        }
+
+        /// Computes the position of the circular drag handle indicator, inset from
+        /// the bottom-right corner of the visual magnifier so it sits within the
+        /// surface's own bounds.
         geom::Point compute_drag_handle_position(
             geom::Point const& logical_top_left,
             geom::Size const& logical_size,
@@ -708,17 +862,15 @@ private:
         {
             auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
 
-            int const vertical_padding = 8;
             int const stack_width = drag_handle_diameter;
-            int const stack_height = 2 * drag_handle_diameter + vertical_padding;
 
             int const x = vis_x + vis_w - stack_width;
-            int const y = vis_y + vis_h / 2 - stack_height / 2;
+            int const y = vis_y + vis_h / 2 - zoom_stack_height / 2;
 
-            return {geom::Point{x, y}, geom::Point{x, y + drag_handle_diameter + vertical_padding}};
+            return {geom::Point{x, y}, geom::Point{x, y + drag_handle_diameter + zoom_stack_padding}};
         }
 
-        /// Repositions all handle and button indicators for the given capture geometry.
+        /// Repositions all handle and button indicators for the given surface geometry.
         /// No-op when not in decoupled mode.
         void reposition_all_handles(
             geom::Point const& tl,
@@ -742,20 +894,33 @@ private:
             {
                 auto const old_logical_rect = render_scene_into_surface.capture_area();
 
-                // The visual magnifier is scaled about the centre of its logical
-                // capture area. Keep that centre fixed so changing zoom does not
-                // shift the on-screen position.
-                geom::Point const old_visual_centre =
-                    center(old_logical_rect.top_left, old_logical_rect.size);
+                if (decoupled)
+                {
+                    auto const old_surface_centre =
+                        center(surf->top_left(), old_logical_rect.size);
 
-                magnification = new_magnification;
-                auto const new_logical_size = logical_size_from_visual(visual_size, magnification);
+                    magnification = new_magnification;
+                    auto const new_logical_size = logical_size_from_visual(visual_size, magnification);
+                    geom::Point const new_surface_top_left{
+                        old_surface_centre.x.as_int() - new_logical_size.width.as_int() / 2,
+                        old_surface_centre.y.as_int() - new_logical_size.height.as_int() / 2};
 
-                geom::Point const new_logical_top_left{
-                    old_visual_centre.x.as_int() - new_logical_size.width.as_int() / 2,
-                    old_visual_centre.y.as_int() - new_logical_size.height.as_int() / 2};
+                    apply_positioned_geometry(
+                        surf, new_surface_top_left, *this, render_scene_into_surface);
+                }
+                else
+                {
+                    auto const old_logical_centre =
+                        center(old_logical_rect.top_left, old_logical_rect.size);
 
-                apply_visual_geometry(surf, new_logical_top_left, *this, render_scene_into_surface);
+                    magnification = new_magnification;
+                    auto const new_logical_size = logical_size_from_visual(visual_size, magnification);
+                    geom::Point const new_logical_top_left{
+                        old_logical_centre.x.as_int() - new_logical_size.width.as_int() / 2,
+                        old_logical_centre.y.as_int() - new_logical_size.height.as_int() / 2};
+
+                    apply_visual_geometry(surf, new_logical_top_left, *this, render_scene_into_surface);
+                }
             }
             else
             {
@@ -803,6 +968,7 @@ private:
         std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
 
         geom::Point cursor_pos;
+        geom::Rectangle screen_bounds;
         float magnification{default_magnification};
         /// The physical (screen) size of the magnifier.  When the magnification
         /// level changes the logical capture size is recalculated from this so
@@ -812,20 +978,53 @@ private:
         bool decoupled{false};
     };
 
-    /// Sets the logical capture area and transform so that the magnifier
-    /// renders with the supplied logical top-left and keeps the same physical
-    /// (visual) footprint.  The current visual size is taken from the state.
+    /// Applies independent logical capture and surface presentation positions.
+    static void apply_geometry(
+        std::shared_ptr<ms::Surface> const& surf,
+        geom::Point const& logical_top_left,
+        geom::Point const& surface_top_left,
+        State& s,
+        RenderSceneIntoSurface& render_scene_into_surface)
+    {
+        auto const logical_size = logical_size_from_visual(s.visual_size, s.magnification);
+        render_scene_into_surface.capture_area(geom::Rectangle{logical_top_left, logical_size});
+        // capture_area() moves the backing surface to the capture position, so
+        // apply the independent presentation position afterwards.
+        surf->move_to(surface_top_left);
+        surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(s.magnification, s.magnification, 1)));
+        s.reposition_all_handles(surface_top_left, logical_size, s.magnification);
+    }
+
+    /// Applies normal placement, where capture and presentation positions match.
     static void apply_visual_geometry(
         std::shared_ptr<ms::Surface> const& surf,
         geom::Point const& logical_top_left,
         State& s,
         RenderSceneIntoSurface& render_scene_into_surface)
     {
+        apply_geometry(surf, logical_top_left, logical_top_left, s, render_scene_into_surface);
+    }
+
+    /// Keeps the visual magnifier on-screen and maps its position proportionally
+    /// onto the logical capture's available screen range.
+    static void apply_positioned_geometry(
+        std::shared_ptr<ms::Surface> const& surf,
+        geom::Point const& desired_top_left,
+        State& s,
+        RenderSceneIntoSurface& render_scene_into_surface)
+    {
+        if (!s.decoupled)
+        {
+            apply_visual_geometry(surf, desired_top_left, s, render_scene_into_surface);
+            return;
+        }
+
         auto const logical_size = logical_size_from_visual(s.visual_size, s.magnification);
-        surf->move_to(logical_top_left);
-        render_scene_into_surface.capture_area(geom::Rectangle{logical_top_left, logical_size});
-        surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(s.magnification, s.magnification, 1)));
-        s.reposition_all_handles(logical_top_left, logical_size, s.magnification);
+        auto const surface_top_left =
+            s.clamp_position_to_screen(desired_top_left, logical_size, s.magnification);
+        auto const logical_top_left =
+            s.capture_position_for_surface(surface_top_left, logical_size, s.magnification);
+        apply_geometry(surf, logical_top_left, surface_top_left, s, render_scene_into_surface);
     }
 
     /// Applies visual geometry with the magnifier's logical top-left computed
@@ -836,8 +1035,9 @@ private:
         RenderSceneIntoSurface& render_scene_into_surface)
     {
         auto const logical_size = logical_size_from_visual(s.visual_size, s.magnification);
-        auto const top_left = surface_top_left_from_cursor(logical_size, s.cursor_pos);
-        apply_visual_geometry(surf, top_left, s, render_scene_into_surface);
+        auto top_left = surface_top_left_from_cursor(logical_size, s.cursor_pos);
+
+        apply_positioned_geometry(surf, top_left, s, render_scene_into_surface);
     }
 
     class Observer : public mi::CursorObserver
@@ -961,8 +1161,11 @@ private:
     protected:
         void on_drag_start(State& s, int, int) override
         {
-            if (auto const surf = s.surface.lock())
-                drag_start_magnifier_pos = surf->top_left();
+            auto const surf = s.surface.lock();
+            if (!surf)
+                return;
+
+            drag_start_magnifier_pos = surf->top_left();
         }
 
         void on_drag_move(State& s, int ax, int ay) override
@@ -970,12 +1173,15 @@ private:
             geom::Displacement const delta{
                 geom::DeltaX{ax} - grab_abs.dx,
                 geom::DeltaY{ay} - grab_abs.dy};
-            geom::Point const new_logical_tl{
+            geom::Point const new_surface_top_left{
                 drag_start_magnifier_pos.x + delta.dx,
                 drag_start_magnifier_pos.y + delta.dy};
 
             if (auto const surf = s.surface.lock())
-                self->apply_visual_geometry(surf, new_logical_tl, s, self->render_scene_into_surface);
+            {
+                self->apply_positioned_geometry(
+                    surf, new_surface_top_left, s, self->render_scene_into_surface);
+            }
         }
 
         geom::Point drag_start_magnifier_pos{};
@@ -1002,7 +1208,8 @@ private:
     ///
     /// on_drag_start records the pinned visual corner. on_drag_move measures the visual
     /// extent from pin to finger, converts it back to a logical size (/ mag), then
-    /// back-solves the logical top-left so the pinned visual corner stays put.
+    /// back-solves the surface top-left so the pinned visual corner stays put unless
+    /// keeping the resized magnifier on-screen requires clamping it.
     class ResizeDragObserver : public HandleObserver
     {
     public:
@@ -1052,7 +1259,7 @@ private:
             int const w = new_logical_size.width.as_int();
             int const h = new_logical_size.height.as_int();
 
-            geom::Point const new_logical_tl{
+            geom::Point const new_surface_top_left{
                 pin_pos.x.as_int() - outer * w,
                 pin_pos.y.as_int() - outer * h,
             };
@@ -1063,7 +1270,8 @@ private:
 
             s.visual_size = new_logical_size * mag;
 
-            self->apply_visual_geometry(surf, new_logical_tl, s, self->render_scene_into_surface);
+            self->apply_positioned_geometry(
+                surf, new_surface_top_left, s, self->render_scene_into_surface);
         }
 
         geom::Point pin_pos{};
@@ -1134,6 +1342,21 @@ private:
     RenderSceneIntoSurface render_scene_into_surface;
     mir::Synchronised<State> state;
 };
+
+void miral::Magnifier::Self::DisplayConfigObserver::update_bounds(
+    std::shared_ptr<mg::DisplayConfiguration const> const& config)
+{
+    geom::Rectangles rects;
+    config->for_each_output(
+        [&rects](mg::DisplayConfigurationOutput const& output)
+        {
+            if (output.used && output.connected)
+                rects.add(output.extents());
+        });
+
+    auto s = state.lock();
+    s->screen_bounds = rects.size() > 0 ? rects.bounding_rectangle() : geom::Rectangle{};
+}
 
 miral::Magnifier::Magnifier()
     : self(std::make_shared<Self>())

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -797,8 +797,7 @@ private:
             std::lock_guard lock(self->mutex);
             if (action == mir_pointer_action_button_down &&
                 mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                self->set_magnification_locked(
-                    std::clamp(self->magnification + delta, min_magnification + zoom_step, max_magnification));
+                apply_zoom_locked();
         }
 
         void handle_touch(MirTouchEvent const* tev)
@@ -809,8 +808,14 @@ private:
 
             std::lock_guard lock(self->mutex);
             if (action == mir_touch_action_down)
-                self->set_magnification_locked(
-                    std::clamp(self->magnification + delta, min_magnification + zoom_step, max_magnification));
+                apply_zoom_locked();
+        }
+
+        /// Clamps and applies the zoom step. Callers must hold self->mutex.
+        void apply_zoom_locked()
+        {
+            self->set_magnification_locked(
+                std::clamp(self->magnification + delta, min_magnification + zoom_step, max_magnification));
         }
 
         Self* self;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -641,7 +641,7 @@ public:
             s->zoom_in.init(server, HandleKind::zoom_in, capture_compositor_id);
             s->zoom_out.init(server, HandleKind::zoom_out, capture_compositor_id);
 
-            if (s->decoupled)
+            if (!s->follow_cursor)
             {
                 s->attach_observers(this);
 
@@ -714,9 +714,10 @@ public:
 
         if (enable)
         {
-            if (s->decoupled)
+            if (!s->follow_cursor)
             {
-                // Place surface at last known cursor position when enabling in decoupled mode.
+                // Place surface at last known cursor position when enabling
+                // and not following the cursor.
                 place_at_cursor(surf, *s, render_scene_into_surface);
                 s->show_all_handles();
             }
@@ -751,39 +752,41 @@ public:
         return render_scene_into_surface.capture_area().size;
     }
 
-    void set_decoupled(bool new_decoupled)
+    void follow_cursor()
     {
         auto s = state.lock();
-        if (s->decoupled == new_decoupled)
+        if (s->follow_cursor)
             return;
 
-        s->decoupled = new_decoupled;
-
-        if (s->decoupled)
+        s->follow_cursor = true;
+        for (auto* handle : {&s->drag, &s->resize, &s->zoom_in, &s->zoom_out})
         {
-            if (auto const surf = s->surface.lock())
-            {
-                s->attach_observers(this);
-                if (s->default_enabled)
-                {
-                    auto const logical_rect = render_scene_into_surface.capture_area();
-                    apply_positioned_geometry(
-                        surf, logical_rect.top_left, *s, render_scene_into_surface);
-                    s->show_all_handles();
-                }
-            }
+            handle->detach_observer();
+            handle->hide();
         }
-        else
-        {
-            for (auto* handle : {&s->drag, &s->resize, &s->zoom_in, &s->zoom_out})
-            {
-                handle->detach_observer();
-                handle->hide();
-            }
 
-            if (auto const surf = s->surface.lock(); surf && s->default_enabled)
+        if (auto const surf = s->surface.lock(); surf && s->default_enabled)
+        {
+            place_at_cursor(surf, *s, render_scene_into_surface);
+        }
+    }
+
+    void stop_following_cursor()
+    {
+        auto s = state.lock();
+        if (!s->follow_cursor)
+            return;
+
+        s->follow_cursor = false;
+
+        if (auto const surf = s->surface.lock())
+        {
+            s->attach_observers(this);
+            if (s->default_enabled)
             {
-                place_at_cursor(surf, *s, render_scene_into_surface);
+                auto const logical_rect = render_scene_into_surface.capture_area();
+                apply_positioned_geometry(surf, logical_rect.top_left, *s, render_scene_into_surface);
+                s->show_all_handles();
             }
         }
     }
@@ -820,7 +823,7 @@ private:
 
         auto point_is_on_magnifier_surface(geom::PointF const& point) const -> bool
         {
-            if (!decoupled || !default_enabled)
+            if (follow_cursor || !default_enabled)
                 return false;
 
             auto const surf = surface.lock();
@@ -866,9 +869,9 @@ private:
         /// rect fits within screen_bounds (preferring to keep the top-left edge
         /// on-screen if the rect is bigger than the screen in some dimension).
         /// Used when placing the magnifier so its handles don't end up
-        /// off-screen and unreachable, e.g. after enabling/decoupling while the
-        /// cursor was near a screen edge. Returns logical_top_left unchanged if
-        /// screen bounds aren't known yet.
+        /// off-screen and unreachable, e.g. after stopping following the
+        /// cursor while it was near a screen edge. Returns logical_top_left
+        /// unchanged if screen bounds aren't known yet.
         geom::Point clamp_position_to_screen(
             geom::Point const& logical_top_left,
             geom::Size const& logical_size,
@@ -1023,13 +1026,13 @@ private:
         }
 
         /// Repositions all handle and button indicators for the given surface geometry.
-        /// No-op when not in decoupled mode.
+        /// No-op when following the cursor.
         void reposition_all_handles(
             geom::Point const& tl,
             geom::Size const& sz,
             float mag)
         {
-            if (!decoupled)
+            if (follow_cursor)
                 return;
 
             auto const [dp, rp] = compute_both_handle_positions(tl, sz, mag);
@@ -1046,7 +1049,7 @@ private:
             {
                 auto const old_logical_rect = render_scene_into_surface.capture_area();
 
-                if (decoupled)
+                if (!follow_cursor)
                 {
                     auto const old_surface_centre =
                         center(surf->top_left(), old_logical_rect.size);
@@ -1129,7 +1132,7 @@ private:
         /// that the magnifier's on-screen footprint stays the same.
         geom::Size visual_size;
         bool default_enabled{false};
-        bool decoupled{false};
+        bool follow_cursor{true};
     };
 
     struct GeometryPositions
@@ -1179,7 +1182,7 @@ private:
         State& s,
         RenderSceneIntoSurface& render_scene_into_surface)
     {
-        if (!s.decoupled)
+        if (s.follow_cursor)
         {
             apply_visual_geometry(surf, desired_top_left, s, render_scene_into_surface);
             return;
@@ -1223,8 +1226,7 @@ private:
             auto s = self->state.lock();
             s->cursor_pos = geom::Point{abs_x, abs_y};
 
-            // In decoupled mode the surface stays put; only update when coupled.
-            if (s->decoupled)
+            if (!s->follow_cursor)
                 return;
 
             auto const surf = s->surface.lock();
@@ -1521,7 +1523,7 @@ auto miral::Magnifier::Self::InputFilter::handle(MirEvent const& event) -> bool
         return false;
 
     auto const s = state.lock();
-    if (!s->decoupled || !s->default_enabled)
+    if (s->follow_cursor || !s->default_enabled)
     {
         reset_gestures();
         return false;
@@ -1679,12 +1681,12 @@ miral::Magnifier::Magnifier(live_config::Store& config_store)
             capture_size(size);
         });
     config_store.add_bool_attribute(
-        {"magnifier", "decouple"},
-        "Whether the magnifier is decoupled from the cursor position",
+        {"magnifier", "follow_cursor"},
+        "Whether the magnifier follows the cursor",
         [this](live_config::Key const&, std::optional<bool> val)
         {
             if (val.has_value())
-                decouple(*val);
+                *val ? follow_cursor() : stop_following_cursor();
         });
 }
 
@@ -1717,9 +1719,15 @@ miral::Magnifier& miral::Magnifier::capture_size(mir::geometry::Size const& size
     return *this;
 }
 
-miral::Magnifier& miral::Magnifier::decouple(bool decoupled)
+miral::Magnifier& miral::Magnifier::follow_cursor()
 {
-    self->set_decoupled(decoupled);
+    self->follow_cursor();
+    return *this;
+}
+
+miral::Magnifier& miral::Magnifier::stop_following_cursor()
+{
+    self->stop_following_cursor();
     return *this;
 }
 

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -765,6 +765,23 @@ private:
             cursor_pos.y.as_int() - window_size.height.as_int() / 2};
     }
 
+    /// Pixel-space bounds of the magnified visual surface.
+    struct VisualBounds { int x, y, w, h; };
+
+    /// Returns the pixel-space top-left and size of the visual magnifier surface
+    /// given its logical capture rectangle and magnification factor.
+    VisualBounds compute_visual_bounds(
+        geom::Point const& logical_top_left,
+        geom::Size const& logical_size,
+        float mag) const
+    {
+        int const w = mag * logical_size.width.as_int();
+        int const h = mag * logical_size.height.as_int();
+        int const x = logical_top_left.x.as_int() - (mag - 1.0f) / 2.0f * logical_size.width.as_int();
+        int const y = logical_top_left.y.as_int() - (mag - 1.0f) / 2.0f * logical_size.height.as_int();
+        return {x, y, w, h};
+    }
+
     /// Computes the position of the circular drag handle indicator.
     ///
     /// The handle is placed at the visual bottom-right corner of the magnifier.
@@ -773,12 +790,7 @@ private:
         geom::Size const& logical_size,
         float mag) const
     {
-        int const vis_w = mag * logical_size.width.as_int();
-        int const vis_h = mag * logical_size.height.as_int();
-
-        // Visual top-left of the magnifier.
-        int const vis_x = logical_top_left.x.as_int() - (mag - 1.0f) / 2.0f * logical_size.width.as_int();
-        int const vis_y = logical_top_left.y.as_int() - (mag - 1.0f) / 2.0f * logical_size.height.as_int();
+        auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
 
         int hx = vis_x + vis_w - drag_handle_diameter;
         int hy = vis_y + vis_h - drag_handle_diameter;
@@ -794,9 +806,7 @@ private:
         geom::Size const& logical_size,
         float mag) const
     {
-        // Visual top-left of the magnifier.
-        int const vis_x = logical_top_left.x.as_int() - (mag - 1.0f) / 2.0f * logical_size.width.as_int();
-        int const vis_y = logical_top_left.y.as_int() - (mag - 1.0f) / 2.0f * logical_size.height.as_int();
+        auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
 
         // Default: circle centred on the top-left corner of the visual magnifier,
         // so it sits half outside the content area.

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -227,40 +227,41 @@ private:
         // Draw a drag-pan icon: four arrowheads (N/S/E/W) connected by slim stems.
         static int constexpr tip_dist  = 15;
         static int constexpr head_len  = 5;
-        static int constexpr stem_half = 1;
+        static int constexpr stem_thickness = 3;
+        static int constexpr base_dist = (tip_dist - head_len);
 
         int const w  = painter.buffer_width();
         int const h  = painter.buffer_height();
-        int const ci = (w - 1) / 2;
-        int const cj = (h - 1) / 2;
-        int const tip_n  = cj - tip_dist;
-        int const tip_s  = cj + tip_dist;
-        int const tip_w  = ci - tip_dist;
-        int const tip_e  = ci + tip_dist;
-        int const base_n = cj - (tip_dist - head_len);
-        int const base_s = cj + (tip_dist - head_len);
-        int const base_w = ci - (tip_dist - head_len);
-        int const base_e = ci + (tip_dist - head_len);
+        int const center_x = (w - 1) / 2;
+        int const center_y = (h - 1) / 2;
+        int const tip_n  = center_y - tip_dist;
+        int const tip_s  = center_y + tip_dist;
+        int const tip_w  = center_x - tip_dist;
+        int const tip_e  = center_x + tip_dist;
+        int const base_n = center_y - base_dist;
+        int const base_s = center_y + base_dist;
+        int const base_w = center_x - base_dist;
+        int const base_e = center_x + base_dist;
 
         // Stems
-        painter.draw_vertical_line(ci - stem_half, base_n, base_s, stem_half * 2 + 1, icon_grey, icon_alpha);
-        painter.draw_horizontal_line(base_w, base_e, cj - stem_half, stem_half * 2 + 1, icon_grey, icon_alpha);
+        painter.draw_vertical_line(center_x - stem_thickness / 2, base_n, base_s, stem_thickness, icon_grey, icon_alpha);
+        painter.draw_horizontal_line(base_w, base_e, center_y - stem_thickness / 2, stem_thickness, icon_grey, icon_alpha);
 
         // North arrowhead — rows from tip_n+1 to base_n, width grows by 1 px per row
         for (int y = tip_n + 1; y <= base_n; ++y)
-            painter.draw_horizontal_line(ci - (y - tip_n), ci + (y - tip_n), y, 1, icon_grey, icon_alpha);
+            painter.draw_horizontal_line(center_x - (y - tip_n), center_x + (y - tip_n), y, 1, icon_grey, icon_alpha);
 
         // South arrowhead
         for (int y = base_s; y < tip_s; ++y)
-            painter.draw_horizontal_line(ci - (tip_s - y), ci + (tip_s - y), y, 1, icon_grey, icon_alpha);
+            painter.draw_horizontal_line(center_x - (tip_s - y), center_x + (tip_s - y), y, 1, icon_grey, icon_alpha);
 
         // West arrowhead — columns from tip_w+1 to base_w
         for (int x = tip_w + 1; x <= base_w; ++x)
-            painter.draw_vertical_line(x, cj - (x - tip_w), cj + (x - tip_w), 1, icon_grey, icon_alpha);
+            painter.draw_vertical_line(x, center_y - (x - tip_w), center_y + (x - tip_w), 1, icon_grey, icon_alpha);
 
         // East arrowhead
         for (int x = base_e; x < tip_e; ++x)
-            painter.draw_vertical_line(x, cj - (tip_e - x), cj + (tip_e - x), 1, icon_grey, icon_alpha);
+            painter.draw_vertical_line(x, center_y - (tip_e - x), center_y + (tip_e - x), 1, icon_grey, icon_alpha);
     }
 
     static void fill_resize_buffer(mg::Buffer& buffer)

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -67,6 +67,12 @@ auto const drag_handle_diameter = 48;
 /// Magnification step applied by each zoom button press.
 auto const zoom_step = 0.5f;
 
+/// Painter colour/alpha constants for handle indicator graphics.
+uint8_t constexpr disc_grey  = 40;
+uint8_t constexpr disc_alpha = 200;
+uint8_t constexpr icon_grey  = 210;
+uint8_t constexpr icon_alpha = 230;
+
 enum class HandleKind { drag, resize, zoom_in, zoom_out };
 
 class HandleIndicator : public ms::BasicSurface
@@ -212,7 +218,7 @@ private:
     {
         BufferPainter painter{buffer};
         painter.clear();
-        painter.fill_circle(40, 200);
+        painter.fill_circle(disc_grey, disc_alpha);
 
         // Draw a drag-pan icon: four arrowheads (N/S/E/W) connected by slim stems.
         static int constexpr tip_dist  = 15;
@@ -233,31 +239,31 @@ private:
         int const base_e = ci + (tip_dist - head_len);
 
         // Stems
-        painter.draw_vertical_line(ci - stem_half, base_n, base_s, stem_half * 2 + 1, 210, 230);
-        painter.draw_horizontal_line(base_w, base_e, cj - stem_half, stem_half * 2 + 1, 210, 230);
+        painter.draw_vertical_line(ci - stem_half, base_n, base_s, stem_half * 2 + 1, icon_grey, icon_alpha);
+        painter.draw_horizontal_line(base_w, base_e, cj - stem_half, stem_half * 2 + 1, icon_grey, icon_alpha);
 
         // North arrowhead — rows from tip_n+1 to base_n, width grows by 1 px per row
         for (int y = tip_n + 1; y <= base_n; ++y)
-            painter.draw_horizontal_line(ci - (y - tip_n), ci + (y - tip_n), y, 1, 210, 230);
+            painter.draw_horizontal_line(ci - (y - tip_n), ci + (y - tip_n), y, 1, icon_grey, icon_alpha);
 
         // South arrowhead
         for (int y = base_s; y < tip_s; ++y)
-            painter.draw_horizontal_line(ci - (tip_s - y), ci + (tip_s - y), y, 1, 210, 230);
+            painter.draw_horizontal_line(ci - (tip_s - y), ci + (tip_s - y), y, 1, icon_grey, icon_alpha);
 
         // West arrowhead — columns from tip_w+1 to base_w
         for (int x = tip_w + 1; x <= base_w; ++x)
-            painter.draw_vertical_line(x, cj - (x - tip_w), cj + (x - tip_w), 1, 210, 230);
+            painter.draw_vertical_line(x, cj - (x - tip_w), cj + (x - tip_w), 1, icon_grey, icon_alpha);
 
         // East arrowhead
         for (int x = base_e; x < tip_e; ++x)
-            painter.draw_vertical_line(x, cj - (tip_e - x), cj + (tip_e - x), 1, 210, 230);
+            painter.draw_vertical_line(x, cj - (tip_e - x), cj + (tip_e - x), 1, icon_grey, icon_alpha);
     }
 
     static void fill_resize_buffer(mg::Buffer& buffer)
     {
         BufferPainter painter{buffer};
         painter.clear();
-        painter.fill_circle(40, 200);
+        painter.fill_circle(disc_grey, disc_alpha);
 
         // Corner bracket: two 2-px arms meeting at the top-left corner, which is
         // where the resize handle always sits within the magnifier surface.
@@ -268,15 +274,15 @@ private:
         int const corner_x =  w / 4;
         int const corner_y =  h / 4;
 
-        painter.draw_horizontal_line(corner_x, corner_x + arm_len, corner_y, thickness, 210, 230);
-        painter.draw_vertical_line(corner_x, corner_y, corner_y + arm_len, thickness, 210, 230);
+        painter.draw_horizontal_line(corner_x, corner_x +  arm_len, corner_y, thickness, icon_grey, icon_alpha);
+        painter.draw_vertical_line(corner_x, corner_y , corner_y +  arm_len, thickness, icon_grey, icon_alpha);
     }
 
     static void fill_zoom_buffer(mg::Buffer& buffer, bool zoom_in)
     {
         BufferPainter painter{buffer};
         painter.clear();
-        painter.fill_circle(40, 200);
+        painter.fill_circle(disc_grey, disc_alpha);
 
         // Draw + (zoom in) or – (zoom out) symbol.
         int const w = painter.buffer_width();
@@ -289,8 +295,8 @@ private:
             (w + bar_len) / 2 - 1,
             (h - bar_thickness) / 2,
             bar_thickness,
-            210,
-            230);
+            icon_grey,
+            icon_alpha);
 
         if (zoom_in)
             painter.draw_vertical_line(
@@ -298,8 +304,8 @@ private:
                 (h - bar_len) / 2,
                 (h + bar_len) / 2 - 1,
                 bar_thickness,
-                210,
-                230);
+                icon_grey,
+                icon_alpha);
     }
 
     SoftwareBufferPool mutable pool;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -441,11 +441,38 @@ public:
 
         server.add_stop_callback([&]
         {
-            std::lock_guard lock(mutex);
-            if (auto const locked = cursor_multiplexer.lock())
-                locked->unregister_interest(*observer);
+            // The naive way to do this would be:
+            //  - lock self->mutex
+            //  - unregister observers
+            //
+            // This may cause a deadlock in the following case:
+            //  - lock self->mutex
+            //  - on another thread, the observer gets called into, attempts to lock self->mutex and blocks
+            //  - unregistering the observer waits until the observer returns, which it will not since its waiting on the lock
+            //  - deadlock: unregister waiting on observer, observer waiting on lock held to unregister
+            //
+            //  The lock is only required to grab references to the observers
+            //  and handles, so we lock, copy, then unregister without holding
+            //  the lock.
 
-            for (auto* handle : {&drag, &resize, &zoom_in, &zoom_out})
+            std::shared_ptr<mi::CursorObserverMultiplexer> local_cursor_mux;
+            std::shared_ptr<Observer> local_observer;
+            Handle local_drag, local_resize, local_zoom_in, local_zoom_out;
+            {
+                std::lock_guard lock(mutex);
+
+                local_cursor_mux = cursor_multiplexer.lock();
+                local_observer = observer;
+                local_drag = std::exchange(drag, {});
+                local_resize = std::exchange(resize, {});
+                local_zoom_in = std::exchange(zoom_in, {});
+                local_zoom_out = std::exchange(zoom_out, {});
+            }
+
+            if (local_cursor_mux && local_observer)
+                local_cursor_mux->unregister_interest(*local_observer);
+
+            for (auto* handle : {&local_drag, &local_resize, &local_zoom_in, &local_zoom_out})
                 handle->reset();
         });
     }

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -105,53 +105,115 @@ public:
     }
 
 private:
-    static void fill_drag_buffer(mg::Buffer& buffer)
+    class BufferPainter
     {
-        auto const writable = mrs::as_write_mappable(std::shared_ptr<mg::Buffer>(&buffer, [](mg::Buffer*) {}));
-        auto const mapping  = writable->map_writeable();
-        auto* const pixels  = reinterpret_cast<uint8_t*>(mapping->data());
-        int const stride    = mapping->stride().as_int();
-        int const w         = buffer.size().width.as_int();
-        int const h         = buffer.size().height.as_int();
-
-        // For mir_pixel_format_argb_8888 on little-endian: memory layout [B, G, R, A].
-        auto const set_pixel = [&](int x, int y, uint8_t grey, uint8_t alpha)
+    public:
+        explicit BufferPainter(mg::Buffer& buffer) :
+            writable{mrs::as_write_mappable(std::shared_ptr<mg::Buffer>(&buffer, [](mg::Buffer*) {}))},
+            mapping{writable->map_writeable()},
+            pixels{reinterpret_cast<uint8_t*>(mapping->data())},
+            stride{mapping->stride().as_int()},
+            width{buffer.size().width.as_int()},
+            height{buffer.size().height.as_int()}
         {
-            uint8_t* p = pixels + y * stride + x * 4;
-            p[0] = grey; p[1] = grey; p[2] = grey; p[3] = alpha;
-        };
+        }
 
-        // Start fully transparent.
-        for (int y = 0; y < h; ++y)
-            for (int x = 0; x < w; ++x)
+        void clear()
+        {
+            for (int y = 0; y < height; ++y)
+                for (int x = 0; x < width; ++x)
                 set_pixel(x, y, 0, 0);
+        }
 
-        // Draw a filled circle with a semi-transparent dark background.
-        float const cx   = (w - 1) / 2.0f;
-        float const cy   = (h - 1) / 2.0f;
-        float const r    = std::min(cx, cy);
-        float const r_sq = r * r;
-
-        for (int y = 0; y < h; ++y)
+        void fill_circle(uint8_t grey, uint8_t alpha)
         {
-            for (int x = 0; x < w; ++x)
+            float const cx = (width - 1) / 2.0f;
+            float const cy = (height - 1) / 2.0f;
+            float const r = std::min(cx, cy);
+            float const r_sq = r * r;
+
+            for (int y = 0; y < height; ++y)
             {
-                float const dx = x - cx;
-                float const dy = y - cy;
-                if (dx * dx + dy * dy <= r_sq)
-                    set_pixel(x, y, 40, 200);
+                for (int x = 0; x < width; ++x)
+                {
+                    float const dx = x - cx;
+                    float const dy = y - cy;
+                    if (dx * dx + dy * dy <= r_sq)
+                        set_pixel(x, y, grey, alpha);
+                }
             }
         }
 
-        // Draw a drag-pan icon: four arrowheads (N/S/E/W) connected by slim stems.
-        // head_half == head_len so the half-width grows by exactly 1 px per row, with
-        // no isolated single-pixel tip rows (the tip row itself is skipped).
-        static int constexpr tip_dist  = 15; // distance from centre to arrow tip
-        static int constexpr head_len  = 5;  // rows from stem junction to tip (== head_half)
-        static int constexpr stem_half = 1;  // half-width of connecting stems (3 px total)
+        void draw_horizontal_line(
+            int x0,
+            int x1,
+            int y,
+            int thickness,
+            uint8_t grey,
+            uint8_t alpha)
+        {
+            for (int t = 0; t < thickness; ++t)
+                for (int x = std::min(x0, x1); x <= std::max(x0, x1); ++x)
+                    set_pixel(x, y + t, grey, alpha);
+        }
 
-        int const ci     = static_cast<int>(cx);
-        int const cj     = static_cast<int>(cy);
+        void draw_vertical_line(
+            int x,
+            int y0,
+            int y1,
+            int thickness,
+            uint8_t grey,
+            uint8_t alpha)
+        {
+            for (int t = 0; t < thickness; ++t)
+                for (int y = std::min(y0, y1); y <= std::max(y0, y1); ++y)
+                    set_pixel(x + t, y, grey, alpha);
+        }
+
+        auto buffer_width() const -> int
+        {
+            return width;
+        }
+
+        auto buffer_height() const -> int
+        {
+            return height;
+        }
+
+    private:
+        void set_pixel(int x, int y, uint8_t grey, uint8_t alpha)
+        {
+            if (x < 0 || x >= width || y < 0 || y >= height)
+                return;
+
+            // For mir_pixel_format_argb_8888 on little-endian: memory layout [B, G, R, A].
+            uint8_t* p = pixels + y * stride + x * 4;
+            p[0] = grey; p[1] = grey; p[2] = grey; p[3] = alpha;
+        }
+
+        std::shared_ptr<mrs::WriteMappable> const writable;
+        std::unique_ptr<mrs::Mapping<std::byte>> const mapping;
+        uint8_t* const pixels;
+        int const stride;
+        int const width;
+        int const height;
+    };
+
+    static void fill_drag_buffer(mg::Buffer& buffer)
+    {
+        BufferPainter painter{buffer};
+        painter.clear();
+        painter.fill_circle(40, 200);
+
+        // Draw a drag-pan icon: four arrowheads (N/S/E/W) connected by slim stems.
+        static int constexpr tip_dist  = 15;
+        static int constexpr head_len  = 5;
+        static int constexpr stem_half = 1;
+
+        int const w  = painter.buffer_width();
+        int const h  = painter.buffer_height();
+        int const ci = (w - 1) / 2;
+        int const cj = (h - 1) / 2;
         int const tip_n  = cj - tip_dist;
         int const tip_s  = cj + tip_dist;
         int const tip_w  = ci - tip_dist;
@@ -161,93 +223,44 @@ private:
         int const base_w = ci - (tip_dist - head_len);
         int const base_e = ci + (tip_dist - head_len);
 
-        auto const in_icon = [&](int x, int y) -> bool
-        {
-            // Vertical stem
-            if (std::abs(x - ci) <= stem_half && y >= base_n && y <= base_s)
-                return true;
-            // Horizontal stem
-            if (std::abs(y - cj) <= stem_half && x >= base_w && x <= base_e)
-                return true;
-            // North arrowhead — skip y==tip_n so the tip starts at 3 px wide, not 1
-            if (y > tip_n && y <= base_n)
-            {
-                if (std::abs(x - ci) <= y - tip_n) return true;
-            }
-            // South arrowhead
-            if (y >= base_s && y < tip_s)
-            {
-                if (std::abs(x - ci) <= tip_s - y) return true;
-            }
-            // West arrowhead
-            if (x > tip_w && x <= base_w)
-            {
-                if (std::abs(y - cj) <= x - tip_w) return true;
-            }
-            // East arrowhead
-            if (x >= base_e && x < tip_e)
-            {
-                if (std::abs(y - cj) <= tip_e - x) return true;
-            }
-            return false;
-        };
+        // Stems
+        painter.draw_vertical_line(ci - stem_half, base_n, base_s, stem_half * 2 + 1, 210, 230);
+        painter.draw_horizontal_line(base_w, base_e, cj - stem_half, stem_half * 2 + 1, 210, 230);
 
-        for (int y = 0; y < h; ++y)
-            for (int x = 0; x < w; ++x)
-                if (in_icon(x, y))
-                    set_pixel(x, y, 210, 230);
+        // North arrowhead — rows from tip_n+1 to base_n, width grows by 1 px per row
+        for (int y = tip_n + 1; y <= base_n; ++y)
+            painter.draw_horizontal_line(ci - (y - tip_n), ci + (y - tip_n), y, 1, 210, 230);
+
+        // South arrowhead
+        for (int y = base_s; y < tip_s; ++y)
+            painter.draw_horizontal_line(ci - (tip_s - y), ci + (tip_s - y), y, 1, 210, 230);
+
+        // West arrowhead — columns from tip_w+1 to base_w
+        for (int x = tip_w + 1; x <= base_w; ++x)
+            painter.draw_vertical_line(x, cj - (x - tip_w), cj + (x - tip_w), 1, 210, 230);
+
+        // East arrowhead
+        for (int x = base_e; x < tip_e; ++x)
+            painter.draw_vertical_line(x, cj - (tip_e - x), cj + (tip_e - x), 1, 210, 230);
     }
 
     static void fill_resize_buffer(mg::Buffer& buffer)
     {
-        auto const writable = mrs::as_write_mappable(std::shared_ptr<mg::Buffer>(&buffer, [](mg::Buffer*) {}));
-        auto const mapping  = writable->map_writeable();
-        auto* const pixels  = reinterpret_cast<uint8_t*>(mapping->data());
-        int const stride    = mapping->stride().as_int();
-        int const w         = buffer.size().width.as_int();
-        int const h         = buffer.size().height.as_int();
-
-        auto const set_pixel = [&](int x, int y, uint8_t grey, uint8_t alpha)
-        {
-            if (x < 0 || x >= w || y < 0 || y >= h) return;
-            uint8_t* p = pixels + y * stride + x * 4;
-            p[0] = grey; p[1] = grey; p[2] = grey; p[3] = alpha;
-        };
-
-        // Start fully transparent.
-        for (int y = 0; y < h; ++y)
-            for (int x = 0; x < w; ++x)
-                set_pixel(x, y, 0, 0);
-
-        // Draw a filled circle with a semi-transparent dark background.
-        float const cx_f  = (w - 1) / 2.0f;
-        float const cy_f  = (h - 1) / 2.0f;
-        float const r     = std::min(cx_f, cy_f);
-        float const r_sq  = r * r;
-        for (int y = 0; y < h; ++y)
-            for (int x = 0; x < w; ++x)
-            {
-                float const dx = x - cx_f, dy = y - cy_f;
-                if (dx * dx + dy * dy <= r_sq)
-                    set_pixel(x, y, 40, 200);
-            }
+        BufferPainter painter{buffer};
+        painter.clear();
+        painter.fill_circle(40, 200);
 
         // Corner bracket: two 2-px arms meeting at the top-left corner, which is
         // where the resize handle always sits within the magnifier surface.
         static int constexpr arm_len   = 12;
         static int constexpr thickness = 2;
-        int const corner_x = w / 4 ;
-        int const corner_y = h / 4;
+        int const w = painter.buffer_width();
+        int const h = painter.buffer_height();
+        int const corner_x =  w / 4;
+        int const corner_y =  h / 4;
 
-        // Horizontal arm
-        for (int t = 0; t < thickness; ++t)
-            for (int i = 0; i <= arm_len; ++i)
-                set_pixel(corner_x + i, corner_y + t, 210, 230);
-
-        // Vertical arm (skip corner pixel to avoid double-draw)
-        for (int t = 0; t < thickness; ++t)
-            for (int i = 1; i <= arm_len; ++i)
-                set_pixel(corner_x + t, corner_y + i, 210, 230);
+        painter.draw_horizontal_line(corner_x, corner_x + arm_len, corner_y, thickness, 210, 230);
+        painter.draw_vertical_line(corner_x, corner_y, corner_y + arm_len, thickness, 210, 230);
     }
 
     SoftwareBufferPool mutable pool;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -74,7 +74,8 @@ static std::string name_for_kind(HandleKind kind)
     case HandleKind::zoom_in:  return "magnifier-zoom-in-handle";
     case HandleKind::zoom_out: return "magnifier-zoom-out-handle";
     }
-    return "magnifier-handle";
+
+    std::unreachable();
 }
 
 class HandleIndicator : public ms::BasicSurface

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -241,9 +241,7 @@ private:
 
             // For mir_pixel_format_argb_8888 on little-endian: memory layout [B, G, R, A].
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            std::span<std::uint8_t> const pixels{
-                reinterpret_cast<std::uint8_t*>(mapping->data()),
-                mapping->len()};
+            std::span<std::uint8_t> const pixels{reinterpret_cast<std::uint8_t*>(mapping->data()), mapping->len()};
             auto const offset = y * stride.as_value() + x * MIR_BYTES_PER_PIXEL(format);
             auto const pixel = pixels.subspan(offset, MIR_BYTES_PER_PIXEL(format));
             pixel[0] = pixel[1] = pixel[2] = grey;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -1689,13 +1689,21 @@ miral::Magnifier::Magnifier(live_config::Store& config_store)
             size.height = geom::Height(*val);
             capture_size(size);
         });
-    config_store.add_bool_attribute(
-        {"magnifier", "follow_cursor"},
-        "Whether the magnifier follows the cursor",
-        [this](live_config::Key const&, std::optional<bool> val)
+    config_store.add_string_attribute(
+        {"magnifier", "behavior"},
+        "What behavior the magnifier should exhibit",
+        [this](live_config::Key const&, std::optional<std::string_view> val)
         {
-            if (val.has_value())
-                *val ? follow_cursor() : stop_following_cursor();
+            if (!val.has_value())
+                return;
+
+            if (*val == "follow_cursor")
+                set_behavior(Behavior::follow_cursor);
+            else if (*val == "freely_positioned")
+                set_behavior(Behavior::freely_positioned);
+            else
+                mir::log_warning(
+                    "Config key 'magnifier.behavior' should be either 'follow_cursor' or 'freely_positioned'");
         });
 }
 
@@ -1728,15 +1736,17 @@ miral::Magnifier& miral::Magnifier::capture_size(mir::geometry::Size const& size
     return *this;
 }
 
-miral::Magnifier& miral::Magnifier::follow_cursor()
+miral::Magnifier& miral::Magnifier::set_behavior(Behavior behavior)
 {
-    self->follow_cursor();
-    return *this;
-}
-
-miral::Magnifier& miral::Magnifier::stop_following_cursor()
-{
-    self->stop_following_cursor();
+    switch (behavior)
+    {
+    case Behavior::follow_cursor:
+        self->follow_cursor();
+        break;
+    case Behavior::freely_positioned:
+        self->stop_following_cursor();
+        break;
+    }
     return *this;
 }
 

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -422,10 +422,7 @@ public:
 
             if (decoupled)
             {
-                drag.attach_observer<DragHandleObserver>(this);
-                resize.attach_observer<ResizeDragObserver>(this);
-                zoom_in.attach_observer<ZoomButtonObserver>(this, +zoom_step);
-                zoom_out.attach_observer<ZoomButtonObserver>(this, -zoom_step);
+                attach_observers_locked();
 
                 if (auto const surf = surface.lock(); surf && default_enabled)
                 {
@@ -505,11 +502,7 @@ public:
         {
             if (auto const surf = surface.lock())
             {
-                drag.attach_observer<DragHandleObserver>(this);
-                resize.attach_observer<ResizeDragObserver>(this);
-                zoom_in.attach_observer<ZoomButtonObserver>(this, +zoom_step);
-                zoom_out.attach_observer<ZoomButtonObserver>(this, -zoom_step);
-
+                attach_observers_locked();
                 if (default_enabled)
                 {
                     reposition_all_handles_locked(surf->top_left(), surf->window_size(), magnification);
@@ -963,6 +956,16 @@ private:
     {
         for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
             h->hide();
+    }
+
+    /// Creates and registers concrete observers on each handle. Guards against
+    /// missing indicators. Callers must hold mutex.
+    void attach_observers_locked()
+    {
+        drag.attach_observer<DragHandleObserver>(this);
+        resize.attach_observer<ResizeDragObserver>(this);
+        zoom_in.attach_observer<ZoomButtonObserver>(this, +zoom_step);
+        zoom_out.attach_observer<ZoomButtonObserver>(this, -zoom_step);
     }
 
     std::mutex mutex;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -129,18 +129,16 @@ private:
         explicit BufferPainter(mg::Buffer& buffer) :
             writable{mrs::as_write_mappable(std::shared_ptr<mg::Buffer>(&buffer, [](mg::Buffer*) {}))},
             mapping{writable->map_writeable()},
-            pixels{reinterpret_cast<uint8_t*>(mapping->data())},
             stride{mapping->stride().as_int()},
             width{buffer.size().width.as_int()},
             height{buffer.size().height.as_int()}
         {
+            assert(mapping->format() == format);
         }
 
         void clear()
         {
-            for (int y = 0; y < height; ++y)
-                for (int x = 0; x < width; ++x)
-                    set_pixel(x, y, 0, 0);
+            std::memset(mapping->data(), 0, mapping->len());
         }
 
         void fill_circle(uint8_t grey, uint8_t alpha)
@@ -205,13 +203,16 @@ private:
                 return;
 
             // For mir_pixel_format_argb_8888 on little-endian: memory layout [B, G, R, A].
-            uint8_t* p = pixels + y * stride + x * 4;
-            p[0] = grey; p[1] = grey; p[2] = grey; p[3] = alpha;
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            auto* pixels = reinterpret_cast<std::uint8_t*>(mapping->data());
+            auto* p = pixels + y * stride + x * MIR_BYTES_PER_PIXEL(format);
+            p[0] = p[1] = p[2] = grey;
+            p[3] = alpha;
         }
 
+        static auto constexpr format = mir_pixel_format_argb_8888;
         std::shared_ptr<mrs::WriteMappable> const writable;
         std::unique_ptr<mrs::Mapping<std::byte>> const mapping;
-        uint8_t* const pixels;
         int const stride;
         int const width;
         int const height;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -44,6 +44,7 @@
 
 #include <glm/gtc/matrix_transform.hpp>
 
+#include <span>
 
 namespace mi = mir::input;
 namespace ms = mir::scene;
@@ -68,13 +69,13 @@ auto const drag_handle_diameter = 48;
 auto const zoom_stack_padding = 8;
 
 /// Height of the vertical zoom-in/zoom-out button stack.
-auto const zoom_stack_height = 2 * drag_handle_diameter + zoom_stack_padding;
+geom::Height const zoom_stack_height{2 * drag_handle_diameter + zoom_stack_padding};
 
 /// Minimum on-screen (visual) width/height of the magnifier surface, in pixels.
 /// Derived so the drag handle (bottom-right corner) and the zoom button stack
 /// (right edge, vertically centred) never overlap each other: the drag handle
 /// needs a full diameter of clearance both above and below the centred stack.
-auto const min_visual_dimension = 2 * drag_handle_diameter + zoom_stack_height;
+auto const min_visual_dimension = 2 * drag_handle_diameter + zoom_stack_height.as_int();
 
 /// Magnification step applied by each zoom button press.
 auto const zoom_step = 0.25f;
@@ -157,12 +158,27 @@ private:
     class BufferPainter
     {
     public:
+        struct HorizontalLine
+        {
+            geom::X start;
+            geom::X end;
+            geom::Y y;
+            geom::Height thickness;
+        };
+
+        struct VerticalLine
+        {
+            geom::X x;
+            geom::Y start;
+            geom::Y end;
+            geom::Width thickness;
+        };
+
         explicit BufferPainter(mg::Buffer& buffer) :
             writable{mrs::as_write_mappable(std::shared_ptr<mg::Buffer>(&buffer, [](mg::Buffer*) {}))},
             mapping{writable->map_writeable()},
-            stride{mapping->stride().as_int()},
-            width{buffer.size().width.as_int()},
-            height{buffer.size().height.as_int()}
+            stride{mapping->stride()},
+            size{buffer.size()}
         {
             assert(mapping->format() == format);
         }
@@ -174,79 +190,78 @@ private:
 
         void fill_circle(uint8_t grey, uint8_t alpha)
         {
-            float const cx = (width - 1) / 2.0f;
-            float const cy = (height - 1) / 2.0f;
-            float const r = std::min(cx, cy);
-            float const r_sq = r * r;
+            auto const cx = geom::as_x((size.width - geom::DeltaX{1}) / 2.0f);
+            auto const cy = geom::as_y((size.height - geom::DeltaY{1}) / 2.0f);
+            auto const r = std::min(cx.as_value(), cy.as_value());
+            auto const r_sq = r * r;
 
-            for (int y = 0; y < height; ++y)
+            for (geom::Y y{0}; y < geom::as_y(size.height); y = y + geom::DeltaY{1})
             {
-                for (int x = 0; x < width; ++x)
+                for (geom::X x{0}; x < geom::as_x(size.width); x = x + geom::DeltaX{1})
                 {
-                    float const dx = x - cx;
-                    float const dy = y - cy;
-                    if (dx * dx + dy * dy <= r_sq)
-                        set_pixel(x, y, grey, alpha);
+                    auto const dx = x - cx;
+                    auto const dy = y - cy;
+                    auto const delta = dx.as_value() * dx.as_value() + dy.as_value() * dy.as_value();
+
+                    if (delta <= r_sq)
+                        set_pixel(geom::Point{x, y}, grey, alpha);
                 }
             }
         }
 
         void draw_horizontal_line(
-            int x0,
-            int x1,
-            int y,
-            int thickness,
+            HorizontalLine const& line,
             uint8_t grey,
             uint8_t alpha)
         {
-            for (int t = 0; t < thickness; ++t)
-                for (int x = std::min(x0, x1); x <= std::max(x0, x1); ++x)
-                    set_pixel(x, y + t, grey, alpha);
+            auto const true_start = std::min<geom::X>(line.start, line.end);
+            auto const true_end = std::max<geom::X>(line.start, line.end);
+            for (int t = 0; t < line.thickness.as_value(); ++t)
+                for (auto x = true_start; x <= true_end; x = x + geom::DeltaX{1})
+                    set_pixel(geom::Point{x, line.y + geom::DeltaY{t}}, grey, alpha);
         }
 
         void draw_vertical_line(
-            int x,
-            int y0,
-            int y1,
-            int thickness,
+            VerticalLine const& line,
             uint8_t grey,
             uint8_t alpha)
         {
-            for (int t = 0; t < thickness; ++t)
-                for (int y = std::min(y0, y1); y <= std::max(y0, y1); ++y)
-                    set_pixel(x + t, y, grey, alpha);
+            auto const true_start = std::min<geom::Y>(line.start, line.end);
+            auto const true_end = std::max<geom::Y>(line.start, line.end);
+            for (int t = 0; t < line.thickness.as_value(); ++t)
+                for (auto y = true_start; y <= true_end; y = y + geom::DeltaY{1})
+                    set_pixel(geom::Point{line.x + geom::DeltaX{t}, y}, grey, alpha);
         }
 
-        auto buffer_width() const -> int
+        auto buffer_size() const -> geom::Size
         {
-            return width;
-        }
-
-        auto buffer_height() const -> int
-        {
-            return height;
+            return size;
         }
 
     private:
-        void set_pixel(int x, int y, uint8_t grey, uint8_t alpha)
+        void set_pixel(geom::Point const& point, uint8_t grey, uint8_t alpha)
         {
-            if (x < 0 || x >= width || y < 0 || y >= height)
+            auto const x = point.x.as_value();
+            auto const y = point.y.as_value();
+            if (x < 0 || x >= size.width.as_value() || y < 0 || y >= size.height.as_value())
                 return;
 
             // For mir_pixel_format_argb_8888 on little-endian: memory layout [B, G, R, A].
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            auto* pixels = reinterpret_cast<std::uint8_t*>(mapping->data());
-            auto* p = pixels + y * stride + x * MIR_BYTES_PER_PIXEL(format);
-            p[0] = p[1] = p[2] = grey;
-            p[3] = alpha;
+            std::span<std::uint8_t> const pixels{
+                reinterpret_cast<std::uint8_t*>(mapping->data()),
+                mapping->len()};
+            auto const offset = y * stride.as_value() + x * MIR_BYTES_PER_PIXEL(format);
+            auto const pixel = pixels.subspan(offset, MIR_BYTES_PER_PIXEL(format));
+            pixel[0] = pixel[1] = pixel[2] = grey;
+            pixel[3] = alpha;
         }
 
         static auto constexpr format = mir_pixel_format_argb_8888;
         std::shared_ptr<mrs::WriteMappable> const writable;
         std::unique_ptr<mrs::Mapping<std::byte>> const mapping;
-        int const stride;
-        int const width;
-        int const height;
+        geom::Stride const stride;
+        geom::Size const size;
     };
 
     static void fill_drag_buffer(mg::Buffer& buffer)
@@ -261,38 +276,85 @@ private:
         static int constexpr stem_thickness = 3;
         static int constexpr base_dist = (tip_dist - head_len);
 
-        int const w  = painter.buffer_width();
-        int const h  = painter.buffer_height();
-        int const center_x = (w - 1) / 2;
-        int const center_y = (h - 1) / 2;
-        int const tip_n  = center_y - tip_dist;
-        int const tip_s  = center_y + tip_dist;
-        int const tip_w  = center_x - tip_dist;
-        int const tip_e  = center_x + tip_dist;
-        int const base_n = center_y - base_dist;
-        int const base_s = center_y + base_dist;
-        int const base_w = center_x - base_dist;
-        int const base_e = center_x + base_dist;
+        auto const [w, h]  = painter.buffer_size();
+        auto const center_x = geom::as_x((w - geom::DeltaX{1}) / 2);
+        auto const center_y = geom::as_y((h - geom::DeltaY{1}) / 2);
+        auto const tip_n  = center_y - geom::DeltaY{tip_dist};
+        auto const tip_s  = center_y + geom::DeltaY{tip_dist};
+        auto const tip_w  = center_x - geom::DeltaX{tip_dist};
+        auto const tip_e  = center_x + geom::DeltaX{tip_dist};
+        auto const base_n = center_y - geom::DeltaY{base_dist};
+        auto const base_s = center_y + geom::DeltaY{base_dist};
+        auto const base_w = center_x - geom::DeltaX{base_dist};
+        auto const base_e = center_x + geom::DeltaX{base_dist};
 
         // Stems
-        painter.draw_vertical_line(center_x - stem_thickness / 2, base_n, base_s, stem_thickness, icon_grey, icon_alpha);
-        painter.draw_horizontal_line(base_w, base_e, center_y - stem_thickness / 2, stem_thickness, icon_grey, icon_alpha);
+        painter.draw_vertical_line(
+            {
+                .x = center_x - geom::DeltaX{stem_thickness / 2},
+                .start = base_n,
+                .end = base_s,
+                .thickness = geom::Width{stem_thickness},
+            },
+            icon_grey,
+            icon_alpha);
+        painter.draw_horizontal_line(
+            {
+                .start = base_w,
+                .end = base_e,
+                .y = center_y - geom::DeltaY{stem_thickness / 2},
+                .thickness = geom::Height{stem_thickness},
+            },
+            icon_grey,
+            icon_alpha);
 
         // North arrowhead — rows from tip_n+1 to base_n, width grows by 1 px per row
-        for (int y = tip_n + 1; y <= base_n; ++y)
-            painter.draw_horizontal_line(center_x - (y - tip_n), center_x + (y - tip_n), y, 1, icon_grey, icon_alpha);
+        for (auto y = tip_n + geom::DeltaY{1}; y <= base_n; y = y + geom::DeltaY{1})
+            painter.draw_horizontal_line(
+                {
+                    .start = center_x - geom::DeltaX((y - tip_n).as_value()),
+                    .end = center_x + geom::DeltaX((y - tip_n).as_value()),
+                    .y = y,
+                    .thickness = geom::Height{1},
+                },
+                icon_grey,
+                icon_alpha);
 
         // South arrowhead
-        for (int y = base_s; y < tip_s; ++y)
-            painter.draw_horizontal_line(center_x - (tip_s - y), center_x + (tip_s - y), y, 1, icon_grey, icon_alpha);
+        for (auto y = base_s; y < tip_s; y = y + geom::DeltaY{1})
+            painter.draw_horizontal_line(
+                {
+                    .start = center_x - geom::DeltaX((tip_s - y).as_value()),
+                    .end = center_x + geom::DeltaX((tip_s - y).as_value()),
+                    .y = y,
+                    .thickness = geom::Height{1},
+                },
+                icon_grey,
+                icon_alpha);
 
         // West arrowhead — columns from tip_w+1 to base_w
-        for (int x = tip_w + 1; x <= base_w; ++x)
-            painter.draw_vertical_line(x, center_y - (x - tip_w), center_y + (x - tip_w), 1, icon_grey, icon_alpha);
+        for (auto x = tip_w + geom::DeltaX{1}; x <= base_w; x = x + geom::DeltaX{1})
+            painter.draw_vertical_line(
+                {
+                    .x = x,
+                    .start = center_y - geom::DeltaY((x - tip_w).as_value()),
+                    .end = center_y + geom::DeltaY((x - tip_w).as_value()),
+                    .thickness = geom::Width{1},
+                },
+                icon_grey,
+                icon_alpha);
 
         // East arrowhead
-        for (int x = base_e; x < tip_e; ++x)
-            painter.draw_vertical_line(x, center_y - (tip_e - x), center_y + (tip_e - x), 1, icon_grey, icon_alpha);
+        for (auto x = base_e; x < tip_e; x = x + geom::DeltaX{1})
+            painter.draw_vertical_line(
+                {
+                    .x = x,
+                    .start = center_y - geom::DeltaY((tip_e - x).as_value()),
+                    .end = center_y + geom::DeltaY((tip_e - x).as_value()),
+                    .thickness = geom::Width{1},
+                },
+                icon_grey,
+                icon_alpha);
     }
 
     static void fill_resize_buffer(mg::Buffer& buffer)
@@ -305,13 +367,28 @@ private:
         // where the resize handle always sits within the magnifier surface.
         static int constexpr arm_len   = 12;
         static int constexpr thickness = 2;
-        int const w = painter.buffer_width();
-        int const h = painter.buffer_height();
-        int const corner_x =  w / 4;
-        int const corner_y =  h / 4;
+        auto const [w, h] = painter.buffer_size();
+        auto const corner_x =  geom::as_x(w / 4);
+        auto const corner_y =  geom::as_y(h / 4);
 
-        painter.draw_horizontal_line(corner_x, corner_x +  arm_len, corner_y, thickness, icon_grey, icon_alpha);
-        painter.draw_vertical_line(corner_x, corner_y , corner_y +  arm_len, thickness, icon_grey, icon_alpha);
+        painter.draw_horizontal_line(
+            {
+                .start = corner_x,
+                .end = corner_x + geom::DeltaX{arm_len},
+                .y = corner_y,
+                .thickness = geom::Height{thickness},
+            },
+            icon_grey,
+            icon_alpha);
+        painter.draw_vertical_line(
+            {
+                .x = corner_x,
+                .start = corner_y,
+                .end = corner_y + geom::DeltaY{arm_len},
+                .thickness = geom::Width{thickness},
+            },
+            icon_grey,
+            icon_alpha);
     }
 
     static void fill_zoom_buffer(mg::Buffer& buffer, bool zoom_in)
@@ -321,25 +398,28 @@ private:
         painter.fill_circle(disc_grey, disc_alpha);
 
         // Draw + (zoom in) or – (zoom out) symbol.
-        int const w = painter.buffer_width();
-        int const h = painter.buffer_height();
-        int const bar_thickness = std::max(2, w / 12);
-        int const bar_len       = w * 5 / 8;
+        auto const [w, h] = painter.buffer_size();
+        int const bar_thickness = std::max(geom::Width{2}, w / 12).as_value();
+        int const bar_len = (w * 5 / 8).as_value();
 
         painter.draw_horizontal_line(
-            (w - bar_len) / 2,
-            (w + bar_len) / 2 - 1,
-            (h - bar_thickness) / 2,
-            bar_thickness,
+            {
+                .start = geom::as_x((w - geom::Width{bar_len}) / 2),
+                .end = geom::as_x((w + geom::Width{bar_len}) / 2 - geom::DeltaX{1}),
+                .y = geom::as_y((h - geom::Height{bar_thickness}) / 2),
+                .thickness = geom::Height{bar_thickness},
+            },
             icon_grey,
             icon_alpha);
 
         if (zoom_in)
             painter.draw_vertical_line(
-                (w - bar_thickness) / 2,
-                (h - bar_len) / 2,
-                (h + bar_len) / 2 - 1,
-                bar_thickness,
+                {
+                    .x = geom::as_x((w - geom::Width{bar_thickness}) / 2),
+                    .start = geom::as_y((h - geom::Height{bar_len}) / 2),
+                    .end = geom::as_y((h + geom::Height{bar_len}) / 2 - geom::DeltaY{1}),
+                    .thickness = geom::Width{bar_thickness},
+                },
                 icon_grey,
                 icon_alpha);
     }
@@ -425,9 +505,10 @@ private:
 
 geom::Point surface_top_left_from_cursor(geom::Size const& window_size, geom::Point const& cursor_pos)
 {
-    return geom::Point{
-        cursor_pos.x.as_int() - window_size.width.as_int() / 2,
-        cursor_pos.y.as_int() - window_size.height.as_int() / 2};
+    return cursor_pos -
+        geom::Displacement{
+            geom::as_delta(window_size.width / 2),
+            geom::as_delta(window_size.height / 2)};
 }
 
 geom::Size logical_size_from_visual(geom::Size const& visual_size, float mag)
@@ -450,9 +531,10 @@ geom::Size clamp_visual_size(geom::Size const& visual_size)
 /// centre, so it also fixes the away direction for handle placement.
 geom::Point center(geom::Point const& top_left, geom::Size const& size)
 {
-    return geom::Point{
-        top_left.x.as_int() + size.width.as_int() / 2,
-        top_left.y.as_int() + size.height.as_int() / 2};
+    return top_left +
+        geom::Displacement{
+            geom::as_delta(size.width / 2),
+            geom::as_delta(size.height / 2)};
 }
 }
 
@@ -729,7 +811,13 @@ private:
     struct State
     {
         /// Pixel-space rectangle of signed integer coordinates.
-        struct VisualBounds { int x, y, w, h; };
+        struct VisualBounds
+        {
+            geom::X x;
+            geom::Y y;
+            geom::Width w;
+            geom::Height h;
+        };
 
         ///
         /// The visual rectangle is `mag` times larger than the logical one but
@@ -740,10 +828,10 @@ private:
             geom::Size const& logical_size,
             float mag) const
         {
-            int const w = mag * logical_size.width.as_int();
-            int const h = mag * logical_size.height.as_int();
-            int const x = logical_top_left.x.as_int() - (mag - 1.0f) / 2.0f * logical_size.width.as_int();
-            int const y = logical_top_left.y.as_int() - (mag - 1.0f) / 2.0f * logical_size.height.as_int();
+            auto const w = mag * logical_size.width;
+            auto const h = mag * logical_size.height;
+            auto const x = logical_top_left.x - geom::as_delta((mag - 1.0f) / 2.0f * logical_size.width);
+            auto const y = logical_top_left.y - geom::as_delta((mag - 1.0f) / 2.0f * logical_size.height);
             return {x, y, w, h};
         }
 
@@ -759,13 +847,15 @@ private:
             auto const surface_top_left = surf->top_left();
             auto const logical_size = surf->window_size();
             auto const visual = compute_visual_bounds(surface_top_left, logical_size, magnification);
-            auto const contains = [&point](int x, int y, int width, int height)
+            auto const contains = [&point](geom::Rectangle const& area)
             {
-                return point.x.as_value() >= x && point.x.as_value() < x + width &&
-                    point.y.as_value() >= y && point.y.as_value() < y + height;
+                return point.x.as_value() >= area.left().as_int() &&
+                    point.x.as_value() < area.right().as_int() &&
+                    point.y.as_value() >= area.top().as_int() &&
+                    point.y.as_value() < area.bottom().as_int();
             };
 
-            if (!contains(visual.x, visual.y, visual.w, visual.h))
+            if (!contains(geom::Rectangle{{visual.x, visual.y}, {visual.w, visual.h}}))
                 return false;
 
             auto const [drag_position, resize_position] =
@@ -776,11 +866,9 @@ private:
             for (auto const& handle_position :
                 {drag_position, resize_position, zoom_in_position, zoom_out_position})
             {
-                if (contains(
-                    handle_position.x.as_int(),
-                    handle_position.y.as_int(),
-                    drag_handle_diameter,
-                    drag_handle_diameter))
+                if (contains(geom::Rectangle{
+                    handle_position,
+                    {drag_handle_diameter, drag_handle_diameter}}))
                 {
                     return false;
                 }
@@ -805,22 +893,22 @@ private:
                 return logical_top_left;
 
             auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
-            int const screen_left = screen_bounds.top_left.x.as_int();
-            int const screen_top = screen_bounds.top_left.y.as_int();
-            int const screen_right = screen_left + screen_bounds.size.width.as_int();
-            int const screen_bottom = screen_top + screen_bounds.size.height.as_int();
+            auto const screen_left = screen_bounds.top_left.x;
+            auto const screen_top = screen_bounds.top_left.y;
+            auto const screen_right = screen_left + geom::as_delta(screen_bounds.size.width);
+            auto const screen_bottom = screen_top + geom::as_delta(screen_bounds.size.height);
 
-            int dx = 0;
+            auto dx = geom::DeltaX{0};
             if (vis_x < screen_left)
                 dx = screen_left - vis_x;
-            else if (vis_x + vis_w > screen_right)
-                dx = screen_right - (vis_x + vis_w);
+            else if (vis_x + geom::as_delta(vis_w) > screen_right)
+                dx = screen_right - (vis_x + geom::as_delta(vis_w));
 
-            int dy = 0;
+            auto dy = geom::DeltaY{0};
             if (vis_y < screen_top)
                 dy = screen_top - vis_y;
-            else if (vis_y + vis_h > screen_bottom)
-                dy = screen_bottom - (vis_y + vis_h);
+            else if (vis_y + geom::as_delta(vis_h) > screen_bottom)
+                dy = screen_bottom - (vis_y + geom::as_delta(vis_h));
 
             return logical_top_left + geom::Displacement{geom::DeltaX{dx}, geom::DeltaY{dy}};
         }
@@ -838,51 +926,54 @@ private:
                 return surface_top_left;
 
             auto const visual = compute_visual_bounds(surface_top_left, logical_size, mag);
-            int const screen_left = screen_bounds.top_left.x.as_int();
-            int const screen_top = screen_bounds.top_left.y.as_int();
-            int const screen_width = screen_bounds.size.width.as_int();
-            int const screen_height = screen_bounds.size.height.as_int();
-            int const handle_clearance =
-                static_cast<int>(std::ceil(drag_handle_diameter / mag));
+            auto const screen_left = screen_bounds.top_left.x;
+            auto const screen_top = screen_bounds.top_left.y;
+            auto const screen_width = screen_bounds.size.width;
+            auto const screen_height = screen_bounds.size.height;
+            auto const handle_clearance = static_cast<int>(std::ceil(drag_handle_diameter / mag));
 
-            auto const map_axis = [](
-                int visual_start,
-                int visual_extent,
-                int logical_extent,
-                int screen_start,
-                int screen_extent,
-                int max_out_of_bounds)
+            struct AxisMapping
             {
-                int const visual_travel = screen_extent - visual_extent;
+                int visual_start;
+                int visual_extent;
+                int logical_extent;
+                int screen_start;
+                int screen_extent;
+                int max_out_of_bounds;
+            };
+
+            auto const map_axis = [](AxisMapping const& axis)
+            {
+                int const visual_travel = axis.screen_extent - axis.visual_extent;
 
                 if (visual_travel <= 0)
-                    return screen_start + (screen_extent - logical_extent) / 2;
+                    return axis.screen_start + (axis.screen_extent - axis.logical_extent) / 2;
 
-                double const progress = std::clamp(
-                    static_cast<double>(visual_start - screen_start) / visual_travel,
-                    0.0,
-                    1.0);
-                int const out_of_bounds = std::min(logical_extent / 2, max_out_of_bounds);
-                int const capture_start = screen_start - out_of_bounds;
-                int const capture_travel = screen_extent - logical_extent + 2 * out_of_bounds;
+                auto const progress =
+                    std::clamp(static_cast<double>(axis.visual_start - axis.screen_start) / visual_travel, 0.0, 1.0);
+                int const out_of_bounds = std::min(axis.logical_extent / 2, axis.max_out_of_bounds);
+                int const capture_start = axis.screen_start - out_of_bounds;
+                int const capture_travel = axis.screen_extent - axis.logical_extent + 2 * out_of_bounds;
                 return capture_start + static_cast<int>(std::round(progress * capture_travel));
             };
 
             return geom::Point{
-                map_axis(
-                    visual.x,
-                    visual.w,
-                    logical_size.width.as_int(),
-                    screen_left,
-                    screen_width,
-                    handle_clearance),
-                map_axis(
-                    visual.y,
-                    visual.h,
-                    logical_size.height.as_int(),
-                    screen_top,
-                    screen_height,
-                    handle_clearance)};
+                map_axis({
+                    .visual_start = visual.x.as_value(),
+                    .visual_extent = visual.w.as_value(),
+                    .logical_extent = logical_size.width.as_value(),
+                    .screen_start = screen_left.as_value(),
+                    .screen_extent = screen_width.as_value(),
+                    .max_out_of_bounds = handle_clearance,
+                }),
+                map_axis({
+                    .visual_start = visual.y.as_value(),
+                    .visual_extent = visual.h.as_value(),
+                    .logical_extent = logical_size.height.as_value(),
+                    .screen_start = screen_top.as_value(),
+                    .screen_extent = screen_height.as_value(),
+                    .max_out_of_bounds = handle_clearance,
+                })};
         }
 
         /// Computes the position of the circular drag handle indicator, inset from
@@ -895,8 +986,8 @@ private:
         {
             auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
 
-            int hx = vis_x + vis_w - drag_handle_diameter;
-            int hy = vis_y + vis_h - drag_handle_diameter;
+            auto hx = vis_x + geom::as_delta(vis_w) - geom::DeltaX{drag_handle_diameter};
+            auto hy = vis_y + geom::as_delta(vis_h) - geom::DeltaY{drag_handle_diameter};
 
             return geom::Point{hx, hy};
         }
@@ -913,10 +1004,7 @@ private:
 
             // Default: circle centred on the top-left corner of the visual magnifier,
             // so it sits half outside the content area.
-            int hx = vis_x;
-            int hy = vis_y;
-
-            return geom::Point{hx, hy};
+            return geom::Point{vis_x, vis_y};
         }
 
         std::pair<geom::Point, geom::Point> compute_both_handle_positions(
@@ -939,12 +1027,14 @@ private:
         {
             auto const [vis_x, vis_y, vis_w, vis_h] = compute_visual_bounds(logical_top_left, logical_size, mag);
 
-            int const stack_width = drag_handle_diameter;
+            geom::Width const stack_width{drag_handle_diameter};
 
-            int const x = vis_x + vis_w - stack_width;
-            int const y = vis_y + vis_h / 2 - zoom_stack_height / 2;
+            auto const x = vis_x + geom::as_delta(vis_w) - geom::as_delta(stack_width);
+            auto const y = vis_y + geom::as_delta(vis_h / 2) - geom::as_delta(zoom_stack_height / 2);
 
-            return {geom::Point{x, y}, geom::Point{x, y + drag_handle_diameter + zoom_stack_padding}};
+            return {
+                geom::Point{x, y},
+                geom::Point{x, y + geom::DeltaY{drag_handle_diameter} + geom::DeltaY{zoom_stack_padding}}};
         }
 
         /// Repositions all handle and button indicators for the given surface geometry.
@@ -978,9 +1068,10 @@ private:
 
                     magnification = new_magnification;
                     auto const new_logical_size = logical_size_from_visual(visual_size, magnification);
-                    geom::Point const new_surface_top_left{
-                        old_surface_centre.x.as_int() - new_logical_size.width.as_int() / 2,
-                        old_surface_centre.y.as_int() - new_logical_size.height.as_int() / 2};
+                    auto const new_surface_top_left = old_surface_centre -
+                        geom::Displacement{
+                            geom::as_delta(new_logical_size.width / 2),
+                            geom::as_delta(new_logical_size.height / 2)};
 
                     apply_positioned_geometry(
                         surf, new_surface_top_left, *this, render_scene_into_surface);
@@ -992,9 +1083,10 @@ private:
 
                     magnification = new_magnification;
                     auto const new_logical_size = logical_size_from_visual(visual_size, magnification);
-                    geom::Point const new_logical_top_left{
-                        old_logical_centre.x.as_int() - new_logical_size.width.as_int() / 2,
-                        old_logical_centre.y.as_int() - new_logical_size.height.as_int() / 2};
+                    auto const new_logical_top_left = old_logical_centre -
+                        geom::Displacement{
+                            geom::as_delta(new_logical_size.width / 2),
+                            geom::as_delta(new_logical_size.height / 2)};
 
                     apply_visual_geometry(surf, new_logical_top_left, *this, render_scene_into_surface);
                 }
@@ -1055,21 +1147,26 @@ private:
         bool decoupled{false};
     };
 
+    struct GeometryPositions
+    {
+        geom::Point logical_top_left;
+        geom::Point surface_top_left;
+    };
+
     /// Applies independent logical capture and surface presentation positions.
     static void apply_geometry(
         std::shared_ptr<ms::Surface> const& surf,
-        geom::Point const& logical_top_left,
-        geom::Point const& surface_top_left,
+        GeometryPositions const& positions,
         State& s,
         RenderSceneIntoSurface& render_scene_into_surface)
     {
         auto const logical_size = logical_size_from_visual(s.visual_size, s.magnification);
-        render_scene_into_surface.capture_area(geom::Rectangle{logical_top_left, logical_size});
+        render_scene_into_surface.capture_area(geom::Rectangle{positions.logical_top_left, logical_size});
         // capture_area() moves the backing surface to the capture position, so
         // apply the independent presentation position afterwards.
-        surf->move_to(surface_top_left);
+        surf->move_to(positions.surface_top_left);
         surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(s.magnification, s.magnification, 1)));
-        s.reposition_all_handles(surface_top_left, logical_size, s.magnification);
+        s.reposition_all_handles(positions.surface_top_left, logical_size, s.magnification);
     }
 
     /// Applies normal placement, where capture and presentation positions match.
@@ -1079,7 +1176,14 @@ private:
         State& s,
         RenderSceneIntoSurface& render_scene_into_surface)
     {
-        apply_geometry(surf, logical_top_left, logical_top_left, s, render_scene_into_surface);
+        apply_geometry(
+            surf,
+            {
+                .logical_top_left = logical_top_left,
+                .surface_top_left = logical_top_left,
+            },
+            s,
+            render_scene_into_surface);
     }
 
     /// Keeps the visual magnifier on-screen and maps its position proportionally
@@ -1101,7 +1205,14 @@ private:
             s.clamp_position_to_screen(desired_top_left, logical_size, s.magnification);
         auto const logical_top_left =
             s.capture_position_for_surface(surface_top_left, logical_size, s.magnification);
-        apply_geometry(surf, logical_top_left, surface_top_left, s, render_scene_into_surface);
+        apply_geometry(
+            surf,
+            {
+                .logical_top_left = logical_top_left,
+                .surface_top_left = surface_top_left,
+            },
+            s,
+            render_scene_into_surface);
     }
 
     /// Applies visual geometry with the magnifier's logical top-left computed
@@ -1175,36 +1286,36 @@ private:
         }
 
     protected:
-        virtual void on_drag_start(State& s, int ax, int ay) = 0;
-        virtual void on_drag_move(State& s, int ax, int ay) = 0;
+        virtual void on_drag_start(State& s, geom::Point point) = 0;
+        virtual void on_drag_move(State& s, geom::Point point) = 0;
 
         Self* self;
         bool drag_active{false};
         geom::Displacement grab_abs{};
 
     private:
-        void begin_drag(State& s, int ax, int ay)
+        void begin_drag(State& s, geom::Point point)
         {
             drag_active = true;
-            grab_abs = {geom::DeltaX{ax}, geom::DeltaY{ay}};
-            on_drag_start(s, ax, ay);
+            grab_abs = {geom::as_delta(point.x), geom::as_delta(point.y)};
+            on_drag_start(s, point);
         }
 
         void handle_pointer(MirPointerEvent const* pev)
         {
             auto const action = mir_pointer_event_action(pev);
-            auto const ax = static_cast<int>(
-                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_x)));
-            auto const ay = static_cast<int>(
-                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_y)));
+            auto const point = geom::Point{
+                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_x)),
+                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_y)),
+            };
 
             auto s = self->state.lock();
             if (action == mir_pointer_action_button_down &&
                 mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                begin_drag(*s, ax, ay);
+                begin_drag(*s, point);
             else if (action == mir_pointer_action_motion && drag_active &&
                      mir_pointer_event_button_state(pev, mir_pointer_button_primary))
-                on_drag_move(*s, ax, ay);
+                on_drag_move(*s, point);
             else if (action == mir_pointer_action_button_up)
                 drag_active = false;
         }
@@ -1214,16 +1325,16 @@ private:
             if (mir_touch_event_point_count(tev) != 1)
                 return;
             auto const action = mir_touch_event_action(tev, 0);
-            auto const ax = static_cast<int>(
-                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_x)));
-            auto const ay = static_cast<int>(
-                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_y)));
+            auto const point = geom::Point{
+                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_x)),
+                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_y)),
+            };
 
             auto s = self->state.lock();
             if (action == mir_touch_action_down)
-                begin_drag(*s, ax, ay);
+                begin_drag(*s, point);
             else if (action == mir_touch_action_change && drag_active)
-                on_drag_move(*s, ax, ay);
+                on_drag_move(*s, point);
             else if (action == mir_touch_action_up)
                 drag_active = false;
         }
@@ -1236,7 +1347,7 @@ private:
         using HandleObserver::HandleObserver;
 
     protected:
-        void on_drag_start(State& s, int, int) override
+        void on_drag_start(State& s, geom::Point) override
         {
             auto const surf = s.surface.lock();
             if (!surf)
@@ -1245,11 +1356,10 @@ private:
             drag_start_magnifier_pos = surf->top_left();
         }
 
-        void on_drag_move(State& s, int ax, int ay) override
+        void on_drag_move(State& s, geom::Point point) override
         {
             geom::Displacement const delta{
-                geom::DeltaX{ax} - grab_abs.dx,
-                geom::DeltaY{ay} - grab_abs.dy};
+                geom::as_delta(point.x - grab_abs.dx), geom::as_delta(point.y - grab_abs.dy)};
             geom::Point const new_surface_top_left{
                 drag_start_magnifier_pos.x + delta.dx,
                 drag_start_magnifier_pos.y + delta.dy};
@@ -1293,7 +1403,7 @@ private:
         using HandleObserver::HandleObserver;
 
     protected:
-        void on_drag_start(State& s, int, int) override
+        void on_drag_start(State& s, geom::Point) override
         {
             auto const surf = s.surface.lock();
             if (!surf)
@@ -1303,42 +1413,41 @@ private:
             float const mag = s.magnification;
 
             float const outer = (mag + 1.0f) / 2.0f;
-            pin_pos = geom::Point{
-                tl.x.as_int() + outer * sz.width.as_int(),
-                tl.y.as_int() + outer * sz.height.as_int(),
-            };
+            pin_pos = tl + geom::Displacement{geom::as_delta(outer * sz.width), geom::as_delta(outer * sz.height)};
         }
 
-        void on_drag_move(State& s, int ax, int ay) override
+        void on_drag_move(State& s, geom::Point point) override
         {
             float const mag = s.magnification;
 
             // Visual size from the finger position to the pinned corner
-            int const raw_vis_w = pin_pos.x.as_int() - ax;
-            int const raw_vis_h = pin_pos.y.as_int() - ay;
+            geom::Width const raw_vis_w{geom::as_width(pin_pos.x - point.x)};
+            geom::Height const raw_vis_h {geom::as_height(pin_pos.y - point.y)};
 
             // Enforce the surface's minimum on-screen footprint before converting
             // to a logical size (rounding up so the visual size never dips below
             // the minimum), and cap the logical size at a sane maximum.
             auto const clamped_visual_size = clamp_visual_size(geom::Size{raw_vis_w, raw_vis_h});
-            auto const to_logical_dim = [mag](int visual_dim)
+            auto const to_logical_dimension = [mag](auto visual_dimension)
             {
-                return std::min(static_cast<int>(std::ceil(visual_dim / mag)), 1000);
+                return decltype(visual_dimension){
+                    std::min(static_cast<int>(std::ceil(visual_dimension.as_value() / mag)), 1000)};
             };
-            geom::Size const new_logical_size = geom::Size{
-                to_logical_dim(clamped_visual_size.width.as_int()),
-                to_logical_dim(clamped_visual_size.height.as_int())};
+
+            geom::Size const new_logical_size{
+                to_logical_dimension(clamped_visual_size.width),
+                to_logical_dimension(clamped_visual_size.height)};
 
             // Back-solve the logical top-left from the pinned visual corner, inverting
             // the visual-edge identity above so the pinned corner stays fixed.
             float const outer = (mag + 1.0f) / 2.0f;
 
-            int const w = new_logical_size.width.as_int();
-            int const h = new_logical_size.height.as_int();
-
             geom::Point const new_surface_top_left{
-                pin_pos.x.as_int() - outer * w,
-                pin_pos.y.as_int() - outer * h,
+                pin_pos -
+                    geom::Displacement{
+                        geom::as_delta(outer * new_logical_size.width),
+                        geom::as_delta(outer * new_logical_size.height),
+                    },
             };
 
             auto const surf = s.surface.lock();

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -14,12 +14,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "render_scene_into_surface.h"
-#include "software_buffer_pool.h"
 #include <miral/magnifier.h>
 
-#include <input-method-unstable-v2_wrapper.h>
-#include <wayland_wrapper.h>
+#include "render_scene_into_surface.h"
+#include "software_buffer_pool.h"
 
 #include <miral/live_config.h>
 #include <mir/log.h>
@@ -31,17 +29,12 @@
 #include <mir/scene/surface.h>
 #include <mir/scene/null_surface_observer.h>
 #include <mir/scene/basic_surface.h>
-#include <mir/scene/scene_report.h>
-#include <mir/compositor/stream.h>
 #include <mir/graphics/graphic_buffer_allocator.h>
-#include <mir/renderer/sw/pixel_source.h>
 #include <mir/shell/surface_stack.h>
 #include <mir/observer_registrar.h>
 
 #include <glm/gtc/matrix_transform.hpp>
 
-#include <cmath>
-#include <algorithm>
 
 namespace mi = mir::input;
 namespace ms = mir::scene;
@@ -52,9 +45,6 @@ namespace msh = mir::shell;
 
 namespace
 {
-using miral::SoftwareBufferPool;
-using miral::create_stream_info;
-
 auto const default_capture_width = 150;
 auto const default_capture_height = 150;
 auto const min_magnification = 1.0f;
@@ -100,7 +90,7 @@ public:
             name_for_kind(kind),
             initial_rect,
             mir_pointer_unconfined,
-            create_stream_info(),
+            miral::create_stream_info(),
             nullptr,
             scene_report,
             display_config_registrar},
@@ -320,7 +310,7 @@ private:
                 icon_alpha);
     }
 
-    SoftwareBufferPool mutable pool;
+    miral::SoftwareBufferPool mutable pool;
 };
 
 class Handle

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -69,10 +69,10 @@ auto const zoom_step = 0.5f;
 
 enum class HandleKind { drag, resize, zoom_in, zoom_out };
 
-class DragHandleIndicator : public ms::BasicSurface
+class HandleIndicator : public ms::BasicSurface
 {
 public:
-    DragHandleIndicator(
+    HandleIndicator(
         geom::Rectangle const& initial_rect,
         HandleKind kind,
         std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
@@ -321,9 +321,9 @@ public:
     auto create_handle_indicator(
         mir::Server& server,
         HandleKind kind,
-        geom::Rectangle const& rect) -> std::shared_ptr<DragHandleIndicator>
+        geom::Rectangle const& rect) -> std::shared_ptr<HandleIndicator>
     {
-        auto indicator = std::make_shared<DragHandleIndicator>(
+        auto indicator = std::make_shared<HandleIndicator>(
             rect,
             kind,
             server.the_buffer_allocator(),
@@ -1014,13 +1014,13 @@ private:
     std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
     std::shared_ptr<Observer> observer;
     std::weak_ptr<ms::Surface> surface;
-    std::shared_ptr<DragHandleIndicator> drag_handle_indicator;
+    std::shared_ptr<HandleIndicator> drag_handle_indicator;
     std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
     std::shared_ptr<DragHandleObserver> drag_handle_observer;
-    std::shared_ptr<DragHandleIndicator> resize_handle_indicator;
+    std::shared_ptr<HandleIndicator> resize_handle_indicator;
     std::shared_ptr<ResizeDragObserver> resize_drag_observer;
-    std::shared_ptr<DragHandleIndicator> zoom_in_indicator;
-    std::shared_ptr<DragHandleIndicator> zoom_out_indicator;
+    std::shared_ptr<HandleIndicator> zoom_in_indicator;
+    std::shared_ptr<HandleIndicator> zoom_out_indicator;
     std::shared_ptr<ZoomButtonObserver> zoom_in_observer;
     std::shared_ptr<ZoomButtonObserver> zoom_out_observer;
     geom::Point cursor_pos;

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -304,6 +304,80 @@ private:
 
     SoftwareBufferPool mutable pool;
 };
+
+class Handle
+{
+public:
+    Handle() = default;
+
+    void init(mir::Server& server, HandleKind kind)
+    {
+        indicator = std::make_shared<HandleIndicator>(
+            handle_rect,
+            kind,
+            server.the_buffer_allocator(),
+            server.the_scene_report(),
+            server.the_display_configuration_observer_registrar());
+        handle_surface_stack = server.the_surface_stack();
+
+        server.the_surface_stack()->add_surface(indicator, mi::InputReceptionMode::normal);
+        indicator->set_cursor_image(server.the_default_cursor_image());
+    }
+
+    void reset()
+    {
+        detach_observer();
+        if (auto const surface_stack = handle_surface_stack.lock())
+            surface_stack->remove_surface(indicator);
+        indicator.reset();
+    }
+
+    template<typename ObserverType, typename... Args>
+    void attach_observer(Args&&... args)
+    {
+        if (!indicator)
+            return;
+
+        observer = std::make_shared<ObserverType>(std::forward<Args>(args)...);
+        indicator->register_interest(observer);
+    }
+
+    void detach_observer()
+    {
+        if (!observer)
+            return;
+
+        indicator->unregister_interest(*observer);
+        observer.reset();
+    }
+
+    void move_to(geom::Point const& pos)
+    {
+        if (indicator)
+            indicator->move_to(pos);
+    }
+
+    void show()
+    {
+        if (indicator)
+            indicator->show();
+    }
+
+    void hide()
+    {
+        if (indicator)
+            indicator->hide();
+    }
+
+private:
+    static constexpr geom::Rectangle handle_rect{
+        {0, 0},
+        {geom::Width{drag_handle_diameter}, geom::Height{drag_handle_diameter}}};
+
+    std::shared_ptr<HandleIndicator> indicator;
+    std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
+    std::shared_ptr<ms::NullSurfaceObserver> observer;
+};
 }
 
 class miral::Magnifier::Self
@@ -314,25 +388,6 @@ public:
         render_scene_into_surface
             .capture_area(geom::Rectangle{{300, 300}, geom::Size(default_capture_width, default_capture_height)})
             .overlay_cursor(false);
-    }
-
-    /// Creates a handle indicator surface, adds it to the surface stack and
-    /// gives it the default cursor image.
-    auto create_handle_indicator(
-        mir::Server& server,
-        HandleKind kind,
-        geom::Rectangle const& rect) -> std::shared_ptr<HandleIndicator>
-    {
-        auto indicator = std::make_shared<HandleIndicator>(
-            rect,
-            kind,
-            server.the_buffer_allocator(),
-            server.the_scene_report(),
-            server.the_display_configuration_observer_registrar());
-
-        server.the_surface_stack()->add_surface(indicator, mi::InputReceptionMode::normal);
-        indicator->set_cursor_image(server.the_default_cursor_image());
-        return indicator;
     }
 
     void init(mir::Server& server)
@@ -360,30 +415,17 @@ public:
             server.the_cursor_observer_multiplexer()->register_interest(observer);
             cursor_multiplexer = server.the_cursor_observer_multiplexer();
 
-            // Create the drag handle indicator.
-            geom::Rectangle const handle_rect{
-                {0, 0},
-                {geom::Width{drag_handle_diameter}, geom::Height{drag_handle_diameter}}};
-
-            drag_handle_indicator   = create_handle_indicator(server, HandleKind::drag, handle_rect);
-            resize_handle_indicator = create_handle_indicator(server, HandleKind::resize, handle_rect);
-            zoom_in_indicator       = create_handle_indicator(server, HandleKind::zoom_in, handle_rect);
-            zoom_out_indicator      = create_handle_indicator(server, HandleKind::zoom_out, handle_rect);
-            handle_surface_stack    = server.the_surface_stack();
+            drag.init(server, HandleKind::drag);
+            resize.init(server, HandleKind::resize);
+            zoom_in.init(server, HandleKind::zoom_in);
+            zoom_out.init(server, HandleKind::zoom_out);
 
             if (decoupled)
             {
-                drag_handle_observer = std::make_shared<DragHandleObserver>(this);
-                drag_handle_indicator->register_interest(drag_handle_observer);
-
-                resize_drag_observer = std::make_shared<ResizeDragObserver>(this);
-                resize_handle_indicator->register_interest(resize_drag_observer);
-
-                zoom_in_observer = std::make_shared<ZoomButtonObserver>(this, +zoom_step);
-                zoom_in_indicator->register_interest(zoom_in_observer);
-
-                zoom_out_observer = std::make_shared<ZoomButtonObserver>(this, -zoom_step);
-                zoom_out_indicator->register_interest(zoom_out_observer);
+                drag.attach_observer<DragHandleObserver>(this);
+                resize.attach_observer<ResizeDragObserver>(this);
+                zoom_in.attach_observer<ZoomButtonObserver>(this, +zoom_step);
+                zoom_out.attach_observer<ZoomButtonObserver>(this, -zoom_step);
 
                 if (auto const surf = surface.lock(); surf && default_enabled)
                 {
@@ -399,43 +441,8 @@ public:
             if (auto const locked = cursor_multiplexer.lock())
                 locked->unregister_interest(*observer);
 
-            if (drag_handle_observer)
-            {
-                drag_handle_indicator->unregister_interest(*drag_handle_observer);
-                drag_handle_observer.reset();
-            }
-
-
-            if (resize_drag_observer)
-            {
-                resize_handle_indicator->unregister_interest(*resize_drag_observer);
-                resize_drag_observer.reset();
-            }
-
-            if (zoom_in_observer)
-            {
-                zoom_in_indicator->unregister_interest(*zoom_in_observer);
-                zoom_in_observer.reset();
-            }
-
-            if (zoom_out_observer)
-            {
-                zoom_out_indicator->unregister_interest(*zoom_out_observer);
-                zoom_out_observer.reset();
-            }
-
-            if (auto const locked = handle_surface_stack.lock())
-            {
-                locked->remove_surface(drag_handle_indicator);
-                locked->remove_surface(resize_handle_indicator);
-                locked->remove_surface(zoom_in_indicator);
-                locked->remove_surface(zoom_out_indicator);
-            }
-
-            drag_handle_indicator.reset();
-            resize_handle_indicator.reset();
-            zoom_in_indicator.reset();
-            zoom_out_indicator.reset();
+            for (auto* handle : {&drag, &resize, &zoom_in, &zoom_out})
+                handle->reset();
         });
     }
 
@@ -498,26 +505,11 @@ public:
         {
             if (auto const surf = surface.lock())
             {
-                if (drag_handle_indicator)
-                {
-                    drag_handle_observer = std::make_shared<DragHandleObserver>(this);
-                    drag_handle_indicator->register_interest(drag_handle_observer);
-                }
-                if (resize_handle_indicator)
-                {
-                    resize_drag_observer = std::make_shared<ResizeDragObserver>(this);
-                    resize_handle_indicator->register_interest(resize_drag_observer);
-                }
-                if (zoom_in_indicator)
-                {
-                    zoom_in_observer = std::make_shared<ZoomButtonObserver>(this, +zoom_step);
-                    zoom_in_indicator->register_interest(zoom_in_observer);
-                }
-                if (zoom_out_indicator)
-                {
-                    zoom_out_observer = std::make_shared<ZoomButtonObserver>(this, -zoom_step);
-                    zoom_out_indicator->register_interest(zoom_out_observer);
-                }
+                drag.attach_observer<DragHandleObserver>(this);
+                resize.attach_observer<ResizeDragObserver>(this);
+                zoom_in.attach_observer<ZoomButtonObserver>(this, +zoom_step);
+                zoom_out.attach_observer<ZoomButtonObserver>(this, -zoom_step);
+
                 if (default_enabled)
                 {
                     reposition_all_handles_locked(surf->top_left(), surf->window_size(), magnification);
@@ -527,41 +519,10 @@ public:
         }
         else
         {
-            if (drag_handle_indicator)
+            for (auto* handle : {&drag, &resize, &zoom_in, &zoom_out})
             {
-                if (drag_handle_observer)
-                {
-                    drag_handle_indicator->unregister_interest(*drag_handle_observer);
-                    drag_handle_observer.reset();
-                }
-                drag_handle_indicator->hide();
-            }
-            if (resize_handle_indicator)
-            {
-                if (resize_drag_observer)
-                {
-                    resize_handle_indicator->unregister_interest(*resize_drag_observer);
-                    resize_drag_observer.reset();
-                }
-                resize_handle_indicator->hide();
-            }
-            if (zoom_in_indicator)
-            {
-                if (zoom_in_observer)
-                {
-                    zoom_in_indicator->unregister_interest(*zoom_in_observer);
-                    zoom_in_observer.reset();
-                }
-                zoom_in_indicator->hide();
-            }
-            if (zoom_out_indicator)
-            {
-                if (zoom_out_observer)
-                {
-                    zoom_out_indicator->unregister_interest(*zoom_out_observer);
-                    zoom_out_observer.reset();
-                }
-                zoom_out_indicator->hide();
+                handle->detach_observer();
+                handle->hide();
             }
 
             if (auto const surf = surface.lock(); surf && default_enabled)
@@ -973,12 +934,11 @@ private:
             return;
 
         auto const [dp, rp] = compute_both_handle_positions(tl, sz, mag);
-        if (drag_handle_indicator)   drag_handle_indicator->move_to(dp);
-        if (resize_handle_indicator) resize_handle_indicator->move_to(rp);
-
         auto const [zp, zm] = compute_zoom_button_positions(tl, sz, mag);
-        if (zoom_in_indicator)  zoom_in_indicator->move_to(zp);
-        if (zoom_out_indicator) zoom_out_indicator->move_to(zm);
+        drag.move_to(dp);
+        resize.move_to(rp);
+        zoom_in.move_to(zp);
+        zoom_out.move_to(zm);
     }
 
     /// Updates the magnification without acquiring the mutex (caller must hold it).
@@ -995,18 +955,14 @@ private:
 
     void show_all_handles_locked()
     {
-        if (drag_handle_indicator)   drag_handle_indicator->show();
-        if (resize_handle_indicator) resize_handle_indicator->show();
-        if (zoom_in_indicator)  zoom_in_indicator->show();
-        if (zoom_out_indicator) zoom_out_indicator->show();
+        for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
+            h->show();
     }
 
     void hide_all_handles_locked()
     {
-        if (drag_handle_indicator)   drag_handle_indicator->hide();
-        if (resize_handle_indicator) resize_handle_indicator->hide();
-        if (zoom_in_indicator)  zoom_in_indicator->hide();
-        if (zoom_out_indicator) zoom_out_indicator->hide();
+        for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
+            h->hide();
     }
 
     std::mutex mutex;
@@ -1014,15 +970,87 @@ private:
     std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
     std::shared_ptr<Observer> observer;
     std::weak_ptr<ms::Surface> surface;
-    std::shared_ptr<HandleIndicator> drag_handle_indicator;
-    std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
-    std::shared_ptr<DragHandleObserver> drag_handle_observer;
-    std::shared_ptr<HandleIndicator> resize_handle_indicator;
-    std::shared_ptr<ResizeDragObserver> resize_drag_observer;
-    std::shared_ptr<HandleIndicator> zoom_in_indicator;
-    std::shared_ptr<HandleIndicator> zoom_out_indicator;
-    std::shared_ptr<ZoomButtonObserver> zoom_in_observer;
-    std::shared_ptr<ZoomButtonObserver> zoom_out_observer;
+    geom::Rectangle screen_bounds;
+
+    class Handle
+    {
+    public:
+        Handle() = default;
+
+        void init(mir::Server& server, HandleKind kind)
+        {
+            indicator = std::make_shared<HandleIndicator>(
+                handle_rect,
+                kind,
+                server.the_buffer_allocator(),
+                server.the_scene_report(),
+                server.the_display_configuration_observer_registrar());
+            handle_surface_stack = server.the_surface_stack();
+
+            server.the_surface_stack()->add_surface(indicator, mi::InputReceptionMode::normal);
+            indicator->set_cursor_image(server.the_default_cursor_image());
+        }
+
+        void reset()
+        {
+            detach_observer();
+            if(auto const surface_stack = handle_surface_stack.lock())
+                surface_stack->remove_surface(indicator);
+            indicator.reset();
+        }
+
+        template<typename ObserverType, typename... Args>
+        void attach_observer(Args&&... args)
+        {
+            if(!indicator)
+                return;
+
+            observer = std::make_shared<ObserverType>(std::forward<Args>(args)...);
+            indicator->register_interest(observer);
+        }
+
+        void detach_observer()
+        {
+            if (!observer)
+                return;
+
+            indicator->unregister_interest(*observer);
+            observer.reset();
+        }
+
+        void move_to(geom::Point const& pos)
+        {
+            if (indicator)
+                indicator->move_to(pos);
+        }
+
+        void show()
+        {
+            if (indicator)
+                indicator->show();
+        }
+
+        void hide()
+        {
+            if (indicator)
+                indicator->hide();
+        }
+
+    private:
+        static constexpr geom::Rectangle handle_rect{
+            {0, 0},
+            {geom::Width{drag_handle_diameter}, geom::Height{drag_handle_diameter}}};
+
+        std::shared_ptr<HandleIndicator> indicator;
+        std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
+        std::shared_ptr<ms::NullSurfaceObserver> observer;
+    };
+
+    Handle drag;
+    Handle resize;
+    Handle zoom_in;
+    Handle zoom_out;
+
     geom::Point cursor_pos;
     float magnification{default_magnification};
     bool default_enabled{false};

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -261,6 +261,8 @@ public:
         server.add_init_callback(
             [&]
             {
+                input_filter = std::make_shared<InputFilter>(state);
+                server.the_composite_event_filter()->prepend(input_filter);
 
                 server.the_main_loop()->spawn([=, this, &server] { this->post_init(server); });
             });
@@ -304,6 +306,7 @@ public:
                 for (auto* handle : {&local_drag, &local_resize, &local_zoom_in, &local_zoom_out})
                     handle->reset();
 
+                input_filter.reset();
             });
     }
 
@@ -451,6 +454,23 @@ public:
     }
 
 private:
+    class InputFilter : public mi::EventFilter
+    {
+    public:
+        explicit InputFilter(mir::Synchronised<State>& state) : state{state} {}
+
+        auto handle(MirEvent const& event) -> bool override;
+
+    private:
+        void reset_gestures();
+        auto handle_pointer(MirPointerEvent const& event, State const& state) -> bool;
+        auto handle_touch(MirTouchEvent const& event, State const& state) -> bool;
+
+        mir::Synchronised<State>& state;
+        std::optional<bool> pointer_gesture_consumed;
+        std::optional<bool> touch_gesture_consumed;
+    };
+
     class DisplayConfigObserver : public mg::DisplayConfigurationObserver
     {
     public:
@@ -756,10 +776,88 @@ private:
 
     mir::Synchronised<State> state;
 
+    std::shared_ptr<InputFilter> input_filter;
     std::shared_ptr<CursorObserver> cursor_observer;
     std::shared_ptr<DisplayConfigObserver> display_config_observer;
     std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
 };
+
+auto miral::Magnifier::Self::InputFilter::handle(MirEvent const& event) -> bool
+{
+    if (event.type() != mir_event_type_input)
+        return false;
+
+    auto const s = state.lock();
+    if (s->follow_cursor || !s->default_enabled)
+    {
+        reset_gestures();
+        return false;
+    }
+
+    auto const* input_event = event.to_input();
+    switch (input_event->input_type())
+    {
+    case mir_input_event_type_pointer:
+        return handle_pointer(*input_event->to_pointer(), *s);
+    case mir_input_event_type_touch:
+        return handle_touch(*input_event->to_touch(), *s);
+    default:
+        return false;
+    }
+}
+
+void miral::Magnifier::Self::InputFilter::reset_gestures()
+{
+    pointer_gesture_consumed.reset();
+    touch_gesture_consumed.reset();
+}
+
+auto miral::Magnifier::Self::InputFilter::handle_pointer(MirPointerEvent const& event, State const& state) -> bool
+{
+    auto const action = event.action();
+    if (action == mir_pointer_action_button_down && !pointer_gesture_consumed)
+    {
+        pointer_gesture_consumed =
+            event.position()
+                .transform([&state](auto const& position) { return state.point_is_on_magnifier_surface(position); })
+                .value_or(false);
+    }
+
+    if (pointer_gesture_consumed)
+    {
+        auto const consumed = *pointer_gesture_consumed;
+        if (action == mir_pointer_action_button_up && event.buttons() == 0)
+            pointer_gesture_consumed.reset();
+        return consumed;
+    }
+
+    return event.position()
+        .transform([&state](auto const& position) { return state.point_is_on_magnifier_surface(position); })
+        .value_or(false);
+}
+
+auto miral::Magnifier::Self::InputFilter::handle_touch(MirTouchEvent const& event, State const& state) -> bool
+{
+    if (!touch_gesture_consumed)
+    {
+        bool starts_on_magnifier = false;
+        for (auto i = 0u; i != event.pointer_count(); ++i)
+        {
+            starts_on_magnifier = starts_on_magnifier || state.point_is_on_magnifier_surface(event.position(i));
+        }
+        touch_gesture_consumed = starts_on_magnifier;
+    }
+
+    auto const consumed = *touch_gesture_consumed;
+    bool gesture_ended = event.pointer_count() > 0;
+    for (auto i = 0u; i != event.pointer_count(); ++i)
+        gesture_ended = gesture_ended && event.action(i) == mir_touch_action_up;
+
+    if (gesture_ended)
+        touch_gesture_consumed.reset();
+
+    return consumed;
+}
 
 void miral::Magnifier::Self::DisplayConfigObserver::update_bounds(
     std::shared_ptr<mg::DisplayConfiguration const> const& config)

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -14,18 +14,34 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "render_scene_into_surface.h"
 #include <miral/magnifier.h>
 
-#include <input-method-unstable-v2_wrapper.h>
-#include <wayland_wrapper.h>
+#include "magnifier_handle_indicator.h"
+#include "magnifier_layout.h"
+#include "render_scene_into_surface.h"
 
 #include <miral/live_config.h>
+#include <mir/events/event.h>
+#include <mir/events/input_event.h>
+#include <mir/events/pointer_event.h>
+#include <mir/events/touch_event.h>
 #include <mir/log.h>
 #include <mir/server.h>
+#include <mir/synchronised.h>
+#include <mir/graphics/display.h>
+#include <mir/graphics/display_configuration.h>
+#include <mir/graphics/display_configuration_observer.h>
+#include <mir/geometry/rectangles.h>
+#include <mir/input/composite_event_filter.h>
 #include <mir/input/cursor_observer.h>
 #include <mir/input/cursor_observer_multiplexer.h>
+#include <mir/input/event_filter.h>
 #include <mir/scene/surface.h>
+#include <mir/scene/null_surface_observer.h>
+#include <mir/scene/basic_surface.h>
+#include <mir/shell/surface_stack.h>
+#include <mir/observer_registrar.h>
+#include <mir/main_loop.h>
 
 #include <glm/gtc/matrix_transform.hpp>
 
@@ -33,12 +49,182 @@ namespace mi = mir::input;
 namespace ms = mir::scene;
 namespace geom = mir::geometry;
 namespace mg = mir::graphics;
+namespace msh = mir::shell;
+namespace mc = mir::compositor;
 
 namespace
 {
 auto const default_capture_width = 150;
 auto const default_capture_height = 150;
-auto const default_magnification = 1.5f;
+auto const min_magnification = 1.0f;
+auto const default_magnification = 1.25f;
+auto const max_magnification = 8.0f;
+
+/// Magnification step applied by each zoom button press.
+auto const zoom_step = 0.25f;
+
+class Handle
+{
+public:
+    Handle() = default;
+
+    void init(mir::Server& server, miral::HandleKind kind, mc::CompositorID capture_compositor_id)
+    {
+        indicator = std::make_shared<miral::HandleIndicator>(
+            handle_rect,
+            kind,
+            capture_compositor_id,
+            server.the_buffer_allocator(),
+            server.the_scene_report(),
+            server.the_display_configuration_observer_registrar());
+        handle_surface_stack = server.the_surface_stack();
+
+        server.the_surface_stack()->add_surface(indicator, mi::InputReceptionMode::normal);
+        indicator->set_cursor_image(server.the_default_cursor_image());
+    }
+
+    void reset()
+    {
+        detach_observer();
+        if (auto const surface_stack = handle_surface_stack.lock())
+            surface_stack->remove_surface(indicator);
+        indicator.reset();
+    }
+
+    template<typename ObserverType, typename... Args>
+    void attach_observer(Args&&... args)
+    {
+        if (!indicator)
+            return;
+
+        observer = std::make_shared<ObserverType>(std::forward<Args>(args)...);
+        indicator->register_interest(observer);
+    }
+
+    void detach_observer()
+    {
+        if (!observer)
+            return;
+
+        indicator->unregister_interest(*observer);
+        observer.reset();
+    }
+
+    void move_to(geom::Point const& pos)
+    {
+        if (indicator)
+            indicator->move_to(pos);
+    }
+
+    void show()
+    {
+        if (indicator)
+            indicator->show();
+    }
+
+    void hide()
+    {
+        if (indicator)
+            indicator->hide();
+    }
+
+private:
+    static constexpr geom::Rectangle handle_rect{
+        {0, 0},
+        {
+            geom::Width{miral::MagnifierLayout::handle_diameter},
+            geom::Height{miral::MagnifierLayout::handle_diameter}}};
+
+    std::shared_ptr<miral::HandleIndicator> indicator;
+    std::weak_ptr<msh::SurfaceStack> handle_surface_stack;
+    std::shared_ptr<ms::NullSurfaceObserver> observer;
+};
+
+struct DisplayConfigObserver;
+struct CursorObserver;
+struct State
+{
+    auto layout() const -> miral::MagnifierLayout
+    {
+        return {screen_bounds, visual_size, magnification};
+    }
+
+    auto placement_for(ms::Surface const& surf) const -> miral::MagnifierLayout::Placement
+    {
+        return {
+            .capture_area = render_scene_into_surface.capture_area(),
+            .surface_top_left = surf.top_left(),
+            .visual_size = visual_size};
+    }
+
+    auto point_is_on_magnifier_surface(geom::PointF const& point) const -> bool
+    {
+        if (follow_cursor || !default_enabled)
+            return false;
+
+        auto const surf = surface.lock();
+        if (!surf)
+            return false;
+
+        return layout().contains_content(point, placement_for(*surf));
+    }
+
+    void apply_geometry(miral::MagnifierLayout::Placement const& placement)
+    {
+        visual_size = placement.visual_size;
+        render_scene_into_surface.capture_area(placement.capture_area);
+
+        if (!follow_cursor)
+        {
+            auto const positions = layout().handle_positions(placement);
+            drag.move_to(positions.drag);
+            resize.move_to(positions.resize);
+            zoom_in.move_to(positions.zoom_in);
+            zoom_out.move_to(positions.zoom_out);
+        }
+
+        if (auto const surf = surface.lock())
+        {
+            surf->move_to(placement.surface_top_left);
+            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
+        }
+    }
+
+    void show_all_handles()
+    {
+        for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
+            h->show();
+    }
+
+    void hide_all_handles()
+    {
+        for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
+            h->hide();
+    }
+
+    /// Unregisters and discards the observer on each handle that has one.
+    void detach_observers()
+    {
+        for (auto* h : {&drag, &resize, &zoom_in, &zoom_out})
+            h->detach_observer();
+    }
+
+    std::weak_ptr<ms::Surface> surface;
+    Handle drag;
+    Handle resize;
+    Handle zoom_in;
+    Handle zoom_out;
+    geom::Point cursor_pos;
+    geom::Rectangles screen_bounds;
+    float magnification{default_magnification};
+    /// The physical (screen) size of the magnifier.  When the magnification
+    /// level changes the logical capture size is recalculated from this so
+    /// that the magnifier's on-screen footprint stays the same.
+    geom::Size visual_size;
+    bool default_enabled{false};
+    bool follow_cursor{true};
+    miral::RenderSceneIntoSurface render_scene_into_surface;
+};
 }
 
 class miral::Magnifier::Self
@@ -46,137 +232,567 @@ class miral::Magnifier::Self
 public:
     Self()
     {
-        render_scene_into_surface
+        state.lock()
+            ->render_scene_into_surface
             .capture_area(geom::Rectangle{{300, 300}, geom::Size(default_capture_width, default_capture_height)})
             .overlay_cursor(false);
     }
 
     void init(mir::Server& server)
     {
-        render_scene_into_surface.on_surface_ready([this](auto const& surf)
-        {
-            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
-            surf->set_depth_layer(mir_depth_layer_always_on_top);
-            surf->set_focus_mode(mir_focus_mode_disabled);
+        auto const s = state.lock();
+        s->render_scene_into_surface.on_surface_ready(
+            [this](auto const& surf)
+            {
+                surf->set_depth_layer(mir_depth_layer_always_on_top);
+                surf->set_focus_mode(mir_focus_mode_disabled);
+                auto s = state.lock();
 
-            if (default_enabled)
-                surf->show();
+                if (s->default_enabled)
+                    surf->show();
+                else
+                    surf->hide();
+
+                s->surface = surf;
+            });
+
+        s->render_scene_into_surface(server);
+
+        server.add_init_callback(
+            [&]
+            {
+
+                server.the_main_loop()->spawn([=, this, &server] { this->post_init(server); });
+            });
+
+        server.add_stop_callback(
+            [&]
+            {
+                // The naive way to do this would be:
+                //  - lock self->state
+                //  - unregister observers
+                //
+                // This may cause a deadlock in the following case:
+                //  - lock self->state
+                //  - on another thread, the observer gets called into, attempts to lock self->state and blocks
+                //  - unregistering the observer waits until the observer returns,
+                //    which it will not since its waiting on the lock
+                //  - deadlock: unregister waiting on observer, observer waiting on lock held to unregister
+                //
+                //  The lock is only required to grab references to the observers
+                //  and handles, so we lock, copy, then unregister without holding
+                //  the lock.
+
+                Handle local_drag, local_resize, local_zoom_in, local_zoom_out;
+                {
+                    auto s = state.lock();
+
+                    local_drag = std::exchange(s->drag, {});
+                    local_resize = std::exchange(s->resize, {});
+                    local_zoom_in = std::exchange(s->zoom_in, {});
+                    local_zoom_out = std::exchange(s->zoom_out, {});
+                }
+
+                auto const cursor_mux = cursor_multiplexer.lock();
+                if (cursor_mux && cursor_observer)
+                    cursor_mux->unregister_interest(*cursor_observer);
+
+                if (display_config_observer)
+                    server.the_display_configuration_observer_registrar()->unregister_interest(
+                        *display_config_observer);
+
+                for (auto* handle : {&local_drag, &local_resize, &local_zoom_in, &local_zoom_out})
+                    handle->reset();
+
+            });
+    }
+
+    void post_init(mir::Server& server)
+    {
+        cursor_observer = std::make_shared<CursorObserver>(this);
+        server.the_cursor_observer_multiplexer()->register_interest(cursor_observer);
+        cursor_multiplexer = server.the_cursor_observer_multiplexer();
+
+        display_config_observer = std::make_shared<DisplayConfigObserver>(*this);
+        server.the_display_configuration_observer_registrar()->register_interest(display_config_observer);
+
+        auto s = state.lock();
+
+        if (s->visual_size == geom::Size{})
+        {
+            s->visual_size =
+                geom::Size{default_capture_width, default_capture_height} * s->magnification;
+        }
+
+        auto const capture_compositor_id = s->render_scene_into_surface.capture_compositor_id();
+        s->drag.init(server, HandleKind::drag, capture_compositor_id);
+        s->resize.init(server, HandleKind::resize, capture_compositor_id);
+        s->zoom_in.init(server, HandleKind::zoom_in, capture_compositor_id);
+        s->zoom_out.init(server, HandleKind::zoom_out, capture_compositor_id);
+
+        if (auto const surf = s->surface.lock(); surf && s->default_enabled)
+        {
+            if (!s->follow_cursor)
+            {
+                attach_observers(*s);
+                auto const logical_rect = s->render_scene_into_surface.capture_area();
+                s->apply_geometry(s->layout().freely_positioned(logical_rect.top_left));
+                s->show_all_handles();
+            }
             else
-                surf->hide();
-
-            std::lock_guard lock(mutex);
-            surface = surf;
-        });
-
-        render_scene_into_surface(server);
-
-        server.add_init_callback([&]
-        {
-            observer = std::make_shared<Observer>(this);
-            server.the_cursor_observer_multiplexer()->register_interest(observer);
-            cursor_multiplexer = server.the_cursor_observer_multiplexer();
-        });
-
-        server.add_stop_callback([&]
-        {
-            std::lock_guard lock(mutex);
-            if (auto const locked = cursor_multiplexer.lock())
-                locked->unregister_interest(*observer);
-        });
+            {
+                place_at_cursor(*s);
+            }
+        }
     }
 
     void set_enable(bool enable)
     {
-        std::lock_guard lock(mutex);
-        default_enabled = enable;
-        if (auto const surf = surface.lock())
+        auto s = state.lock();
+        s->default_enabled = enable;
+        auto const surf = s->surface.lock();
+        if (!surf)
+            return;
+
+        if (enable)
         {
-            if (enable)
-                surf->show();
-            else
-                surf->hide();
+            if (!s->follow_cursor)
+            {
+                // Place surface at last known cursor position when enabling
+                // and not following the cursor.
+                place_at_cursor(*s);
+                s->show_all_handles();
+            }
+            surf->show();
+        }
+        else
+        {
+            surf->hide();
+            s->hide_all_handles();
         }
     }
 
     void set_magnification(float new_magnification)
     {
-        std::lock_guard lock(mutex);
-        magnification = new_magnification;
-        if (auto const surf = surface.lock())
-            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
+        set_magnification(*state.lock(), new_magnification);
+    }
+
+    void set_magnification(State& s, float new_magnification)
+    {
+        if (auto const surf = s.surface.lock())
+        {
+            auto const old_layout = s.layout();
+            auto const old_placement = s.placement_for(*surf);
+            s.magnification = new_magnification;
+            auto const new_layout = s.layout();
+
+            if (!s.follow_cursor)
+            {
+                s.apply_geometry(
+                    new_layout.freely_positioned_centered_on(old_layout.surface_center(old_placement)));
+            }
+            else
+            {
+                s.apply_geometry(new_layout.centered_on(old_layout.capture_center(old_placement)));
+            }
+        }
+        else
+        {
+            s.magnification = new_magnification;
+        }
     }
 
     void set_capture_size(geom::Size const& size)
     {
-        std::lock_guard lock(mutex);
-        auto const capture_position = Observer::cursor_position_to_capture_position(size, cursor_pos);
-        render_scene_into_surface.capture_area({ capture_position, size });
+        auto s = state.lock();
+        auto const layout = miral::MagnifierLayout{s->screen_bounds, size * s->magnification, s->magnification};
+        s->apply_geometry(
+            s->follow_cursor ?
+                layout.centered_on(s->cursor_pos) :
+                layout.freely_positioned_centered_on(s->cursor_pos));
     }
 
-    geom::Size current_size() const
+    geom::Size current_size() const { return state.lock()->render_scene_into_surface.capture_area().size; }
+
+    void follow_cursor()
     {
-        return render_scene_into_surface.capture_area().size;
+        auto s = state.lock();
+        if (s->follow_cursor)
+            return;
+
+        s->follow_cursor = true;
+        for (auto* handle : {&s->drag, &s->resize, &s->zoom_in, &s->zoom_out})
+        {
+            handle->detach_observer();
+            handle->hide();
+        }
+
+        place_at_cursor(*s);
+    }
+
+    void stop_following_cursor()
+    {
+        auto s = state.lock();
+        if (!s->follow_cursor)
+            return;
+
+        s->follow_cursor = false;
+
+        if (auto const surf = s->surface.lock())
+        {
+            attach_observers(*s);
+            if (s->default_enabled)
+            {
+                auto const logical_rect = s->render_scene_into_surface.capture_area();
+                s->apply_geometry(s->layout().freely_positioned(logical_rect.top_left));
+                s->show_all_handles();
+            }
+        }
     }
 
 private:
-    class Observer : public mi::CursorObserver
+    class DisplayConfigObserver : public mg::DisplayConfigurationObserver
     {
     public:
-        explicit Observer(Self* self) : self(self) {}
+        DisplayConfigObserver(Self& self) : self{self} {}
 
-        void cursor_moved_to(float abs_x, float abs_y) override
+        void initial_configuration(std::shared_ptr<mg::DisplayConfiguration const> const& config) override
+        { update_bounds(config); }
+
+        void configuration_applied(std::shared_ptr<mg::DisplayConfiguration const> const& config) override
+        { update_bounds(config); }
+
+        void base_configuration_updated(std::shared_ptr<mg::DisplayConfiguration const> const&) override {}
+        void session_configuration_applied(
+            std::shared_ptr<ms::Session> const&,
+            std::shared_ptr<mg::DisplayConfiguration> const&) override
+        {}
+        void session_configuration_removed(std::shared_ptr<ms::Session> const&) override {}
+        void configuration_failed(std::shared_ptr<mg::DisplayConfiguration const> const&, std::exception const&)
+            override
+        {}
+        void catastrophic_configuration_error(
+            std::shared_ptr<mg::DisplayConfiguration const> const&,
+            std::exception const&) override
+        {}
+        void configuration_updated_for_session(
+            std::shared_ptr<ms::Session> const&,
+            std::shared_ptr<mg::DisplayConfiguration const> const&) override
+        {}
+
+    private:
+        void update_bounds(std::shared_ptr<mg::DisplayConfiguration const> const& config);
+        Self& self;
+    };
+
+    /// Creates and registers concrete observers on each handle. Guards against
+    /// missing indicators.
+    void attach_observers(State& state)
+    {
+        state.drag.attach_observer<DragHandleObserver>(this);
+        state.resize.attach_observer<ResizeDragObserver>(this);
+        state.zoom_in.attach_observer<ZoomButtonObserver>(this, +zoom_step);
+        state.zoom_out.attach_observer<ZoomButtonObserver>(this, -zoom_step);
+    }
+
+    /// Applies visual geometry with the magnifier's logical top-left computed
+    /// from its current visual size so the surface is centred on the cursor.
+    void place_at_cursor(State& s)
+    {
+        auto const layout = s.layout();
+        s.apply_geometry(
+            s.follow_cursor ?
+                layout.centered_on(s.cursor_pos) :
+                layout.freely_positioned_centered_on(s.cursor_pos));
+    }
+
+    /// Base for observers that turn a pointer/touch drag on a handle surface
+    /// into on_drag_start()/on_drag_move() callbacks. Both callbacks are invoked
+    /// with the magnifier mutex held; grab_abs holds the drag's grab position.
+    class HandleObserver : public ms::NullSurfaceObserver
+    {
+    public:
+        explicit HandleObserver(Self* self) : self(self) {}
+
+        void input_consumed(ms::Surface const*, std::shared_ptr<MirEvent const> const& event) override
         {
-            std::lock_guard lock(self->mutex);
-            self->cursor_pos = geom::Point{abs_x, abs_y};
-            auto const surf = self->surface.lock();
+            if (mir_event_get_type(event.get()) != mir_event_type_input)
+                return;
+            auto const* input_ev = mir_event_get_input_event(event.get());
+            switch (mir_input_event_get_type(input_ev))
+            {
+            case mir_input_event_type_pointer:
+                handle_pointer(mir_input_event_get_pointer_event(input_ev));
+                break;
+            case mir_input_event_type_touch:
+                handle_touch(mir_input_event_get_touch_event(input_ev));
+                break;
+            default:
+                break;
+            }
+        }
+
+    protected:
+        virtual void on_drag_start(State& s, geom::Point point) = 0;
+        virtual void on_drag_move(State& s, geom::Point point) = 0;
+
+        Self* self;
+        bool drag_active{false};
+        geom::Displacement grab_abs{};
+
+    private:
+        void begin_drag(State& s, geom::Point point)
+        {
+            drag_active = true;
+            grab_abs = {geom::as_delta(point.x), geom::as_delta(point.y)};
+            on_drag_start(s, point);
+        }
+
+        void handle_pointer(MirPointerEvent const* pev)
+        {
+            auto const action = mir_pointer_event_action(pev);
+            auto const point = geom::Point{
+                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_x)),
+                std::round(mir_pointer_event_axis_value(pev, mir_pointer_axis_y)),
+            };
+
+            auto s = self->state.lock();
+            if (action == mir_pointer_action_button_down &&
+                mir_pointer_event_button_state(pev, mir_pointer_button_primary))
+                begin_drag(*s, point);
+            else if (
+                action == mir_pointer_action_motion && drag_active &&
+                mir_pointer_event_button_state(pev, mir_pointer_button_primary))
+                on_drag_move(*s, point);
+            else if (action == mir_pointer_action_button_up)
+                drag_active = false;
+        }
+
+        void handle_touch(MirTouchEvent const* tev)
+        {
+            if (mir_touch_event_point_count(tev) != 1)
+                return;
+            auto const action = mir_touch_event_action(tev, 0);
+            auto const point = geom::Point{
+                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_x)),
+                std::round(mir_touch_event_axis_value(tev, 0, mir_touch_axis_y)),
+            };
+
+            auto s = self->state.lock();
+            if (action == mir_touch_action_down)
+                begin_drag(*s, point);
+            else if (action == mir_touch_action_change && drag_active)
+                on_drag_move(*s, point);
+            else if (action == mir_touch_action_up)
+                drag_active = false;
+        }
+    };
+
+    /// Moves the magnifier when its drag handle is dragged.
+    class DragHandleObserver : public HandleObserver
+    {
+    public:
+        using HandleObserver::HandleObserver;
+
+    protected:
+        void on_drag_start(State& s, geom::Point) override
+        {
+            auto const surf = s.surface.lock();
             if (!surf)
                 return;
 
-            auto const capture_position = cursor_position_to_capture_position(
-                surf->window_size(),
-                self->cursor_pos);
-            surf->move_to(capture_position);
-            self->render_scene_into_surface.capture_area(
-                geom::Rectangle{capture_position, surf->window_size()});
+            drag_start_magnifier_pos = surf->top_left();
+        }
+
+        void on_drag_move(State& s, geom::Point point) override
+        {
+            geom::Displacement const delta{
+                geom::as_delta(point.x - grab_abs.dx), geom::as_delta(point.y - grab_abs.dy)};
+            geom::Point const new_surface_top_left{
+                drag_start_magnifier_pos.x + delta.dx, drag_start_magnifier_pos.y + delta.dy};
+
+            s.apply_geometry(s.layout().freely_positioned(new_surface_top_left));
+        }
+
+        geom::Point drag_start_magnifier_pos{};
+    };
+
+    class CursorObserver : public mi::CursorObserver
+    {
+    public:
+        explicit CursorObserver(Self* self) : self(self) {}
+
+        void cursor_moved_to(float abs_x, float abs_y) override
+        {
+            auto s = self->state.lock();
+            s->cursor_pos = geom::Point{abs_x, abs_y};
+
+            if (!s->follow_cursor)
+                return;
+
+            auto const surf = s->surface.lock();
+            if (!surf)
+                return;
+
+            self->place_at_cursor(*s);
         }
 
         void pointer_usable() override {}
         void pointer_unusable() override {}
         void image_set_to(std::shared_ptr<mg::CursorImage>) override {}
 
-        static geom::Point cursor_position_to_capture_position(
-            geom::Size const& window_size,
-            geom::Point const& cursor_pos)
-        {
-            return geom::Point{
-                cursor_pos.x.as_value() - window_size.width.as_value() / 2,
-                cursor_pos.y.as_value() - window_size.height.as_value() / 2
-            };
-        }
-
     private:
         Self* self;
     };
 
-    friend Observer;
+    /// Observes input on the resize handle indicator and changes the magnifier capture size.
+    /// Resizes the magnifier capture area when its resize handle is dragged.
+    ///
+    /// Resizing model
+    /// --------------
+    /// The magnifier draws a *logical* capture rectangle (top-left L, size sw x sh)
+    /// scaled by `mag` into a larger *visual* rectangle on screen. Both share the same
+    /// centre, so (with inner = (mag-1)/2, outer = (mag+1)/2) the visual edges are:
+    ///     visual left/top    = L - inner * size
+    ///     visual right/bottom = L + outer * size
+    ///
+    /// A resize drag keeps the visual corner *opposite* the grabbed handle pinned and
+    /// lets the grabbed corner follow the finger:
+    ///
+    ///     pin +-----------+
+    ///         |  visual   |
+    ///         |   rect    |
+    ///         +-----------X  <- grabbed corner follows the finger (ax, ay)
+    ///
+    /// on_drag_start records the pinned visual corner. on_drag_move measures the visual
+    /// extent from pin to finger, converts it back to a logical size (/ mag), then
+    /// back-solves the surface top-left so the pinned visual corner stays put unless
+    /// keeping the resized magnifier on-screen requires clamping it.
+    class ResizeDragObserver : public HandleObserver
+    {
+    public:
+        using HandleObserver::HandleObserver;
 
-    std::mutex mutex;
-    RenderSceneIntoSurface render_scene_into_surface;
+    protected:
+        void on_drag_start(State& s, geom::Point) override
+        {
+            auto const surf = s.surface.lock();
+            if (!surf)
+                return;
+            auto const layout = s.layout();
+            pin_pos = layout.resize_anchor(s.placement_for(*surf));
+        }
+
+        void on_drag_move(State& s, geom::Point point) override
+        {
+            auto const surf = s.surface.lock();
+            if (!surf)
+                return;
+
+            s.apply_geometry(s.layout().resized_from_pinned_corner(pin_pos, point));
+        }
+
+        geom::Point pin_pos{};
+    };
+
+    /// Adjusts the magnification level when a zoom button is tapped or touched.
+    class ZoomButtonObserver : public ms::NullSurfaceObserver
+    {
+    public:
+        ZoomButtonObserver(Self* self, float delta) : self{self}, delta{delta} {}
+
+        void input_consumed(ms::Surface const*, std::shared_ptr<MirEvent const> const& event) override
+        {
+            if (mir_event_get_type(event.get()) != mir_event_type_input)
+                return;
+            auto const* input_ev = mir_event_get_input_event(event.get());
+            switch (mir_input_event_get_type(input_ev))
+            {
+            case mir_input_event_type_pointer:
+                handle_pointer(mir_input_event_get_pointer_event(input_ev));
+                break;
+            case mir_input_event_type_touch:
+                handle_touch(mir_input_event_get_touch_event(input_ev));
+                break;
+            default:
+                break;
+            }
+        }
+
+    private:
+        void handle_pointer(MirPointerEvent const* pev)
+        {
+            auto const action = mir_pointer_event_action(pev);
+            auto s = self->state.lock();
+            if (action == mir_pointer_action_button_down &&
+                mir_pointer_event_button_state(pev, mir_pointer_button_primary))
+            {
+                apply_zoom(*s);
+            }
+        }
+
+        void handle_touch(MirTouchEvent const* tev)
+        {
+            if (mir_touch_event_point_count(tev) != 1)
+                return;
+            auto const action = mir_touch_event_action(tev, 0);
+            auto s = self->state.lock();
+            if (action == mir_touch_action_down)
+            {
+                apply_zoom(*s);
+            }
+        }
+
+        /// Clamps and applies the zoom step. Caller must hold self->state.
+        void apply_zoom(State& s)
+        {
+            self->set_magnification(
+                s, std::clamp(s.magnification + delta, min_magnification + zoom_step, max_magnification));
+        }
+
+        Self* self;
+        float delta;
+    };
+
+    mir::Synchronised<State> state;
+
+    std::shared_ptr<CursorObserver> cursor_observer;
+    std::shared_ptr<DisplayConfigObserver> display_config_observer;
     std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
-    std::shared_ptr<Observer> observer;
-    std::weak_ptr<ms::Surface> surface;
-    geom::Point cursor_pos;
-    float magnification = default_magnification;
-    bool default_enabled = false;
 };
 
-miral::Magnifier::Magnifier()
-    : self(std::make_shared<Self>())
+void miral::Magnifier::Self::DisplayConfigObserver::update_bounds(
+    std::shared_ptr<mg::DisplayConfiguration const> const& config)
 {
+    geom::Rectangles rects;
+    config->for_each_output(
+        [&rects](mg::DisplayConfigurationOutput const& output)
+        {
+            if (output.used && output.connected)
+                rects.add(output.extents());
+        });
+
+    auto s = self.state.lock();
+    s->screen_bounds = rects;
+    if (auto const surf = s->surface.lock())
+    {
+        auto const top_left = surf->top_left();
+        auto const pre_clamp_visual_size = s->visual_size;
+        auto const layout = s->layout();
+        auto const placement =
+            s->follow_cursor ?
+                layout.centered_on(s->cursor_pos) :
+                layout.freely_positioned(top_left);
+        if (pre_clamp_visual_size == placement.visual_size)
+            return;
+
+        s->apply_geometry(placement);
+    }
 }
 
-miral::Magnifier::Magnifier(live_config::Store& config_store)
-    : Magnifier()
+miral::Magnifier::Magnifier() : self(std::make_shared<Self>()) {}
+
+miral::Magnifier::Magnifier(live_config::Store& config_store) : Magnifier()
 {
     config_store.add_bool_attribute(
         {"magnifier", "enable"},
@@ -192,18 +808,8 @@ miral::Magnifier::Magnifier(live_config::Store& config_store)
         {"magnifier", "magnification"},
         "The magnification scale ",
         default_magnification,
-        [this](live_config::Key const& key, std::optional<float> val)
-        {
-            if (val.has_value() && *val <= 1.f)
-            {
-                mir::log_warning(
-                    "Config key '%s' should be greater than or equal to 1",
-                    key.to_string().c_str());
-                return;
-            }
-
-            magnification(val.value_or(default_magnification));
-        });
+        [this](live_config::Key const&, std::optional<float> val)
+        { magnification(val.value_or(default_magnification)); });
     config_store.add_int_attribute(
         {"magnifier", "capture_size", "width"},
         "The width of the rectangular region that will be magnified",
@@ -212,9 +818,7 @@ miral::Magnifier::Magnifier(live_config::Store& config_store)
         {
             if (val.has_value() && *val <= 0)
             {
-                mir::log_warning(
-                    "Config key '%s' should be greater than 0",
-                    key.to_string().c_str());
+                mir::log_warning("Config key '%s' should be greater than 0", key.to_string().c_str());
                 return;
             }
 
@@ -233,9 +837,7 @@ miral::Magnifier::Magnifier(live_config::Store& config_store)
         {
             if (val.has_value() && *val <= 0)
             {
-                mir::log_warning(
-                    "Config key '%s' should be greater than 0",
-                    key.to_string().c_str());
+                mir::log_warning("Config key '%s' should be greater than 0", key.to_string().c_str());
                 return;
             }
 
@@ -256,14 +858,15 @@ miral::Magnifier& miral::Magnifier::enable(bool enabled)
 
 miral::Magnifier& miral::Magnifier::magnification(float magnification)
 {
-    if (magnification <= 1.f)
+    auto const clamped_magnification = std::clamp(magnification, min_magnification, max_magnification);
+    if (magnification != clamped_magnification)
     {
-        mir::log_warning(
-            "Magnification should be greater than or equal to 1");
+        mir::log_warning("Magnification should be between %.2f and %.2f", min_magnification, max_magnification);
+
         return *this;
     }
 
-    self->set_magnification(magnification);
+    self->set_magnification(clamped_magnification);
     return *this;
 }
 
@@ -273,7 +876,18 @@ miral::Magnifier& miral::Magnifier::capture_size(mir::geometry::Size const& size
     return *this;
 }
 
-void miral::Magnifier::operator()(mir::Server& server)
+miral::Magnifier& miral::Magnifier::set_behavior(Behavior behavior)
 {
-    self->init(server);
+    switch (behavior)
+    {
+    case Behavior::follow_cursor:
+        self->follow_cursor();
+        break;
+    case Behavior::freely_positioned:
+        self->stop_following_cursor();
+        break;
+    }
+    return *this;
 }
+
+void miral::Magnifier::operator()(mir::Server& server) { self->init(server); }

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -946,6 +946,22 @@ miral::Magnifier::Magnifier(live_config::Store& config_store) : Magnifier()
             size.height = geom::Height(*val);
             capture_size(size);
         });
+    config_store.add_string_attribute(
+        {"magnifier", "behavior"},
+        "What behavior the magnifier should exhibit",
+        [this](live_config::Key const&, std::optional<std::string_view> val)
+        {
+            if (!val.has_value())
+                return;
+
+            if (*val == "follow_cursor")
+                set_behavior(Behavior::follow_cursor);
+            else if (*val == "freely_positioned")
+                set_behavior(Behavior::freely_positioned);
+            else
+                mir::log_warning(
+                    "Config key 'magnifier.behavior' should be either 'follow_cursor' or 'freely_positioned'");
+        });
 }
 
 miral::Magnifier& miral::Magnifier::enable(bool enabled)

--- a/src/miral/magnifier_handle_indicator.cpp
+++ b/src/miral/magnifier_handle_indicator.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "magnifier_handle_indicator.h"
+
+#include <mir/geometry/dimensions.h>
+#include <mir/graphics/graphic_buffer_allocator.h>
+
+namespace geomtery = mir::geometry;
+namespace mg = mir::graphics;
+namespace mrs = mir::renderer::software;
+
+namespace
+{
+class BufferPainter
+{
+public:
+    struct HorizontalLine
+    {
+        geomtery::X start;
+        geomtery::X end;
+        geomtery::Y y;
+        geomtery::Height thickness;
+    };
+
+    struct VerticalLine
+    {
+        geomtery::X x;
+        geomtery::Y start;
+        geomtery::Y end;
+        geomtery::Width thickness;
+    };
+
+    explicit BufferPainter(mg::Buffer& buffer) :
+        writable{mrs::as_write_mappable(std::shared_ptr<mg::Buffer>(&buffer, [](mg::Buffer*) {}))},
+        mapping{writable->map_writeable()},
+        stride{mapping->stride()},
+        size{buffer.size()}
+    { assert(mapping->format() == format); }
+
+    void clear() { std::memset(mapping->data(), 0, mapping->len()); }
+
+    void fill_circle()
+    {
+        auto const cx = geomtery::as_x((size.width - geomtery::DeltaX{1}) / 2.0f);
+        auto const cy = geomtery::as_y((size.height - geomtery::DeltaY{1}) / 2.0f);
+        auto const r = std::min(cx.as_value(), cy.as_value());
+        auto const r_sq = r * r;
+
+        for (geomtery::Y y{0}; y < geomtery::as_y(size.height); y = y + geomtery::DeltaY{1})
+        {
+            for (geomtery::X x{0}; x < geomtery::as_x(size.width); x = x + geomtery::DeltaX{1})
+            {
+                auto const dx = x - cx;
+                auto const dy = y - cy;
+                auto const delta = dx.as_value() * dx.as_value() + dy.as_value() * dy.as_value();
+
+                if (delta <= r_sq)
+                    set_pixel(geomtery::Point{x, y}, disc_grey);
+            }
+        }
+    }
+
+    void draw_horizontal_line(HorizontalLine const& line)
+    {
+        auto const true_start = std::min<geomtery::X>(line.start, line.end);
+        auto const true_end = std::max<geomtery::X>(line.start, line.end);
+        for (int t = 0; t < line.thickness.as_value(); ++t)
+            for (auto x = true_start; x <= true_end; x = x + geomtery::DeltaX{1})
+                set_pixel(geomtery::Point{x, line.y + geomtery::DeltaY{t}}, icon_grey);
+    }
+
+    void draw_vertical_line(VerticalLine const& line)
+    {
+        auto const true_start = std::min<geomtery::Y>(line.start, line.end);
+        auto const true_end = std::max<geomtery::Y>(line.start, line.end);
+        for (int t = 0; t < line.thickness.as_value(); ++t)
+            for (auto y = true_start; y <= true_end; y = y + geomtery::DeltaY{1})
+                set_pixel(geomtery::Point{line.x + geomtery::DeltaX{t}, y}, icon_grey);
+    }
+
+    auto buffer_size() const -> geomtery::Size { return size; }
+
+private:
+    void set_pixel(geomtery::Point const& point, uint8_t grey)
+    {
+        auto const x = point.x.as_value();
+        auto const y = point.y.as_value();
+        if (x < 0 || x >= size.width.as_value() || y < 0 || y >= size.height.as_value())
+            return;
+
+        // For mir_pixel_format_argb_8888 on little-endian: memory layout [B, G, R, A].
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        std::span<std::uint8_t> const pixels{reinterpret_cast<std::uint8_t*>(mapping->data()), mapping->len()};
+        auto const offset = y * stride.as_value() + x * MIR_BYTES_PER_PIXEL(format);
+        auto const pixel = pixels.subspan(offset, MIR_BYTES_PER_PIXEL(format));
+        pixel[0] = pixel[1] = pixel[2] = grey;
+        pixel[3] = background_alpha;
+    }
+
+    /// Painter colour/alpha constants for handle indicator graphics.
+    inline uint8_t static disc_grey = 40;
+    inline uint8_t static icon_grey = 210;
+    inline uint8_t static background_alpha = 150;
+
+    static auto constexpr format = mir_pixel_format_argb_8888;
+    std::shared_ptr<mrs::WriteMappable> const writable;
+    std::unique_ptr<mrs::Mapping<std::byte>> const mapping;
+    geomtery::Stride const stride;
+    geomtery::Size const size;
+};
+
+static void fill_drag_buffer(mg::Buffer& buffer)
+{
+    BufferPainter painter{buffer};
+    painter.clear();
+    painter.fill_circle();
+
+    // Draw a drag-pan icon: four arrowheads (N/S/E/W) connected by slim stems.
+    static int constexpr tip_dist = 15;
+    static int constexpr head_len = 5;
+    static int constexpr stem_thickness = 3;
+    static int constexpr base_dist = (tip_dist - head_len);
+
+    auto const [w, h] = painter.buffer_size();
+    auto const center_x = geomtery::as_x((w - geomtery::DeltaX{1}) / 2);
+    auto const center_y = geomtery::as_y((h - geomtery::DeltaY{1}) / 2);
+    auto const tip_n = center_y - geomtery::DeltaY{tip_dist};
+    auto const tip_s = center_y + geomtery::DeltaY{tip_dist};
+    auto const tip_w = center_x - geomtery::DeltaX{tip_dist};
+    auto const tip_e = center_x + geomtery::DeltaX{tip_dist};
+    auto const base_n = center_y - geomtery::DeltaY{base_dist};
+    auto const base_s = center_y + geomtery::DeltaY{base_dist};
+    auto const base_w = center_x - geomtery::DeltaX{base_dist};
+    auto const base_e = center_x + geomtery::DeltaX{base_dist};
+
+    // Stems
+    painter.draw_vertical_line({
+        .x = center_x - geomtery::DeltaX{stem_thickness / 2},
+        .start = base_n,
+        .end = base_s,
+        .thickness = geomtery::Width{stem_thickness},
+    });
+    painter.draw_horizontal_line({
+        .start = base_w,
+        .end = base_e,
+        .y = center_y - geomtery::DeltaY{stem_thickness / 2},
+        .thickness = geomtery::Height{stem_thickness},
+    });
+
+    // North arrowhead — rows from tip_n+1 to base_n, width grows by 1 px per row
+    for (auto y = tip_n + geomtery::DeltaY{1}; y <= base_n; y = y + geomtery::DeltaY{1})
+        painter.draw_horizontal_line({
+            .start = center_x - geomtery::DeltaX((y - tip_n).as_value()),
+            .end = center_x + geomtery::DeltaX((y - tip_n).as_value()),
+            .y = y,
+            .thickness = geomtery::Height{1},
+        });
+
+    // South arrowhead
+    for (auto y = base_s; y < tip_s; y = y + geomtery::DeltaY{1})
+        painter.draw_horizontal_line({
+            .start = center_x - geomtery::DeltaX((tip_s - y).as_value()),
+            .end = center_x + geomtery::DeltaX((tip_s - y).as_value()),
+            .y = y,
+            .thickness = geomtery::Height{1},
+        });
+
+    // West arrowhead — columns from tip_w+1 to base_w
+    for (auto x = tip_w + geomtery::DeltaX{1}; x <= base_w; x = x + geomtery::DeltaX{1})
+        painter.draw_vertical_line({
+            .x = x,
+            .start = center_y - geomtery::DeltaY((x - tip_w).as_value()),
+            .end = center_y + geomtery::DeltaY((x - tip_w).as_value()),
+            .thickness = geomtery::Width{1},
+        });
+
+    // East arrowhead
+    for (auto x = base_e; x < tip_e; x = x + geomtery::DeltaX{1})
+        painter.draw_vertical_line({
+            .x = x,
+            .start = center_y - geomtery::DeltaY((tip_e - x).as_value()),
+            .end = center_y + geomtery::DeltaY((tip_e - x).as_value()),
+            .thickness = geomtery::Width{1},
+        });
+}
+
+static void fill_resize_buffer(mg::Buffer& buffer)
+{
+    BufferPainter painter{buffer};
+    painter.clear();
+    painter.fill_circle();
+
+    // Corner bracket: two 2-px arms meeting at the top-left corner, which is
+    // where the resize handle always sits within the magnifier surface.
+    static int constexpr arm_len = 12;
+    static int constexpr thickness = 2;
+    auto const [w, h] = painter.buffer_size();
+    auto const corner_x = geomtery::as_x(w / 4);
+    auto const corner_y = geomtery::as_y(h / 4);
+
+    painter.draw_horizontal_line({
+        .start = corner_x,
+        .end = corner_x + geomtery::DeltaX{arm_len},
+        .y = corner_y,
+        .thickness = geomtery::Height{thickness},
+    });
+    painter.draw_vertical_line({
+        .x = corner_x,
+        .start = corner_y,
+        .end = corner_y + geomtery::DeltaY{arm_len},
+        .thickness = geomtery::Width{thickness},
+    });
+}
+
+static void fill_zoom_buffer(mg::Buffer& buffer, bool zoom_in)
+{
+    BufferPainter painter{buffer};
+    painter.clear();
+    painter.fill_circle();
+
+    // Draw + (zoom in) or – (zoom out) symbol.
+    auto const [w, h] = painter.buffer_size();
+    int const bar_thickness = std::max(geomtery::Width{2}, w / 12).as_value();
+    int const bar_len = (w * 5 / 8).as_value();
+
+    painter.draw_horizontal_line({
+        .start = geomtery::as_x((w - geomtery::Width{bar_len}) / 2),
+        .end = geomtery::as_x((w + geomtery::Width{bar_len}) / 2 - geomtery::DeltaX{1}),
+        .y = geomtery::as_y((h - geomtery::Height{bar_thickness}) / 2),
+        .thickness = geomtery::Height{bar_thickness},
+    });
+
+    if (zoom_in)
+        painter.draw_vertical_line({
+            .x = geomtery::as_x((w - geomtery::Width{bar_thickness}) / 2),
+            .start = geomtery::as_y((h - geomtery::Height{bar_len}) / 2),
+            .end = geomtery::as_y((h + geomtery::Height{bar_len}) / 2 - geomtery::DeltaY{1}),
+            .thickness = geomtery::Width{bar_thickness},
+        });
+}
+
+static std::string name_for_kind(miral::HandleKind kind)
+{
+    switch (kind)
+    {
+    case miral::HandleKind::drag:
+        return "magnifier-drag-handle";
+    case miral::HandleKind::resize:
+        return "magnifier-resize-handle";
+    case miral::HandleKind::zoom_in:
+        return "magnifier-zoom-in-handle";
+    case miral::HandleKind::zoom_out:
+        return "magnifier-zoom-out-handle";
+    }
+
+    std::unreachable();
+}
+}
+
+miral::HandleIndicator::HandleIndicator(
+    mir::geometry::Rectangle const& initial_rect,
+    HandleKind kind,
+    mir::compositor::CompositorID capture_compositor_id,
+    std::shared_ptr<mir::graphics::GraphicBufferAllocator> const& allocator,
+    std::shared_ptr<mir::scene::SceneReport> const& scene_report,
+    std::shared_ptr<mir::ObserverRegistrar<mir::graphics::DisplayConfigurationObserver>> const&
+        display_config_registrar) :
+    BasicSurface{
+        name_for_kind(kind),
+        initial_rect,
+        mir_pointer_unconfined,
+        miral::create_stream_info(),
+        nullptr,
+        scene_report,
+        display_config_registrar},
+    pool{
+        [allocator, initial_rect]
+        { return allocator->alloc_software_buffer(initial_rect.size, mir_pixel_format_argb_8888); },
+        1},
+    capture_compositor_id{capture_compositor_id}
+{
+    auto buffer = pool.claim();
+    switch (kind)
+    {
+    case HandleKind::drag:
+        fill_drag_buffer(*buffer);
+        break;
+    case HandleKind::resize:
+        fill_resize_buffer(*buffer);
+        break;
+    case HandleKind::zoom_in:
+    case HandleKind::zoom_out:
+        fill_zoom_buffer(*buffer, kind == HandleKind::zoom_in);
+        break;
+    }
+    auto const sz = window_size();
+    get_streams().begin()->stream->submit_buffer(buffer, sz, geomtery::RectangleD{{0, 0}, sz});
+
+    set_depth_layer(mir_depth_layer_always_on_top);
+    set_focus_mode(mir_focus_mode_disabled);
+    hide();
+}
+
+auto miral::HandleIndicator::generate_renderables(mir::compositor::CompositorID id) const
+    -> mir::graphics::RenderableList
+{
+    if (id == capture_compositor_id)
+        return {};
+    return BasicSurface::generate_renderables(id);
+}

--- a/src/miral/magnifier_handle_indicator.h
+++ b/src/miral/magnifier_handle_indicator.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_MAGNIFIER_HANDLE_INDICATOR_H
+#define MIRAL_MAGNIFIER_HANDLE_INDICATOR_H
+
+#include "software_buffer_pool.h"
+#include <mir/scene/basic_surface.h>
+#include <mir/geometry/forward.h>
+#include <mir/compositor/compositor_id.h>
+
+namespace mir
+{
+namespace graphics { class GraphicBufferAllocator; }
+namespace scene { class SceneReport; }
+}
+
+namespace miral
+{
+enum class HandleKind { drag, resize, zoom_in, zoom_out };
+
+class HandleIndicator : public mir::scene::BasicSurface
+{
+public:
+    HandleIndicator(
+        mir::geometry::Rectangle const& initial_rect,
+        HandleKind kind,
+        mir::compositor::CompositorID capture_compositor_id,
+        std::shared_ptr<mir::graphics::GraphicBufferAllocator> const& allocator,
+        std::shared_ptr<mir::scene::SceneReport> const& scene_report,
+        std::shared_ptr<mir::ObserverRegistrar<mir::graphics::DisplayConfigurationObserver>> const&
+            display_config_registrar);
+
+    auto generate_renderables(mir::compositor::CompositorID id) const -> mir::graphics::RenderableList override;
+
+private:
+    miral::SoftwareBufferPool mutable pool;
+    mir::compositor::CompositorID capture_compositor_id;
+};
+}
+
+#endif

--- a/src/miral/magnifier_layout.cpp
+++ b/src/miral/magnifier_layout.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "magnifier_layout.h"
+
+#include <algorithm>
+#include <cmath>
+#include <ranges>
+
+namespace geom = mir::geometry;
+
+namespace
+{
+auto constexpr zoom_stack_padding = 8;
+geom::Height const zoom_stack_height{
+    2 * miral::MagnifierLayout::handle_diameter + zoom_stack_padding};
+auto const minimum_visual_dimension =
+    2 * miral::MagnifierLayout::handle_diameter + zoom_stack_height.as_int();
+
+auto outputs_usable(geom::Rectangles const& outputs) -> bool
+{
+    return outputs.size() != 0 &&
+           std::ranges::none_of(
+               outputs,
+               [](auto const& output)
+               { return output.size.width == geom::Width{0} || output.size.height == geom::Height{0}; });
+}
+
+auto find_current_output(geom::Rectangles const& outputs, geom::Rectangle const& bounds) -> geom::Rectangle
+{
+    auto maximum_overlap = 0u;
+    auto current_output = outputs.begin();
+
+    for (auto output = outputs.begin(); output != outputs.end(); ++output)
+    {
+        auto const overlap = geom::generic::intersection_of(*output, bounds);
+        auto const overlap_area = overlap.size.width.as_uint32_t() * overlap.size.height.as_uint32_t();
+        if (overlap_area > maximum_overlap)
+        {
+            maximum_overlap = overlap_area;
+            current_output = output;
+        }
+    }
+
+    return *current_output;
+}
+
+auto overlaps_multiple_outputs(geom::Rectangles const& outputs, geom::Rectangle const& bounds) -> bool
+{
+    auto overlap_count = 0;
+    return std::ranges::any_of(
+        outputs,
+        [&](auto const& output)
+        { return output.overlaps(bounds) && ++overlap_count > 1; });
+}
+
+auto minimum_clamped(geom::Size size) -> geom::Size
+{
+    return {
+        std::max(size.width, geom::Width{minimum_visual_dimension}),
+        std::max(size.height, geom::Height{minimum_visual_dimension})};
+}
+
+auto output_clamped(geom::Size size, geom::Size output_size) -> geom::Size
+{
+    auto const maximum_size = output_size * 0.8;
+    return {
+        std::min(size.width, maximum_size.width),
+        std::min(size.height, maximum_size.height)};
+}
+
+auto center(geom::Point top_left, geom::Size size) -> geom::Point
+{
+    return top_left +
+           geom::Displacement{
+               geom::as_delta(size.width / 2),
+               geom::as_delta(size.height / 2)};
+}
+
+auto top_left_centered_on(geom::Point center_point, geom::Size size) -> geom::Point
+{
+    return center_point -
+           geom::Displacement{
+               geom::as_delta(size.width / 2),
+               geom::as_delta(size.height / 2)};
+}
+}
+
+miral::MagnifierLayout::MagnifierLayout(
+    geom::Rectangles const& outputs,
+    geom::Size requested_visual_size,
+    float magnification) :
+    outputs{outputs},
+    requested_visual_size{minimum_clamped(requested_visual_size)},
+    magnification{magnification}
+{
+}
+
+auto miral::MagnifierLayout::centered_on(geom::Point center_point) const -> Placement
+{
+    auto const candidate_logical_size = logical_size(requested_visual_size);
+    auto const candidate_top_left = top_left_centered_on(center_point, candidate_logical_size);
+    auto const visual_size = effective_visual_size(candidate_top_left);
+    auto const surface_top_left = top_left_centered_on(center_point, logical_size(visual_size));
+    return placement_with_size(surface_top_left, surface_top_left, visual_size);
+}
+
+auto miral::MagnifierLayout::freely_positioned(geom::Point desired_surface_top_left) const -> Placement
+{
+    return freely_positioned_with_size(
+        desired_surface_top_left,
+        effective_visual_size(desired_surface_top_left));
+}
+
+auto miral::MagnifierLayout::freely_positioned_centered_on(geom::Point center_point) const -> Placement
+{
+    auto const candidate_logical_size = logical_size(requested_visual_size);
+    auto const candidate_top_left = top_left_centered_on(center_point, candidate_logical_size);
+    auto const visual_size = effective_visual_size(candidate_top_left);
+    return freely_positioned_with_size(
+        top_left_centered_on(center_point, logical_size(visual_size)),
+        visual_size);
+}
+
+auto miral::MagnifierLayout::resized_from_pinned_corner(
+    geom::Point pinned_visual_bottom_right,
+    geom::Point dragged_visual_top_left) const -> Placement
+{
+    auto const raw_visual_size = minimum_clamped({
+        geom::as_width(pinned_visual_bottom_right.x - dragged_visual_top_left.x),
+        geom::as_height(pinned_visual_bottom_right.y - dragged_visual_top_left.y)});
+    auto const to_logical_dimension = [this](auto visual_dimension)
+    {
+        return decltype(visual_dimension){
+            std::min(static_cast<int>(std::ceil(visual_dimension.as_value() / magnification)), 1000)};
+    };
+    auto const resized_logical_size = geom::Size{
+        to_logical_dimension(raw_visual_size.width),
+        to_logical_dimension(raw_visual_size.height)};
+    auto const resized_visual_size = resized_logical_size * magnification;
+    auto const outer = (magnification + 1.0f) / 2.0f;
+    auto const desired_surface_top_left =
+        pinned_visual_bottom_right -
+        geom::Displacement{
+            geom::as_delta(outer * resized_logical_size.width),
+            geom::as_delta(outer * resized_logical_size.height)};
+
+    // Feed the resized footprint through the same output clamping and capture
+    // mapping as any other freely positioned placement.
+    return MagnifierLayout{outputs, resized_visual_size, magnification}.freely_positioned(desired_surface_top_left);
+}
+
+auto miral::MagnifierLayout::handle_positions(Placement const& placement) const -> HandlePositions
+{
+    auto const bounds = visual_bounds(placement);
+    auto const zoom_x = bounds.right() - geom::DeltaX{handle_diameter};
+    auto const zoom_y =
+        bounds.top() + geom::as_delta(bounds.size.height / 2) - geom::as_delta(zoom_stack_height / 2);
+
+    return {
+        .drag = {
+            bounds.right() - geom::DeltaX{handle_diameter},
+            bounds.bottom() - geom::DeltaY{handle_diameter}},
+        .resize = bounds.top_left,
+        .zoom_in = {zoom_x, zoom_y},
+        .zoom_out = {zoom_x, zoom_y + geom::DeltaY{handle_diameter + zoom_stack_padding}}};
+}
+
+auto miral::MagnifierLayout::contains_content(
+    geom::PointF const& point,
+    Placement const& placement) const -> bool
+{
+    auto const contains = [&point](geom::Rectangle const& area)
+    {
+        return point.x.as_value() >= area.left().as_value() &&
+               point.x.as_value() < area.right().as_value() &&
+               point.y.as_value() >= area.top().as_value() &&
+               point.y.as_value() < area.bottom().as_value();
+    };
+
+    if (!contains(visual_bounds(placement)))
+        return false;
+
+    auto const handles = handle_positions(placement);
+    for (auto const& handle : {handles.drag, handles.resize, handles.zoom_in, handles.zoom_out})
+    {
+        if (contains({handle, {handle_diameter, handle_diameter}}))
+            return false;
+    }
+
+    return true;
+}
+
+auto miral::MagnifierLayout::resize_anchor(Placement const& placement) const -> geom::Point
+{
+    auto const bounds = visual_bounds(placement);
+    return {bounds.right(), bounds.bottom()};
+}
+
+auto miral::MagnifierLayout::surface_center(Placement const& placement) const -> geom::Point
+{
+    return center(placement.surface_top_left, placement.capture_area.size);
+}
+
+auto miral::MagnifierLayout::capture_center(Placement const& placement) const -> geom::Point
+{
+    return center(placement.capture_area.top_left, placement.capture_area.size);
+}
+
+auto miral::MagnifierLayout::placement_with_size(
+    geom::Point capture_top_left,
+    geom::Point surface_top_left,
+    geom::Size visual_size) const -> Placement
+{
+    return {
+        .capture_area = {capture_top_left, logical_size(visual_size)},
+        .surface_top_left = surface_top_left,
+        .visual_size = visual_size};
+}
+
+auto miral::MagnifierLayout::freely_positioned_with_size(
+    geom::Point desired_surface_top_left,
+    geom::Size visual_size) const -> Placement
+{
+    auto const logical_size = this->logical_size(visual_size);
+    auto const surface_top_left = clamp_surface_position(desired_surface_top_left, logical_size);
+    return placement_with_size(
+        capture_position_for(surface_top_left, logical_size),
+        surface_top_left,
+        visual_size);
+}
+
+auto miral::MagnifierLayout::logical_size(geom::Size visual_size) const -> geom::Size
+{
+    return {
+        geom::Width{std::max(1.0f, std::round(visual_size.width.as_value() / magnification))},
+        geom::Height{std::max(1.0f, std::round(visual_size.height.as_value() / magnification))}};
+}
+
+auto miral::MagnifierLayout::effective_visual_size(geom::Point candidate_surface_top_left) const -> geom::Size
+{
+    if (!outputs_usable(outputs))
+        return requested_visual_size;
+
+    auto const candidate = placement_with_size(
+        candidate_surface_top_left,
+        candidate_surface_top_left,
+        requested_visual_size);
+    auto const current_output = find_current_output(outputs, visual_bounds(candidate));
+    return output_clamped(requested_visual_size, current_output.size);
+}
+
+auto miral::MagnifierLayout::visual_bounds(Placement const& placement) const -> geom::Rectangle
+{
+    auto const logical_size = placement.capture_area.size;
+    auto const visual_size = logical_size * magnification;
+    auto const top_left =
+        placement.surface_top_left -
+        geom::Displacement{
+            geom::as_delta((magnification - 1.0f) / 2.0f * logical_size.width),
+            geom::as_delta((magnification - 1.0f) / 2.0f * logical_size.height)};
+    return {top_left, visual_size};
+}
+
+auto miral::MagnifierLayout::clamp_surface_position(
+    geom::Point desired_surface_top_left,
+    geom::Size logical_size) const -> geom::Point
+{
+    if (!outputs_usable(outputs))
+        return desired_surface_top_left;
+
+    auto const placement = placement_with_size(
+        desired_surface_top_left,
+        desired_surface_top_left,
+        logical_size * magnification);
+    auto const bounds = visual_bounds(placement);
+    if (overlaps_multiple_outputs(outputs, bounds))
+        return desired_surface_top_left;
+
+    auto const current_output = find_current_output(outputs, bounds);
+    auto const output_right = current_output.right();
+    auto const output_bottom = current_output.bottom();
+    auto dx = geom::DeltaX{0};
+    if (bounds.left() < current_output.left())
+        dx = current_output.left() - bounds.left();
+    else if (bounds.right() > output_right)
+        dx = output_right - bounds.right();
+
+    auto dy = geom::DeltaY{0};
+    if (bounds.top() < current_output.top())
+        dy = current_output.top() - bounds.top();
+    else if (bounds.bottom() > output_bottom)
+        dy = output_bottom - bounds.bottom();
+
+    return desired_surface_top_left + geom::Displacement{dx, dy};
+}
+
+auto miral::MagnifierLayout::capture_position_for(
+    geom::Point surface_top_left,
+    geom::Size logical_size) const -> geom::Point
+{
+    if (!outputs_usable(outputs))
+        return surface_top_left;
+
+    auto const placement =
+        placement_with_size(surface_top_left, surface_top_left, logical_size * magnification);
+    auto const bounds = visual_bounds(placement);
+    auto const current_output = find_current_output(outputs, bounds);
+    auto const handle_clearance = static_cast<int>(std::ceil(handle_diameter / magnification));
+
+    struct AxisMapping
+    {
+        int visual_start;
+        int visual_extent;
+        int logical_extent;
+        int output_start;
+        int output_extent;
+    };
+
+    auto const map_axis = [handle_clearance](AxisMapping const& axis)
+    {
+        auto const visual_travel = axis.output_extent - axis.visual_extent;
+        if (visual_travel <= 0)
+            return axis.output_start + (axis.output_extent - axis.logical_extent) / 2;
+
+        auto const progress =
+            std::clamp(static_cast<double>(axis.visual_start - axis.output_start) / visual_travel, 0.0, 1.0);
+        auto const out_of_bounds = std::min(axis.logical_extent / 2, handle_clearance);
+        auto const capture_start = axis.output_start - out_of_bounds;
+        auto const capture_travel = axis.output_extent - axis.logical_extent + 2 * out_of_bounds;
+        return capture_start + static_cast<int>(std::round(progress * capture_travel));
+    };
+
+    return {
+        map_axis({
+            .visual_start = bounds.left().as_value(),
+            .visual_extent = bounds.size.width.as_value(),
+            .logical_extent = logical_size.width.as_value(),
+            .output_start = current_output.left().as_value(),
+            .output_extent = current_output.size.width.as_value()}),
+        map_axis({
+            .visual_start = bounds.top().as_value(),
+            .visual_extent = bounds.size.height.as_value(),
+            .logical_extent = logical_size.height.as_value(),
+            .output_start = current_output.top().as_value(),
+            .output_extent = current_output.size.height.as_value()})};
+}

--- a/src/miral/magnifier_layout.h
+++ b/src/miral/magnifier_layout.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_MAGNIFIER_LAYOUT_H
+#define MIRAL_MAGNIFIER_LAYOUT_H
+
+#include <mir/geometry/point.h>
+#include <mir/geometry/rectangle.h>
+#include <mir/geometry/rectangles.h>
+#include <mir/geometry/size.h>
+
+namespace miral
+{
+class MagnifierLayout
+{
+public:
+    static int constexpr handle_diameter = 48;
+
+    struct Placement
+    {
+        // capture_area.size is the logical size corresponding to visual_size
+        // at this layout's magnification.
+        mir::geometry::Rectangle capture_area;
+        mir::geometry::Point surface_top_left;
+        mir::geometry::Size visual_size;
+    };
+
+    struct HandlePositions
+    {
+        mir::geometry::Point drag;
+        mir::geometry::Point resize;
+        mir::geometry::Point zoom_in;
+        mir::geometry::Point zoom_out;
+    };
+
+    MagnifierLayout(
+        mir::geometry::Rectangles const& outputs,
+        mir::geometry::Size requested_visual_size,
+        float magnification);
+
+    auto centered_on(mir::geometry::Point center) const -> Placement;
+    auto freely_positioned(mir::geometry::Point desired_surface_top_left) const -> Placement;
+    auto freely_positioned_centered_on(mir::geometry::Point center) const -> Placement;
+    auto resized_from_pinned_corner(
+        mir::geometry::Point pinned_visual_bottom_right,
+        mir::geometry::Point dragged_visual_top_left) const -> Placement;
+
+    auto handle_positions(Placement const& placement) const -> HandlePositions;
+    auto contains_content(mir::geometry::PointF const& point, Placement const& placement) const -> bool;
+    auto resize_anchor(Placement const& placement) const -> mir::geometry::Point;
+    auto surface_center(Placement const& placement) const -> mir::geometry::Point;
+    auto capture_center(Placement const& placement) const -> mir::geometry::Point;
+
+private:
+    auto placement_with_size(
+        mir::geometry::Point capture_top_left,
+        mir::geometry::Point surface_top_left,
+        mir::geometry::Size visual_size) const -> Placement;
+    auto freely_positioned_with_size(
+        mir::geometry::Point desired_surface_top_left,
+        mir::geometry::Size visual_size) const -> Placement;
+    auto logical_size(mir::geometry::Size visual_size) const -> mir::geometry::Size;
+    auto effective_visual_size(mir::geometry::Point candidate_surface_top_left) const -> mir::geometry::Size;
+    auto visual_bounds(Placement const& placement) const -> mir::geometry::Rectangle;
+    auto clamp_surface_position(
+        mir::geometry::Point desired_surface_top_left,
+        mir::geometry::Size logical_size) const -> mir::geometry::Point;
+    auto capture_position_for(
+        mir::geometry::Point surface_top_left,
+        mir::geometry::Size logical_size) const -> mir::geometry::Point;
+
+    mir::geometry::Rectangles outputs;
+    mir::geometry::Size requested_visual_size;
+    float magnification;
+};
+}
+
+#endif

--- a/src/miral/render_scene_into_surface.cpp
+++ b/src/miral/render_scene_into_surface.cpp
@@ -122,6 +122,11 @@ public:
         overlay_cursor = next_overlay_cursor;
     }
 
+    mc::CompositorID screen_shooter_id() const
+    {
+        return screen_shooter->id();
+    }
+
 private:
     std::mutex mutable mutex;
     std::shared_ptr<mc::Scene> const scene;
@@ -197,8 +202,14 @@ public:
             on_surface_ready(surface);
     }
 
+    mc::CompositorID capture_compositor_id() const
+    {
+        std::lock_guard lock{mutex};
+        return surface ? surface->screen_shooter_id() : nullptr;
+    }
+
 private:
-    std::mutex mutex;
+    mutable std::mutex mutex;
     std::function<void(std::shared_ptr<mir::scene::Surface> const&)> on_surface_ready{[](auto const&){}};
     geom::Rectangle initial_capture_area;
     bool initial_overlay_cursor = false;
@@ -228,6 +239,11 @@ miral::RenderSceneIntoSurface& miral::RenderSceneIntoSurface::overlay_cursor(boo
 {
     self->set_overlay_cursor(overlay_cursor);
     return *this;
+}
+
+auto miral::RenderSceneIntoSurface::capture_compositor_id() const -> mir::compositor::CompositorID
+{
+    return self->capture_compositor_id();
 }
 
 miral::RenderSceneIntoSurface& miral::RenderSceneIntoSurface::on_surface_ready(

--- a/src/miral/render_scene_into_surface.cpp
+++ b/src/miral/render_scene_into_surface.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "render_scene_into_surface.h"
+#include "software_buffer_pool.h"
 
 #include <mir/executor.h>
 #include <mir/server.h>
@@ -38,132 +39,10 @@ namespace mc = mir::compositor;
 namespace mrs = mir::renderer::software;
 namespace mi = mir::input;
 
+
 namespace
 {
-class ClaimedBuffer : public mg::Buffer
-{
-public:
-    explicit ClaimedBuffer(
-        std::shared_ptr<Buffer> const& buffer,
-        std::function<void()>&& release_callback)
-        : buffer(buffer), release_callback(std::move(release_callback))
-    {
-    }
-
-    ~ClaimedBuffer() override
-    {
-        release_callback();
-    }
-
-    std::unique_ptr<mrs::Mapping<std::byte const>> map_readable() const override
-    {
-        return buffer->map_readable();
-    }
-    mg::BufferID id() const override { return buffer->id(); }
-    geom::Size size() const override { return buffer->size(); }
-    MirPixelFormat pixel_format() const override { return buffer->pixel_format(); }
-    mg::NativeBufferBase* native_buffer_base() override { return buffer->native_buffer_base(); }
-
-private:
-    std::shared_ptr<Buffer> const buffer;
-    std::function<void()> const release_callback;
-};
-
-/// A simple buffer pool. Users provide the buffers that back the pool.
-/// These buffers may be claimed later.
-class BufferPool
-{
-public:
-    using BufferBuilder = std::function<std::shared_ptr<mg::Buffer>()>;
-
-    BufferPool(BufferBuilder&& builder_func, size_t default_size)
-        : data(std::make_shared<Self>(std::move(builder_func), default_size))
-    {
-    }
-
-    /// Claims the next free buffer from the pool. This may resize the buffer pool
-    /// if that is required to claim a buffer.
-    /// \returns A buffer from the pool
-    std::shared_ptr<mg::Buffer> claim()
-    {
-        std::lock_guard lock{data->mutex};
-        for (size_t i = 0; i < data->buffers.size(); ++i)
-        {
-            if (auto& [used, buffer] = data->buffers[i]; !used)
-            {
-                used = true;
-                std::weak_ptr weak_data = data;
-                return std::make_shared<ClaimedBuffer>(buffer, [weak_data=weak_data, i]
-                {
-                    if (auto const locked = weak_data.lock())
-                    {
-                        std::lock_guard lock{locked->mutex};
-                        locked->buffers[i].first = false;
-                    }
-                });
-            }
-        }
-
-        data->buffers.emplace_back(true, data->builder());
-        size_t i = data->buffers.size() - 1;
-
-        std::weak_ptr weak_data = data;
-        return std::make_shared<ClaimedBuffer>(data->buffers[i].second, [weak_data=weak_data, i]
-        {
-            if (auto const locked = weak_data.lock())
-            {
-                std::lock_guard lock{locked->mutex};
-                locked->buffers[i].first = false;
-            }
-        });
-    }
-
-    void set_builder(BufferBuilder&& in_builder)
-    {
-        std::lock_guard lock{data->mutex};
-        data->builder = std::move(in_builder);
-        for (auto& b: data->buffers)
-            b = { b.first, data->builder() };
-    }
-
-private:
-    struct Self
-    {
-        Self(BufferBuilder&& builder_func, size_t default_size)
-            : builder(std::move(builder_func))
-        {
-            for (size_t i = 0; i < default_size; ++i)
-                buffers.emplace_back(false, builder());
-        }
-
-        std::mutex mutex;
-        BufferBuilder builder;
-
-        /// List of available buffers along with their "claimed" status.
-        std::vector<std::pair<bool, std::shared_ptr<mg::Buffer>>> buffers;
-    };
-
-    std::shared_ptr<Self> data;
-};
-
-class AlwaysHasSubmittedBufferStream : public mc::Stream
-{
-public:
-    bool has_submitted_buffer() const override
-    {
-        return true;
-    }
-};
-
-std::list<ms::StreamInfo> create_stream_info()
-{
-    std::list<ms::StreamInfo> result;
-    result.push_back({
-        std::make_shared<AlwaysHasSubmittedBufferStream>(),
-        geom::Displacement{}
-    });
-    return result;
-}
+using miral::SoftwareBufferPool;
 
 class SceneRenderingSurface : public ms::BasicSurface
 {
@@ -243,6 +122,11 @@ public:
         overlay_cursor = next_overlay_cursor;
     }
 
+    mc::CompositorID screen_shooter_id() const
+    {
+        return screen_shooter->id();
+    }
+
 private:
     std::mutex mutable mutex;
     std::shared_ptr<mc::Scene> const scene;
@@ -250,7 +134,7 @@ private:
     bool overlay_cursor = false;
     std::shared_ptr<mc::ScreenShooter> screen_shooter;
     std::shared_ptr<mg::GraphicBufferAllocator> allocator;
-    BufferPool mutable pool;
+    SoftwareBufferPool mutable pool;
 };
 }
 
@@ -318,8 +202,14 @@ public:
             on_surface_ready(surface);
     }
 
+    mc::CompositorID capture_compositor_id() const
+    {
+        std::lock_guard lock{mutex};
+        return surface ? surface->screen_shooter_id() : nullptr;
+    }
+
 private:
-    std::mutex mutex;
+    mutable std::mutex mutex;
     std::function<void(std::shared_ptr<mir::scene::Surface> const&)> on_surface_ready{[](auto const&){}};
     geom::Rectangle initial_capture_area;
     bool initial_overlay_cursor = false;
@@ -349,6 +239,11 @@ miral::RenderSceneIntoSurface& miral::RenderSceneIntoSurface::overlay_cursor(boo
 {
     self->set_overlay_cursor(overlay_cursor);
     return *this;
+}
+
+auto miral::RenderSceneIntoSurface::capture_compositor_id() const -> mir::compositor::CompositorID
+{
+    return self->capture_compositor_id();
 }
 
 miral::RenderSceneIntoSurface& miral::RenderSceneIntoSurface::on_surface_ready(

--- a/src/miral/render_scene_into_surface.cpp
+++ b/src/miral/render_scene_into_surface.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "render_scene_into_surface.h"
+#include "software_buffer_pool.h"
 
 #include <mir/executor.h>
 #include <mir/server.h>
@@ -38,132 +39,10 @@ namespace mc = mir::compositor;
 namespace mrs = mir::renderer::software;
 namespace mi = mir::input;
 
+
 namespace
 {
-class ClaimedBuffer : public mg::Buffer
-{
-public:
-    explicit ClaimedBuffer(
-        std::shared_ptr<Buffer> const& buffer,
-        std::function<void()>&& release_callback)
-        : buffer(buffer), release_callback(std::move(release_callback))
-    {
-    }
-
-    ~ClaimedBuffer() override
-    {
-        release_callback();
-    }
-
-    std::unique_ptr<mrs::Mapping<std::byte const>> map_readable() const override
-    {
-        return buffer->map_readable();
-    }
-    mg::BufferID id() const override { return buffer->id(); }
-    geom::Size size() const override { return buffer->size(); }
-    MirPixelFormat pixel_format() const override { return buffer->pixel_format(); }
-    mg::NativeBufferBase* native_buffer_base() override { return buffer->native_buffer_base(); }
-
-private:
-    std::shared_ptr<Buffer> const buffer;
-    std::function<void()> const release_callback;
-};
-
-/// A simple buffer pool. Users provide the buffers that back the pool.
-/// These buffers may be claimed later.
-class BufferPool
-{
-public:
-    using BufferBuilder = std::function<std::shared_ptr<mg::Buffer>()>;
-
-    BufferPool(BufferBuilder&& builder_func, size_t default_size)
-        : data(std::make_shared<Self>(std::move(builder_func), default_size))
-    {
-    }
-
-    /// Claims the next free buffer from the pool. This may resize the buffer pool
-    /// if that is required to claim a buffer.
-    /// \returns A buffer from the pool
-    std::shared_ptr<mg::Buffer> claim()
-    {
-        std::lock_guard lock{data->mutex};
-        for (size_t i = 0; i < data->buffers.size(); ++i)
-        {
-            if (auto& [used, buffer] = data->buffers[i]; !used)
-            {
-                used = true;
-                std::weak_ptr weak_data = data;
-                return std::make_shared<ClaimedBuffer>(buffer, [weak_data=weak_data, i]
-                {
-                    if (auto const locked = weak_data.lock())
-                    {
-                        std::lock_guard lock{locked->mutex};
-                        locked->buffers[i].first = false;
-                    }
-                });
-            }
-        }
-
-        data->buffers.emplace_back(true, data->builder());
-        size_t i = data->buffers.size() - 1;
-
-        std::weak_ptr weak_data = data;
-        return std::make_shared<ClaimedBuffer>(data->buffers[i].second, [weak_data=weak_data, i]
-        {
-            if (auto const locked = weak_data.lock())
-            {
-                std::lock_guard lock{locked->mutex};
-                locked->buffers[i].first = false;
-            }
-        });
-    }
-
-    void set_builder(BufferBuilder&& in_builder)
-    {
-        std::lock_guard lock{data->mutex};
-        data->builder = std::move(in_builder);
-        for (auto& b: data->buffers)
-            b = { b.first, data->builder() };
-    }
-
-private:
-    struct Self
-    {
-        Self(BufferBuilder&& builder_func, size_t default_size)
-            : builder(std::move(builder_func))
-        {
-            for (size_t i = 0; i < default_size; ++i)
-                buffers.emplace_back(false, builder());
-        }
-
-        std::mutex mutex;
-        BufferBuilder builder;
-
-        /// List of available buffers along with their "claimed" status.
-        std::vector<std::pair<bool, std::shared_ptr<mg::Buffer>>> buffers;
-    };
-
-    std::shared_ptr<Self> data;
-};
-
-class AlwaysHasSubmittedBufferStream : public mc::Stream
-{
-public:
-    bool has_submitted_buffer() const override
-    {
-        return true;
-    }
-};
-
-std::list<ms::StreamInfo> create_stream_info()
-{
-    std::list<ms::StreamInfo> result;
-    result.push_back({
-        std::make_shared<AlwaysHasSubmittedBufferStream>(),
-        geom::Displacement{}
-    });
-    return result;
-}
+using miral::SoftwareBufferPool;
 
 class SceneRenderingSurface : public ms::BasicSurface
 {
@@ -250,7 +129,7 @@ private:
     bool overlay_cursor = false;
     std::shared_ptr<mc::ScreenShooter> screen_shooter;
     std::shared_ptr<mg::GraphicBufferAllocator> allocator;
-    BufferPool mutable pool;
+    SoftwareBufferPool mutable pool;
 };
 }
 

--- a/src/miral/render_scene_into_surface.h
+++ b/src/miral/render_scene_into_surface.h
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <memory>
+#include <mir/compositor/compositor_id.h>
 #include <mir/geometry/rectangle.h>
 
 namespace mir
@@ -50,6 +51,12 @@ public:
 
     /// Set to true if the the cursor should be included in the scene capture.
     RenderSceneIntoSurface& overlay_cursor(bool overlay_cursor);
+
+    /// Returns the compositor ID of the internal screen shooter.
+    /// Companion surfaces that should be excluded from the captured (magnified)
+    /// output can return an empty renderable list when generate_renderables()
+    /// is called with this ID.
+    mir::compositor::CompositorID capture_compositor_id() const;
 
     /// Provides access to the surface when it is ready.
     RenderSceneIntoSurface& on_surface_ready(std::function<void(std::shared_ptr<mir::scene::Surface> const&)>&& callback);

--- a/src/miral/software_buffer_pool.cpp
+++ b/src/miral/software_buffer_pool.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "software_buffer_pool.h"
+
+#include <mir/geometry/displacement.h>
+
+namespace mg = mir::graphics;
+namespace mrs = mir::renderer::software;
+namespace geom = mir::geometry;
+namespace ms = mir::scene;
+
+namespace
+{
+/// A mc::Stream that always reports having a submitted buffer so that
+/// BasicSurface::generate_renderables() includes the surface in every frame.
+class AlwaysHasSubmittedBufferStream : public mir::compositor::Stream
+{
+public:
+    bool has_submitted_buffer() const override { return true; }
+};
+
+/// Wraps a buffer and calls a release callback when destroyed, returning it
+/// to its owning SoftwareBufferPool.
+class ClaimedBuffer : public mir::graphics::Buffer
+{
+public:
+    ClaimedBuffer(std::shared_ptr<mir::graphics::Buffer> const& buffer, std::function<void()>&& release_callback);
+
+    ~ClaimedBuffer() override;
+
+    ClaimedBuffer(ClaimedBuffer const&) = delete;
+    ClaimedBuffer& operator=(ClaimedBuffer const&) = delete;
+    ClaimedBuffer(ClaimedBuffer&&) = delete;
+    ClaimedBuffer& operator=(ClaimedBuffer&&) = delete;
+
+    auto map_readable() const -> std::unique_ptr<mir::renderer::software::Mapping<std::byte const>> override;
+    mir::graphics::BufferID id() const override;
+    mir::geometry::Size size() const override;
+    MirPixelFormat pixel_format() const override;
+    mir::graphics::NativeBufferBase* native_buffer_base() override;
+
+private:
+    std::shared_ptr<mir::graphics::Buffer> buffer;
+    std::function<void()> release_callback;
+};
+}
+
+ClaimedBuffer::ClaimedBuffer(
+    std::shared_ptr<mg::Buffer> const& buffer,
+    std::function<void()>&& release_callback) :
+    buffer(buffer),
+    release_callback(std::move(release_callback))
+{}
+
+ClaimedBuffer::~ClaimedBuffer() { release_callback(); }
+
+auto ClaimedBuffer::map_readable() const -> std::unique_ptr<mrs::Mapping<std::byte const>>
+{ return buffer->map_readable(); }
+
+mg::BufferID ClaimedBuffer::id() const { return buffer->id(); }
+geom::Size ClaimedBuffer::size() const { return buffer->size(); }
+MirPixelFormat ClaimedBuffer::pixel_format() const { return buffer->pixel_format(); }
+mg::NativeBufferBase* ClaimedBuffer::native_buffer_base() { return buffer->native_buffer_base(); }
+
+miral::SoftwareBufferPool::Self::Self(BufferBuilder&& builder_func, size_t initial_size) : builder(std::move(builder_func))
+{
+    for (size_t i = 0; i < initial_size; ++i)
+        buffers.emplace_back(false, builder());
+}
+
+miral::SoftwareBufferPool::SoftwareBufferPool(BufferBuilder&& builder_func, size_t initial_size) :
+    data(std::make_shared<Self>(std::move(builder_func), initial_size))
+{}
+
+std::shared_ptr<mg::Buffer> miral::SoftwareBufferPool::claim()
+{
+    std::lock_guard lock{data->mutex};
+    for (size_t i = 0; i < data->buffers.size(); ++i)
+    {
+        if (auto& [used, buffer] = data->buffers[i]; !used)
+        {
+            used = true;
+            std::weak_ptr weak_data = data;
+            return std::make_shared<ClaimedBuffer>(
+                buffer,
+                [weak_data, i]
+                {
+                    if (auto const locked = weak_data.lock())
+                    {
+                        std::lock_guard l{locked->mutex};
+                        locked->buffers[i].first = false;
+                    }
+                });
+        }
+    }
+
+    // All slots in use — grow the pool.
+    data->buffers.emplace_back(true, data->builder());
+    size_t const i = data->buffers.size() - 1;
+    std::weak_ptr weak_data = data;
+    return std::make_shared<ClaimedBuffer>(
+        data->buffers[i].second,
+        [weak_data, i]
+        {
+            if (auto const locked = weak_data.lock())
+            {
+                std::lock_guard l{locked->mutex};
+                locked->buffers[i].first = false;
+            }
+        });
+}
+
+void miral::SoftwareBufferPool::set_builder(BufferBuilder&& builder)
+{
+    std::lock_guard lock{data->mutex};
+    data->builder = std::move(builder);
+    for (auto& b : data->buffers)
+        b = {b.first, data->builder()};
+}
+
+std::list<ms::StreamInfo> miral::create_stream_info()
+{
+    std::list<ms::StreamInfo> result;
+    result.push_back({std::make_shared<AlwaysHasSubmittedBufferStream>(), geom::Displacement{}});
+    return result;
+}

--- a/src/miral/software_buffer_pool.cpp
+++ b/src/miral/software_buffer_pool.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "software_buffer_pool.h"
+
+#include <mir/geometry/displacement.h>
+
+namespace mg = mir::graphics;
+namespace mrs = mir::renderer::software;
+namespace geom = mir::geometry;
+namespace ms = mir::scene;
+
+namespace
+{
+/// A mc::Stream that always reports having a submitted buffer so that
+/// BasicSurface::generate_renderables() includes the surface in every frame.
+class AlwaysHasSubmittedBufferStream : public mir::compositor::Stream
+{
+public:
+    bool has_submitted_buffer() const override { return true; }
+};
+
+/// Wraps a buffer and calls a release callback when destroyed, returning it
+/// to its owning SoftwareBufferPool.
+class ClaimedBuffer : public mir::graphics::Buffer
+{
+public:
+    ClaimedBuffer(std::shared_ptr<mir::graphics::Buffer> const& buffer, std::function<void()>&& release_callback);
+
+    ~ClaimedBuffer() override;
+
+    auto map_readable() const -> std::unique_ptr<mir::renderer::software::Mapping<std::byte const>> override;
+    mir::graphics::BufferID id() const override;
+    mir::geometry::Size size() const override;
+    MirPixelFormat pixel_format() const override;
+    mir::graphics::NativeBufferBase* native_buffer_base() override;
+
+private:
+    std::shared_ptr<mir::graphics::Buffer> const buffer;
+    std::function<void()> const release_callback;
+};
+}
+
+ClaimedBuffer::ClaimedBuffer(
+    std::shared_ptr<mg::Buffer> const& buffer,
+    std::function<void()>&& release_callback) :
+    buffer(buffer),
+    release_callback(std::move(release_callback))
+{}
+
+ClaimedBuffer::~ClaimedBuffer() { release_callback(); }
+
+auto ClaimedBuffer::map_readable() const -> std::unique_ptr<mrs::Mapping<std::byte const>>
+{ return buffer->map_readable(); }
+
+mg::BufferID ClaimedBuffer::id() const { return buffer->id(); }
+geom::Size ClaimedBuffer::size() const { return buffer->size(); }
+MirPixelFormat ClaimedBuffer::pixel_format() const { return buffer->pixel_format(); }
+mg::NativeBufferBase* ClaimedBuffer::native_buffer_base() { return buffer->native_buffer_base(); }
+
+miral::SoftwareBufferPool::Self::Self(BufferBuilder&& builder_func, size_t initial_size) : builder(std::move(builder_func))
+{
+    for (size_t i = 0; i < initial_size; ++i)
+        buffers.emplace_back(false, builder());
+}
+
+miral::SoftwareBufferPool::SoftwareBufferPool(BufferBuilder&& builder_func, size_t initial_size) :
+    data(std::make_shared<Self>(std::move(builder_func), initial_size))
+{}
+
+std::shared_ptr<mg::Buffer> miral::SoftwareBufferPool::claim()
+{
+    std::lock_guard lock{data->mutex};
+    for (size_t i = 0; i < data->buffers.size(); ++i)
+    {
+        if (auto& [used, buffer] = data->buffers[i]; !used)
+        {
+            used = true;
+            std::weak_ptr weak_data = data;
+            return std::make_shared<ClaimedBuffer>(
+                buffer,
+                [weak_data, i]
+                {
+                    if (auto const locked = weak_data.lock())
+                    {
+                        std::lock_guard l{locked->mutex};
+                        locked->buffers[i].first = false;
+                    }
+                });
+        }
+    }
+
+    // All slots in use — grow the pool.
+    data->buffers.emplace_back(true, data->builder());
+    size_t const i = data->buffers.size() - 1;
+    std::weak_ptr weak_data = data;
+    return std::make_shared<ClaimedBuffer>(
+        data->buffers[i].second,
+        [weak_data, i]
+        {
+            if (auto const locked = weak_data.lock())
+            {
+                std::lock_guard l{locked->mutex};
+                locked->buffers[i].first = false;
+            }
+        });
+}
+
+void miral::SoftwareBufferPool::set_builder(BufferBuilder&& builder)
+{
+    std::lock_guard lock{data->mutex};
+    data->builder = std::move(builder);
+    for (auto& b : data->buffers)
+        b = {b.first, data->builder()};
+}
+
+std::list<ms::StreamInfo> miral::create_stream_info()
+{
+    std::list<ms::StreamInfo> result;
+    result.push_back({std::make_shared<AlwaysHasSubmittedBufferStream>(), geom::Displacement{}});
+    return result;
+}

--- a/src/miral/software_buffer_pool.cpp
+++ b/src/miral/software_buffer_pool.cpp
@@ -42,6 +42,11 @@ public:
 
     ~ClaimedBuffer() override;
 
+    ClaimedBuffer(ClaimedBuffer const&) = delete;
+    ClaimedBuffer& operator=(ClaimedBuffer const&) = delete;
+    ClaimedBuffer(ClaimedBuffer&&) = delete;
+    ClaimedBuffer& operator=(ClaimedBuffer&&) = delete;
+
     auto map_readable() const -> std::unique_ptr<mir::renderer::software::Mapping<std::byte const>> override;
     mir::graphics::BufferID id() const override;
     mir::geometry::Size size() const override;
@@ -49,8 +54,8 @@ public:
     mir::graphics::NativeBufferBase* native_buffer_base() override;
 
 private:
-    std::shared_ptr<mir::graphics::Buffer> const buffer;
-    std::function<void()> const release_callback;
+    std::shared_ptr<mir::graphics::Buffer> buffer;
+    std::function<void()> release_callback;
 };
 }
 

--- a/src/miral/software_buffer_pool.h
+++ b/src/miral/software_buffer_pool.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_SOFTWARE_BUFFER_POOL_H
+#define MIRAL_SOFTWARE_BUFFER_POOL_H
+
+#include <mir/compositor/stream.h>
+#include <mir/geometry/dimensions.h>
+#include <mir/graphics/buffer.h>
+#include <mir/renderer/sw/pixel_source.h>
+#include <mir/scene/surface.h>
+
+#include <functional>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace mir::graphics { class GraphicBufferAllocator; }
+
+namespace miral
+{
+
+/// Minimal double-buffered pool.  Callers claim one slot at a time via
+/// claim(); the slot is returned to the pool when the ClaimedBuffer is
+/// destroyed.  If all slots are in use the pool grows automatically.
+class SoftwareBufferPool
+{
+public:
+    using BufferBuilder = std::function<std::shared_ptr<mir::graphics::Buffer>()>;
+
+    SoftwareBufferPool(BufferBuilder&& builder_func, size_t initial_size);
+
+    /// Claims the next free buffer, growing the pool if necessary.
+    std::shared_ptr<mir::graphics::Buffer> claim();
+
+    /// Replaces the buffer builder and rebuilds all existing buffers.
+    void set_builder(BufferBuilder&& builder);
+
+private:
+    struct Self
+    {
+        Self(BufferBuilder&& builder_func, size_t initial_size);
+        std::mutex mutex;
+        BufferBuilder builder;
+        std::vector<std::pair<bool, std::shared_ptr<mir::graphics::Buffer>>> buffers;
+    };
+
+    std::shared_ptr<Self> data;
+};
+
+/// Creates a StreamInfo list containing a single AlwaysHasSubmittedBufferStream.
+std::list<mir::scene::StreamInfo> create_stream_info();
+
+} // namespace miral
+
+#endif // MIRAL_SOFTWARE_BUFFER_POOL_H

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -222,7 +222,8 @@ global:
     miral::LocatePointer::schedule_request*;
     miral::Magnifier::Magnifier*;
     miral::Magnifier::capture_size*;
-    miral::Magnifier::decouple*;
+    miral::Magnifier::follow_cursor*;
+    miral::Magnifier::stop_following_cursor*;
     miral::Magnifier::enable*;
     miral::Magnifier::magnification*;
     miral::Magnifier::operator*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -222,11 +222,10 @@ global:
     miral::LocatePointer::schedule_request*;
     miral::Magnifier::Magnifier*;
     miral::Magnifier::capture_size*;
-    miral::Magnifier::follow_cursor*;
-    miral::Magnifier::stop_following_cursor*;
     miral::Magnifier::enable*;
     miral::Magnifier::magnification*;
     miral::Magnifier::operator*;
+    miral::Magnifier::set_behavior*;
     miral::MinimalWindowManager::?MinimalWindowManager*;
     miral::MinimalWindowManager::MinimalWindowManager*;
     miral::MinimalWindowManager::advise_delete_app*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -225,6 +225,7 @@ global:
     miral::Magnifier::enable*;
     miral::Magnifier::magnification*;
     miral::Magnifier::operator*;
+    miral::Magnifier::set_behavior*;
     miral::MinimalWindowManager::?MinimalWindowManager*;
     miral::MinimalWindowManager::MinimalWindowManager*;
     miral::MinimalWindowManager::advise_delete_app*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -222,6 +222,7 @@ global:
     miral::LocatePointer::schedule_request*;
     miral::Magnifier::Magnifier*;
     miral::Magnifier::capture_size*;
+    miral::Magnifier::decouple*;
     miral::Magnifier::enable*;
     miral::Magnifier::magnification*;
     miral::Magnifier::operator*;

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -53,6 +53,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     ini_file_with_overrides.cpp
     override_watcher.cpp
     version_compare.cpp
+    magnifier_layout.cpp
     ${MIRAL_TEST_SOURCES}
 )
 

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -29,6 +29,7 @@
 #include <mir/input/input_device_registry.h>
 #include <mir/input/input_sink.h>
 #include <mir/input/virtual_input_device.h>
+#include <mir/main_loop.h>
 #include <mir/test/signal.h>
 #include <mir/executor.h>
 #include "add_virtual_device.h"
@@ -84,6 +85,13 @@ public:
     { return magnifier_renderable()->screen_position().top_left; }
 
     auto scene_element_count() const -> size_t { return server().the_scene()->scene_elements_for(this).size(); }
+
+    void wait_for_magnifier_initialization()
+    {
+        mir::test::Signal initialized;
+        server().the_main_loop()->spawn([&initialized] { initialized.raise(); });
+        ASSERT_TRUE(initialized.wait_for(2s)) << "timed out waiting for magnifier initialization";
+    }
 
     static constexpr auto magnifier_index = 0;
     Magnifier magnifier;
@@ -205,17 +213,15 @@ TEST_F(MagnifierTest, decoupling_after_start_shows_handles)
 // would deadlock. The test body runs on a separate thread while the main loop
 // runs in the background.
 //
-// Synchronisation: a SentinelCursorObserver is registered on the multiplexer.
-// Because for_each_observer dispatches in registration order (magnifier's
-// observer registered first), the sentinel fires only after the magnifier has
-// processed each cursor event. Waiting for the sentinel's initial-state
-// delivery acts as a "fence" that guarantees all earlier main-loop tasks
-// (including the magnifier's own initial cursor event) have run.
+// Synchronisation: Magnifier registers its cursor observer from a main-loop
+// task. Wait for that task before registering a sentinel, so the sentinel is
+// ordered after Magnifier when cursor events are dispatched.
 
 TEST_F(MagnifierTest, cursor_not_tracked_in_decoupled_mode)
 {
     magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
     start_server();
+    wait_for_magnifier_initialization();
 
     auto const mux = server().the_cursor_observer_multiplexer();
     auto sentinel = std::make_shared<SentinelCursorObserver>();
@@ -238,6 +244,7 @@ TEST_F(MagnifierTest, cursor_tracked_in_coupled_mode)
 {
     magnifier.enable(true);
     start_server();
+    wait_for_magnifier_initialization();
 
     auto const mux = server().the_cursor_observer_multiplexer();
     auto sentinel = std::make_shared<SentinelCursorObserver>();

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -18,7 +18,10 @@
 #include <mir/server.h>
 #include <mir/compositor/scene.h>
 #include <mir/compositor/scene_element.h>
+#include <mir/events/event_builders.h>
+#include <mir/events/touch_contact.h>
 #include <mir/graphics/renderable.h>
+#include <mir/input/composite_event_filter.h>
 #include <mir/input/cursor_observer.h>
 #include <mir/input/cursor_observer_multiplexer.h>
 #include <mir/input/event_builder.h>
@@ -262,6 +265,7 @@ struct MagnifierHandleTest : MagnifierTest
                 server.add_init_callback(
                     [&server, this]
                     {
+                        composite_event_filter = server.the_composite_event_filter();
                         input_device_registry = server.the_input_device_registry();
                         input_device_hub = server.the_input_device_hub();
                     });
@@ -365,6 +369,7 @@ struct MagnifierHandleTest : MagnifierTest
 
     std::weak_ptr<mi::InputDeviceRegistry> input_device_registry;
     std::weak_ptr<mi::InputDeviceHub> input_device_hub;
+    std::weak_ptr<mi::CompositeEventFilter> composite_event_filter;
     std::shared_ptr<mi::VirtualInputDevice> pointer_device;
 
 private:
@@ -434,6 +439,112 @@ TEST_F(MagnifierHandleTest, double_clicking_drag_handle_does_not_move_magnifier)
     click(handle_center);
 
     EXPECT_THAT(magnifier_top_left(), Eq(before));
+}
+
+TEST_F(MagnifierHandleTest, consumes_pointer_events_on_decoupled_magnifier_surface)
+{
+    auto const event = mir::events::make_pointer_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        mir_pointer_action_motion,
+        MirPointerButtons{},
+        element_center(magnifier_index),
+        geom::DisplacementF{},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+
+    EXPECT_TRUE(composite_event_filter.lock()->handle(*event));
+}
+
+TEST_F(MagnifierHandleTest, consumes_touch_events_on_decoupled_magnifier_surface)
+{
+    auto const event = mir::events::make_touch_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        std::vector<mir::events::TouchContact>{{
+            0,
+            mir_touch_action_down,
+            mir_touch_tooltype_finger,
+            element_center(magnifier_index),
+            1.0f,
+            1.0f,
+            1.0f,
+            0.0f}});
+
+    EXPECT_TRUE(composite_event_filter.lock()->handle(*event));
+}
+
+TEST_F(MagnifierHandleTest, does_not_consume_events_outside_decoupled_magnifier_surface)
+{
+    auto const pointer_event = mir::events::make_pointer_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        mir_pointer_action_motion,
+        MirPointerButtons{},
+        geom::PointF{799.0f, 599.0f},
+        geom::DisplacementF{},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    auto const touch_event = mir::events::make_touch_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        std::vector<mir::events::TouchContact>{{
+            0,
+            mir_touch_action_down,
+            mir_touch_tooltype_finger,
+            geom::PointF{799.0f, 599.0f},
+            1.0f,
+            1.0f,
+            1.0f,
+            0.0f}});
+
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));
+}
+
+TEST_F(MagnifierHandleTest, does_not_consume_events_when_magnifier_is_inactive)
+{
+    auto const magnifier_center = element_center(magnifier_index);
+    magnifier.decouple(false);
+
+    auto const pointer_event = mir::events::make_pointer_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        mir_pointer_action_motion,
+        MirPointerButtons{},
+        magnifier_center,
+        geom::DisplacementF{},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    auto const touch_event = mir::events::make_touch_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        std::vector<mir::events::TouchContact>{{
+            0,
+            mir_touch_action_down,
+            mir_touch_tooltype_finger,
+            magnifier_center,
+            1.0f,
+            1.0f,
+            1.0f,
+            0.0f}});
+
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));
+
+    magnifier.decouple(true).enable(false);
+
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));
 }
 
 TEST_F(MagnifierHandleTest, zoom_in_handle_increases_magnification)

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -58,6 +58,7 @@ struct SentinelCursorObserver : public mi::CursorObserver
     void image_set_to(std::shared_ptr<mir::graphics::CursorImage>) override {}
     mir::test::Signal signal;
 };
+
 }
 
 class MagnifierTest : public TestServer
@@ -123,14 +124,33 @@ TEST_F(MagnifierTest, magnification_results_in_scaled_transform)
 
 TEST_F(MagnifierTest, can_set_capture_size)
 {
-    magnifier.capture_size(Size(500, 500));
+    magnifier.capture_size(Size(200, 200));
     magnifier.enable(true);
     add_start_callback([&]
     {
         EXPECT_THAT(scene_element_count(), Eq(1));
-        EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(500, 500)));
+        EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(200, 200)));
     });
     start_server();
+}
+
+TEST_F(MagnifierTest, capture_size_is_limited_to_80_percent_of_the_output)
+{
+    magnifier.enable(true);
+    start_server();
+
+    auto const mux = server().the_cursor_observer_multiplexer();
+    auto sentinel = std::make_shared<SentinelCursorObserver>();
+    mux->register_interest(sentinel);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for initial cursor state";
+
+    magnifier.capture_size(Size(1000, 1000));
+    magnifier_renderable()->buffer();
+
+    auto const capture_size = magnifier_renderable()->screen_position().size;
+    EXPECT_THAT(capture_size.width, Lt(Width{1000}));
+    EXPECT_THAT(capture_size.height, Lt(Height{1000}));
+    mux->unregister_interest(*sentinel);
 }
 
 TEST_F(MagnifierTest, decoupled_mode_shows_handle_indicators)

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -553,7 +553,7 @@ TEST_F(MagnifierHandleTest, zoom_in_handle_increases_magnification)
 
     click(element_center(zoom_in_handle_index));
 
-    auto const expected = glm::scale(glm::mat4(1.0), glm::vec3(2, 2, 1));
+    auto const expected = glm::scale(glm::mat4(1.0), glm::vec3(1.5f, 1.5f, 1.0f));
     EXPECT_THAT(magnifier_renderable()->transformation(), Eq(expected));
     EXPECT_THAT(magnifier_renderable()->transformation(), Ne(before));
 }

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -19,16 +19,43 @@
 #include <mir/compositor/scene.h>
 #include <mir/compositor/scene_element.h>
 #include <mir/graphics/renderable.h>
+#include <mir/input/cursor_observer.h>
+#include <mir/input/cursor_observer_multiplexer.h>
+#include <mir/input/event_builder.h>
+#include <mir/input/input_device_hub.h>
+#include <mir/input/input_device_registry.h>
+#include <mir/input/input_sink.h>
+#include <mir/input/virtual_input_device.h>
+#include <mir/test/signal.h>
+#include <mir/executor.h>
+#include "add_virtual_device.h"
 
 #include <miral/test_server.h>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <glm/gtc/matrix_transform.hpp>
 
-namespace mtf = mir_test_framework;
+namespace geom = mir::geometry;
+namespace mi = mir::input;
 
 using namespace testing;
 using namespace miral;
+using namespace std::chrono_literals;
+
+namespace
+{
+/// Raises a signal each time cursor_moved_to() fires. Used by cursor-tracking
+/// tests to wait for cursor events to propagate through the main loop before
+/// inspecting surface state.
+struct SentinelCursorObserver : public mi::CursorObserver
+{
+    void cursor_moved_to(float, float) override { signal.raise(); }
+    void pointer_usable() override {}
+    void pointer_unusable() override {}
+    void image_set_to(std::shared_ptr<mir::graphics::CursorImage>) override {}
+    mir::test::Signal signal;
+};
+}
 
 class MagnifierTest : public TestServer
 {
@@ -46,6 +73,15 @@ public:
         add_server_init(magnifier);
     }
 
+    auto magnifier_renderable() const -> std::shared_ptr<mir::graphics::Renderable>
+    { return server().the_scene()->scene_elements_for(this).at(magnifier_index)->renderable(); }
+
+    auto magnifier_top_left() const -> geom::Point
+    { return magnifier_renderable()->screen_position().top_left; }
+
+    auto scene_element_count() const -> size_t { return server().the_scene()->scene_elements_for(this).size(); }
+
+    static constexpr auto magnifier_index = 0;
     Magnifier magnifier;
 };
 
@@ -53,9 +89,7 @@ TEST_F(MagnifierTest, magnifier_disabled_by_default)
 {
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(0));
+        EXPECT_THAT(scene_element_count(), Eq(0));
     });
     start_server();
 }
@@ -65,9 +99,7 @@ TEST_F(MagnifierTest, can_start_enabled)
     magnifier.enable(true);
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(1));
+        EXPECT_THAT(scene_element_count(), Eq(1));
     });
     start_server();
 }
@@ -78,12 +110,9 @@ TEST_F(MagnifierTest, magnification_results_in_scaled_transform)
     magnifier.enable(true);
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(1));
+        EXPECT_THAT(scene_element_count(), Eq(1));
         auto const expected = glm::scale(glm::mat4(1.0), glm::vec3(2, 2, 1));
-
-        EXPECT_THAT(elements.at(0)->renderable()->transformation(), Eq(expected));
+        EXPECT_THAT(magnifier_renderable()->transformation(), Eq(expected));
     });
     start_server();
 }
@@ -94,10 +123,307 @@ TEST_F(MagnifierTest, can_set_capture_size)
     magnifier.enable(true);
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(1));
-        EXPECT_THAT(elements.at(0)->renderable()->screen_position().size, Eq(Size(500, 500)));
+        EXPECT_THAT(scene_element_count(), Eq(1));
+        EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(500, 500)));
     });
     start_server();
+}
+
+TEST_F(MagnifierTest, decoupled_mode_shows_handle_indicators)
+{
+    magnifier.enable(true).decouple(true);
+    add_start_callback([&]
+    {
+        // 4 indicators + 1 magnifier surface
+        EXPECT_THAT(scene_element_count(), Eq(5));
+    });
+    start_server();
+}
+
+TEST_F(MagnifierTest, handles_hidden_when_disabled_in_decoupled_mode)
+{
+    magnifier.enable(true).decouple(true);
+    add_start_callback([&]
+    {
+        magnifier.enable(false);
+        EXPECT_THAT(scene_element_count(), Eq(0));
+    });
+    start_server();
+}
+
+TEST_F(MagnifierTest, toggling_to_coupled_hides_handles)
+{
+    magnifier.enable(true).decouple(true);
+    add_start_callback([&]
+    {
+        EXPECT_THAT(scene_element_count(), Eq(5));
+        magnifier.decouple(false);
+        EXPECT_THAT(scene_element_count(), Eq(1));
+    });
+    start_server();
+}
+
+TEST_F(MagnifierTest, decoupling_after_start_shows_handles)
+{
+    magnifier.enable(true);
+    add_start_callback([&]
+    {
+        EXPECT_THAT(scene_element_count(), Eq(1));
+        magnifier.decouple(true);
+        EXPECT_THAT(scene_element_count(), Eq(5));
+    });
+    start_server();
+}
+
+// These tests run in the test body (after start_server() returns) rather than
+// inside add_start_callback. Start callbacks are enqueued on the main loop via
+// main_loop->enqueue, so blocking inside one waiting for more main-loop work
+// would deadlock. The test body runs on a separate thread while the main loop
+// runs in the background.
+//
+// Synchronisation: a SentinelCursorObserver is registered on the multiplexer.
+// Because for_each_observer dispatches in registration order (magnifier's
+// observer registered first), the sentinel fires only after the magnifier has
+// processed each cursor event. Waiting for the sentinel's initial-state
+// delivery acts as a "fence" that guarantees all earlier main-loop tasks
+// (including the magnifier's own initial cursor event) have run.
+
+TEST_F(MagnifierTest, cursor_not_tracked_in_decoupled_mode)
+{
+    magnifier.enable(true).decouple(true);
+    start_server();
+
+    auto const mux = server().the_cursor_observer_multiplexer();
+    auto sentinel = std::make_shared<SentinelCursorObserver>();
+    mux->register_interest(sentinel);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for initial cursor state";
+    sentinel->signal.reset();
+
+    auto const before = magnifier_top_left();
+
+    mux->cursor_moved_to(400, 300);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for cursor event";
+
+    auto const after = magnifier_top_left();
+
+    EXPECT_THAT(after, Eq(before));
+    mux->unregister_interest(*sentinel);
+}
+
+TEST_F(MagnifierTest, cursor_tracked_in_coupled_mode)
+{
+    magnifier.enable(true);
+    start_server();
+
+    auto const mux = server().the_cursor_observer_multiplexer();
+    auto sentinel = std::make_shared<SentinelCursorObserver>();
+    mux->register_interest(sentinel);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for initial cursor state";
+    sentinel->signal.reset();
+
+    auto const before = magnifier_top_left();
+
+    mux->cursor_moved_to(400, 300);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for cursor event";
+
+    auto const after = magnifier_top_left();
+
+    EXPECT_THAT(after, Ne(before));
+    mux->unregister_interest(*sentinel);
+}
+
+// Input events are dispatched synchronously through SurfaceInputDispatcher into
+// the handle surface observers, but the observers run via BasicSurface::Multiplexer
+// which uses linearising_executor (deferred background thread). State changes
+// (move_to, resize, set_transformation) are applied asynchronously. We flush
+// the executor before reading scene state.
+//
+// Handle positions depend on the initial surface placement (at {0,0} from the
+// BasicSurface constructor). We read positions dynamically from the live scene
+// elements to avoid brittle hardcoded coordinates.
+//
+// Scene element ordering (fixed, determined by creation order in add_init_callback):
+//   [0] magnifier surface  (size 150×150)
+//   [1] drag handle        (size 48×48)
+//   [2] resize handle      (size 48×48)
+//   [3] zoom-in handle     (size 48×48)
+//   [4] zoom-out handle    (size 48×48)
+
+struct MagnifierHandleTest : MagnifierTest
+{
+    MagnifierHandleTest()
+    {
+        magnifier.enable(true).decouple(true);
+
+        add_server_init(
+            [this](mir::Server& server)
+            {
+                server.add_init_callback(
+                    [&server, this]
+                    {
+                        input_device_registry = server.the_input_device_registry();
+                        input_device_hub = server.the_input_device_hub();
+                    });
+            });
+    }
+
+    void SetUp() override
+    {
+        MagnifierTest::SetUp();
+        start_server();
+        pointer_device = miral::test::add_test_device(
+            input_device_registry.lock(), input_device_hub.lock(), mi::DeviceCapability::pointer);
+    }
+
+    /// Returns the centre of the scene element at `index` as a float point.
+    geom::PointF element_center(int index)
+    {
+        auto const elements = server().the_scene()->scene_elements_for(this);
+        auto const pos = elements.at(static_cast<std::size_t>(index))->renderable()->screen_position();
+        return geom::PointF{
+            static_cast<float>(pos.top_left.x.as_int() + pos.size.width.as_int() / 2.0f),
+            static_cast<float>(pos.top_left.y.as_int() + pos.size.height.as_int() / 2.0f)};
+    }
+
+    // Scene-element indices matching add_init_callback creation order.
+    static constexpr auto drag_handle_index = 1;
+    static constexpr auto resize_handle_index = 2;
+    static constexpr auto zoom_in_handle_index = 3;
+    /// centre, dragging to `target`.
+    ///
+    /// Input observers run on the linearising_executor (deferred background
+    /// thread), so we flush it before returning to ensure surface state is
+    /// fully updated when the caller checks it.
+    void drag(geom::PointF from, geom::PointF to)
+    {
+        pointer_device->if_started_then(
+            [&](mi::InputSink* sink, mi::EventBuilder* builder)
+            {
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_button_down,
+                    mir_pointer_button_primary,
+                    from,
+                    geom::DisplacementF{0, 0},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_motion,
+                    mir_pointer_button_primary,
+                    to,
+                    geom::DisplacementF{to.x.as_value() - from.x.as_value(),
+                                       to.y.as_value() - from.y.as_value()},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_button_up,
+                    MirPointerButtons{0},
+                    to,
+                    geom::DisplacementF{0, 0},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+            });
+        flush_observer_callbacks();
+    }
+
+    /// Emit a button-down then button-up at `pos` (a tap / click).
+    void click(geom::PointF pos)
+    {
+        pointer_device->if_started_then(
+            [&](mi::InputSink* sink, mi::EventBuilder* builder)
+            {
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_button_down,
+                    mir_pointer_button_primary,
+                    pos,
+                    geom::DisplacementF{0, 0},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_button_up,
+                    MirPointerButtons{0},
+                    pos,
+                    geom::DisplacementF{0, 0},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+            });
+        flush_observer_callbacks();
+    }
+
+    // auto magnifier() const -> std::shared_ptr<mir::compositor::SceneElement>
+    // { return server().the_scene()->scene_elements_for(this).at(magnifier_index); }
+
+    std::weak_ptr<mi::InputDeviceRegistry> input_device_registry;
+    std::weak_ptr<mi::InputDeviceHub> input_device_hub;
+    std::shared_ptr<mi::VirtualInputDevice> pointer_device;
+
+private:
+    /// Surface input observers use BasicSurface::Multiplexer which dispatches
+    /// via linearising_executor (a non-blocking deferred executor backed by a
+    /// thread pool). Spawn a sentinel task AFTER the input events so that when
+    /// it fires, all earlier callbacks — including the handle observer state
+    /// updates (move_to, resize, set_transformation) — have already run.
+    void flush_observer_callbacks()
+    {
+        mir::test::Signal done;
+        mir::linearising_executor.spawn([&done]() { done.raise(); });
+        ASSERT_TRUE(done.wait_for(2s)) << "linearising_executor timed out";
+    }
+};
+
+TEST_F(MagnifierHandleTest, drag_handle_moves_magnifier)
+{
+    auto const before = magnifier_top_left();
+
+    auto const from = element_center(drag_handle_index);
+    drag(from, geom::PointF{from.x.as_value() + 20, from.y.as_value()});
+
+    auto const after = magnifier_top_left();
+
+    EXPECT_THAT(after.x.as_int(), Eq(before.x.as_int() + 20));
+    EXPECT_THAT(after.y.as_int(), Eq(before.y.as_int()));
+}
+
+TEST_F(MagnifierHandleTest, zoom_in_handle_increases_magnification)
+{
+    auto const before = magnifier_renderable()->transformation();
+
+    click(element_center(zoom_in_handle_index));
+
+    auto const expected = glm::scale(glm::mat4(1.0), glm::vec3(2, 2, 1));
+    EXPECT_THAT(magnifier_renderable()->transformation(), Eq(expected));
+    EXPECT_THAT(magnifier_renderable()->transformation(), Ne(before));
+}
+
+// Dragging the resize handle away from the magnifier centre must increase the
+// capture size, visible as the enlarged screen_position().size of the surface.
+//
+// screen_position().size comes from the buffer stream's TrackingSubmission. The
+// MultiMonitorArbiter only advances to a newly-submitted buffer once the
+// previous submission has been "claimed" (i.e. buffer() called on the
+// Renderable). We trigger that manually here, mimicking what a real compositor
+// render pass would do, to flush the stale pre-resize submission and expose the
+// post-resize buffer with the new size.
+TEST_F(MagnifierHandleTest, resize_handle_changes_capture_size)
+{
+    auto const mag_center = element_center(magnifier_index);
+    auto const from = element_center(resize_handle_index);
+    // Move 30 pixels away from the magnifier centre to enlarge the capture area.
+    geom::PointF const to{
+        from.x.as_value() + (from.x.as_value() >= mag_center.x.as_value() ? 30.0f : -30.0f),
+        from.y.as_value() + (from.y.as_value() >= mag_center.y.as_value() ? 30.0f : -30.0f)};
+    drag(from, to);
+
+    // Advance the arbiter: claim the stale current frame so the next
+    // scene_elements_for call receives the new post-resize submission.
+    magnifier_renderable()->buffer();
+
+    auto const size = magnifier_renderable()->screen_position().size;
+
+    EXPECT_THAT(size.width.as_int(),  Gt(150));
+    EXPECT_THAT(size.height.as_int(), Gt(150));
 }

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -135,7 +135,7 @@ TEST_F(MagnifierTest, can_set_capture_size)
 
 TEST_F(MagnifierTest, decoupled_mode_shows_handle_indicators)
 {
-    magnifier.enable(true).stop_following_cursor();
+    magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
     add_start_callback([&]
     {
         // 4 indicators + 1 magnifier surface
@@ -146,7 +146,7 @@ TEST_F(MagnifierTest, decoupled_mode_shows_handle_indicators)
 
 TEST_F(MagnifierTest, handles_hidden_when_disabled_in_decoupled_mode)
 {
-    magnifier.enable(true).stop_following_cursor();
+    magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
     add_start_callback([&]
     {
         magnifier.enable(false);
@@ -157,11 +157,11 @@ TEST_F(MagnifierTest, handles_hidden_when_disabled_in_decoupled_mode)
 
 TEST_F(MagnifierTest, toggling_to_coupled_hides_handles)
 {
-    magnifier.enable(true).stop_following_cursor();
+    magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
     add_start_callback([&]
     {
         EXPECT_THAT(scene_element_count(), Eq(5));
-        magnifier.follow_cursor();
+        magnifier.set_behavior(Magnifier::Behavior::follow_cursor);
         EXPECT_THAT(scene_element_count(), Eq(1));
     });
     start_server();
@@ -173,7 +173,7 @@ TEST_F(MagnifierTest, decoupling_after_start_shows_handles)
     add_start_callback([&]
     {
         EXPECT_THAT(scene_element_count(), Eq(1));
-        magnifier.stop_following_cursor();
+        magnifier.set_behavior(Magnifier::Behavior::freely_positioned);
         EXPECT_THAT(scene_element_count(), Eq(5));
     });
     start_server();
@@ -194,7 +194,7 @@ TEST_F(MagnifierTest, decoupling_after_start_shows_handles)
 
 TEST_F(MagnifierTest, cursor_not_tracked_in_decoupled_mode)
 {
-    magnifier.enable(true).stop_following_cursor();
+    magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
     start_server();
 
     auto const mux = server().the_cursor_observer_multiplexer();
@@ -257,7 +257,7 @@ struct MagnifierHandleTest : MagnifierTest
 {
     MagnifierHandleTest()
     {
-        magnifier.enable(true).stop_following_cursor();
+        magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
 
         add_server_init(
             [this](mir::Server& server)
@@ -511,7 +511,7 @@ TEST_F(MagnifierHandleTest, does_not_consume_events_outside_decoupled_magnifier_
 TEST_F(MagnifierHandleTest, does_not_consume_events_when_magnifier_is_inactive)
 {
     auto const magnifier_center = element_center(magnifier_index);
-    magnifier.follow_cursor();
+    magnifier.set_behavior(Magnifier::Behavior::follow_cursor);
 
     auto const pointer_event = mir::events::make_pointer_event(
         MirInputDeviceId{},
@@ -541,7 +541,7 @@ TEST_F(MagnifierHandleTest, does_not_consume_events_when_magnifier_is_inactive)
     EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
     EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));
 
-    magnifier.stop_following_cursor().enable(false);
+    magnifier.set_behavior(Magnifier::Behavior::freely_positioned).enable(false);
 
     EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
     EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -135,7 +135,7 @@ TEST_F(MagnifierTest, can_set_capture_size)
 
 TEST_F(MagnifierTest, decoupled_mode_shows_handle_indicators)
 {
-    magnifier.enable(true).decouple(true);
+    magnifier.enable(true).stop_following_cursor();
     add_start_callback([&]
     {
         // 4 indicators + 1 magnifier surface
@@ -146,7 +146,7 @@ TEST_F(MagnifierTest, decoupled_mode_shows_handle_indicators)
 
 TEST_F(MagnifierTest, handles_hidden_when_disabled_in_decoupled_mode)
 {
-    magnifier.enable(true).decouple(true);
+    magnifier.enable(true).stop_following_cursor();
     add_start_callback([&]
     {
         magnifier.enable(false);
@@ -157,11 +157,11 @@ TEST_F(MagnifierTest, handles_hidden_when_disabled_in_decoupled_mode)
 
 TEST_F(MagnifierTest, toggling_to_coupled_hides_handles)
 {
-    magnifier.enable(true).decouple(true);
+    magnifier.enable(true).stop_following_cursor();
     add_start_callback([&]
     {
         EXPECT_THAT(scene_element_count(), Eq(5));
-        magnifier.decouple(false);
+        magnifier.follow_cursor();
         EXPECT_THAT(scene_element_count(), Eq(1));
     });
     start_server();
@@ -173,7 +173,7 @@ TEST_F(MagnifierTest, decoupling_after_start_shows_handles)
     add_start_callback([&]
     {
         EXPECT_THAT(scene_element_count(), Eq(1));
-        magnifier.decouple(true);
+        magnifier.stop_following_cursor();
         EXPECT_THAT(scene_element_count(), Eq(5));
     });
     start_server();
@@ -194,7 +194,7 @@ TEST_F(MagnifierTest, decoupling_after_start_shows_handles)
 
 TEST_F(MagnifierTest, cursor_not_tracked_in_decoupled_mode)
 {
-    magnifier.enable(true).decouple(true);
+    magnifier.enable(true).stop_following_cursor();
     start_server();
 
     auto const mux = server().the_cursor_observer_multiplexer();
@@ -257,7 +257,7 @@ struct MagnifierHandleTest : MagnifierTest
 {
     MagnifierHandleTest()
     {
-        magnifier.enable(true).decouple(true);
+        magnifier.enable(true).stop_following_cursor();
 
         add_server_init(
             [this](mir::Server& server)
@@ -511,7 +511,7 @@ TEST_F(MagnifierHandleTest, does_not_consume_events_outside_decoupled_magnifier_
 TEST_F(MagnifierHandleTest, does_not_consume_events_when_magnifier_is_inactive)
 {
     auto const magnifier_center = element_center(magnifier_index);
-    magnifier.decouple(false);
+    magnifier.follow_cursor();
 
     auto const pointer_event = mir::events::make_pointer_event(
         MirInputDeviceId{},
@@ -541,7 +541,7 @@ TEST_F(MagnifierHandleTest, does_not_consume_events_when_magnifier_is_inactive)
     EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
     EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));
 
-    magnifier.decouple(true).enable(false);
+    magnifier.stop_following_cursor().enable(false);
 
     EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
     EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -113,6 +113,7 @@ TEST_F(MagnifierTest, magnification_results_in_scaled_transform)
         EXPECT_THAT(scene_element_count(), Eq(1));
         auto const expected = glm::scale(glm::mat4(1.0), glm::vec3(2, 2, 1));
         EXPECT_THAT(magnifier_renderable()->transformation(), Eq(expected));
+        EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(150, 150)));
     });
     start_server();
 }

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -279,11 +279,16 @@ struct MagnifierHandleTest : MagnifierTest
     /// Returns the centre of the scene element at `index` as a float point.
     geom::PointF element_center(int index)
     {
-        auto const elements = server().the_scene()->scene_elements_for(this);
-        auto const pos = elements.at(static_cast<std::size_t>(index))->renderable()->screen_position();
+        auto const pos = element_rectangle(index);
         return geom::PointF{
             static_cast<float>(pos.top_left.x.as_int() + pos.size.width.as_int() / 2.0f),
             static_cast<float>(pos.top_left.y.as_int() + pos.size.height.as_int() / 2.0f)};
+    }
+
+    geom::Rectangle element_rectangle(int index)
+    {
+        auto const elements = server().the_scene()->scene_elements_for(this);
+        return elements.at(static_cast<std::size_t>(index))->renderable()->screen_position();
     }
 
     // Scene-element indices matching add_init_callback creation order.
@@ -387,6 +392,48 @@ TEST_F(MagnifierHandleTest, drag_handle_moves_magnifier)
 
     EXPECT_THAT(after.x.as_int(), Eq(before.x.as_int() + 20));
     EXPECT_THAT(after.y.as_int(), Eq(before.y.as_int()));
+}
+
+TEST_F(MagnifierHandleTest, drag_handle_moves_magnifier_flush_to_screen_corners)
+{
+    auto from = element_center(drag_handle_index);
+    auto visual_top_left = element_rectangle(resize_handle_index).top_left;
+    drag(
+        from,
+        geom::PointF{
+            from.x.as_value() - visual_top_left.x.as_int(),
+            from.y.as_value() - visual_top_left.y.as_int()});
+
+    EXPECT_THAT(element_rectangle(resize_handle_index).top_left, Eq(geom::Point{0, 0}));
+
+    from = element_center(drag_handle_index);
+    auto const drag_rect = element_rectangle(drag_handle_index);
+    int const visual_right = drag_rect.top_left.x.as_int() + drag_rect.size.width.as_int();
+    int const visual_bottom = drag_rect.top_left.y.as_int() + drag_rect.size.height.as_int();
+    drag(
+        from,
+        geom::PointF{
+            from.x.as_value() + 800 - visual_right,
+            from.y.as_value() + 600 - visual_bottom});
+
+    auto const final_drag_rect = element_rectangle(drag_handle_index);
+    EXPECT_THAT(
+        final_drag_rect.top_left.x.as_int() + final_drag_rect.size.width.as_int(),
+        Eq(800));
+    EXPECT_THAT(
+        final_drag_rect.top_left.y.as_int() + final_drag_rect.size.height.as_int(),
+        Eq(600));
+}
+
+TEST_F(MagnifierHandleTest, double_clicking_drag_handle_does_not_move_magnifier)
+{
+    auto const before = magnifier_top_left();
+    auto const handle_center = element_center(drag_handle_index);
+
+    click(handle_center);
+    click(handle_center);
+
+    EXPECT_THAT(magnifier_top_left(), Eq(before));
 }
 
 TEST_F(MagnifierHandleTest, zoom_in_handle_increases_magnification)

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -18,17 +18,49 @@
 #include <mir/server.h>
 #include <mir/compositor/scene.h>
 #include <mir/compositor/scene_element.h>
+#include <mir/events/event_builders.h>
+#include <mir/events/touch_contact.h>
 #include <mir/graphics/renderable.h>
+#include <mir/input/composite_event_filter.h>
+#include <mir/input/cursor_observer.h>
+#include <mir/input/cursor_observer_multiplexer.h>
+#include <mir/input/event_builder.h>
+#include <mir/input/input_device_hub.h>
+#include <mir/input/input_device_registry.h>
+#include <mir/input/input_sink.h>
+#include <mir/input/virtual_input_device.h>
+#include <mir/main_loop.h>
+#include <mir/test/signal.h>
+#include <mir/executor.h>
+#include "add_virtual_device.h"
 
 #include <miral/test_server.h>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <glm/gtc/matrix_transform.hpp>
 
-namespace mtf = mir_test_framework;
+namespace geom = mir::geometry;
+namespace mi = mir::input;
 
 using namespace testing;
 using namespace miral;
+using namespace std::chrono_literals;
+
+namespace
+{
+/// Raises a signal each time cursor_moved_to() fires. Used by cursor-tracking
+/// tests to wait for cursor events to propagate through the main loop before
+/// inspecting surface state.
+struct SentinelCursorObserver : public mi::CursorObserver
+{
+    void cursor_moved_to(float, float) override { signal.raise(); }
+    void pointer_usable() override {}
+    void pointer_unusable() override {}
+    void image_set_to(std::shared_ptr<mir::graphics::CursorImage>) override {}
+    mir::test::Signal signal;
+};
+
+}
 
 class MagnifierTest : public TestServer
 {
@@ -46,6 +78,22 @@ public:
         add_server_init(magnifier);
     }
 
+    auto magnifier_renderable() const -> std::shared_ptr<mir::graphics::Renderable>
+    { return server().the_scene()->scene_elements_for(this).at(magnifier_index)->renderable(); }
+
+    auto magnifier_top_left() const -> geom::Point
+    { return magnifier_renderable()->screen_position().top_left; }
+
+    auto scene_element_count() const -> size_t { return server().the_scene()->scene_elements_for(this).size(); }
+
+    void wait_for_magnifier_initialization()
+    {
+        mir::test::Signal initialized;
+        server().the_main_loop()->spawn([&initialized] { initialized.raise(); });
+        ASSERT_TRUE(initialized.wait_for(2s)) << "timed out waiting for magnifier initialization";
+    }
+
+    static constexpr auto magnifier_index = 0;
     Magnifier magnifier;
 };
 
@@ -53,9 +101,7 @@ TEST_F(MagnifierTest, magnifier_disabled_by_default)
 {
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(0));
+        EXPECT_THAT(scene_element_count(), Eq(0));
     });
     start_server();
 }
@@ -65,9 +111,7 @@ TEST_F(MagnifierTest, can_start_enabled)
     magnifier.enable(true);
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(1));
+        EXPECT_THAT(scene_element_count(), Eq(1));
     });
     start_server();
 }
@@ -78,26 +122,506 @@ TEST_F(MagnifierTest, magnification_results_in_scaled_transform)
     magnifier.enable(true);
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(1));
+        EXPECT_THAT(scene_element_count(), Eq(1));
         auto const expected = glm::scale(glm::mat4(1.0), glm::vec3(2, 2, 1));
-
-        EXPECT_THAT(elements.at(0)->renderable()->transformation(), Eq(expected));
+        EXPECT_THAT(magnifier_renderable()->transformation(), Eq(expected));
+        EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(150, 150)));
     });
     start_server();
 }
 
 TEST_F(MagnifierTest, can_set_capture_size)
 {
-    magnifier.capture_size(Size(500, 500));
+    magnifier.capture_size(Size(200, 200));
     magnifier.enable(true);
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(1));
-        EXPECT_THAT(elements.at(0)->renderable()->screen_position().size, Eq(Size(500, 500)));
+        EXPECT_THAT(scene_element_count(), Eq(1));
+        EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(200, 200)));
     });
     start_server();
+}
+
+TEST_F(MagnifierTest, capture_size_is_limited_to_80_percent_of_the_output)
+{
+    magnifier.enable(true);
+    start_server();
+
+    auto const mux = server().the_cursor_observer_multiplexer();
+    auto sentinel = std::make_shared<SentinelCursorObserver>();
+    mux->register_interest(sentinel);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for initial cursor state";
+
+    magnifier.capture_size(Size(1000, 1000));
+    magnifier_renderable()->buffer();
+
+    auto const capture_size = magnifier_renderable()->screen_position().size;
+    EXPECT_THAT(capture_size.width, Lt(Width{1000}));
+    EXPECT_THAT(capture_size.height, Lt(Height{1000}));
+    mux->unregister_interest(*sentinel);
+}
+
+TEST_F(MagnifierTest, decoupled_mode_shows_handle_indicators)
+{
+    magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
+    add_start_callback([&]
+    {
+        // 4 indicators + 1 magnifier surface
+        EXPECT_THAT(scene_element_count(), Eq(5));
+    });
+    start_server();
+}
+
+TEST_F(MagnifierTest, handles_hidden_when_disabled_in_decoupled_mode)
+{
+    magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
+    add_start_callback([&]
+    {
+        magnifier.enable(false);
+        EXPECT_THAT(scene_element_count(), Eq(0));
+    });
+    start_server();
+}
+
+TEST_F(MagnifierTest, toggling_to_coupled_hides_handles)
+{
+    magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
+    add_start_callback([&]
+    {
+        EXPECT_THAT(scene_element_count(), Eq(5));
+        magnifier.set_behavior(Magnifier::Behavior::follow_cursor);
+        EXPECT_THAT(scene_element_count(), Eq(1));
+    });
+    start_server();
+}
+
+TEST_F(MagnifierTest, decoupling_after_start_shows_handles)
+{
+    magnifier.enable(true);
+    add_start_callback([&]
+    {
+        EXPECT_THAT(scene_element_count(), Eq(1));
+        magnifier.set_behavior(Magnifier::Behavior::freely_positioned);
+        EXPECT_THAT(scene_element_count(), Eq(5));
+    });
+    start_server();
+}
+
+// These tests run in the test body (after start_server() returns) rather than
+// inside add_start_callback. Start callbacks are enqueued on the main loop via
+// main_loop->enqueue, so blocking inside one waiting for more main-loop work
+// would deadlock. The test body runs on a separate thread while the main loop
+// runs in the background.
+//
+// Synchronisation: Magnifier registers its cursor observer from a main-loop
+// task. Wait for that task before registering a sentinel, so the sentinel is
+// ordered after Magnifier when cursor events are dispatched.
+
+TEST_F(MagnifierTest, cursor_not_tracked_in_decoupled_mode)
+{
+    magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
+    start_server();
+    wait_for_magnifier_initialization();
+
+    auto const mux = server().the_cursor_observer_multiplexer();
+    auto sentinel = std::make_shared<SentinelCursorObserver>();
+    mux->register_interest(sentinel);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for initial cursor state";
+    sentinel->signal.reset();
+
+    auto const before = magnifier_top_left();
+
+    mux->cursor_moved_to(400, 300);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for cursor event";
+
+    auto const after = magnifier_top_left();
+
+    EXPECT_THAT(after, Eq(before));
+    mux->unregister_interest(*sentinel);
+}
+
+TEST_F(MagnifierTest, cursor_tracked_in_coupled_mode)
+{
+    magnifier.enable(true);
+    start_server();
+    wait_for_magnifier_initialization();
+
+    auto const mux = server().the_cursor_observer_multiplexer();
+    auto sentinel = std::make_shared<SentinelCursorObserver>();
+    mux->register_interest(sentinel);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for initial cursor state";
+    sentinel->signal.reset();
+
+    auto const before = magnifier_top_left();
+
+    mux->cursor_moved_to(400, 300);
+    ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for cursor event";
+
+    auto const after = magnifier_top_left();
+
+    EXPECT_THAT(after, Ne(before));
+    mux->unregister_interest(*sentinel);
+}
+
+// Input events are dispatched synchronously through SurfaceInputDispatcher into
+// the handle surface observers, but the observers run via BasicSurface::Multiplexer
+// which uses linearising_executor (deferred background thread). State changes
+// (move_to, resize, set_transformation) are applied asynchronously. We flush
+// the executor before reading scene state.
+//
+// Handle positions depend on the initial surface placement (at {0,0} from the
+// BasicSurface constructor). We read positions dynamically from the live scene
+// elements to avoid brittle hardcoded coordinates.
+//
+// Scene element ordering (fixed, determined by creation order in add_init_callback):
+//   [0] magnifier surface  (size 150×150)
+//   [1] drag handle        (size 48×48)
+//   [2] resize handle      (size 48×48)
+//   [3] zoom-in handle     (size 48×48)
+//   [4] zoom-out handle    (size 48×48)
+
+struct MagnifierHandleTest : MagnifierTest
+{
+    MagnifierHandleTest()
+    {
+        magnifier.enable(true).set_behavior(Magnifier::Behavior::freely_positioned);
+
+        add_server_init(
+            [this](mir::Server& server)
+            {
+                server.add_init_callback(
+                    [&server, this]
+                    {
+                        composite_event_filter = server.the_composite_event_filter();
+                        input_device_registry = server.the_input_device_registry();
+                        input_device_hub = server.the_input_device_hub();
+                    });
+            });
+    }
+
+    void SetUp() override
+    {
+        MagnifierTest::SetUp();
+        start_server();
+        pointer_device = miral::test::add_test_device(
+            input_device_registry.lock(), input_device_hub.lock(), mi::DeviceCapability::pointer);
+    }
+
+    /// Returns the centre of the scene element at `index` as a float point.
+    geom::PointF element_center(int index)
+    {
+        auto const pos = element_rectangle(index);
+        return geom::PointF{
+            static_cast<float>(pos.top_left.x.as_int() + pos.size.width.as_int() / 2.0f),
+            static_cast<float>(pos.top_left.y.as_int() + pos.size.height.as_int() / 2.0f)};
+    }
+
+    geom::Rectangle element_rectangle(int index)
+    {
+        auto const elements = server().the_scene()->scene_elements_for(this);
+        return elements.at(static_cast<std::size_t>(index))->renderable()->screen_position();
+    }
+
+    // Scene-element indices matching add_init_callback creation order.
+    static constexpr auto drag_handle_index = 1;
+    static constexpr auto resize_handle_index = 2;
+    static constexpr auto zoom_in_handle_index = 3;
+    static constexpr auto zoom_out_handle_index = 4;
+    /// centre, dragging to `target`.
+    ///
+    /// Input observers run on the linearising_executor (deferred background
+    /// thread), so we flush it before returning to ensure surface state is
+    /// fully updated when the caller checks it.
+    void drag(geom::PointF from, geom::PointF to)
+    {
+        pointer_device->if_started_then(
+            [&](mi::InputSink* sink, mi::EventBuilder* builder)
+            {
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_button_down,
+                    mir_pointer_button_primary,
+                    from,
+                    geom::DisplacementF{0, 0},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_motion,
+                    mir_pointer_button_primary,
+                    to,
+                    geom::DisplacementF{to.x.as_value() - from.x.as_value(),
+                                       to.y.as_value() - from.y.as_value()},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_button_up,
+                    MirPointerButtons{0},
+                    to,
+                    geom::DisplacementF{0, 0},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+            });
+        flush_observer_callbacks();
+    }
+
+    /// Emit a button-down then button-up at `pos` (a tap / click).
+    void click(geom::PointF pos)
+    {
+        pointer_device->if_started_then(
+            [&](mi::InputSink* sink, mi::EventBuilder* builder)
+            {
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_button_down,
+                    mir_pointer_button_primary,
+                    pos,
+                    geom::DisplacementF{0, 0},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+                sink->handle_input(builder->pointer_event(
+                    std::nullopt,
+                    mir_pointer_action_button_up,
+                    MirPointerButtons{0},
+                    pos,
+                    geom::DisplacementF{0, 0},
+                    mir_pointer_axis_source_none,
+                    {}, {}));
+            });
+        flush_observer_callbacks();
+    }
+
+    // auto magnifier() const -> std::shared_ptr<mir::compositor::SceneElement>
+    // { return server().the_scene()->scene_elements_for(this).at(magnifier_index); }
+
+    std::weak_ptr<mi::InputDeviceRegistry> input_device_registry;
+    std::weak_ptr<mi::InputDeviceHub> input_device_hub;
+    std::weak_ptr<mi::CompositeEventFilter> composite_event_filter;
+    std::shared_ptr<mi::VirtualInputDevice> pointer_device;
+
+private:
+    /// Surface input observers use BasicSurface::Multiplexer which dispatches
+    /// via linearising_executor (a non-blocking deferred executor backed by a
+    /// thread pool). Spawn a sentinel task AFTER the input events so that when
+    /// it fires, all earlier callbacks — including the handle observer state
+    /// updates (move_to, resize, set_transformation) — have already run.
+    void flush_observer_callbacks()
+    {
+        mir::test::Signal done;
+        mir::linearising_executor.spawn([&done]() { done.raise(); });
+        ASSERT_TRUE(done.wait_for(2s)) << "linearising_executor timed out";
+    }
+};
+
+TEST_F(MagnifierHandleTest, drag_handle_moves_magnifier)
+{
+    auto const before = magnifier_top_left();
+
+    auto const from = element_center(drag_handle_index);
+    drag(from, geom::PointF{from.x.as_value() + 20, from.y.as_value()});
+
+    auto const after = magnifier_top_left();
+
+    EXPECT_THAT(after.x.as_int(), Eq(before.x.as_int() + 20));
+    EXPECT_THAT(after.y.as_int(), Eq(before.y.as_int()));
+}
+
+TEST_F(MagnifierHandleTest, drag_handle_moves_magnifier_flush_to_screen_corners)
+{
+    auto from = element_center(drag_handle_index);
+    auto visual_top_left = element_rectangle(resize_handle_index).top_left;
+    drag(
+        from,
+        geom::PointF{
+            from.x.as_value() - visual_top_left.x.as_int(),
+            from.y.as_value() - visual_top_left.y.as_int()});
+
+    EXPECT_THAT(element_rectangle(resize_handle_index).top_left, Eq(geom::Point{0, 0}));
+
+    from = element_center(drag_handle_index);
+    auto const drag_rect = element_rectangle(drag_handle_index);
+    int const visual_right = drag_rect.top_left.x.as_int() + drag_rect.size.width.as_int();
+    int const visual_bottom = drag_rect.top_left.y.as_int() + drag_rect.size.height.as_int();
+    drag(
+        from,
+        geom::PointF{
+            from.x.as_value() + 800 - visual_right,
+            from.y.as_value() + 600 - visual_bottom});
+
+    auto const final_drag_rect = element_rectangle(drag_handle_index);
+    EXPECT_THAT(
+        final_drag_rect.top_left.x.as_int() + final_drag_rect.size.width.as_int(),
+        Eq(800));
+    EXPECT_THAT(
+        final_drag_rect.top_left.y.as_int() + final_drag_rect.size.height.as_int(),
+        Eq(600));
+}
+
+TEST_F(MagnifierHandleTest, double_clicking_drag_handle_does_not_move_magnifier)
+{
+    auto const before = magnifier_top_left();
+    auto const handle_center = element_center(drag_handle_index);
+
+    click(handle_center);
+    click(handle_center);
+
+    EXPECT_THAT(magnifier_top_left(), Eq(before));
+}
+
+TEST_F(MagnifierHandleTest, consumes_pointer_events_on_decoupled_magnifier_surface)
+{
+    auto const event = mir::events::make_pointer_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        mir_pointer_action_motion,
+        MirPointerButtons{},
+        element_center(magnifier_index),
+        geom::DisplacementF{},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+
+    EXPECT_TRUE(composite_event_filter.lock()->handle(*event));
+}
+
+TEST_F(MagnifierHandleTest, consumes_touch_events_on_decoupled_magnifier_surface)
+{
+    auto const event = mir::events::make_touch_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        std::vector<mir::events::TouchContact>{{
+            0,
+            mir_touch_action_down,
+            mir_touch_tooltype_finger,
+            element_center(magnifier_index),
+            1.0f,
+            1.0f,
+            1.0f,
+            0.0f}});
+
+    EXPECT_TRUE(composite_event_filter.lock()->handle(*event));
+}
+
+TEST_F(MagnifierHandleTest, does_not_consume_events_outside_decoupled_magnifier_surface)
+{
+    auto const pointer_event = mir::events::make_pointer_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        mir_pointer_action_motion,
+        MirPointerButtons{},
+        geom::PointF{799.0f, 599.0f},
+        geom::DisplacementF{},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    auto const touch_event = mir::events::make_touch_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        std::vector<mir::events::TouchContact>{{
+            0,
+            mir_touch_action_down,
+            mir_touch_tooltype_finger,
+            geom::PointF{799.0f, 599.0f},
+            1.0f,
+            1.0f,
+            1.0f,
+            0.0f}});
+
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));
+}
+
+TEST_F(MagnifierHandleTest, does_not_consume_events_when_magnifier_is_inactive)
+{
+    auto const magnifier_center = element_center(magnifier_index);
+    magnifier.set_behavior(Magnifier::Behavior::follow_cursor);
+
+    auto const pointer_event = mir::events::make_pointer_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        mir_pointer_action_motion,
+        MirPointerButtons{},
+        magnifier_center,
+        geom::DisplacementF{},
+        mir_pointer_axis_source_none,
+        {},
+        {});
+    auto const touch_event = mir::events::make_touch_event(
+        MirInputDeviceId{},
+        std::chrono::nanoseconds{},
+        MirInputEventModifiers{},
+        std::vector<mir::events::TouchContact>{{
+            0,
+            mir_touch_action_down,
+            mir_touch_tooltype_finger,
+            magnifier_center,
+            1.0f,
+            1.0f,
+            1.0f,
+            0.0f}});
+
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));
+
+    magnifier.set_behavior(Magnifier::Behavior::freely_positioned).enable(false);
+
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*pointer_event));
+    EXPECT_FALSE(composite_event_filter.lock()->handle(*touch_event));
+}
+
+TEST_F(MagnifierHandleTest, zoom_in_handle_increases_magnification)
+{
+    auto const before = magnifier_renderable()->transformation();
+
+    click(element_center(zoom_in_handle_index));
+
+    auto const expected = glm::scale(glm::mat4(1.0), glm::vec3(1.5f, 1.5f, 1.0f));
+    EXPECT_THAT(magnifier_renderable()->transformation(), Eq(expected));
+    EXPECT_THAT(magnifier_renderable()->transformation(), Ne(before));
+}
+
+TEST_F(MagnifierHandleTest, zoom_out_handle_decreases_magnification)
+{
+    auto const initial = magnifier_renderable()->transformation();
+    click(element_center(zoom_in_handle_index));
+    ASSERT_THAT(magnifier_renderable()->transformation(), Ne(initial));
+
+    click(element_center(zoom_out_handle_index));
+
+    EXPECT_THAT(magnifier_renderable()->transformation(), Eq(initial));
+}
+
+// Dragging the resize handle away from the magnifier centre must increase the
+// capture size, visible as the enlarged screen_position().size of the surface.
+//
+// screen_position().size comes from the buffer stream's TrackingSubmission. The
+// MultiMonitorArbiter only advances to a newly-submitted buffer once the
+// previous submission has been "claimed" (i.e. buffer() called on the
+// Renderable). We trigger that manually here, mimicking what a real compositor
+// render pass would do, to flush the stale pre-resize submission and expose the
+// post-resize buffer with the new size.
+TEST_F(MagnifierHandleTest, resize_handle_changes_capture_size)
+{
+    auto const mag_center = element_center(magnifier_index);
+    auto const from = element_center(resize_handle_index);
+    // Move 30 pixels away from the magnifier centre to enlarge the capture area.
+    geom::PointF const to{
+        from.x.as_value() + (from.x.as_value() >= mag_center.x.as_value() ? 30.0f : -30.0f),
+        from.y.as_value() + (from.y.as_value() >= mag_center.y.as_value() ? 30.0f : -30.0f)};
+    drag(from, to);
+
+    // Advance the arbiter: claim the stale current frame so the next
+    // scene_elements_for call receives the new post-resize submission.
+    magnifier_renderable()->buffer();
+
+    auto const size = magnifier_renderable()->screen_position().size;
+
+    EXPECT_THAT(size.width.as_int(),  Gt(150));
+    EXPECT_THAT(size.height.as_int(), Gt(150));
 }

--- a/tests/miral/magnifier_layout.cpp
+++ b/tests/miral/magnifier_layout.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "magnifier_layout.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace geom = mir::geometry;
+using namespace testing;
+
+namespace
+{
+geom::Rectangles outputs()
+{
+    geom::Rectangles result;
+    result.add({{0, 0}, {800, 600}});
+    return result;
+}
+}
+
+TEST(MagnifierLayout, clamps_visual_size_before_deriving_centered_capture)
+{
+    miral::MagnifierLayout const layout{outputs(), {1000, 1000}, 2.0f};
+
+    auto const placement = layout.centered_on({400, 300});
+
+    EXPECT_THAT(placement.visual_size, Eq(geom::Size{640, 480}));
+    EXPECT_THAT(placement.capture_area, Eq(geom::Rectangle{{240, 180}, {320, 240}}));
+    EXPECT_THAT(placement.surface_top_left, Eq(placement.capture_area.top_left));
+}
+
+TEST(MagnifierLayout, freely_positioned_surface_is_clamped_to_output)
+{
+    miral::MagnifierLayout const layout{outputs(), {200, 200}, 1.0f};
+
+    auto const placement = layout.freely_positioned({-50, -50});
+
+    EXPECT_THAT(placement.surface_top_left, Eq(geom::Point{0, 0}));
+}
+
+TEST(MagnifierLayout, chooses_output_using_visual_bounds)
+{
+    auto bounds = outputs();
+    bounds.add({{800, 0}, {400, 300}});
+    miral::MagnifierLayout const layout{bounds, {500, 500}, 2.0f};
+
+    auto const placement = layout.centered_on({790, 150});
+
+    EXPECT_THAT(placement.visual_size, Eq(geom::Size{500, 480}));
+}
+
+TEST(MagnifierLayout, computes_distinct_zoom_button_positions)
+{
+    miral::MagnifierLayout const layout{outputs(), {200, 200}, 1.0f};
+    auto const placement = layout.freely_positioned({100, 100});
+
+    auto const positions = layout.handle_positions(placement);
+
+    EXPECT_THAT(positions.zoom_out.x, Eq(positions.zoom_in.x));
+    EXPECT_THAT(positions.zoom_out.y - positions.zoom_in.y, Eq(geom::DeltaY{56}));
+}
+
+TEST(MagnifierLayout, content_hit_testing_excludes_controls)
+{
+    miral::MagnifierLayout const layout{outputs(), {200, 200}, 1.0f};
+    auto const placement = layout.freely_positioned({100, 100});
+    auto const positions = layout.handle_positions(placement);
+
+    EXPECT_TRUE(layout.contains_content({200.0f, 200.0f}, placement));
+    EXPECT_FALSE(layout.contains_content(
+        {
+            static_cast<float>(positions.drag.x.as_value() + miral::MagnifierLayout::handle_diameter / 2),
+            static_cast<float>(positions.drag.y.as_value() + miral::MagnifierLayout::handle_diameter / 2),
+        },
+        placement));
+}
+
+TEST(MagnifierLayout, pinned_resize_preserves_opposite_visual_corner)
+{
+    miral::MagnifierLayout const layout{{}, {200, 200}, 1.25f};
+    auto const initial = layout.freely_positioned({100, 100});
+    auto const anchor = layout.resize_anchor(initial);
+    auto const resize_handle = layout.handle_positions(initial).resize;
+
+    auto const resized = layout.resized_from_pinned_corner(
+        anchor,
+        {resize_handle.x - geom::DeltaX{20}, resize_handle.y - geom::DeltaY{20}});
+
+    EXPECT_THAT(layout.resize_anchor(resized), Eq(anchor));
+    EXPECT_THAT(resized.visual_size.width, Gt(initial.visual_size.width));
+    EXPECT_THAT(resized.visual_size.height, Gt(initial.visual_size.height));
+}


### PR DESCRIPTION
Related: #3954

This PR is only for the visual part of the magnifier. It will be followed up by another PR to handle input remapping through the magnification surface.

## What's new?

- Updates the magnifier to add a new decoupled mode that does not follow the pointer. And adds touch and pointer compatible buttons to move, resize, and control zoom.
- The area being zoomed is interpolated to land on edges and corners as the magnification surface does. (Thanks @Saviq!)

## How to test

- Enable the magnifier via `Ctrl + =`.
- It should start in coupled mode by default
- Press `Ctrl + Alt + M` to decouple it
- Observe as the surface stops following the mouse, and becomes accompanied by a few buttons to control it
- Touch emulation can be tested by pulling #5091 

