### PR TITLE
ApplicationSwitcher: if we have either an app_id or a window title we are not a "ghost": Use what we have for both properties

### DIFF
--- a/src/miral/application_switcher.cpp
+++ b/src/miral/application_switcher.cpp
@@ -706,6 +706,8 @@ private:
         if (it != toplevels_in_focus_order.end())
         {
             it->window_title = window_title;
+            if (it->ghost) it->app_id = window_title;
+            it->ghost = false;
         }
         else
         {


### PR DESCRIPTION
Fixes: #5063