### PR TITLE
[miral] Ref qualify WindowSpecification properties

### DIFF
--- a/debian/libmiral8.symbols
+++ b/debian/libmiral8.symbols
@@ -66,11 +66,11 @@ libmiral.so.8 libmiral8 #MINVER#
  (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (bool)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)@MIRAL_6.0" 6.0.0
  (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (double)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, double)@MIRAL_6.0" 6.0.0
  (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (int)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)@MIRAL_6.0" 6.0.0
+ (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*)@MIRAL_6.0" 6.0.0
+ (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (std::optional<bool> const&)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (std::optional<int> const&)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (std::optional<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const&)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_6.0" 6.0.0
- (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*)@MIRAL_6.0" 6.0.0
- (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::ConfigurationOption::ConfigurationOption(std::function<void (std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::ConfigurationOption::operator()(mir::Server&) const@MIRAL_6.0" 6.0.0
  (c++)"miral::ConfigurationOption::operator=(miral::ConfigurationOption const&)@MIRAL_6.0" 6.0.0
@@ -528,82 +528,82 @@ libmiral.so.8 libmiral8 #MINVER#
  (c++)"miral::WindowSpecification::WindowSpecification()@MIRAL_6.0" 6.0.0
  (c++)"miral::WindowSpecification::WindowSpecification(mir::shell::SurfaceSpecification const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::WindowSpecification::WindowSpecification(miral::WindowSpecification const&)@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::alpha() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::alpha()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::application_id[abi:cxx11]() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::application_id[abi:cxx11]()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::attached_edges() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::attached_edges()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::aux_rect() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::aux_rect()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::aux_rect_placement_gravity() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::aux_rect_placement_gravity()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::aux_rect_placement_offset() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::aux_rect_placement_offset()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::confine_pointer() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::confine_pointer()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::depth_layer() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::depth_layer()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::exclusive_rect() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::exclusive_rect()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::focus_mode() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::focus_mode()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::height_inc() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::height_inc()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::ignore_exclusion_zones() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::ignore_exclusion_zones()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::input_mode() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::input_mode()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::input_shape() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::input_shape()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::max_aspect() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::max_aspect()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::max_height() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::max_height()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::max_width() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::max_width()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::min_aspect() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::min_aspect()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::min_height() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::min_height()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::min_width() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::min_width()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::name[abi:cxx11]() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::name[abi:cxx11]()@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::alpha() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::alpha() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::application_id[abi:cxx11]() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::application_id[abi:cxx11]() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::attached_edges() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::attached_edges() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::aux_rect() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::aux_rect() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::aux_rect_placement_gravity() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::aux_rect_placement_gravity() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::aux_rect_placement_offset() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::aux_rect_placement_offset() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::confine_pointer() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::confine_pointer() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::depth_layer() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::depth_layer() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::exclusive_rect() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::exclusive_rect() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::focus_mode() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::focus_mode() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::height_inc() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::height_inc() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::ignore_exclusion_zones() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::ignore_exclusion_zones() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::input_mode() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::input_mode() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::input_shape() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::input_shape() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::max_aspect() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::max_aspect() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::max_height() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::max_height() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::max_width() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::max_width() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::min_aspect() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::min_aspect() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::min_height() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::min_height() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::min_width() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::min_width() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::name[abi:cxx11]() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::name[abi:cxx11]() const &@MIRAL_6.0" 6.0.0
  (c++)"miral::WindowSpecification::operator=(miral::WindowSpecification const&)@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::output_id() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::output_id()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::parent() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::parent()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::parent_size() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::parent_size()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::placement_hints() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::placement_hints()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::preferred_orientation() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::preferred_orientation()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::server_side_decorated() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::server_side_decorated()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::shell_chrome() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::shell_chrome()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::size() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::size()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::state() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::state()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::tiled_edges() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::tiled_edges()@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::output_id() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::output_id() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::parent() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::parent() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::parent_size() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::parent_size() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::placement_hints() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::placement_hints() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::preferred_orientation() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::preferred_orientation() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::server_side_decorated() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::server_side_decorated() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::shell_chrome() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::shell_chrome() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::size() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::size() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::state() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::state() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::tiled_edges() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::tiled_edges() const &@MIRAL_6.0" 6.0.0
  (c++)"miral::WindowSpecification::to_surface_specification() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::top_left() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::top_left()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::type() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::type()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::userdata() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::userdata()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::visible_on_lock_screen() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::visible_on_lock_screen()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::width_inc() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::width_inc()@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::window_placement_gravity() const@MIRAL_6.0" 6.0.0
- (c++)"miral::WindowSpecification::window_placement_gravity()@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::top_left() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::top_left() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::type() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::type() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::userdata() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::userdata() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::visible_on_lock_screen() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::visible_on_lock_screen() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::width_inc() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::width_inc() const &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::window_placement_gravity() &@MIRAL_6.0" 6.0.0
+ (c++)"miral::WindowSpecification::window_placement_gravity() const &@MIRAL_6.0" 6.0.0
  (c++)"miral::WindowSpecification::~WindowSpecification()@MIRAL_6.0" 6.0.0
  (c++)"miral::X11Support::X11Support()@MIRAL_6.0" 6.0.0
  (c++)"miral::X11Support::X11Support(miral::X11Support const&)@MIRAL_6.0" 6.0.0

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -94,7 +94,7 @@ public:
     /// The top left corner of the window.
     ///
     /// \returns the top left point
-    auto top_left() const -> std::optional<Point> const&;
+    auto top_left() const& -> std::optional<Point> const&;
 
     /// The size of the window for window management purposes.
     ///
@@ -112,28 +112,28 @@ public:
     /// This value is **not** guaranteed to be honored by the client.
     ///
     /// \returns the size
-    auto size() const -> std::optional<Size> const&;
+    auto size() const& -> std::optional<Size> const&;
 
     /// The name of the window.
     ///
     /// \returns the name
-    auto name() const -> std::optional<std::string> const&;
+    auto name() const& -> std::optional<std::string> const&;
 
     /// The output id optionally associated with a fullscreen window.
     ///
     /// \returns the output id
     /// \sa miral::Output - the class that holds this output id
-    auto output_id() const -> std::optional<int> const&;
+    auto output_id() const& -> std::optional<int> const&;
 
     /// The type of the window.
     ///
     /// \returns the type
-    auto type() const -> std::optional<MirWindowType> const&;
+    auto type() const& -> std::optional<MirWindowType> const&;
 
     /// The state of the window.
     ///
     /// \returns the state
-    auto state() const -> std::optional<MirWindowState> const&;
+    auto state() const& -> std::optional<MirWindowState> const&;
 
     /// The preferred orientation of the window.
     ///
@@ -141,7 +141,7 @@ public:
     /// the current orientation of the output.
     ///
     /// \returns a the orientation.
-    auto preferred_orientation() const -> std::optional<MirOrientationMode> const&;
+    auto preferred_orientation() const& -> std::optional<MirOrientationMode> const&;
 
     /// Describes the auxiliary rectangle.
     ///
@@ -158,13 +158,13 @@ public:
     /// The final position is offset by `#aux_rect`.
     ///
     /// \returns the auxiliary rectangle
-    auto aux_rect() const -> std::optional<Rectangle> const&;
+    auto aux_rect() const& -> std::optional<Rectangle> const&;
 
     /// The placement hint describes how child window placement should be
     /// adjusted they cannot be placed in the requested position
     ///
     /// \returns the placement hints
-    auto placement_hints() const -> std::optional<MirPlacementHints> const&;
+    auto placement_hints() const& -> std::optional<MirPlacementHints> const&;
 
     /// Describes the placement gravity.
     ///
@@ -181,7 +181,7 @@ public:
     /// The final position is offset by `#aux_rect`.
     ///
     /// \returns the placement gravity
-    auto window_placement_gravity() const -> std::optional<MirPlacementGravity> const&;
+    auto window_placement_gravity() const& -> std::optional<MirPlacementGravity> const&;
 
     /// Describes the auxiliary rectangle placement gravity.
     ///
@@ -198,7 +198,7 @@ public:
     /// The final position is offset by `#aux_rect`.
     ///
     /// \returns the auxiliary placement gravity
-    auto aux_rect_placement_gravity() const -> std::optional<MirPlacementGravity> const&;
+    auto aux_rect_placement_gravity() const& -> std::optional<MirPlacementGravity> const&;
 
     /// Describes the auxiliary rectangle placement offset.
     ///
@@ -215,27 +215,27 @@ public:
     /// The final position is offset by `#aux_rect`.
     ///
     /// \returns the auxiliary placement gravity
-    auto aux_rect_placement_offset() const -> std::optional<Displacement> const&;
+    auto aux_rect_placement_offset() const& -> std::optional<Displacement> const&;
 
     /// The minimum width of the window.
     ///
     /// \returns the minimum width
-    auto min_width() const -> std::optional<Width> const&;
+    auto min_width() const& -> std::optional<Width> const&;
 
     /// The minimum height of the window.
     ///
     /// \returns the minimum height
-    auto min_height() const -> std::optional<Height> const&;
+    auto min_height() const& -> std::optional<Height> const&;
 
     /// The maximum width of the window.
     ///
     /// \returns the maximum width
-    auto max_width() const -> std::optional<Width> const&;
+    auto max_width() const& -> std::optional<Width> const&;
 
     /// The maximum height of the window.
     ///
     /// \returns a const reference to the maximum height
-    auto max_height() const -> std::optional<Height> const&;
+    auto max_height() const& -> std::optional<Height> const&;
 
     /// The size increments of the window in the X direction.
     ///
@@ -245,7 +245,7 @@ public:
     /// Wayland protocols do not support this property, so it generally will not be requested by clients.
     ///
     /// \returns the width increment.
-    auto width_inc() const -> std::optional<DeltaX> const&;
+    auto width_inc() const& -> std::optional<DeltaX> const&;
 
     /// The size increments of the window in the Y direction.
     ///
@@ -255,26 +255,26 @@ public:
     /// Wayland protocols do not support this property, so it generally will not be requested by clients.
     ///
     /// \returns the height increment
-    auto height_inc() const -> std::optional<DeltaY> const&;
+    auto height_inc() const& -> std::optional<DeltaY> const&;
 
     /// The minimum aspect ratio.
     ///
     /// Wayland protocols do not support this property, so it generally will not be requested by clients.
     ///
     /// \returns the min aspect ratio
-    auto min_aspect() const -> std::optional<AspectRatio> const&;
+    auto min_aspect() const& -> std::optional<AspectRatio> const&;
 
     /// The maximum aspect ratio.
     ///
     /// Wayland protocols do not support this property, so it generally will not be requested by clients.
     ///
     /// \returns the max aspect ratio
-    auto max_aspect() const -> std::optional<AspectRatio> const&;
+    auto max_aspect() const& -> std::optional<AspectRatio> const&;
 
     /// The parent surface of the window.
     ///
     /// \returns the pending parent surface
-    auto parent() const -> std::optional<std::weak_ptr<mir::scene::Surface>> const&;
+    auto parent() const& -> std::optional<std::weak_ptr<mir::scene::Surface>> const&;
 
     /// The input shape of the window.
     ///
@@ -282,24 +282,24 @@ public:
     /// for the window.
     ///
     /// \returns the list of rectangles that describes the input region
-    auto input_shape() const -> std::optional<std::vector<Rectangle>> const&;
+    auto input_shape() const& -> std::optional<std::vector<Rectangle>> const&;
 
     /// The input mode of the window.
     ///
     /// \returns the input mode
-    auto input_mode() const -> std::optional<InputReceptionMode> const&;
+    auto input_mode() const& -> std::optional<InputReceptionMode> const&;
 
     /// The shell chrome of the window.
     ///
     /// This is currently unused.
     ///
     /// \returns the shell chrome
-    auto shell_chrome() const -> std::optional<MirShellChrome> const&;
+    auto shell_chrome() const& -> std::optional<MirShellChrome> const&;
 
     /// The pointer confinement of the window.
     ///
     /// \returns the pointer confinement
-    auto confine_pointer() const -> std::optional<MirPointerConfinementState> const&;
+    auto confine_pointer() const& -> std::optional<MirPointerConfinementState> const&;
 
     /// Custom userdata set on the window.
     ///
@@ -307,12 +307,12 @@ public:
     /// set any information that they would like associated with the window.
     ///
     /// \returns the userdata
-    auto userdata() const -> std::optional<std::shared_ptr<void>> const&;
+    auto userdata() const& -> std::optional<std::shared_ptr<void>> const&;
 
     /// The new position of the window frame.
     ///
     /// \returns a reference to  the top left point
-    auto top_left() -> std::optional<Point>&;
+    auto top_left() & -> std::optional<Point>&;
 
     /// The size of the window for window management purposes.
     ///
@@ -330,28 +330,28 @@ public:
     /// This value is **not** guaranteed to be honored by the client.
     ///
     /// \returns the size
-    auto size() -> std::optional<Size>&;
+    auto size() & -> std::optional<Size>&;
 
     /// The name of the window.
     ///
     /// \returns the name of the window
-    auto name() -> std::optional<std::string>&;
+    auto name() & -> std::optional<std::string>&;
 
     /// The output id of the window.
     ///
     /// \returns the output id
     /// \sa miral::Output - the class that holds this output id
-    auto output_id() -> std::optional<int>&;
+    auto output_id() & -> std::optional<int>&;
 
     /// The type of the window.
     ///
     /// \returns the type of the window
-    auto type() -> std::optional<MirWindowType>&;
+    auto type() & -> std::optional<MirWindowType>&;
 
     /// The state of the window.
     ///
     /// \returns the state of the window
-    auto state() -> std::optional<MirWindowState>&;
+    auto state() & -> std::optional<MirWindowState>&;
 
     /// The preferred orientation of the window.
     ///
@@ -359,7 +359,7 @@ public:
     /// the current orientation of the output.
     ///
     /// \returns the orientation of the window.
-    auto preferred_orientation() -> std::optional<MirOrientationMode>&;
+    auto preferred_orientation() & -> std::optional<MirOrientationMode>&;
 
     /// Describes the auxiliary rectangle.
     ///
@@ -376,14 +376,14 @@ public:
     /// The final position is offset by `#aux_rect`.
     ///
     /// \returns the auxiliary rectangle
-    auto aux_rect() -> std::optional<Rectangle>&;
+    auto aux_rect() & -> std::optional<Rectangle>&;
 
     /// The placement hint describes how windows with type #mir_window_type_menu,
     /// #mir_window_type_satellite or #mir_window_type_tip should be adjusted when
     /// their placement would cause them to extend beyond their current output.
     ///
     /// \returns the placement hints
-    auto placement_hints() -> std::optional<MirPlacementHints>&;
+    auto placement_hints() & -> std::optional<MirPlacementHints>&;
 
     /// Describes the placement gravity.
     ///
@@ -400,7 +400,7 @@ public:
     /// The final position is offset by `#aux_rect`.
     ///
     /// \returns the placement gravity
-    auto window_placement_gravity() -> std::optional<MirPlacementGravity>&;
+    auto window_placement_gravity() & -> std::optional<MirPlacementGravity>&;
 
     /// Describes the auxiliary rectangle placement gravity.
     ///
@@ -417,7 +417,7 @@ public:
     /// The final position is offset by `#aux_rect`.
     ///
     /// \returns the auxiliary placement gravity
-    auto aux_rect_placement_gravity() -> std::optional<MirPlacementGravity>&;
+    auto aux_rect_placement_gravity() & -> std::optional<MirPlacementGravity>&;
 
     /// Describes the auxiliary rectangle placement offset.
     ///
@@ -434,27 +434,27 @@ public:
     /// The final position is offset by `#aux_rect`.
     ///
     /// \returns the auxiliary placement gravity
-    auto aux_rect_placement_offset() -> std::optional<Displacement>&;
+    auto aux_rect_placement_offset() & -> std::optional<Displacement>&;
 
     /// The minimum width of the window.
     ///
     /// \returns the minimum width
-    auto min_width() -> std::optional<Width>&;
+    auto min_width() & -> std::optional<Width>&;
 
     /// The minimum height of the window.
     ///
     /// \returns the minimum height
-    auto min_height() -> std::optional<Height>&;
+    auto min_height() & -> std::optional<Height>&;
 
     /// The maximum width of the window.
     ///
     /// \returns the maximum width
-    auto max_width() -> std::optional<Width>&;
+    auto max_width() & -> std::optional<Width>&;
 
     /// The maximum height of the window
     ///
     /// \returns a reference to the maximum height
-    auto max_height() -> std::optional<Height>&;
+    auto max_height() & -> std::optional<Height>&;
 
     /// The size increments of the window in the X direction.
     ///
@@ -464,7 +464,7 @@ public:
     /// Wayland protocols do not support this property, so it generally will not be requested by clients.
     ///
     /// \returns the width increment
-    auto width_inc() -> std::optional<DeltaX>&;
+    auto width_inc() & -> std::optional<DeltaX>&;
 
     /// The size increments of the window in the Y direction.
     ///
@@ -474,26 +474,26 @@ public:
     /// Wayland protocols do not support this property, so it generally will not be requested by clients.
     ///
     /// \returns the height increment
-    auto height_inc() -> std::optional<DeltaY>&;
+    auto height_inc() & -> std::optional<DeltaY>&;
 
     /// The minimum aspect ratio.
     ///
     /// Wayland protocols do not support this property, so it generally will not be requested by clients.
     ///
     /// \returns the min aspect ratio
-    auto min_aspect() -> std::optional<AspectRatio>&;
+    auto min_aspect() & -> std::optional<AspectRatio>&;
 
     /// The maximum aspect ratio.
     ///
     /// Wayland protocols do not support this property, so it generally will not be requested by clients.
     ///
     /// \returns the max aspect ratio
-    auto max_aspect() -> std::optional<AspectRatio>&;
+    auto max_aspect() & -> std::optional<AspectRatio>&;
 
     /// The parent of this window.
     ///
     /// \returns the parent of this window
-    auto parent() -> std::optional<std::weak_ptr<mir::scene::Surface>>&;
+    auto parent() & -> std::optional<std::weak_ptr<mir::scene::Surface>>&;
 
     /// The input shape of the window.
     ///
@@ -501,24 +501,24 @@ public:
     /// for the window.
     ///
     /// \returns the list of rectangles that describes the input region
-    auto input_shape() -> std::optional<std::vector<Rectangle>>&;
+    auto input_shape() & -> std::optional<std::vector<Rectangle>>&;
 
     /// The input mode of the window.
     ///
     /// \returns the input mode
-    auto input_mode() -> std::optional<InputReceptionMode>&;
+    auto input_mode() & -> std::optional<InputReceptionMode>&;
 
     /// The shell chrome of the window.
     ///
     /// This is currently unused.
     ///
     /// \returns the shell chrome
-    auto shell_chrome() -> std::optional<MirShellChrome>&;
+    auto shell_chrome() & -> std::optional<MirShellChrome>&;
 
     /// The pointer confinement of the window.
     ///
     /// \returns the pointer confinement
-    auto confine_pointer() -> std::optional<MirPointerConfinementState>&;
+    auto confine_pointer() & -> std::optional<MirPointerConfinementState>&;
 
     /// Custom userdata set on the window.
     ///
@@ -526,17 +526,17 @@ public:
     /// set any information that they would like associated with the window.
     ///
     /// \returns the userdata
-    auto userdata() -> std::optional<std::shared_ptr<void>>&;
+    auto userdata() & -> std::optional<std::shared_ptr<void>>&;
 
     /// The depth layer of a child window is updated with the depth layer of its parent, but can be overridden.
     ///
     /// \returns the depth layer
-    auto depth_layer() const -> std::optional<MirDepthLayer> const&;
+    auto depth_layer() const& -> std::optional<MirDepthLayer> const&;
 
     /// The depth layer of a child window is updated with the depth layer of its parent, but can be overridden.
     ///
     /// \returns the depth layer
-    auto depth_layer() -> std::optional<MirDepthLayer>&;
+    auto depth_layer() & -> std::optional<MirDepthLayer>&;
 
     /// The set of window edges that are attached to edges of the output.
     ///
@@ -545,7 +545,7 @@ public:
     /// If all edges are specified, it takes up the entire output
     ///
     /// \returns the edges
-    auto attached_edges() const -> std::optional<MirPlacementGravity> const&;
+    auto attached_edges() const& -> std::optional<MirPlacementGravity> const&;
 
     /// The set of window edges that are attached to edges of the output.
     ///
@@ -554,7 +554,7 @@ public:
     /// If all edges are specified, it takes up the entire output
     ///
     /// \returns the edges
-    auto attached_edges() -> std::optional<MirPlacementGravity>&;
+    auto attached_edges() & -> std::optional<MirPlacementGravity>&;
 
     /// The area over which the window should not be occluded.
     ///
@@ -563,7 +563,7 @@ public:
     /// If the outer optional is set but the inner is not, the window's exclusive rect is cleared
     ///
     /// \returns the exclusive rectangle
-    auto exclusive_rect() const -> std::optional<std::optional<mir::geometry::Rectangle>> const&;
+    auto exclusive_rect() const& -> std::optional<std::optional<mir::geometry::Rectangle>> const&;
 
     /// The area over which the window should not be occluded.
     ///
@@ -572,79 +572,79 @@ public:
     /// If the outer optional is set but the inner is not, the window's exclusive rect is cleared
     ///
     /// \returns the exclusive rectangle
-    auto exclusive_rect() -> std::optional<std::optional<mir::geometry::Rectangle>>&;
+    auto exclusive_rect() & -> std::optional<std::optional<mir::geometry::Rectangle>>&;
 
     /// Decides whether this window should ignore the exclusion zones set by other windows.
     ///
     /// This is only meaningful for windows attached to an edge.
     ///
     /// \returns the flag
-    auto ignore_exclusion_zones() const -> std::optional<bool> const&;
+    auto ignore_exclusion_zones() const& -> std::optional<bool> const&;
 
     /// Decides whether this window should ignore the exclusion zones set by other windows.
     ///
     /// This is only meaningful for windows attached to an edge.
     ///
     /// \returns the flag
-    auto ignore_exclusion_zones() -> std::optional<bool>&;
+    auto ignore_exclusion_zones() & -> std::optional<bool>&;
 
     /// The D-bus service name and basename of the app's .desktop file.
     ///
     /// See https://specifications.freedesktop.org/desktop-entry-spec/
     ///
     /// \returns the application id
-    auto application_id() const -> std::optional<std::string> const&;
+    auto application_id() const& -> std::optional<std::string> const&;
 
     /// The D-bus service name and basename of the app's .desktop file.
     ///
     /// See https://specifications.freedesktop.org/desktop-entry-spec/
     ///
     /// \returns the application id
-    auto application_id() -> std::optional<std::string>&;
+    auto application_id() & -> std::optional<std::string>&;
 
     /// If this window should have server-side decorations provided by Mir
     /// Currently, Mir only respects this value during surface construction
     ///
     /// \returns the flag
-    auto server_side_decorated() const -> std::optional<bool> const&;
+    auto server_side_decorated() const& -> std::optional<bool> const&;
 
     /// If this window should have server-side decorations provided by Mir
     /// Currently, Mir only respects this value during surface construction
     ///
     /// \returns the flag
-    auto server_side_decorated() -> std::optional<bool>&;
+    auto server_side_decorated() & -> std::optional<bool>&;
 
     /// Describes how the window should gain and lose focus.
     ///
     /// \returns the focus mode
-    auto focus_mode() const -> std::optional<MirFocusMode> const&;
+    auto focus_mode() const& -> std::optional<MirFocusMode> const&;
 
     /// Describes how the window should gain and lose focus.
     ///
     /// \returns the focus mode
-    auto focus_mode() -> std::optional<MirFocusMode>&;
+    auto focus_mode() & -> std::optional<MirFocusMode>&;
 
     /// If this surface should be shown while the compositor is locked.
     ///
     /// \returns the flag
-    auto visible_on_lock_screen() const -> std::optional<bool> const&;
+    auto visible_on_lock_screen() const& -> std::optional<bool> const&;
 
     /// If this surface should be shown while the compositor is locked.
     ///
     /// \returns the flag
-    auto visible_on_lock_screen() -> std::optional<bool>&;
+    auto visible_on_lock_screen() & -> std::optional<bool>&;
 
     /// Describes which edges are touching part of the tiling grid.
     ///
     /// \returns the tiled edges
     /// \remark Since MirAL 5.3
-    auto tiled_edges() const -> std::optional<mir::Flags<MirTiledEdge>> const&;
+    auto tiled_edges() const& -> std::optional<mir::Flags<MirTiledEdge>> const&;
 
     /// Describes which edges are touching part of the tiling grid.
     ///
     /// \returns the tiled edges
     /// \remark Since MirAL 5.3
-    auto tiled_edges() -> std::optional<mir::Flags<MirTiledEdge>>&;
+    auto tiled_edges() & -> std::optional<mir::Flags<MirTiledEdge>>&;
 
     /// The alpha of the window.
     ///
@@ -652,7 +652,7 @@ public:
     ///
     /// \returns the alpha
     /// \remark Since MirAL 5.7
-    auto alpha() -> std::optional<float>&;
+    auto alpha() & -> std::optional<float>&;
 
     /// The alpha of the window.
     ///
@@ -660,7 +660,7 @@ public:
     ///
     /// \returns the alpha
     /// \remark Since MirAL 5.7
-    auto alpha() const -> std::optional<float> const&;
+    auto alpha() const& -> std::optional<float> const&;
 
     /// The expected size of the parent window for constrained popup placement.
     ///
@@ -670,7 +670,7 @@ public:
     ///
     /// \returns the expected parent size
     /// \remark Since MirAL 5.8
-    auto parent_size() -> std::optional<Size>&;
+    auto parent_size() & -> std::optional<Size>&;
 
     /// The expected size of the parent window for constrained popup placement.
     ///
@@ -680,7 +680,7 @@ public:
     ///
     /// \returns the expected parent size
     /// \remark Since MirAL 5.8
-    auto parent_size() const -> std::optional<Size> const&;
+    auto parent_size() const& -> std::optional<Size> const&;
 
     /// Create a [mir::shell::SurfaceSpecification] from this window spec.
     ///

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -128,376 +128,376 @@ auto miral::WindowSpecification::operator=(WindowSpecification const& that) -> W
 
 miral::WindowSpecification::~WindowSpecification() = default;
 
-auto miral::WindowSpecification::top_left() const -> std::optional<Point> const&
+auto miral::WindowSpecification::top_left() const & -> std::optional<Point> const&
 {
     return self->top_left;
 }
 
-auto miral::WindowSpecification::size() const -> std::optional<Size> const&
+auto miral::WindowSpecification::size() const & -> std::optional<Size> const&
 {
     return self->size;
 }
 
-auto miral::WindowSpecification::name() const -> std::optional<std::string> const&
+auto miral::WindowSpecification::name() const & -> std::optional<std::string> const&
 {
     return self->name;
 }
 
-auto miral::WindowSpecification::output_id() const -> std::optional<int> const&
+auto miral::WindowSpecification::output_id() const & -> std::optional<int> const&
 {
     return self->output_id;
 }
 
-auto miral::WindowSpecification::type() const -> std::optional<MirWindowType> const&
+auto miral::WindowSpecification::type() const & -> std::optional<MirWindowType> const&
 {
     return self->type;
 }
 
-auto miral::WindowSpecification::state() const -> std::optional<MirWindowState> const&
+auto miral::WindowSpecification::state() const & -> std::optional<MirWindowState> const&
 {
     return self->state;
 }
 
-auto miral::WindowSpecification::preferred_orientation() const -> std::optional<MirOrientationMode> const&
+auto miral::WindowSpecification::preferred_orientation() const & -> std::optional<MirOrientationMode> const&
 {
     return self->preferred_orientation;
 }
 
-auto miral::WindowSpecification::aux_rect() const -> std::optional<Rectangle> const&
+auto miral::WindowSpecification::aux_rect() const & -> std::optional<Rectangle> const&
 {
     return self->aux_rect;
 }
 
-auto miral::WindowSpecification::placement_hints() const -> std::optional<MirPlacementHints> const&
+auto miral::WindowSpecification::placement_hints() const & -> std::optional<MirPlacementHints> const&
 {
     return self->placement_hints;
 }
 
-auto miral::WindowSpecification::window_placement_gravity() const -> std::optional<MirPlacementGravity> const&
+auto miral::WindowSpecification::window_placement_gravity() const & -> std::optional<MirPlacementGravity> const&
 {
     return self->window_placement_gravity;
 }
 
-auto miral::WindowSpecification::aux_rect_placement_gravity() const -> std::optional<MirPlacementGravity> const&
+auto miral::WindowSpecification::aux_rect_placement_gravity() const & -> std::optional<MirPlacementGravity> const&
 {
     return self->aux_rect_placement_gravity;
 }
 
-auto miral::WindowSpecification::aux_rect_placement_offset() const -> std::optional<Displacement> const&
+auto miral::WindowSpecification::aux_rect_placement_offset() const & -> std::optional<Displacement> const&
 {
     return self->aux_rect_placement_offset;
 }
 
-auto miral::WindowSpecification::min_width() const -> std::optional<Width> const&
+auto miral::WindowSpecification::min_width() const & -> std::optional<Width> const&
 {
     return self->min_width;
 }
 
-auto miral::WindowSpecification::min_height() const -> std::optional<Height> const&
+auto miral::WindowSpecification::min_height() const & -> std::optional<Height> const&
 {
     return self->min_height;
 }
 
-auto miral::WindowSpecification::max_width() const -> std::optional<Width> const&
+auto miral::WindowSpecification::max_width() const & -> std::optional<Width> const&
 {
     return self->max_width;
 }
 
-auto miral::WindowSpecification::max_height() const -> std::optional<Height> const&
+auto miral::WindowSpecification::max_height() const & -> std::optional<Height> const&
 {
     return self->max_height;
 }
 
-auto miral::WindowSpecification::width_inc() const -> std::optional<DeltaX> const&
+auto miral::WindowSpecification::width_inc() const & -> std::optional<DeltaX> const&
 {
     return self->width_inc;
 }
 
-auto miral::WindowSpecification::height_inc() const -> std::optional<DeltaY> const&
+auto miral::WindowSpecification::height_inc() const & -> std::optional<DeltaY> const&
 {
     return self->height_inc;
 }
 
-auto miral::WindowSpecification::min_aspect() const -> std::optional<AspectRatio> const&
+auto miral::WindowSpecification::min_aspect() const & -> std::optional<AspectRatio> const&
 {
     return self->min_aspect;
 }
 
-auto miral::WindowSpecification::max_aspect() const -> std::optional<AspectRatio> const&
+auto miral::WindowSpecification::max_aspect() const & -> std::optional<AspectRatio> const&
 {
     return self->max_aspect;
 }
 
-auto miral::WindowSpecification::parent() const -> std::optional<std::weak_ptr<mir::scene::Surface>> const&
+auto miral::WindowSpecification::parent() const & -> std::optional<std::weak_ptr<mir::scene::Surface>> const&
 {
     return self->parent;
 }
 
-auto miral::WindowSpecification::input_shape() const -> std::optional<std::vector<Rectangle>> const&
+auto miral::WindowSpecification::input_shape() const & -> std::optional<std::vector<Rectangle>> const&
 {
     return self->input_shape;
 }
 
-auto miral::WindowSpecification::input_mode() const -> std::optional<InputReceptionMode> const&
+auto miral::WindowSpecification::input_mode() const & -> std::optional<InputReceptionMode> const&
 {
     return self->input_mode;
 }
 
-auto miral::WindowSpecification::shell_chrome() const -> std::optional<MirShellChrome> const&
+auto miral::WindowSpecification::shell_chrome() const & -> std::optional<MirShellChrome> const&
 {
     return self->shell_chrome;
 }
 
-auto miral::WindowSpecification::confine_pointer() const -> std::optional<MirPointerConfinementState> const&
+auto miral::WindowSpecification::confine_pointer() const & -> std::optional<MirPointerConfinementState> const&
 {
     return self->confine_pointer;
 }
 
-auto miral::WindowSpecification::depth_layer() const -> std::optional<MirDepthLayer> const&
+auto miral::WindowSpecification::depth_layer() const & -> std::optional<MirDepthLayer> const&
 {
     return self->depth_layer;
 }
 
-auto miral::WindowSpecification::attached_edges() const -> std::optional<MirPlacementGravity> const&
+auto miral::WindowSpecification::attached_edges() const & -> std::optional<MirPlacementGravity> const&
 {
     return self->attached_edges;
 }
 
 auto miral::WindowSpecification::exclusive_rect() const
-    -> std::optional<std::optional<mir::geometry::Rectangle>> const&
+    & -> std::optional<std::optional<mir::geometry::Rectangle>> const&
 {
     return self->exclusive_rect;
 }
 
 auto miral::WindowSpecification::ignore_exclusion_zones() const
-    -> std::optional<bool> const&
+    & -> std::optional<bool> const&
 {
     return self->ignore_exclusion_zones;
 }
 
-auto miral::WindowSpecification::userdata() const -> std::optional<std::shared_ptr<void>> const&
+auto miral::WindowSpecification::userdata() const & -> std::optional<std::shared_ptr<void>> const&
 {
     return self->userdata;
 }
 
-auto miral::WindowSpecification::top_left() -> std::optional<Point>&
+auto miral::WindowSpecification::top_left() & -> std::optional<Point>&
 {
     return self->top_left;
 }
 
-auto miral::WindowSpecification::size() -> std::optional<Size>&
+auto miral::WindowSpecification::size() & -> std::optional<Size>&
 {
     return self->size;
 }
 
-auto miral::WindowSpecification::name() -> std::optional<std::string>&
+auto miral::WindowSpecification::name() & -> std::optional<std::string>&
 {
     return self->name;
 }
 
-auto miral::WindowSpecification::output_id() -> std::optional<int>&
+auto miral::WindowSpecification::output_id() & -> std::optional<int>&
 {
     return self->output_id;
 }
 
-auto miral::WindowSpecification::type() -> std::optional<MirWindowType>&
+auto miral::WindowSpecification::type() & -> std::optional<MirWindowType>&
 {
     return self->type;
 }
 
-auto miral::WindowSpecification::state() -> std::optional<MirWindowState>&
+auto miral::WindowSpecification::state() & -> std::optional<MirWindowState>&
 {
     return self->state;
 }
 
-auto miral::WindowSpecification::preferred_orientation() -> std::optional<MirOrientationMode>&
+auto miral::WindowSpecification::preferred_orientation() & -> std::optional<MirOrientationMode>&
 {
     return self->preferred_orientation;
 }
 
-auto miral::WindowSpecification::aux_rect() -> std::optional<Rectangle>&
+auto miral::WindowSpecification::aux_rect() & -> std::optional<Rectangle>&
 {
     return self->aux_rect;
 }
 
-auto miral::WindowSpecification::placement_hints() -> std::optional<MirPlacementHints>&
+auto miral::WindowSpecification::placement_hints() & -> std::optional<MirPlacementHints>&
 {
     return self->placement_hints;
 }
 
-auto miral::WindowSpecification::window_placement_gravity() -> std::optional<MirPlacementGravity>&
+auto miral::WindowSpecification::window_placement_gravity() & -> std::optional<MirPlacementGravity>&
 {
     return self->window_placement_gravity;
 }
 
-auto miral::WindowSpecification::aux_rect_placement_gravity() -> std::optional<MirPlacementGravity>&
+auto miral::WindowSpecification::aux_rect_placement_gravity() & -> std::optional<MirPlacementGravity>&
 {
     return self->aux_rect_placement_gravity;
 }
 
-auto miral::WindowSpecification::aux_rect_placement_offset() -> std::optional<Displacement>&
+auto miral::WindowSpecification::aux_rect_placement_offset() & -> std::optional<Displacement>&
 {
     return self->aux_rect_placement_offset;
 }
 
-auto miral::WindowSpecification::min_width() -> std::optional<Width>&
+auto miral::WindowSpecification::min_width() & -> std::optional<Width>&
 {
     return self->min_width;
 }
 
-auto miral::WindowSpecification::min_height() -> std::optional<Height>&
+auto miral::WindowSpecification::min_height() & -> std::optional<Height>&
 {
     return self->min_height;
 }
 
-auto miral::WindowSpecification::max_width() -> std::optional<Width>&
+auto miral::WindowSpecification::max_width() & -> std::optional<Width>&
 {
     return self->max_width;
 }
 
-auto miral::WindowSpecification::max_height() -> std::optional<Height>&
+auto miral::WindowSpecification::max_height() & -> std::optional<Height>&
 {
     return self->max_height;
 }
 
-auto miral::WindowSpecification::width_inc() -> std::optional<DeltaX>&
+auto miral::WindowSpecification::width_inc() & -> std::optional<DeltaX>&
 {
     return self->width_inc;
 }
 
-auto miral::WindowSpecification::height_inc() -> std::optional<DeltaY>&
+auto miral::WindowSpecification::height_inc() & -> std::optional<DeltaY>&
 {
     return self->height_inc;
 }
 
-auto miral::WindowSpecification::min_aspect() -> std::optional<AspectRatio>&
+auto miral::WindowSpecification::min_aspect() & -> std::optional<AspectRatio>&
 {
     return self->min_aspect;
 }
 
-auto miral::WindowSpecification::max_aspect() -> std::optional<AspectRatio>&
+auto miral::WindowSpecification::max_aspect() & -> std::optional<AspectRatio>&
 {
     return self->max_aspect;
 }
 
-auto miral::WindowSpecification::parent() -> std::optional<std::weak_ptr<mir::scene::Surface>>&
+auto miral::WindowSpecification::parent() & -> std::optional<std::weak_ptr<mir::scene::Surface>>&
 {
     return self->parent;
 }
 
-auto miral::WindowSpecification::input_shape() -> std::optional<std::vector<Rectangle>>&
+auto miral::WindowSpecification::input_shape() & -> std::optional<std::vector<Rectangle>>&
 {
     return self->input_shape;
 }
 
-auto miral::WindowSpecification::input_mode() -> std::optional<InputReceptionMode>&
+auto miral::WindowSpecification::input_mode() & -> std::optional<InputReceptionMode>&
 {
     return self->input_mode;
 }
 
-auto miral::WindowSpecification::shell_chrome() -> std::optional<MirShellChrome>&
+auto miral::WindowSpecification::shell_chrome() & -> std::optional<MirShellChrome>&
 {
     return self->shell_chrome;
 }
 
-auto miral::WindowSpecification::confine_pointer() -> std::optional<MirPointerConfinementState>&
+auto miral::WindowSpecification::confine_pointer() & -> std::optional<MirPointerConfinementState>&
 {
     return self->confine_pointer;
 }
 
-auto miral::WindowSpecification::depth_layer() -> std::optional<MirDepthLayer>&
+auto miral::WindowSpecification::depth_layer() & -> std::optional<MirDepthLayer>&
 {
     return self->depth_layer;
 }
 
-auto miral::WindowSpecification::attached_edges() -> std::optional<MirPlacementGravity>&
+auto miral::WindowSpecification::attached_edges() & -> std::optional<MirPlacementGravity>&
 {
     return self->attached_edges;
 }
 
 auto miral::WindowSpecification::exclusive_rect()
-    -> std::optional<std::optional<mir::geometry::Rectangle>>&
+    & -> std::optional<std::optional<mir::geometry::Rectangle>>&
 {
     return self->exclusive_rect;
 }
 
 auto miral::WindowSpecification::ignore_exclusion_zones()
-    -> std::optional<bool>&
+    & -> std::optional<bool>&
 {
     return self->ignore_exclusion_zones;
 }
 
-auto miral::WindowSpecification::application_id() const -> std::optional<std::string> const&
+auto miral::WindowSpecification::application_id() const & -> std::optional<std::string> const&
 {
     return self->application_id;
 }
 
-auto miral::WindowSpecification::application_id() -> std::optional<std::string>&
+auto miral::WindowSpecification::application_id() & -> std::optional<std::string>&
 {
     return self->application_id;
 }
 
-auto miral::WindowSpecification::server_side_decorated() const -> std::optional<bool> const&
+auto miral::WindowSpecification::server_side_decorated() const & -> std::optional<bool> const&
 {
     return self->server_side_decorated;
 }
 
-auto miral::WindowSpecification::server_side_decorated() -> std::optional<bool>&
+auto miral::WindowSpecification::server_side_decorated() & -> std::optional<bool>&
 {
     return self->server_side_decorated;
 }
 
-auto miral::WindowSpecification::focus_mode() const -> std::optional<MirFocusMode> const&
+auto miral::WindowSpecification::focus_mode() const & -> std::optional<MirFocusMode> const&
 {
     return self->focus_mode;
 }
 
-auto miral::WindowSpecification::focus_mode() -> std::optional<MirFocusMode>&
+auto miral::WindowSpecification::focus_mode() & -> std::optional<MirFocusMode>&
 {
     return self->focus_mode;
 }
 
-auto miral::WindowSpecification::visible_on_lock_screen() const -> std::optional<bool> const&
+auto miral::WindowSpecification::visible_on_lock_screen() const & -> std::optional<bool> const&
 {
     return self->visible_on_lock_screen;
 }
 
-auto miral::WindowSpecification::visible_on_lock_screen() -> std::optional<bool>&
+auto miral::WindowSpecification::visible_on_lock_screen() & -> std::optional<bool>&
 {
     return self->visible_on_lock_screen;
 }
 
-auto miral::WindowSpecification::tiled_edges() const -> std::optional<mir::Flags<MirTiledEdge>> const&
+auto miral::WindowSpecification::tiled_edges() const & -> std::optional<mir::Flags<MirTiledEdge>> const&
 {
     return self->tiled_edges;
 }
 
-auto miral::WindowSpecification::tiled_edges() -> std::optional<mir::Flags<MirTiledEdge>>&
+auto miral::WindowSpecification::tiled_edges() & -> std::optional<mir::Flags<MirTiledEdge>>&
 {
     return self->tiled_edges;
 }
 
-auto miral::WindowSpecification::alpha() -> std::optional<float>&
+auto miral::WindowSpecification::alpha() & -> std::optional<float>&
 {
     return self->opacity;
 }
 
-auto miral::WindowSpecification::alpha() const -> std::optional<float> const&
+auto miral::WindowSpecification::alpha() const & -> std::optional<float> const&
 {
     return self->opacity;
 }
 
-auto miral::WindowSpecification::parent_size() -> std::optional<Size>&
+auto miral::WindowSpecification::parent_size() & -> std::optional<Size>&
 {
     return self->parent_size;
 }
 
-auto miral::WindowSpecification::parent_size() const -> std::optional<Size> const&
+auto miral::WindowSpecification::parent_size() const & -> std::optional<Size> const&
 {
     return self->parent_size;
 }
 
-auto miral::WindowSpecification::userdata() -> std::optional<std::shared_ptr<void>>&
+auto miral::WindowSpecification::userdata() & -> std::optional<std::shared_ptr<void>>&
 {
     return self->userdata;
 }


### PR DESCRIPTION
This prevents accidental misuse like accessing temporaries incorrectly.

While strictly an API (and ABI) change, this should not break any correct code (and we've already bumped to 6.0)