### PR TITLE
Implement solution for situation where protocols can independently create Wayland resources in wayland-rs

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -239,6 +239,11 @@ impl CppBuilder {
                 result.push_str("};\n\n");
             }
 
+            // Emit free-function declarations at namespace scope.
+            for free_fn in &namespace.free_functions {
+                result.push_str(&format!("{};\n\n", free_fn.signature));
+            }
+
             // Close namespace(s)
             for _ in &namespace.name {
                 result.push_str("}\n");
@@ -283,6 +288,18 @@ impl CppBuilder {
                     result.push_str(&format!("    {}\n", body));
                     result.push_str("}\n\n");
                 }
+            }
+
+            // Emit free-function definitions inside the (re-opened) namespace so that they
+            // can refer to other declarations in this namespace by their unqualified names.
+            if !namespace.free_functions.is_empty() {
+                result.push_str(&format!("namespace {}\n{{\n", namespace_str));
+                for free_fn in &namespace.free_functions {
+                    result.push_str(&format!("{}\n{{\n", free_fn.signature));
+                    result.push_str(&format!("    {}\n", free_fn.body));
+                    result.push_str("}\n\n");
+                }
+                result.push_str(&format!("}}  // namespace {}\n\n", namespace_str));
             }
         }
 
@@ -369,10 +386,22 @@ impl CppBuilder {
     }
 }
 
+/// A free (non-member) function emitted at namespace scope: declared in the header and
+/// defined in the .cpp source. Unlike `CppClass` methods, these are never emitted to the
+/// generated Rust/cxx bindings, so they are suitable for pure C++ convenience wrappers.
+pub struct CppFreeFunction {
+    /// The full function signature, without a trailing semicolon or body, e.g.
+    /// `auto create_wl_buffer(WaylandClient const& client, uint32_t version) -> std::shared_ptr<Buffer>`.
+    pub signature: String,
+    /// The function body (statements only, without the surrounding braces).
+    pub body: String,
+}
+
 pub struct CppNamespace {
     pub name: Vec<String>,
     pub classes: Vec<CppClass>,
     forward_declarations: Vec<String>,
+    free_functions: Vec<CppFreeFunction>,
 }
 
 impl CppNamespace {
@@ -385,6 +414,7 @@ impl CppNamespace {
             name: name.into_iter().map(Into::into).collect(),
             classes: vec![],
             forward_declarations: vec![],
+            free_functions: vec![],
         }
     }
 
@@ -393,6 +423,15 @@ impl CppNamespace {
         self.classes
             .last_mut()
             .expect("classes cannot be empty after push")
+    }
+
+    /// Add a free function to be emitted at namespace scope (declaration in the header,
+    /// definition in the .cpp source).
+    pub fn add_free_function(&mut self, signature: impl Into<String>, body: impl Into<String>) {
+        self.free_functions.push(CppFreeFunction {
+            signature: signature.into(),
+            body: body.into(),
+        });
     }
 
     pub fn add_forward_declaration_struct(&mut self, name: &str) {

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -278,7 +278,10 @@ fn create_cpp_builder(
     // wrapper, and return it — ready to be passed to the parent's `send_<event>_event`.
     let mut needs_functional = false;
     for interface in &protocol.interfaces {
-        if !event_created_interfaces.iter().any(|n| n == &interface.name) {
+        if !event_created_interfaces
+            .iter()
+            .any(|n| n == &interface.name)
+        {
             continue;
         }
         add_server_created_wrapper(&mut namespace, &interface.name);

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -19,8 +19,8 @@ use crate::cpp_builder::{
     CppNamespace, CppType,
 };
 use crate::helpers::{
-    format_wayland_interface_to_cpp_class, format_wayland_interface_to_rust_extension_struct,
-    snake_to_pascal,
+    dash_to_snake, format_wayland_interface_to_cpp_class,
+    format_wayland_interface_to_rust_extension_struct, snake_to_pascal,
 };
 use crate::protocol_parser::{
     WaylandArg, WaylandArgType, WaylandEnum, WaylandEvent, WaylandInterface, WaylandProtocol,
@@ -54,9 +54,15 @@ pub fn generate_cpp_protocol_builders(
     let fd_ready_callback_builder = create_fd_ready_callback();
     let ffi_fwd_builder = create_ffi_fwd_builder(protocols);
 
+    // Interfaces that are created server-side and handed back to the client via an event
+    // carrying a `new_id` (e.g. `wl_buffer` via `zwp_linux_buffer_params_v1.created`). For
+    // each such child interface we emit a `create_<interface>` convenience wrapper in the
+    // protocol that *owns* the interface.
+    let event_created_interfaces = collect_event_created_interfaces(protocols);
+
     let mut builders: Vec<CppBuilder> = protocols
         .iter()
-        .map(|protocol| create_cpp_builder(protocol))
+        .map(|protocol| create_cpp_builder(protocol, &event_created_interfaces))
         .collect();
     builders.push(global_builder);
     builders.push(wayland_server_notification_handler_builder);
@@ -243,7 +249,10 @@ fn create_ffi_fwd_builder(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
     builder
 }
 
-fn create_cpp_builder(protocol: &WaylandProtocol) -> CppBuilder {
+fn create_cpp_builder(
+    protocol: &WaylandProtocol,
+    event_created_interfaces: &[String],
+) -> CppBuilder {
     let guard = format!("MIR_WAYLANDRS_{}", protocol.name.to_uppercase());
     let mut builder = CppBuilder::new(guard, protocol.name.as_str());
     let mut namespace = CppNamespace::new(vec!["mir", "wayland_rs"]);
@@ -261,6 +270,21 @@ fn create_cpp_builder(protocol: &WaylandProtocol) -> CppBuilder {
         let class_name = format_wayland_interface_to_cpp_class(interface);
         namespace.add_forward_declaration_class(&class_name);
     }
+
+    // For every interface owned by this protocol that is created server-side and delivered
+    // to the client via an event `new_id`, emit a `create_<interface>` convenience wrapper.
+    // It drives the split allocate/attach FFI in one call: allocate the resource, let the
+    // caller build their C++ subclass from the resulting box, attach it to the resource's
+    // wrapper, and return it — ready to be passed to the parent's `send_<event>_event`.
+    let mut needs_functional = false;
+    for interface in &protocol.interfaces {
+        if !event_created_interfaces.iter().any(|n| n == &interface.name) {
+            continue;
+        }
+        add_server_created_wrapper(&mut namespace, &interface.name);
+        needs_functional = true;
+    }
+
     builder.add_namespace(namespace);
     // Use ffi_fwd.h (generated alongside the protocol headers) instead of the
     // CXX-generated ffi.rs.h to avoid a circular include dependency:
@@ -273,10 +297,80 @@ fn create_cpp_builder(protocol: &WaylandProtocol) -> CppBuilder {
     builder.add_header_include("<string>");
     builder.add_header_include("<optional>");
     builder.add_header_include("<rust/cxx.h>");
+    if needs_functional {
+        builder.add_header_include("<functional>");
+    }
 
     builder.add_cpp_include("\"wayland_rs/src/ffi.rs.h\"");
 
     builder
+}
+
+/// Collect the names of interfaces that are created server-side and returned to the client
+/// through an event carrying a `new_id` argument (e.g. `wl_buffer`). `wl_display` and
+/// `wl_registry` are excluded as they are never created this way.
+fn collect_event_created_interfaces(protocols: &Vec<WaylandProtocol>) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for protocol in protocols {
+        for interface in &protocol.interfaces {
+            for item in &interface.items {
+                let crate::protocol_parser::InterfaceItem::Event(event) = item else {
+                    continue;
+                };
+                for arg in &event.args {
+                    if arg.type_ != WaylandArgType::NewId {
+                        continue;
+                    }
+                    let Some(child_name) = arg.interface.as_ref() else {
+                        continue;
+                    };
+                    if child_name == "wl_display" || child_name == "wl_registry" {
+                        continue;
+                    }
+                    if !seen.iter().any(|s| s == child_name) {
+                        seen.push(child_name.clone());
+                    }
+                }
+            }
+        }
+    }
+    seen
+}
+
+/// Emit the `create_<interface>` server-side wrapper free function into `namespace`.
+///
+/// The generated function mirrors the Rust-driven `create_immed`/`create_buffer` path but
+/// inverted for the C++-driven case: it allocates the resource (`allocate_<interface>`),
+/// invokes the caller-provided `builder` to construct their C++ subclass from the box and the
+/// freshly-assigned protocol object id, attaches that subclass to the resource's wrapper
+/// (`set_<interface>_inner`) so subsequent requests route to it, and returns it.
+fn add_server_created_wrapper(namespace: &mut CppNamespace, interface_name: &str) {
+    let class_name = format_wayland_interface_to_cpp_class(interface_name);
+    let middleware = snake_to_pascal(&format_wayland_interface_to_rust_extension_struct(
+        interface_name,
+    ));
+    let snake = dash_to_snake(interface_name);
+    let allocate_fn = format!("allocate_{}", snake);
+    let set_inner_fn = format!("set_{}_inner", snake);
+    let fn_name = format!("create_{}", snake);
+
+    let signature = format!(
+        "auto {fn_name}(\n\
+         \x20   WaylandClient const& client,\n\
+         \x20   uint32_t version,\n\
+         \x20   std::function<std::shared_ptr<{class_name}>(::rust::Box<{middleware}>, uint32_t)> const& builder)\n\
+         \x20   -> std::shared_ptr<{class_name}>"
+    );
+
+    let body = format!(
+        "auto instance = {allocate_fn}(client, version);\n\
+         \x20   uint32_t const object_id = instance->object_id();\n\
+         \x20   auto result = builder(std::move(instance), object_id);\n\
+         \x20   {set_inner_fn}(*result->get_box(), result);\n\
+         \x20   return result;"
+    );
+
+    namespace.add_free_function(signature, body);
 }
 
 fn wayland_interface_to_cpp_class(interface: &WaylandInterface) -> CppClass {

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -99,7 +99,7 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
 /// explicitly.
 ///
 /// For every interface that appears as the `new_id` of an *event* we generate:
-/// * `create_<interface>` — allocates the resource on behalf of the client,
+/// * `allocate_<interface>` — allocates the resource on behalf of the client,
 ///   registers it and wraps it in its middleware `Box` so C++ can pass it to the
 ///   corresponding `send_<event>_event`.
 /// * `set_<interface>_inner` — stores the fully constructed C++ object into the

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -16,8 +16,9 @@
 
 use crate::cpp_builder::sanitize_identifier;
 use crate::helpers::{
-    dash_to_snake, dash_to_snake_ident, format_has_arg_ident, format_wayland_interface_to_cpp_class,
-    format_wayland_interface_to_rust_extension_struct, generate_namespace, snake_to_pascal,
+    dash_to_snake, dash_to_snake_ident, format_has_arg_ident,
+    format_wayland_interface_to_cpp_class, format_wayland_interface_to_rust_extension_struct,
+    generate_namespace, snake_to_pascal,
 };
 use crate::protocol_parser::{
     InterfaceItem, WaylandArg, WaylandArgType, WaylandInterface, WaylandProtocol, WaylandRequest,
@@ -140,10 +141,7 @@ fn generate_server_side_factories(protocols: &Vec<WaylandProtocol>) -> TokenStre
 }
 
 /// Resolve the fully-qualified Rust path of the resource type for `interface_name`.
-fn resolve_resource_path(
-    protocols: &Vec<WaylandProtocol>,
-    interface_name: &str,
-) -> TokenStream {
+fn resolve_resource_path(protocols: &Vec<WaylandProtocol>, interface_name: &str) -> TokenStream {
     let namespace = protocols
         .iter()
         .find(|protocol| {

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -16,7 +16,7 @@
 
 use crate::cpp_builder::sanitize_identifier;
 use crate::helpers::{
-    dash_to_snake_ident, format_has_arg_ident, format_wayland_interface_to_cpp_class,
+    dash_to_snake, dash_to_snake_ident, format_has_arg_ident, format_wayland_interface_to_cpp_class,
     format_wayland_interface_to_rust_extension_struct, generate_namespace, snake_to_pascal,
 };
 use crate::protocol_parser::{
@@ -30,6 +30,8 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
     let generated_dispatch_implementations = protocols
         .iter()
         .map(|protocol| generate_dispatch_implementations(protocol));
+
+    let server_side_factories = generate_server_side_factories(protocols);
 
     quote! {
         #[allow(dead_code, unused_imports)]
@@ -79,6 +81,132 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
             }
 
             #(#generated_dispatch_implementations)*
+
+            #server_side_factories
+        }
+    }
+}
+
+/// Generate server-side object-creation helpers.
+///
+/// Most Wayland objects are created in response to a client request that carries
+/// a `new_id` argument. A handful of objects, however, are created by the
+/// *server* and handed to the client through an event whose argument is a
+/// `new_id` (for example `zwp_linux_buffer_params_v1.created`, which returns a
+/// server-allocated `wl_buffer`). There is no client-supplied `new_id` and no
+/// `DataInit` available in that flow, so the resource must be allocated
+/// explicitly.
+///
+/// For every interface that appears as the `new_id` of an *event* we generate:
+/// * `create_<interface>` — allocates the resource on behalf of the client,
+///   registers it and wraps it in its middleware `Box` so C++ can pass it to the
+///   corresponding `send_<event>_event`.
+/// * `set_<interface>_inner` — stores the fully constructed C++ object into the
+///   resource's wrapper so subsequent requests route to it (and its lifetime is
+///   tied to the resource), mirroring the request-driven `new_id` path.
+fn generate_server_side_factories(protocols: &Vec<WaylandProtocol>) -> TokenStream {
+    let mut seen: Vec<String> = Vec::new();
+    let mut factories: Vec<TokenStream> = Vec::new();
+
+    for protocol in protocols {
+        for interface in &protocol.interfaces {
+            for item in &interface.items {
+                let InterfaceItem::Event(event) = item else {
+                    continue;
+                };
+                for arg in &event.args {
+                    if arg.type_ != WaylandArgType::NewId {
+                        continue;
+                    }
+                    let Some(child_name) = arg.interface.as_ref() else {
+                        continue;
+                    };
+                    if child_name == "wl_display" || child_name == "wl_registry" {
+                        continue;
+                    }
+                    if seen.iter().any(|s| s == child_name) {
+                        continue;
+                    }
+                    seen.push(child_name.clone());
+                    factories.push(generate_server_side_factory(protocols, child_name));
+                }
+            }
+        }
+    }
+
+    quote! {
+        #(#factories)*
+    }
+}
+
+/// Resolve the fully-qualified Rust path of the resource type for `interface_name`.
+fn resolve_resource_path(
+    protocols: &Vec<WaylandProtocol>,
+    interface_name: &str,
+) -> TokenStream {
+    let namespace = protocols
+        .iter()
+        .find(|protocol| {
+            protocol
+                .interfaces
+                .iter()
+                .any(|interface| interface.name == interface_name)
+        })
+        .map(generate_namespace)
+        .unwrap_or_else(|| quote! { wayland_server::protocol });
+
+    let interface_module = dash_to_snake_ident(interface_name);
+    let interface_struct = format_ident!("{}", snake_to_pascal(interface_name));
+    quote! { #namespace::#interface_module::#interface_struct }
+}
+
+/// Generate the `create_<interface>` / `set_<interface>_inner` helper pair for a
+/// single server-created interface.
+fn generate_server_side_factory(
+    protocols: &Vec<WaylandProtocol>,
+    interface_name: &str,
+) -> TokenStream {
+    let create_fn = format_ident!("allocate_{}", dash_to_snake(interface_name));
+    let set_inner_fn = format_ident!("set_{}_inner", dash_to_snake(interface_name));
+    let wrapper_struct = format_ident!("{}Wrapper", snake_to_pascal(interface_name));
+    let middleware_struct = format_ident!(
+        "{}",
+        format_wayland_interface_to_rust_extension_struct(interface_name)
+    );
+    let cpp_struct = format_ident!("{}", format_wayland_interface_to_cpp_class(interface_name));
+    let resource_path = resolve_resource_path(protocols, interface_name);
+
+    quote! {
+        /// Allocate a server-created resource of this interface for `client`.
+        ///
+        /// The resource is registered and wrapped in its middleware `Box` so that
+        /// C++ can hand it to the appropriate `send_*_event`. The wrapper is left
+        /// without a C++ object until the matching `set_*_inner` is called.
+        pub fn #create_fn(
+            client: &WaylandClient,
+            version: u32,
+        ) -> Result<Box<crate::middleware::#middleware_struct>, Box<dyn std::error::Error>> {
+            let wrapper = Arc::new(Mutex::new(#wrapper_struct { inner: None }));
+            let instance = client
+                .inner_client()
+                .create_resource::<#resource_path, Arc<Mutex<#wrapper_struct>>, ServerState>(
+                    client.display_handle(),
+                    version,
+                    wrapper.clone(),
+                )?;
+            register_resource(&instance);
+            Ok(Box::new(crate::middleware::#middleware_struct { wrapped: instance }))
+        }
+
+        /// Store the fully-constructed C++ object into the resource's wrapper so
+        /// subsequent requests route to it and its lifetime is tied to the resource.
+        pub fn #set_inner_fn(
+            instance: &crate::middleware::#middleware_struct,
+            object: cxx::SharedPtr<ffi::#cpp_struct>,
+        ) {
+            if let Some(data) = instance.wrapped.data::<Arc<Mutex<#wrapper_struct>>>() {
+                data.lock().unwrap().inner = Some(object);
+            }
         }
     }
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -87,6 +87,7 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
 /// For every interface used as the `new_id` of an event we expose:
 /// * `allocate_<interface>(client, version) -> Box<Middleware>` and
 /// * `set_<interface>_inner(instance, object)`.
+fn generate_server_side_factory_ffi_decls(protocols: &Vec<WaylandProtocol>) -> Vec<TokenStream> {
     let mut seen: Vec<String> = Vec::new();
     let mut decls: Vec<TokenStream> = Vec::new();
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -85,9 +85,8 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
 /// object-creation helpers produced in `mod dispatch`.
 ///
 /// For every interface used as the `new_id` of an event we expose:
-/// * `create_<interface>(client, version) -> Box<Middleware>` and
+/// * `allocate_<interface>(client, version) -> Box<Middleware>` and
 /// * `set_<interface>_inner(instance, object)`.
-fn generate_server_side_factory_ffi_decls(protocols: &Vec<WaylandProtocol>) -> Vec<TokenStream> {
     let mut seen: Vec<String> = Vec::new();
     let mut decls: Vec<TokenStream> = Vec::new();
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -8,7 +8,10 @@
 //! These requests are sent from C++.
 
 use crate::cpp_builder::{sanitize_identifier, CppBuilder};
-use crate::helpers::format_wayland_interface_to_rust_extension_struct;
+use crate::helpers::{
+    dash_to_snake, format_wayland_interface_to_cpp_class,
+    format_wayland_interface_to_rust_extension_struct,
+};
 
 use super::protocol_middleware_generation::wayland_arg_to_ffi_rust_str;
 use crate::protocol_parser::{
@@ -27,6 +30,8 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
 
     let rust_types = protocols.iter().flat_map(generate_rust_types);
 
+    let server_side_factory_decls = generate_server_side_factory_ffi_decls(protocols);
+
     // Next, generate the Rust -> C++ side.
     let cpp_tokens: Vec<TokenStream> = builders
         .into_iter()
@@ -38,6 +43,7 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
         use crate::wayland_server_core::*;
         use crate::wayland_client::*;
         use crate::middleware::*;
+        use crate::dispatch::*;
 
         #[cxx::bridge(namespace = "mir::wayland_rs")]
         #[allow(dead_code, unused_imports)]
@@ -65,6 +71,7 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
 
                 #(#rust_types)*
                 #(#rust_tokens)*
+                #(#server_side_factory_decls)*
             }
 
             unsafe extern "C++" {
@@ -72,6 +79,58 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
             }
         }
     }
+}
+
+/// Generate the `extern "Rust"` bridge declarations for the server-side
+/// object-creation helpers produced in `mod dispatch`.
+///
+/// For every interface used as the `new_id` of an event we expose:
+/// * `create_<interface>(client, version) -> Box<Middleware>` and
+/// * `set_<interface>_inner(instance, object)`.
+fn generate_server_side_factory_ffi_decls(protocols: &Vec<WaylandProtocol>) -> Vec<TokenStream> {
+    let mut seen: Vec<String> = Vec::new();
+    let mut decls: Vec<TokenStream> = Vec::new();
+
+    for protocol in protocols {
+        for interface in &protocol.interfaces {
+            for item in &interface.items {
+                let InterfaceItem::Event(event) = item else {
+                    continue;
+                };
+                for arg in &event.args {
+                    if arg.type_ != WaylandArgType::NewId {
+                        continue;
+                    }
+                    let Some(child_name) = arg.interface.as_ref() else {
+                        continue;
+                    };
+                    if child_name == "wl_display" || child_name == "wl_registry" {
+                        continue;
+                    }
+                    if seen.iter().any(|s| s == child_name) {
+                        continue;
+                    }
+                    seen.push(child_name.clone());
+
+                    let create_fn = format_ident!("allocate_{}", dash_to_snake(child_name));
+                    let set_inner_fn = format_ident!("set_{}_inner", dash_to_snake(child_name));
+                    let middleware_struct = format_ident!(
+                        "{}",
+                        format_wayland_interface_to_rust_extension_struct(child_name)
+                    );
+                    let cpp_struct =
+                        format_ident!("{}", format_wayland_interface_to_cpp_class(child_name));
+
+                    decls.push(quote! {
+                        fn #create_fn(client: &WaylandClient, version: u32) -> Result<Box<#middleware_struct>>;
+                        fn #set_inner_fn(instance: &#middleware_struct, object: SharedPtr<#cpp_struct>);
+                    });
+                }
+            }
+        }
+    }
+
+    decls
 }
 
 fn generate_rust_types(protocol: &WaylandProtocol) -> Vec<TokenStream> {
@@ -116,6 +175,7 @@ fn generate_ffi_for_interface(interface: &WaylandInterface) -> TokenStream {
     quote! {
         fn post_error(self: &mut #interface_name_ext, code: u32, message: &CxxString);
         fn version(self: &#interface_name_ext) -> u32;
+        fn object_id(self: &#interface_name_ext) -> u32;
         fn destroy_and_delete(self: &#interface_name_ext);
         #(#events)*
     }

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
@@ -142,6 +142,11 @@ fn generate_extension_for_interface(interface: &WaylandInterface) -> Option<Toke
                 self.wrapped.version()
             }
 
+            pub fn object_id(&self) -> u32 {
+                use wayland_server::Resource;
+                self.wrapped.id().protocol_id()
+            }
+
             pub fn destroy_and_delete(&self) {
                 use wayland_server::Resource;
                 if self.wrapped.is_alive() {

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_client.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_client.rs
@@ -70,6 +70,21 @@ impl WaylandClient {
         Box::new(self.clone())
     }
 
+    /// Access the underlying [Client].
+    ///
+    /// Used by generated server-side factories to create resources on behalf of
+    /// this client (see [Client::create_resource]).
+    pub(crate) fn inner_client(&self) -> &Client {
+        &self.client
+    }
+
+    /// Access the underlying [DisplayHandle].
+    ///
+    /// Used by generated server-side factories when creating resources.
+    pub(crate) fn display_handle(&self) -> &DisplayHandle {
+        &self.handle
+    }
+
     /// Kill this client with a protocol error.
     ///
     /// This will disconnect the client, sending the protocol error as the reason.


### PR DESCRIPTION
## Problem
Typically, Wayland resource creation happens in one direction: clients create a resource that the server gets notified to handle.

But sometimes -- as is the case with the [Linux DMA-BUF protocol](https://wayland.app/protocols/linux-dmabuf-v1#zwp_linux_buffer_params_v1:request:create) -- the server is expected to create a resource and _notify_ the client about it.

Up until now, the wayland Rust frontend only assumed that it went in the first direction.

## Solution
- For every object that can be published in an event, generate two new methods that can be called from C++ into Rust over the FFI boundary:
  - `allocate_*`: allocates the new Wayland resource from C++
  - `set_*_inner`: sets the implementation of the C++ interface in the internal data model
- Then, create a wrapper method around these two calls in C++ ONLY that does the allocation, builder, and set inner function dance all at once so that the caller need not remember it. For example:

```c++
auto create_wl_buffer(
    WaylandClient const& client,
    uint32_t version,
    std::function<std::shared_ptr<Buffer>(::rust::Box<BufferMiddleware>, uint32_t)> const& builder)
    -> std::shared_ptr<Buffer>;
```

That method will now be callable by the class that is creating the new Wayland object instance.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
