### PR TITLE
tics: use dedicated images and fix commenting

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,3 @@
 self-hosted-runner:
   labels:
-    - ubuntu-26.04
-    - amd64
-    - xlarge
-    - resolute
+    - self-hosted-linux-amd64-resolute-large-tiobe

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -66,8 +66,7 @@ jobs:
     permissions:
       checks: write
       contents: read
-      issues: write        # for commenting with TICS results
-      pull-requests: read  # to get the list of changed files
+      pull-requests: write  # for commenting with TICS results
     env:
       PROJECT: mir
       CCACHE_DIR: "/tmp/ccache"

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -61,8 +61,7 @@ jobs:
     needs: [check-paths]
     if: needs.check-paths.outputs.should-run == 'true'
 
-    # TODO: replace with tiobe-labeled image when available
-    runs-on: [self-hosted, amd64, xlarge, resolute]
+    runs-on: [self-hosted-linux-amd64-resolute-large-tiobe]
 
     permissions:
       checks: write


### PR DESCRIPTION
## What's new?

TICS now uses dedicated `resolute` images, and can comment on Pull Requests again.

## How to test

See that TICS posts a comment here.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
