### PR TITLE
Add a touch emulator to map mouse clicks and drags to touch events

### DIFF
--- a/debian/libmiral8.symbols
+++ b/debian/libmiral8.symbols
@@ -377,6 +377,13 @@ libmiral.so.8 libmiral8 #MINVER#
  (c++)"miral::StickyKeys::on_modifier_clicked(std::function<void (int)>&&)@MIRAL_6.0" 6.0.0
  (c++)"miral::StickyKeys::operator()(mir::Server&)@MIRAL_6.0" 6.0.0
  (c++)"miral::StickyKeys::should_disable_if_two_keys_are_pressed_together(bool)@MIRAL_6.0" 6.0.0
+ (c++)"miral::TouchEmulator::TouchEmulator(miral::live_config::Store&)@MIRAL_6.0" 6.0.0
+ (c++)"miral::TouchEmulator::TouchEmulator(std::shared_ptr<miral::TouchEmulator::Self>)@MIRAL_6.0" 6.0.0
+ (c++)"miral::TouchEmulator::disable()@MIRAL_6.0" 6.0.0
+ (c++)"miral::TouchEmulator::disabled()@MIRAL_6.0" 6.0.0
+ (c++)"miral::TouchEmulator::enable()@MIRAL_6.0" 6.0.0
+ (c++)"miral::TouchEmulator::enabled()@MIRAL_6.0" 6.0.0
+ (c++)"miral::TouchEmulator::operator()(mir::Server&)@MIRAL_6.0" 6.0.0
  (c++)"miral::WaylandExtensions::EnableInfo::app() const@MIRAL_6.0" 6.0.0
  (c++)"miral::WaylandExtensions::EnableInfo::name() const@MIRAL_6.0" 6.0.0
  (c++)"miral::WaylandExtensions::EnableInfo::user_preference() const@MIRAL_6.0" 6.0.0

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -36,6 +36,7 @@
 #include <miral/slow_keys.h>
 #include <miral/hover_click.h>
 #include <miral/append_keyboard_event_filter.h>
+#include <miral/touch_emulator.h>
 
 #include <mir/abnormal_exit.h>
 #include <mir/main_loop.h>
@@ -140,6 +141,7 @@ try
     miral::StickyKeys sticky_keys{config_store};
     miral::Keymap keymap{config_store};
     miral::HoverClick hover_click{config_store};
+    miral::TouchEmulator touch_emulator{config_store};
 
     miral::ConfigFile config_file{
         runner,
@@ -175,6 +177,7 @@ try
         slow_keys,
         sticky_keys,
         hover_click,
+        touch_emulator,
         keymap,
     });
 

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -42,6 +42,8 @@
 #include <miral/sticky_keys.h>
 #include <miral/magnifier.h>
 #include <miral/cursor_scale.h>
+#include <miral/touch_emulator.h>
+#include <mir/log.h>
 
 #include <xkbcommon/xkbcommon-keysyms.h>
 
@@ -358,6 +360,28 @@ int main(int argc, char const* argv[])
         return false;
     };
 
+    auto touch_emulator = TouchEmulator::disabled();
+    auto toggle_touch_emulator_filter = [&touch_emulator, touch_emulator_enabled = false](MirKeyboardEvent const* key_event) mutable
+    {
+        auto const modifiers = mir_keyboard_event_modifiers(key_event);
+
+        if (mir_keyboard_event_action(key_event) != mir_keyboard_action_down ||
+            !(modifiers & mir_input_event_modifier_ctrl) ||
+            !(modifiers & mir_input_event_modifier_alt) ||
+            !(modifiers & mir_input_event_modifier_shift) ||
+            mir_keyboard_event_keysym(key_event) != XKB_KEY_E)
+            return false;
+
+        touch_emulator_enabled = !touch_emulator_enabled;
+        if (touch_emulator_enabled)
+            touch_emulator.enable();
+        else
+            touch_emulator.disable();
+
+        return true;
+    };
+
+
     return runner.run_with(
         {
             CursorTheme{"default:DMZ-White"},
@@ -392,6 +416,8 @@ int main(int argc, char const* argv[])
             cursor_scale,
             locate_pointer,
             AppendKeyboardEventFilter{locate_pointer_filter},
-            BasicApplicationSwitcher{}
+            BasicApplicationSwitcher{},
+            touch_emulator,
+            AppendKeyboardEventFilter{toggle_touch_emulator_filter},
         });
 }

--- a/include/miral/miral/touch_emulator.h
+++ b/include/miral/miral/touch_emulator.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_TOUCH_EMULATOR_H
+#define MIRAL_TOUCH_EMULATOR_H
+
+#include <memory>
+
+namespace mir { class Server; }
+
+namespace miral
+{
+namespace live_config { class Store; }
+
+/// Enables or disables the built-in touch emulation in the Mir server.
+///
+/// When enabled, a compositor can synthesize touch events from mouse input,
+/// allowing touch-enabled applications to be tested without a touch screen.
+///
+/// \remark Since MirAL 6.0
+class TouchEmulator
+{
+public:
+    /// Creates a TouchEmulator that is enabled by default.
+    ///
+    /// \returns an enabled TouchEmulator
+    static auto enabled() -> TouchEmulator;
+
+    /// Creates a TouchEmulator that is disabled by default.
+    ///
+    /// \returns a disabled TouchEmulator
+    static auto disabled() -> TouchEmulator;
+
+    /// Enables touch emulation.
+    ///
+    /// \returns a reference to this TouchEmulator
+    auto enable() -> TouchEmulator&;
+
+    /// Disables touch emulation.
+    ///
+    /// \returns a reference to this TouchEmulator
+    auto disable() -> TouchEmulator&;
+
+    /// Construct a `TouchEmulator` instance with access to a live config store.
+    ///
+    /// Available options:
+    ///     - {touch-emulator, enable}: Enable or disable touch emulation.
+    ///
+    /// \param config_store the configuration store used to persist the touch emulation state
+    explicit TouchEmulator(miral::live_config::Store& config_store);
+
+    /// Applies the touch emulator configuration to the Mir \p server.
+    void operator()(mir::Server& server);
+
+private:
+    class Self;
+    explicit TouchEmulator(std::shared_ptr<Self> self);
+    std::shared_ptr<Self> self;
+};
+}
+
+#endif

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(miral-external OBJECT
     sticky_keys.cpp                     ${miral_include}/miral/sticky_keys.h
     locate_pointer.cpp                  ${miral_include}/miral/locate_pointer.h
     logging_config.cpp                  ${miral_include}/miral/logging_config.h
+    touch_emulator.cpp                  ${miral_include}/miral/touch_emulator.h
 )
 
 add_library(miral SHARED

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -336,6 +336,12 @@ global:
     miral::StickyKeys::on_modifier_clicked*;
     miral::StickyKeys::operator*;
     miral::StickyKeys::should_disable_if_two_keys_are_pressed_together*;
+    miral::TouchEmulator::TouchEmulator*;
+    "miral::TouchEmulator::disable()";
+    "miral::TouchEmulator::disabled()";
+    "miral::TouchEmulator::enable()";
+    "miral::TouchEmulator::enabled()";
+    "miral::TouchEmulator::operator()(mir::Server&)";
     miral::WaylandExtensions::?WaylandExtensions*;
     miral::WaylandExtensions::Context::operator*;
     miral::WaylandExtensions::EnableInfo::app*;
@@ -736,6 +742,7 @@ global:
     typeinfo?for?miral::SlowKeys;
     typeinfo?for?miral::StartupInternalClient;
     typeinfo?for?miral::StickyKeys;
+    typeinfo?for?miral::TouchEmulator;
     typeinfo?for?miral::WaylandExtensions::Builder;
     typeinfo?for?miral::WaylandExtensions::Context;
     typeinfo?for?miral::WaylandExtensions::EnableInfo;

--- a/src/miral/touch_emulator.cpp
+++ b/src/miral/touch_emulator.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "miral/touch_emulator.h"
+
+#include <miral/live_config.h>
+#include <miral/prepend_event_filter.h>
+
+#include <mir/events/touch_contact.h>
+#include <mir/geometry/point.h>
+#include <mir/input/device_capability.h>
+#include <mir/input/event_builder.h>
+#include <mir/input/input_device_registry.h>
+#include <mir/input/input_sink.h>
+#include <mir/input/virtual_input_device.h>
+#include <mir/main_loop.h>
+#include <mir/options/option.h>
+#include <mir/server.h>
+#include <mir/synchronised.h>
+
+#include <mir_toolkit/events/input/pointer_event.h>
+#include <mir_toolkit/events/input/input_event.h>
+#include <mir_toolkit/events/event.h>
+#include <mir_toolkit/events/enums.h>
+
+#include <chrono>
+
+namespace mi   = mir::input;
+namespace mev  = mir::events;
+namespace geom = mir::geometry;
+
+
+class miral::TouchEmulator::Self
+{
+public:
+    explicit Self(bool enabled) :
+        touch_device{std::make_shared<mi::VirtualInputDevice>("touch-emulator", mi::DeviceCapability::touchscreen)},
+        filter{[this](MirEvent const* event) { return handle(event); }},
+        state{State{enabled}}
+    {
+    }
+
+    // Called during server configuration to register the (initially inactive) event filter.
+    void register_with(mir::Server& server)
+    {
+        filter(server);
+    }
+
+    void init(mir::Server& server)
+    {
+        auto const state_ = state.lock();
+        main_loop = server.the_main_loop();
+        input_device_registry = server.the_input_device_registry();
+
+        if (state_->active)
+        {
+            input_device_registry.lock()->add_device(touch_device);
+            state_->device_registered = true;
+        }
+    }
+
+    void deinit()
+    {
+        auto const state_ = state.lock();
+        state_->active = false;
+        if (state_->device_registered)
+        {
+            input_device_registry.lock()->remove_device(touch_device);
+            state_->device_registered = false;
+        }
+    }
+
+    void activate()
+    {
+        auto const state_ = state.lock();
+        state_->active = true;
+
+        if (!state_->device_registered)
+        {
+            // If the server has not started, init() registers the device.
+            if (auto const registry = input_device_registry.lock())
+            {
+                registry->add_device(touch_device);
+                state_->device_registered = true;
+            }
+        }
+    }
+
+    void deactivate()
+    {
+        state.lock()->active = false;
+    }
+
+    bool handle(MirEvent const* event)
+    {
+        if (!state.lock()->active)
+            return false;
+
+        if (mir_event_get_type(event) != mir_event_type_input)
+            return false;
+
+        auto const* input_ev = mir_event_get_input_event(event);
+        if (mir_input_event_get_type(input_ev) != mir_input_event_type_pointer)
+            return false;
+
+        auto const* pev = mir_input_event_get_pointer_event(input_ev);
+
+        // Ctrl+drag passes through unchanged for normal pointer interaction.
+        if (mir_pointer_event_modifiers(pev) & mir_input_event_modifier_ctrl)
+            return false;
+
+        auto const action  = mir_pointer_event_action(pev);
+        auto const buttons = mir_pointer_event_buttons(pev);
+        float const x = mir_pointer_event_axis_value(pev, mir_pointer_axis_x);
+        float const y = mir_pointer_event_axis_value(pev, mir_pointer_axis_y);
+        auto const ts = std::chrono::nanoseconds{mir_input_event_get_event_time(input_ev)};
+
+        if (!dragging &&
+            action == mir_pointer_action_button_down &&
+            (buttons & mir_pointer_button_primary))
+        {
+            dragging = true;
+            dispatch_touch(mir_touch_action_down, x, y, ts);
+            return true;
+        }
+        else if (action == mir_pointer_action_motion && dragging)
+        {
+            dispatch_touch( mir_touch_action_change, x, y, ts);
+            return true;
+        }
+        else if (action == mir_pointer_action_button_up && dragging &&
+                 !(buttons & mir_pointer_button_primary))
+        {
+            dragging = false;
+            dispatch_touch(mir_touch_action_up, x, y, ts);
+            return true;
+        }
+
+        // Consume all other pointer events so they don't reach surfaces.
+        return true;
+    }
+
+private:
+    struct State
+    {
+        explicit State(bool enabled) :
+            active{enabled}
+        {
+        }
+
+        bool active;
+        bool device_registered{false};
+    };
+
+    void dispatch_touch(
+        MirTouchAction action,
+        float x,
+        float y,
+        std::chrono::nanoseconds timestamp)
+    {
+        auto const ml = main_loop.lock();
+        if (!ml)
+            return;
+
+        // Enqueue the dispatch so it runs after the current filter invocation
+        // returns.  Calling sink->handle_input() from inside the filter would
+        // re-enter the composite event filter while it is already executing,
+        // causing a deadlock.
+        ml->enqueue(
+            this,
+            [touch_device=touch_device, action, x, y, timestamp]
+            {
+                static MirTouchId constexpr touch_id = 0;
+
+                mev::TouchContact const contact{
+                    touch_id,
+                    action,
+                    mir_touch_tooltype_finger,
+                    geom::PointF{x, y},
+                    1.0f,  // pressure
+                    8.0f,  // touch_major
+                    8.0f,  // touch_minor
+                    0.0f}; // orientation
+
+                touch_device->if_started_then(
+                    [&contact, timestamp](mi::InputSink* sink, mi::EventBuilder* builder)
+                    {
+                        auto ev = builder->touch_event(timestamp, {contact});
+                        sink->handle_input(std::move(ev));
+                    });
+            });
+    }
+
+
+    std::shared_ptr<mi::VirtualInputDevice> const touch_device;
+    miral::PrependEventFilter filter;
+    std::weak_ptr<mir::MainLoop> main_loop;
+    std::weak_ptr<mi::InputDeviceRegistry> input_device_registry;
+    bool dragging{false};
+    mir::Synchronised<State> state;
+};
+
+auto miral::TouchEmulator::enabled() -> TouchEmulator
+{
+    return TouchEmulator{std::make_shared<Self>(true)};
+}
+
+auto miral::TouchEmulator::disabled() -> TouchEmulator
+{
+    return TouchEmulator{std::make_shared<Self>(false)};
+}
+
+auto miral::TouchEmulator::enable() -> TouchEmulator&
+{
+    self->activate();
+    return *this;
+}
+
+auto miral::TouchEmulator::disable() -> TouchEmulator&
+{
+    self->deactivate();
+    return *this;
+}
+
+void miral::TouchEmulator::operator()(mir::Server& server)
+{
+    // Always register the event filter — it is a no-op until activated.
+    self->register_with(server);
+
+    server.add_init_callback([self=this->self, &server]
+    {
+        self->init(server);
+    });
+
+    server.add_stop_callback([self=this->self]
+    {
+        self->deinit();
+    });
+}
+
+miral::TouchEmulator::TouchEmulator(miral::live_config::Store& config_store) : self{std::make_shared<Self>(false)}
+{
+    config_store.add_bool_attribute(
+        {"touch_emulator", "enable"},
+        "Enable or disable touch emulation.",
+        false,
+        [self = this->self](auto const&, std::optional<bool> enabled)
+        {
+            if (enabled.has_value())
+            {
+                if (*enabled)
+                    self->activate();
+                else
+                    self->deactivate();
+            }
+        });
+}
+
+miral::TouchEmulator::TouchEmulator(std::shared_ptr<Self> self) : self{self} {}

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -85,6 +85,7 @@ mir_add_wrapped_executable(miral-test NOINSTALL
     wayland_extensions.cpp
     zone.cpp
     example_xdg_shell_v6.cpp example_xdg_shell_v6.h
+    test_touch_emulator.cpp
 )
 
 mir_generate_protocol_wrapper(miral-test "z" xdg-shell-unstable-v6.xml)

--- a/tests/miral/test_touch_emulator.cpp
+++ b/tests/miral/test_touch_emulator.cpp
@@ -1,0 +1,440 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "add_virtual_device.h"
+#include "mir/test/spin_wait.h"
+
+#include <mir/input/event_builder.h>
+#include <mir/input/input_device_hub.h>
+#include <mir/input/input_device_registry.h>
+#include <mir/input/input_sink.h>
+#include <mir/server.h>
+#include <mir/test/signal.h>
+
+#include <miral/append_event_filter.h>
+#include <miral/test_server.h>
+#include <miral/touch_emulator.h>
+
+#include <mir_toolkit/events/event.h>
+#include <mir_toolkit/events/enums.h>
+#include <mir_toolkit/events/input/input_event.h>
+#include <mir_toolkit/events/input/touch_event.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <vector>
+
+using namespace testing;
+using namespace std::chrono_literals;
+
+namespace mi = mir::input;
+namespace geom = mir::geometry;
+
+struct TestTouchEmulator : miral::TestServer
+{
+    struct CapturedTouch
+    {
+        auto static to_touch(MirEvent const* event) -> MirTouchEvent const*
+        {
+            return mir_input_event_get_touch_event(mir_event_get_input_event(event));
+        }
+
+        explicit CapturedTouch(MirEvent const* event) :
+            action{mir_touch_event_action(to_touch(event), 0)},
+            x{mir_touch_event_axis_value(to_touch(event), 0, mir_touch_axis_x)},
+            y{mir_touch_event_axis_value(to_touch(event), 0, mir_touch_axis_y)}
+        {}
+
+        MirTouchAction const action;
+        float const x;
+        float const y;
+    };
+
+    explicit TestTouchEmulator(
+        bool enabled = true,
+        std::function<void(mir::Server&)> before_touch_emulator = {}) :
+        touch_emulator{enabled ? miral::TouchEmulator::enabled() : miral::TouchEmulator::disabled()}
+    {
+        add_server_init(
+            [this, before_touch_emulator](mir::Server& server)
+            {
+                server.add_init_callback(
+                    [&server, this]
+                    {
+                        input_device_registry = server.the_input_device_registry();
+                        input_device_hub = server.the_input_device_hub();
+                    });
+
+                // Stop callbacks run in reverse registration order, so this hook
+                // lets lifecycle tests inspect state after the emulator's callback.
+                if (before_touch_emulator)
+                    before_touch_emulator(server);
+
+                touch_emulator(server);
+                observer(server);
+            });
+    }
+
+    auto add_pointer()
+    {
+        return miral::test::add_test_device(
+            input_device_registry.lock(), input_device_hub.lock(), mi::DeviceCapability::pointer);
+    }
+
+    struct PointerEvent
+    {
+        MirPointerAction action;
+        MirPointerButtons buttons;
+        float x;
+        float y;
+    };
+
+    void send_pointer_events(
+        std::shared_ptr<mir::input::VirtualInputDevice> const& pointer,
+        std::initializer_list<PointerEvent>&& events)
+    {
+        pointer->if_started_then(
+            [&](mi::InputSink* sink, mi::EventBuilder* builder)
+            {
+                for (auto const& ev : events)
+                {
+                    sink->handle_input(builder->pointer_event(
+                        std::nullopt,
+                        ev.action,
+                        ev.buttons,
+                        std::optional<geom::PointF>{geom::PointF{ev.x, ev.y}},
+                        geom::DisplacementF{0.0f, 0.0f},
+                        mir_pointer_axis_source_none,
+                        {},
+                        {}));
+                }
+            });
+    }
+
+    void send_pointer_event(std::shared_ptr<mir::input::VirtualInputDevice> const& pointer, PointerEvent const& event)
+    { send_pointer_events(pointer, {event}); }
+
+    auto wait_for_touch_count(size_t expected) -> bool
+    {
+        return mir::test::spin_wait_for_condition_or_timeout(
+            [&] { return touch_events.lock()->size() >= expected; }, 100ms);
+    }
+
+    auto captured_touch_events() -> std::vector<CapturedTouch>
+    {
+        return *touch_events.lock();
+    }
+
+    void assert_no_touch()
+    {
+        EXPECT_THAT(wait_for_touch_count(1), Eq(false));
+        EXPECT_THAT(captured_touch_events().size(), Eq(0u));
+    }
+
+    std::weak_ptr<mi::InputDeviceRegistry> input_device_registry;
+    std::weak_ptr<mi::InputDeviceHub> input_device_hub;
+    miral::AppendEventFilter observer{
+        [this](MirEvent const* event) -> bool
+        {
+            if (mir_event_get_type(event) != mir_event_type_input)
+                return false;
+            auto const* input_ev = mir_event_get_input_event(event);
+            if (mir_input_event_get_type(input_ev) == mir_input_event_type_touch)
+            {
+                touch_events.lock()->emplace_back(event);
+            }
+            return false;
+        }};
+
+    miral::TouchEmulator touch_emulator;
+    mir::Synchronised<std::vector<CapturedTouch>> touch_events;
+};
+
+TEST_F(TestTouchEmulator, generates_touch_events)
+{
+    auto pointer = add_pointer();
+
+    send_pointer_event(
+        pointer, {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 100.0f, 200.0f});
+
+    ASSERT_TRUE(wait_for_touch_count(1));
+}
+
+struct TestInitiallyDisabledTouchEmulator : TestTouchEmulator
+{
+    TestInitiallyDisabledTouchEmulator() : TestTouchEmulator{false} {}
+};
+
+struct TestInitiallyDisabledButEnabledBeforeServerStartsTouchEmulator : TestTouchEmulator
+{
+    TestInitiallyDisabledButEnabledBeforeServerStartsTouchEmulator() : TestTouchEmulator{false}
+    {
+        touch_emulator.enable();
+    }
+};
+
+TEST_F(TestInitiallyDisabledTouchEmulator, does_not_generate_touch_events_when_disabled)
+{
+    auto pointer = add_pointer();
+
+    send_pointer_event(
+        pointer, {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 100.0f, 200.0f});
+
+    assert_no_touch();
+}
+
+TEST_F(
+    TestInitiallyDisabledButEnabledBeforeServerStartsTouchEmulator,
+    generates_touch_events_when_enabled_before_server_starts)
+{
+    auto pointer = add_pointer();
+
+    send_pointer_event(
+        pointer, {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 10.0f, 20.0f});
+
+    ASSERT_TRUE(wait_for_touch_count(1));
+}
+
+TEST_F(TestInitiallyDisabledTouchEmulator, generates_touch_events_when_enabled_later)
+{
+    auto pointer = add_pointer();
+
+    send_pointer_event(
+        pointer, {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 10.0f, 20.0f});
+    assert_no_touch();
+    send_pointer_event(pointer, {mir_pointer_action_button_up, MirPointerButtons{0}, 10.0f, 20.0f});
+    assert_no_touch();
+
+    touch_emulator.enable();
+
+    send_pointer_event(
+        pointer, {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 30.0f, 40.0f});
+
+    ASSERT_TRUE(wait_for_touch_count(1));
+    auto const evts = captured_touch_events();
+    ASSERT_THAT(evts.size(), Eq(1u));
+    EXPECT_THAT(evts[0].action, Eq(mir_touch_action_down));
+    EXPECT_THAT(evts[0].x, FloatEq(30.0f));
+    EXPECT_THAT(evts[0].y, FloatEq(40.0f));
+}
+
+TEST_F(TestTouchEmulator, keeps_virtual_device_registered_when_disabled)
+{
+    touch_emulator.disable();
+
+    bool touch_emulator_device_present{false};
+    input_device_hub.lock()->for_each_input_device(
+        [&touch_emulator_device_present](mi::Device const& device)
+        {
+            touch_emulator_device_present |= device.name() == "touch-emulator";
+        });
+
+    EXPECT_THAT(touch_emulator_device_present, Eq(true));
+}
+
+struct TestTouchEmulatorCleanup : TestTouchEmulator
+{
+    TestTouchEmulatorCleanup() :
+        TestTouchEmulator{
+            true,
+            [this](mir::Server& server)
+            {
+                server.add_stop_callback(
+                    [this]
+                    {
+                        bool touch_emulator_device_present{false};
+                        input_device_hub.lock()->for_each_input_device(
+                            [&touch_emulator_device_present](mi::Device const& device)
+                            {
+                                touch_emulator_device_present |= device.name() == "touch-emulator";
+                            });
+                        touch_emulator_device_removed = !touch_emulator_device_present;
+                    });
+            }}
+    {
+    }
+
+    bool touch_emulator_device_removed{false};
+};
+
+TEST_F(TestTouchEmulatorCleanup, removes_device_when_disabled_before_server_stops)
+{
+    touch_emulator.disable();
+
+    stop_server();
+
+    EXPECT_THAT(touch_emulator_device_removed, Eq(true));
+}
+
+TEST_F(TestTouchEmulator, pointer_button_down_generates_touch_down)
+{
+    auto pointer = add_pointer();
+
+    send_pointer_event(
+        pointer, {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 100.0f, 200.0f});
+
+    ASSERT_TRUE(wait_for_touch_count(1));
+    auto const evts = captured_touch_events();
+    ASSERT_THAT(evts.size(), Eq(1u));
+    EXPECT_THAT(evts[0].action, Eq(mir_touch_action_down));
+    EXPECT_THAT(evts[0].x, FloatEq(100.0f));
+    EXPECT_THAT(evts[0].y, FloatEq(200.0f));
+}
+
+TEST_F(TestTouchEmulator, drag_generates_touch_change)
+{
+    auto pointer = add_pointer();
+
+    send_pointer_events(
+        pointer,
+        {
+            {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 100.0f, 200.0f},
+            {mir_pointer_action_motion, MirPointerButtons{mir_pointer_button_primary}, 150.0f, 250.0f},
+        });
+
+    ASSERT_TRUE(wait_for_touch_count(2));
+    auto const evts = captured_touch_events();
+    ASSERT_THAT(evts.size(), Ge(2u));
+    EXPECT_THAT(evts[1].action, Eq(mir_touch_action_change));
+    EXPECT_THAT(evts[1].x, FloatEq(150.0f));
+    EXPECT_THAT(evts[1].y, FloatEq(250.0f));
+}
+
+TEST_F(TestTouchEmulator, button_up_generates_touch_up)
+{
+    auto pointer = add_pointer();
+
+    send_pointer_events(
+        pointer,
+        {
+            {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 100.0f, 200.0f},
+            {mir_pointer_action_button_up, MirPointerButtons{0}, 100.0f, 200.0f},
+        });
+
+    ASSERT_TRUE(wait_for_touch_count(2));
+    auto const evts = captured_touch_events();
+    ASSERT_THAT(evts.size(), Ge(2u));
+    EXPECT_THAT(evts[1].action, Eq(mir_touch_action_up));
+    EXPECT_THAT(evts[1].x, FloatEq(100.0f));
+    EXPECT_THAT(evts[1].y, FloatEq(200.0f));
+}
+
+TEST_F(TestTouchEmulator, full_gesture_produces_down_change_up)
+{
+    auto pointer = add_pointer();
+
+    send_pointer_events(
+        pointer,
+        {
+            {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 10.0f, 20.0f},
+            {mir_pointer_action_motion, MirPointerButtons{mir_pointer_button_primary}, 30.0f, 40.0f},
+            {mir_pointer_action_button_up, MirPointerButtons{0}, 30.0f, 40.0f},
+        });
+
+    ASSERT_TRUE(wait_for_touch_count(3));
+    auto const evts = captured_touch_events();
+    ASSERT_THAT(evts.size(), Eq(3u));
+    EXPECT_THAT(evts[0].action, Eq(mir_touch_action_down));
+    EXPECT_THAT(evts[0].x, FloatEq(10.0f));
+    EXPECT_THAT(evts[0].y, FloatEq(20.0f));
+    EXPECT_THAT(evts[1].action, Eq(mir_touch_action_change));
+    EXPECT_THAT(evts[1].x, FloatEq(30.0f));
+    EXPECT_THAT(evts[1].y, FloatEq(40.0f));
+    EXPECT_THAT(evts[2].action, Eq(mir_touch_action_up));
+    EXPECT_THAT(evts[2].x, FloatEq(30.0f));
+    EXPECT_THAT(evts[2].y, FloatEq(40.0f));
+}
+
+TEST_F(TestTouchEmulator, non_primary_button_does_not_generate_touch)
+{
+    auto pointer = add_pointer();
+
+    send_pointer_events(
+        pointer,
+        {
+            {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_secondary}, 100.0f, 200.0f},
+            {mir_pointer_action_button_up, MirPointerButtons{0}, 100.0f, 200.0f},
+        });
+
+    assert_no_touch();
+}
+
+TEST_F(TestTouchEmulator, no_touch_events_when_disabled)
+{
+    touch_emulator.disable();
+
+    auto pointer = add_pointer();
+
+    send_pointer_event(
+        pointer, {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, 100.0f, 200.0f});
+
+    assert_no_touch();
+}
+
+TEST_F(TestTouchEmulator, disable_and_re_enable_toggles_behavior)
+{
+    auto pointer = add_pointer();
+
+    auto const click = [&](auto x, auto y, auto const& check_down, auto const& check_up)
+    {
+        send_pointer_event(
+            pointer, {mir_pointer_action_button_down, MirPointerButtons{mir_pointer_button_primary}, x, y});
+
+        check_down();
+
+        send_pointer_event(pointer, {mir_pointer_action_button_up, MirPointerButtons{0}, x, y});
+
+        check_up();
+    };
+
+    click(
+        10.0f,
+        20.0f,
+        [this]
+        {
+            ASSERT_TRUE(wait_for_touch_count(1));
+        },
+        [this]
+        {
+            ASSERT_TRUE(wait_for_touch_count(2));
+        });
+
+    touch_emulator.disable();
+    touch_events.lock_mut()->clear();
+    ASSERT_THAT(captured_touch_events().size(), Eq(0u));
+
+    click(30.0f, 40.0f, [this] { assert_no_touch(); }, [this] { assert_no_touch(); });
+
+    touch_emulator.enable();
+    touch_events.lock()->clear();
+
+    click(
+        50.0f,
+        60.0f,
+        [this] { ASSERT_TRUE(wait_for_touch_count(1)); },
+        [this] { ASSERT_TRUE(wait_for_touch_count(2)); });
+
+    auto const evts = captured_touch_events();
+    ASSERT_THAT(evts.size(), Eq(2u));
+    EXPECT_THAT(evts[0].action, Eq(mir_touch_action_down));
+    EXPECT_THAT(evts[0].x, FloatEq(50.0f));
+    EXPECT_THAT(evts[0].y, FloatEq(60.0f));
+    EXPECT_THAT(evts[1].action, Eq(mir_touch_action_up));
+    EXPECT_THAT(evts[1].x, FloatEq(50.0f));
+    EXPECT_THAT(evts[1].y, FloatEq(60.0f));
+}

--- a/tools/symbols_map_generator/main.py
+++ b/tools/symbols_map_generator/main.py
@@ -61,6 +61,11 @@ HIDDEN_SYMBOLS = {
     "miral::MouseKeysConfig::disabled*;",
     "miral::MouseKeysConfig::enable*;",
     "miral::MouseKeysConfig::enabled*;",
+    "miral::TouchEmulator::disable*;",
+    "miral::TouchEmulator::disabled*;",
+    "miral::TouchEmulator::enable*;",
+    "miral::TouchEmulator::enabled*;",
+    "miral::TouchEmulator::operator*;",
 }
 
 class HeaderDirectory(TypedDict):


### PR DESCRIPTION
Closes https://github.com/canonical/mir/pull/5071#discussion_r3559802152

## What's new?

- Adds a `miral::TouchEmulator`. When enabled, it converts mouse clicks and drags to touch events.
  Can be controlled via a keyboard shortcut for example:
  
  ```diff
  +#include <miral/touch_emulator.h>
  +#include <mir/log.h>
   
   #include <xkbcommon/xkbcommon-keysyms.h>
   
  @@ -358,6 +360,34 @@ int main(int argc, char const* argv[])
           return false;
       };
   
  +    auto touch_emulator = TouchEmulator::disabled();
  +    auto toggle_touch_emulator_filter = [&touch_emulator, touch_emulator_enabled = false](MirKeyboardEvent const* key_event) mutable
  +    {
  +        // ...
  +
  +        touch_emulator_enabled = !touch_emulator_enabled;
  +        if (touch_emulator_enabled)
  +        {
  +            touch_emulator.enable();
  +            mir::log_info({mir::logging::input()}, "Touch emulator enabled");
  +        }
  +        else
  +        {
  +            touch_emulator.disable();
  +            mir::log_info({mir::logging::input()}, "Touch emulator disabled");
  +        }
  +
  +        return true;
  +    };
  +
  +
       return runner.run_with(
           {
               CursorTheme{"default:DMZ-White"},
  @@ -392,6 +422,8 @@ int main(int argc, char const* argv[])
               cursor_scale,
               locate_pointer,
               AppendKeyboardEventFilter{locate_pointer_filter},
  -            BasicApplicationSwitcher{}
  +            BasicApplicationSwitcher{},
  +            touch_emulator,
  +            AppendKeyboardEventFilter{toggle_touch_emulator_filter},
           });
   }
  ``` 
  or via live config:
  
  ```diff
   #include <miral/slow_keys.h>
   #include <miral/hover_click.h>
   #include <miral/append_keyboard_event_filter.h>
  +#include <miral/touch_emulator.h>
   
   #include <mir/abnormal_exit.h>
   #include <mir/main_loop.h>
  @@ -140,6 +141,7 @@ try
       miral::StickyKeys sticky_keys{config_store};
       miral::Keymap keymap{config_store};
       miral::HoverClick hover_click{config_store};
  +    miral::TouchEmulator touch_emulator{config_store};
   
       miral::ConfigFile config_file{
           runner,
  @@ -175,6 +177,7 @@ try
           slow_keys,
           sticky_keys,
           hover_click,
  +        touch_emulator,
           keymap,
       });
  ```
  ```ini
  touch_emulator_enable=true
  ``` 

## How to test

- Install [`wev`](https://git.sr.ht/~sircmpwn/wev)
- Run `miral-shell` or `mir_demo_server` (with `--test-client <...> --test-timeout 9999`)
- Press `Ctrl+Alt+Shift+E` on `miral-shell` to toggle the touch emulator on, or modify `~/.config/mir_demo_server.live-config` with the content above.
- Launch a `wev` window
- Observe as clicks and drags are converted to touch events.
- Toggle touch emulation again and observe as motion and click events resume.
