### PR TITLE
Only warn on unsupported input trigger types

### DIFF
--- a/src/server/frontend_wayland/input_trigger_registration_v1.cpp
+++ b/src/server/frontend_wayland/input_trigger_registration_v1.cpp
@@ -499,6 +499,7 @@ void InputTriggerActionControlV1::add_input_trigger_event(struct wl_resource* tr
     if (auto* keyboard_trigger = KeyboardTrigger::from(trigger))
     {
         keyboard_trigger->associate_with_action_group(action_group);
+        return;
     }
 
     mir::log_warning(
@@ -511,6 +512,7 @@ void InputTriggerActionControlV1::drop_input_trigger_event(struct wl_resource* t
     if (auto* keyboard_trigger = KeyboardTrigger::from(trigger))
     {
         keyboard_trigger->unassociate_with_action_group(action_group);
+        return;
     }
 
     mir::log_warning(


### PR DESCRIPTION
InputTriggerActionControlV1::add_input_trigger_event and drop_input_trigger_event logged an "Unsupported trigger type" warning unconditionally, even when a valid keyboard trigger was supplied, because the success branch fell through to the warning. Return after handling a recognised trigger so the warning is only emitted for genuinely unsupported types.
