### PR TITLE
tools: update RPM package ABIs

### DIFF
--- a/.github/instructions/abi-symbols.instructions.md
+++ b/.github/instructions/abi-symbols.instructions.md
@@ -31,7 +31,7 @@ No `*_ABI` bump is required for additive changes.
 1. Bump `MIRAL_VERSION_MAJOR` in `src/CMakeLists.txt`, reset `MIRAL_VERSION_MINOR` and `MIRAL_VERSION_PATCH` to 0
 1. Bump `MIRAL_ABI` in `src/miral/CMakeLists.txt`
 1. Run `generate-miral-symbols-map` then `regenerate-miral-debian-symbols`
-1. Run `./tools/update_package_abis.sh` to update Debian package names (control file, `.install` file renames)
+1. Run `./tools/update_package_abis.sh` to update Debian package names (control file, `.install` file renames) and RPM ABI macros
 
 ### mirserver — any symbol change (additive or breaking)
 
@@ -41,7 +41,7 @@ mirserver has no stable ABI promise. **Every** symbol change requires bumping `M
 1. Bump `MIRSERVER_ABI` in `src/server/CMakeLists.txt`
 1. Bump the minor number in `project(Mir VERSION X.Y.Z)` in the **top-level** `CMakeLists.txt` (the stanza name `MIR_SERVER_INTERNAL_X.Y` derives from this)
 1. `cmake --build <BUILD_DIR> --target generate-mirserver-symbols-map`
-1. Run `./tools/update_package_abis.sh` (handles `debian/control` and `.install` file renames)
+1. Run `./tools/update_package_abis.sh` (handles `debian/control`, `.install` file renames, and RPM ABI macros)
 
 **Note**: there is no `regenerate-mirserver-debian-symbols` target — mirserver debian packaging is managed by `update_package_abis.sh`.
 
@@ -49,7 +49,7 @@ mirserver has no stable ABI promise. **Every** symbol change requires bumping `M
 
 - All version bumps are once-per-release-cycle — check if someone already bumped before you do.
 - CI (`symbols-check.yml`) catches added/removed symbols but does **not** detect changed signatures — those must be moved to a new stanza manually.
-- `tools/update_package_abis.sh` handles `debian/control` and `.install` file renames for all libraries. It does not modify `symbols.map`, CMake variables, or RPM packaging.
+- `tools/update_package_abis.sh` handles `debian/control`, `.install` file renames, and RPM ABI macros for all libraries. It does not modify `symbols.map` or CMake variables.
 - ABI version variables are defined per-library as `set(LIB_ABI N)` (e.g., `MIRAL_ABI`, `MIRCORE_ABI`, `MIRWAYLAND_ABI`, `MIRSERVER_ABI`). Bump these when breaking ABI.
 
 See [How to Update Symbol Maps](../../doc/sphinx/contributing/how-to/update-symbols-map.md) and

--- a/tools/update_package_abis.sh
+++ b/tools/update_package_abis.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Script to check and update debian packaging to match current ABIs
+# Script to check and update packaging to match current ABIs
 
 set -e
 
@@ -27,6 +27,17 @@ packages="\
     mir-platform-graphics-stub:MIR_SERVER_GRAPHICS_PLATFORM_ABI\
     mir-platform-input-stub:MIR_SERVER_INPUT_PLATFORM_ABI"
 
+rpm_abi_macros="\
+    miral_sover:MIRAL_ABI \
+    mircommon_sover:MIRCOMMON_ABI \
+    mircore_sover:MIRCORE_ABI \
+    miroil_sover:MIROIL_ABI \
+    mirplatform_sover:MIRPLATFORM_ABI \
+    mirserver_sover:MIRSERVER_ABI \
+    mirwayland_sover:MIRWAYLAND_ABI \
+    mirplatformgraphics_sover:MIR_SERVER_GRAPHICS_PLATFORM_ABI \
+    mirplatforminput_sover:MIR_SERVER_INPUT_PLATFORM_ABI"
+
 package_name()
 {
     echo "${1%%:*}"
@@ -42,10 +53,10 @@ print_help_and_exit()
     local prog=$(basename $0)
 
     echo "Usage: $prog [OPTION]..."
-    echo "Update debian packaging to match current ABIs"
+    echo "Update packaging to match current ABIs"
     echo ""
     echo "      --no-vcs   do not register file changes (e.g., moves) with the detected VCS"
-    echo "      --check    check for ABI mismatches without updating debian packaging"
+    echo "      --check    check for ABI mismatches without updating packaging"
     echo "                 exit status = 0: no mismatches, 1: mismatches detected"
     echo "                 use --verbose to get more information about the mismatches"
     echo "  -v, --verbose  enable verbore output"
@@ -118,6 +129,17 @@ update_control_file()
     done
 }
 
+update_rpm_spec()
+{
+    for entry in $rpm_abi_macros;
+    do
+        local macro=${entry%%:*}
+        local abi_var=${entry##*:}
+        local abi=$(eval "echo \$${abi_var}")
+        sed -i "s/^%global ${macro} [[:digit:]]\{1,\}/%global ${macro} ${abi}/" rpm/mir.spec
+    done
+}
+
 get_current_install_file()
 {
     local pkg=$1
@@ -174,6 +196,21 @@ check_control_file()
         if [ -n "$result" ];
         then
             report_abi_mismatch "debian/control contains $result, but $pkg ABI is $abi"
+        fi
+    done
+}
+
+check_rpm_spec()
+{
+    for entry in $rpm_abi_macros;
+    do
+        local macro=${entry%%:*}
+        local abi_var=${entry##*:}
+        local abi=$(eval "echo \$${abi_var}")
+        local current=$(sed -n "s/^%global ${macro} \([[:digit:]]\{1,\}\)/\1/p" rpm/mir.spec)
+        if [ "$current" != "$abi" ];
+        then
+            report_abi_mismatch "rpm/mir.spec defines ${macro} as ${current}, but ${abi_var} is ${abi}"
         fi
     done
 }
@@ -250,6 +287,7 @@ then
     check_for_unknown_packages
     check_control_file
     check_install_files
+    check_rpm_spec
     if [ "$has_check_error" = "yes" ];
     then
         log "Consider running tools/update_package_abis.sh to fix the mismatches."
@@ -259,4 +297,5 @@ else
     check_for_unknown_packages
     update_control_file
     update_install_files
+    update_rpm_spec
 fi


### PR DESCRIPTION
Closes #4981

## What's new?

- map Mir's nine RPM `sover` macros to their corresponding CMake ABI variables
- make `--check` report stale values in `rpm/mir.spec`
- make the update path synchronize those values alongside the Debian package metadata
- update the ABI maintenance instructions to describe the RPM behavior

## How to test

1. Change `%global miral_sover 8` in `rpm/mir.spec` to `999`.
2. Run `tools/update_package_abis.sh --check --verbose` and verify it reports:
   `rpm/mir.spec defines miral_sover as 999, but MIRAL_ABI is 8`.
3. Run `tools/update_package_abis.sh --no-vcs` and verify the macro is restored to `8`.

Local validation performed:

- `sh -n tools/update_package_abis.sh`
- simulated stale `miral_sover` check reports the expected mismatch
- simulated update restores all nine RPM macros to the CMake ABI values
- `git diff --check`

The full Linux CI matrix is left to this draft PR because the local machine is macOS and the existing Debian checks depend on GNU tool behavior.

## Checklist

- [ ] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
