### PR TITLE
fatal_error

### DIFF
--- a/debian/libmircore3.symbols
+++ b/debian/libmircore3.symbols
@@ -6,9 +6,7 @@ libmircore.so.3 libmircore3 #MINVER#
  (c++)"mir::Fd::Fd(mir::IntOwnedFd)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::Fd::operator int() const@MIR_CORE_2.29" 2.29.0
  (c++)"mir::Fd::operator=(mir::Fd)@MIR_CORE_2.29" 2.29.0
- (c++)"mir::fatal_error@MIR_CORE_2.29" 2.29.0
- (c++)"mir::fatal_error_abort(char const*, ...)@MIR_CORE_2.29" 2.29.0
- (c++)"mir::fatal_error_except(char const*, ...)@MIR_CORE_2.29" 2.29.0
+ (c++)"mir::fatal_error(char const*, ...)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::geometry::Rectangles::Rectangles()@MIR_CORE_2.29" 2.29.0
  (c++)"mir::geometry::Rectangles::Rectangles(std::initializer_list<mir::geometry::generic::Rectangle<int> > const&)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::geometry::Rectangles::add(mir::geometry::generic::Rectangle<int> const&)@MIR_CORE_2.29" 2.29.0

--- a/doc/sphinx/configuring/reference/options.md.include
+++ b/doc/sphinx/configuring/reference/options.md.include
@@ -178,11 +178,6 @@ Mouse scroll speed scaling factor. Use negative values for natural scrolling.
 
 Mouse vertical scroll speed scaling factor. Use negative values for natural scrolling.
 
-(global-on-fatal-error-except)=
-### `on-fatal-error-except`
-
-Throw an exception when a fatal error condition occurs. This replaces the default behaviour of dumping core and can make it easier to diagnose issues.
-
 (global-platform-display-libs)=
 ### `platform-display-libs`
 

--- a/include/core/mir/fatal.h
+++ b/include/core/mir/fatal.h
@@ -31,7 +31,7 @@ namespace mir
  *   \param [in] reason  A printf-style format string.
  */
 [[noreturn]]
-void fatal_error(char const* reason, ...);
+void fatal_error(char const* reason, ...) __attribute__((format(printf, 1, 2)));
 } // namespace mir
 
 #endif // MIR_FATAL_H_

--- a/include/core/mir/fatal.h
+++ b/include/core/mir/fatal.h
@@ -26,23 +26,12 @@
 namespace mir
 {
 /**
- * fatal_error() is strictly for "this should never happen" situations that
- * you cannot recover from. By default it points at fatal_error_abort().
- * Note the reason parameter is a simple char* so its value is clearly visible
- * in stack trace output.
- * \remark There is no attempt to make this thread-safe, if it needs to be changed
- * that should be done before spinning up the Mir server.
- *   \param [in] reason  A printf-style format string.
- */
-extern void (*fatal_error)(char const* reason, ...);
-
-/**
- * An alternative to fatal_error_except() that kills the program and dump core
- * as cleanly as possible.
+ * fatal_error() is strictly for "this should never happen" situations that you
+ * cannot recover from. Kills the program and dump core as cleanly as possible.
  *   \param [in] reason  A printf-style format string.
  */
 [[noreturn]]
-void fatal_error_abort(char const* reason, ...);
+void fatal_error(char const* reason, ...);
 } // namespace mir
 
 #endif // MIR_FATAL_H_

--- a/include/core/mir/fatal.h
+++ b/include/core/mir/fatal.h
@@ -37,35 +37,12 @@ namespace mir
 extern void (*fatal_error)(char const* reason, ...);
 
 /**
- * Throws an exception that will typically kill the Mir server and propagate from
- * mir::run_mir.
- *   \param [in] reason  A printf-style format string.
- */
-void fatal_error_except(char const* reason, ...);
-
-/**
  * An alternative to fatal_error_except() that kills the program and dump core
  * as cleanly as possible.
  *   \param [in] reason  A printf-style format string.
  */
 [[noreturn]]
 void fatal_error_abort(char const* reason, ...);
-
-// Utility class to override & restore existing error handler
-class FatalErrorStrategy
-{
-public:
-    explicit FatalErrorStrategy(void (*fatal_error_handler)(char const* reason, ...)) :
-        old_fatal_error_handler(fatal_error)
-    { fatal_error = fatal_error_handler; }
-
-    ~FatalErrorStrategy() { fatal_error = old_fatal_error_handler; }
-
-private:
-    void (*old_fatal_error_handler)(char const* reason, ...);
-    FatalErrorStrategy(FatalErrorStrategy const&) = delete;
-    FatalErrorStrategy& operator=(FatalErrorStrategy const&) = delete;
-};
 } // namespace mir
 
 #endif // MIR_FATAL_H_

--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -38,7 +38,6 @@ extern char const* const input_report_opt;
 extern char const* const seat_report_opt;
 extern char const* const touchspots_opt;
 extern char const* const cursor_opt;
-extern char const* const fatal_except_opt;
 extern char const* const debug_opt;
 extern char const* const composite_delay_opt;
 extern char const* const x11_display_opt;

--- a/src/common/input/input_event.cpp
+++ b/src/common/input/input_event.cpp
@@ -244,7 +244,7 @@ MirPointerEvent const* mir_input_event_get_pointer_event(MirInputEvent const* ev
 {
     if(ev->input_type() != mir_input_event_type_pointer)
     {
-        mir::fatal_error("expected pointer input event but event was of type ",
+        mir::fatal_error("expected pointer input event but event was of type %s",
             input_event_type_to_c_str(ev->input_type()));
     }
 

--- a/src/common/input/input_event.cpp
+++ b/src/common/input/input_event.cpp
@@ -53,7 +53,7 @@ char const* input_event_type_to_c_str(MirInputEventType input_event_type)
     case mir_input_event_type_keyboard_resync:
         return "mir_input_event_type_keyboard_resync";
     case mir_input_event_types:
-        mir::fatal_error_abort("Sentinel value 'mir_input_event_types' not supported");
+        mir::fatal_error("Sentinel value 'mir_input_event_types' not supported");
     }
 }
 
@@ -66,7 +66,7 @@ void expect_event_type(EventType const* ev, MirEventType expect)
 {
     if (auto const actual = ev->type(); actual != expect)
     {
-        mir::fatal_error_abort("Expected %s but event is of type %s",
+        mir::fatal_error("Expected %s but event is of type %s",
             mir::event_type_to_c_str(expect), mir::event_type_to_c_str(actual));
     }
 }
@@ -123,7 +123,7 @@ MirKeyboardEvent const* mir_input_event_get_keyboard_event(MirInputEvent const* 
 {
     if (ev->input_type() != mir_input_event_type_key)
     {
-        mir::fatal_error_abort("expected key input event but event was of type %s",
+        mir::fatal_error("expected key input event but event was of type %s",
             input_event_type_to_c_str(ev->input_type()));
     }
 
@@ -166,7 +166,7 @@ MirTouchEvent const* mir_input_event_get_touch_event(MirInputEvent const* ev) MI
 {
     if(ev->input_type() != mir_input_event_type_touch)
     {
-        mir::fatal_error_abort("expected touch input event but event was of type %s",
+        mir::fatal_error("expected touch input event but event was of type %s",
             input_event_type_to_c_str(ev->input_type()));
     }
 
@@ -182,7 +182,7 @@ MirTouchId mir_touch_event_id(MirTouchEvent const* event, size_t touch_index) MI
 {
     if (touch_index >= event->pointer_count())
     {
-        mir::fatal_error_abort("touch index is greater than pointer count");
+        mir::fatal_error("touch index is greater than pointer count");
     }
     return event->id(touch_index);
 
@@ -192,7 +192,7 @@ MirTouchAction mir_touch_event_action(MirTouchEvent const* event, size_t touch_i
 {
     if(touch_index > event->pointer_count())
     {
-        mir::fatal_error_abort("touch index is greater than pointer count");
+        mir::fatal_error("touch index is greater than pointer count");
     }
 
     return static_cast<MirTouchAction>(event->action(touch_index));
@@ -203,7 +203,7 @@ MirTouchTooltype mir_touch_event_tooltype(MirTouchEvent const* event,
 {
     if(touch_index > event->pointer_count())
     {
-        mir::fatal_error_abort("touch index is greater than pointer count");
+        mir::fatal_error("touch index is greater than pointer count");
     }
 
     return event->tool_type(touch_index);
@@ -214,7 +214,7 @@ float mir_touch_event_axis_value(MirTouchEvent const* event,
 {
     if(touch_index > event->pointer_count())
     {
-        mir::fatal_error_abort("touch index is greater than pointer count");
+        mir::fatal_error("touch index is greater than pointer count");
     }
 
     switch (axis)
@@ -244,7 +244,7 @@ MirPointerEvent const* mir_input_event_get_pointer_event(MirInputEvent const* ev
 {
     if(ev->input_type() != mir_input_event_type_pointer)
     {
-        mir::fatal_error_abort("expected pointer input event but event was of type ",
+        mir::fatal_error("expected pointer input event but event was of type ",
             input_event_type_to_c_str(ev->input_type()));
     }
 
@@ -308,7 +308,7 @@ float mir_pointer_event_axis_value(MirPointerEvent const* pev, MirPointerAxis ax
    case mir_pointer_axis_hscroll_value120:
        return pev->h_scroll().value120.as_value();
    default:
-       mir::fatal_error_abort("Invalid axis enumeration %d", axis);
+       mir::fatal_error("Invalid axis enumeration %d", axis);
    }
 })
 
@@ -330,6 +330,6 @@ bool mir_pointer_event_axis_stop(MirPointerEvent const* pev, MirPointerAxis axis
    case mir_pointer_axis_hscroll_value120:
        return false;
    default:
-       mir::fatal_error_abort("Invalid axis enumeration %d", axis);
+       mir::fatal_error("Invalid axis enumeration %d", axis);
    }
 })

--- a/src/common/input/mir_input_config.cpp
+++ b/src/common/input/mir_input_config.cpp
@@ -113,14 +113,14 @@ MirTouchpadConfig& MirInputDevice::touchpad_config()
 {
     if (auto& tmp = impl->touchpad)
         return tmp.value();
-    mir::fatal_error_abort("Touchpad config not available");
+    mir::fatal_error("Touchpad config not available");
 }
 
 MirTouchpadConfig const& MirInputDevice::touchpad_config() const
 {
     if (auto const& tmp = impl->touchpad)
         return tmp.value();
-    mir::fatal_error_abort("Touchpad config not available");
+    mir::fatal_error("Touchpad config not available");
 }
 
 void MirInputDevice::set_touchpad_config(MirTouchpadConfig const& conf)
@@ -137,14 +137,14 @@ MirTouchscreenConfig& MirInputDevice::touchscreen_config()
 {
     if (auto& tmp = impl->touchscreen)
         return tmp.value();
-    mir::fatal_error_abort("Touchscreen config not available");
+    mir::fatal_error("Touchscreen config not available");
 }
 
 MirTouchscreenConfig const& MirInputDevice::touchscreen_config() const
 {
     if (auto const& tmp = impl->touchscreen)
         return tmp.value();
-    mir::fatal_error_abort("Touchscreen config not available");
+    mir::fatal_error("Touchscreen config not available");
 }
 
 void MirInputDevice::set_touchscreen_config(MirTouchscreenConfig const& conf)
@@ -161,14 +161,14 @@ MirKeyboardConfig& MirInputDevice::keyboard_config()
 {
     if (auto& tmp = impl->keyboard)
         return tmp.value();
-    mir::fatal_error_abort("Keyboard config not available");
+    mir::fatal_error("Keyboard config not available");
 }
 
 MirKeyboardConfig const& MirInputDevice::keyboard_config() const
 {
     if (auto const& tmp = impl->keyboard)
         return tmp.value();
-    mir::fatal_error_abort("Keyboard config not available");
+    mir::fatal_error("Keyboard config not available");
 }
 
 void MirInputDevice::set_keyboard_config(MirKeyboardConfig const& conf)
@@ -185,14 +185,14 @@ MirPointerConfig& MirInputDevice::pointer_config()
 {
     if (auto& tmp = impl->pointer)
         return tmp.value();
-    mir::fatal_error_abort("Pointer config not available");
+    mir::fatal_error("Pointer config not available");
 }
 
 MirPointerConfig const& MirInputDevice::pointer_config() const
 {
     if (auto const& tmp = impl->pointer)
         return tmp.value();
-    mir::fatal_error_abort("Pointer config not available");
+    mir::fatal_error("Pointer config not available");
 }
 
 void MirInputDevice::set_pointer_config(MirPointerConfig const& conf)

--- a/src/core/fatal.cpp
+++ b/src/core/fatal.cpp
@@ -40,16 +40,4 @@ void mir::fatal_error_abort(char const* reason, ...)
     std::abort();
 }
 
-void mir::fatal_error_except(char const* reason, ...)
-{
-    char buffer[1024];
-    va_list args;
-
-    va_start(args, reason);
-    std::vsnprintf(buffer, sizeof buffer, reason, args);
-    va_end(args);
-
-    BOOST_THROW_EXCEPTION(std::runtime_error(buffer));
-}
-
 void (*mir::fatal_error)(char const* reason, ...){&mir::fatal_error_abort};

--- a/src/core/fatal.cpp
+++ b/src/core/fatal.cpp
@@ -16,15 +16,12 @@
 
 #include <mir/fatal.h>
 
-#include <boost/throw_exception.hpp>
-
-#include <stdexcept>
 #include <cstdlib>
 #include <cstdio>
 #include <cstdarg>
 
 [[noreturn]]
-void mir::fatal_error_abort(char const* reason, ...)
+void mir::fatal_error(char const* reason, ...)
 {
     va_list args;
 
@@ -39,5 +36,3 @@ void mir::fatal_error_abort(char const* reason, ...)
 
     std::abort();
 }
-
-void (*mir::fatal_error)(char const* reason, ...){&mir::fatal_error_abort};

--- a/src/core/logging/logger.cpp
+++ b/src/core/logging/logger.cpp
@@ -143,7 +143,7 @@ void ml::format_message(std::ostream& out, Severity severity, std::string const&
     }
     catch (std::runtime_error const& e)
     {
-        mir::fatal_error_abort("Cannot format log message: %s", e.what());
+        mir::fatal_error("Cannot format log message: %s", e.what());
     }
 }
 

--- a/src/core/symbols.map
+++ b/src/core/symbols.map
@@ -27,8 +27,6 @@ MIR_CORE_2.29 {
     mir::Fd::invalid*;
     mir::Fd::operator*;
     mir::fatal_error*;
-    mir::fatal_error_abort*;
-    mir::fatal_error_except*;
     mir::geometry::Rectangles::Rectangles*;
     mir::geometry::Rectangles::add*;
     mir::geometry::Rectangles::begin*;

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -201,17 +201,6 @@ public:
         std::string const& interface_name,
         WaylandProtocolExtensionFilter const& policy) override;
 
-    /**
-     * Function to call when a "fatal" error occurs. This implementation allows
-     * the default strategy to be overridden by --on-fatal-error-except to avoid a
-     * core.
-     * To change the default strategy used FatalErrorStrategy. See acceptance test
-     * ServerShutdown.fatal_error_default_can_be_changed_to_abort
-     * for an example.
-     */
-    auto the_fatal_error_strategy() -> void (*)(char const* reason, ...) override final;
-    /** @} */
-
     /** @name graphics configuration - customization
      * configurable interfaces for modifying graphics
      *  @{ */

--- a/src/include/server/mir/server_configuration.h
+++ b/src/include/server/mir/server_configuration.h
@@ -95,7 +95,6 @@ public:
     virtual auto the_display_platforms() -> std::vector<std::shared_ptr<graphics::DisplayPlatform>> const& = 0;
     virtual auto the_rendering_platforms() -> std::vector<std::shared_ptr<graphics::RenderingPlatform>> const& = 0;
     virtual std::shared_ptr<EmergencyCleanup> the_emergency_cleanup() = 0;
-    virtual auto the_fatal_error_strategy() -> void (*)(char const* reason, ...) = 0;
     virtual std::shared_ptr<scene::Clipboard> the_main_clipboard() = 0;
     virtual std::shared_ptr<scene::Clipboard> the_primary_selection_clipboard() = 0;
     virtual std::shared_ptr<scene::TextInputHub> the_text_input_hub() = 0;

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2950,7 +2950,7 @@ void miral::BasicWindowManager::update_application_zones_and_attached_windows()
                 })
                 .or_else([&]()-> decltype(info.exclusive_rect())
                 {
-                    fatal_error_abort("Attached window has no exclusive rect");
+                    fatal_error("Attached window has no exclusive rect");
                     std::unreachable();
                 });
         }
@@ -2969,7 +2969,7 @@ void miral::BasicWindowManager::update_application_zones_and_attached_windows()
                 })
                 .or_else([&]()-> decltype(info.exclusive_rect())
                 {
-                    fatal_error_abort("Attached window has no exclusive rect");
+                    fatal_error("Attached window has no exclusive rect");
                     std::unreachable();
                 });
         }

--- a/src/miral/launch_app.cpp
+++ b/src/miral/launch_app.cpp
@@ -132,7 +132,7 @@ auto execute_with_environment(std::vector<std::string> const app, Environment& a
     posix_spawnattr_t attr;
     if (auto const error = posix_spawnattr_init(&attr))
     {
-        mir::fatal_error_abort("Failed to init spawn attributes: %s", std::strerror(error));
+        mir::fatal_error("Failed to init spawn attributes: %s", std::strerror(error));
     }
 
     // Unblock all signals in the child, preserving their existing dispositions
@@ -144,7 +144,7 @@ auto execute_with_environment(std::vector<std::string> const app, Environment& a
         if (result != 0)
         {
             posix_spawnattr_destroy(&attr);
-            mir::fatal_error_abort("%s: %s", what, std::strerror(result));
+            mir::fatal_error("%s: %s", what, std::strerror(result));
         }
     };
 
@@ -175,7 +175,7 @@ auto execute_with_environment(std::vector<std::string> const app, Environment& a
         // The child calls _exit() immediately, avoiding any non-async-signal-safe work.
         pid_t const placeholder = fork();
         if (placeholder < 0)
-            mir::fatal_error_abort("Failed to fork placeholder process: %s", std::strerror(errno));
+            mir::fatal_error("Failed to fork placeholder process: %s", std::strerror(errno));
         if (placeholder == 0)
             _exit(EXIT_FAILURE);
         return placeholder;

--- a/src/miral/live_config_overrides_list.cpp
+++ b/src/miral/live_config_overrides_list.cpp
@@ -52,7 +52,7 @@ void mlc::OverridesList::for_each(Loader unchanged, Loader fresh, Loader modifie
         catch (std::exception const& e)
         {
             mir::fatal_error(
-                "Openers must not throw exceptions. Failed to open '{}' with exception '{}'",
+                "Openers must not throw exceptions. Failed to open '%s' with exception '%s'",
                 event.path.string().c_str(),
                 e.what());
         }

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -45,7 +45,6 @@ char const* const mo::shared_library_prober_report_opt = "shared-library-prober-
 char const* const mo::shell_report_opt            = "shell-report";
 char const* const mo::touchspots_opt              = "enable-touchspots";
 char const* const mo::cursor_opt                  = "cursor";
-char const* const mo::fatal_except_opt            = "on-fatal-error-except";
 char const* const mo::debug_opt                   = "debug";
 char const* const mo::composite_delay_opt         = "composite-delay";
 char const* const mo::enable_key_repeat_opt       = "enable-key-repeat";
@@ -239,8 +238,6 @@ mo::DefaultConfiguration::DefaultConfiguration(
         (idle_timeout_when_locked_opt, po::value<int>()->default_value(0),
             "Number of seconds Mir will remain idle before turning off the display "
             "when the session is locked, or 0 to keep the display on forever.")
-        (fatal_except_opt, "Throw an exception when a fatal error condition occurs. "
-            "This replaces the default behaviour of dumping core and can make it easier to diagnose issues.")
         (debug_opt, "Enable debugging information. "
             "Useful when developing Mir servers.")
         (console_provider,

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
@@ -259,7 +259,7 @@ void mga::AtomicKMSOutput::reset()
     }
     catch (std::exception const& e)
     {
-        fatal_error(e.what());
+        fatal_error("%s", e.what());
     }
 
     /* Discard previously current crtc */

--- a/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
+++ b/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
@@ -101,7 +101,7 @@ void mgg::RealKMSOutput::reset()
     }
     catch (std::exception const& e)
     {
-        fatal_error(e.what());
+        fatal_error("%s", e.what());
     }
 
     // TODO: What if we can't locate the DPMS property?

--- a/src/server/default_server_configuration.cpp
+++ b/src/server/default_server_configuration.cpp
@@ -169,15 +169,6 @@ std::function<void()> mir::DefaultServerConfiguration::the_stop_callback()
     return []{};
 }
 
-auto mir::DefaultServerConfiguration::the_fatal_error_strategy()
--> void (*)(char const* reason, ...)
-{
-    if (the_options()->is_set(options::fatal_except_opt))
-        return &fatal_error_except;
-    else
-        return fatal_error;
-}
-
 auto mir::DefaultServerConfiguration::the_logger()
     -> std::shared_ptr<ml::Logger>
 {

--- a/src/server/display_server.cpp
+++ b/src/server/display_server.cpp
@@ -150,7 +150,7 @@ struct mir::DisplayServer::Private
                     catch(std::runtime_error const& e)
                     {
                         if (std::chrono::steady_clock::now() > deadline)
-                            fatal_error(("Failed to resume display:\n" + boost::diagnostic_information(e)).c_str());
+                            fatal_error("Failed to resume display:\n%s", boost::diagnostic_information(e).c_str());
 
                         std::this_thread::sleep_for(std::chrono::milliseconds{50});
                         goto retry;

--- a/src/server/frontend_wayland/ext_foreign_toplevel_image_capture_source_v1.cpp
+++ b/src/server/frontend_wayland/ext_foreign_toplevel_image_capture_source_v1.cpp
@@ -231,7 +231,7 @@ void mf::ExtForeignToplevelImageCopyBackend::begin_capture(
     {
     case DamageAmount::none:
         // This should never happen as maybe_capture_frame() checks has_damage() before calling begin_capture()
-        fatal_error_abort("begin_capture() called with no damage - this is a precondition violation");
+        fatal_error("begin_capture() called with no damage - this is a precondition violation");
         break;
 
     case DamageAmount::partial:

--- a/src/server/frontend_wayland/ext_output_image_capture_source_v1.cpp
+++ b/src/server/frontend_wayland/ext_output_image_capture_source_v1.cpp
@@ -216,7 +216,7 @@ void mf::ExtOutputImageCopyBackend::begin_capture(
     {
     case DamageAmount::none:
         // This should never happen as maybe_capture_frame() checks has_damage() before calling begin_capture()
-        fatal_error_abort("begin_capture() called with no damage - this is a precondition violation");
+        fatal_error("begin_capture() called with no damage - this is a precondition violation");
         break;
 
     case DamageAmount::partial:

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -374,7 +374,7 @@ private:
     {
         if (src_len > dest_len)
         {
-            fatal_error("%u elements of data does not fit in %u element long array", src_len, dest_len);
+            fatal_error("%zu elements of data does not fit in %zu element long array", src_len, dest_len);
         }
         for (unsigned i = 0; i < src_len; i++)
         {

--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -67,7 +67,7 @@ public:
                 return handlers[i];
             }
         }
-        mir::fatal_error_abort("Attempted to access signal handler for signal %i not in intercepted list", sig);
+        mir::fatal_error("Attempted to access signal handler for signal %i not in intercepted list", sig);
     }
 
     /**
@@ -114,7 +114,7 @@ public:
                 return AtomicOutPtr{handlers[i]};
             }
         }
-        mir::fatal_error_abort("Attempted to access signal handler for signal %i not in intercepted list", sig);
+        mir::fatal_error("Attempted to access signal handler for signal %i not in intercepted list", sig);
     }
 
 private:
@@ -204,12 +204,12 @@ extern "C" [[noreturn]] void fatal_signal_cleanup(int sig, siginfo_t* info, void
          * However, we've just performed emergency cleanup, so if the handler was trying to fix things up
          * and continue we unfortunately can't let them.
          */
-        mir::fatal_error_abort("Unsupported attempt to continue after a fatal signal: %s", signum_to_string(sig).c_str());
+        mir::fatal_error("Unsupported attempt to continue after a fatal signal: %s", signum_to_string(sig).c_str());
     }
     // The handler doesn't care about fancy context, we can just call it via raise()
     std::raise(sig);
     // We definitely can't continue, though, even if their handler tries.
-    mir::fatal_error_abort("Unsupported attempt to continue after a fatal signal: %s", signum_to_string(sig).c_str());
+    mir::fatal_error("Unsupported attempt to continue after a fatal signal: %s", signum_to_string(sig).c_str());
 }
 }
 
@@ -233,7 +233,7 @@ void mir::run_mir(
         [&server_ptr](int)
         {
             if (!server_ptr)
-                fatal_error_abort("Logic error in mir::run_mir() server_ptr is nullptr");
+                fatal_error("Logic error in mir::run_mir() server_ptr is nullptr");
             server_ptr->stop();
         };
 

--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -248,8 +248,6 @@ void mir::run_mir(
         main_loop->register_signal_handler({SIGINT, SIGHUP, SIGTERM}, terminator);
     }
 
-    FatalErrorStrategy fatal_error_strategy{config.the_fatal_error_strategy()};
-
     DisplayServer server(config);
     server_ptr = &server;
 

--- a/src/server/shell/basic_idle_handler.cpp
+++ b/src/server/shell/basic_idle_handler.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "basic_idle_handler.h"
+
 #include <mir/fatal.h>
 #include <mir/scene/idle_hub.h>
 #include <mir/scene/session_lock.h>
@@ -23,6 +24,7 @@
 #include <mir/input/scene.h>
 #include <mir/shell/display_configuration_controller.h>
 
+#include <cinttypes>
 #include <mutex>
 
 namespace ms = mir::scene;
@@ -286,7 +288,7 @@ void msh::BasicIdleHandler::register_observers(ProofOfMutexLock const&)
     {
         if (*off_timeout <= time::Duration{0})
         {
-            fatal_error("BasicIdleHandler given invalid timeout %d, should be >0", static_cast<int64_t>(off_timeout->count()));
+            fatal_error("BasicIdleHandler given invalid timeout %" PRId64 ", should be >0", static_cast<int64_t>(off_timeout->count()));
         }
         if (*off_timeout >= dim_time_before_off * 2)
         {

--- a/src/server/shell/basic_idle_handler.cpp
+++ b/src/server/shell/basic_idle_handler.cpp
@@ -286,7 +286,7 @@ void msh::BasicIdleHandler::register_observers(ProofOfMutexLock const&)
     {
         if (*off_timeout <= time::Duration{0})
         {
-            fatal_error("BasicIdleHandler given invalid timeout %d, should be >0", off_timeout->count());
+            fatal_error("BasicIdleHandler given invalid timeout %d, should be >0", static_cast<int64_t>(off_timeout->count()));
         }
         if (*off_timeout >= dim_time_before_off * 2)
         {

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -43,7 +43,6 @@ global:
     mir::DefaultServerConfiguration::the_drag_icon_controller*;
     mir::DefaultServerConfiguration::the_emergency_cleanup*;
     mir::DefaultServerConfiguration::the_event_filter_chain_dispatcher*;
-    mir::DefaultServerConfiguration::the_fatal_error_strategy*;
     mir::DefaultServerConfiguration::the_focus_controller*;
     mir::DefaultServerConfiguration::the_frontend_display_changer*;
     mir::DefaultServerConfiguration::the_frontend_surface_stack*;
@@ -841,7 +840,6 @@ global:
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_drag_icon_controller*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_emergency_cleanup*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_event_filter_chain_dispatcher*;
-    non-virtual?thunk?to?mir::DefaultServerConfiguration::the_fatal_error_strategy*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_frontend_display_changer*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_frontend_surface_stack*;
     non-virtual?thunk?to?mir::DefaultServerConfiguration::the_gl_config*;
@@ -1427,7 +1425,6 @@ global:
     virtual?thunk?to?mir::DefaultServerConfiguration::the_display_changer*;
     virtual?thunk?to?mir::DefaultServerConfiguration::the_display_platforms*;
     virtual?thunk?to?mir::DefaultServerConfiguration::the_emergency_cleanup*;
-    virtual?thunk?to?mir::DefaultServerConfiguration::the_fatal_error_strategy*;
     virtual?thunk?to?mir::DefaultServerConfiguration::the_idle_handler*;
     virtual?thunk?to?mir::DefaultServerConfiguration::the_idle_hub*;
     virtual?thunk?to?mir::DefaultServerConfiguration::the_input_dispatcher*;

--- a/tests/mir_test_framework/executable_path.cpp
+++ b/tests/mir_test_framework/executable_path.cpp
@@ -48,7 +48,7 @@ std::string mir_test_framework::library_path()
     {
         // Try to find the location of libmircommon.so
         Dl_info library_info{nullptr, nullptr, nullptr, nullptr};
-        dladdr(reinterpret_cast<void*>(&mir::fatal_error_abort), &library_info);
+        dladdr(reinterpret_cast<void*>(&mir::fatal_error), &library_info);
 
         std::unique_ptr<char, decltype(&std::free)> const tmp{strdup(library_info.dli_fname), &std::free};
         libpath = dirname(tmp.get());

--- a/tests/mir_test_framework/test_display_server.cpp
+++ b/tests/mir_test_framework/test_display_server.cpp
@@ -146,7 +146,7 @@ void miral::TestDisplayServer::start_server()
             }
             catch (std::exception const& e)
             {
-                mir::fatal_error(e.what());
+                mir::fatal_error("%s", e.what());
             }
 
             {

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_real_kms_output.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_real_kms_output.cpp
@@ -17,12 +17,11 @@
 #include <mir/graphics/kms_framebuffer.h>
 #include "src/platforms/gbm-kms/server/kms/real_kms_output.h"
 #include "src/platforms/gbm-kms/server/kms/page_flipper.h"
-#include <mir/fatal.h>
 
-#include <mir/test/fake_shared.h>
-
+#include <mir/test/death.h>
 #include <mir/test/doubles/mock_drm.h>
 #include <mir/test/doubles/mock_gbm.h>
+#include <mir/test/fake_shared.h>
 
 #include <stdexcept>
 
@@ -276,7 +275,6 @@ TEST_F(RealKMSOutputTest, operations_use_possible_crtc)
 
 TEST_F(RealKMSOutputTest, set_crtc_failure_is_handled_gracefully)
 {
-    mir::FatalErrorStrategy on_error{mir::fatal_error_except};
     using namespace testing;
 
     uint32_t const fb_id{67};
@@ -311,9 +309,7 @@ TEST_F(RealKMSOutputTest, set_crtc_failure_is_handled_gracefully)
     EXPECT_NO_THROW({
         EXPECT_FALSE(output.schedule_page_flip(*fb));
     });
-    EXPECT_THROW({  // schedule failed. It's programmer error if you then wait.
-        output.wait_for_page_flip();
-    }, std::runtime_error);
+    MIR_EXPECT_DEATH(output.wait_for_page_flip(), "");
 }
 
 TEST_F(RealKMSOutputTest, clear_crtc_gets_crtc_if_none_is_current)
@@ -452,8 +448,6 @@ TEST_F(RealKMSOutputTest, has_no_cursor_if_no_hardware_support)
 
 TEST_F(RealKMSOutputTest, clear_crtc_is_non_fatal_on_permission_error)
 {
-    mir::FatalErrorStrategy on_error{mir::fatal_error_except};
-
     using namespace testing;
 
     setup_outputs_connected_crtc();
@@ -478,8 +472,6 @@ TEST_F(RealKMSOutputTest, clear_crtc_is_non_fatal_on_permission_error)
 
 TEST_F(RealKMSOutputTest, clear_crtc_throws_if_drm_call_fails_for_non_permission_reason)
 {
-    mir::FatalErrorStrategy on_error{mir::fatal_error_except};
-
     using namespace testing;
 
     setup_outputs_connected_crtc();
@@ -490,12 +482,9 @@ TEST_F(RealKMSOutputTest, clear_crtc_throws_if_drm_call_fails_for_non_permission
         mt::fake_shared(mock_page_flipper)};
 
     EXPECT_CALL(mock_drm, drmModeSetCrtc(_, crtc_ids[0], 0, 0, 0, nullptr, 0, nullptr))
-        .Times(1)
-        .WillOnce(Return(-EINVAL));
+        .WillRepeatedly(Return(-EINVAL));
 
-    EXPECT_THROW({
-        output.clear_crtc();
-    }, std::runtime_error);
+    MIR_EXPECT_DEATH(output.clear_crtc(), "");
 }
 
 TEST_F(RealKMSOutputTest, drm_set_gamma)

--- a/tests/unit-tests/shared_library_test.cpp
+++ b/tests/unit-tests/shared_library_test.cpp
@@ -36,7 +36,7 @@ public:
         : nonexistent_library{"imma_totally_not_a_library"},
           existing_library{mtf::library_path() + "/libmircore.so"},
           nonexistent_function{"yo_dawg"},
-          existing_function{"_ZN3mir17fatal_error_abortEPKcz"},
+          existing_function{"_ZN3mir11fatal_errorEPKcz"},
           existent_version{"MIR_CORE_2.29"},
           nonexistent_version{"GOATS_ON_THE_GREEN"}
     {

--- a/tests/unit-tests/test_fatal.cpp
+++ b/tests/unit-tests/test_fatal.cpp
@@ -28,3 +28,10 @@ TEST(FatalErrorDeathTest, fatal_error_formats_message_to_stderr)
                                       "Mary", 1, "little", "lamb"),
                      "Mary had 1 little lamb");
 }
+
+TEST(FatalErrorDeathTest, fatal_error_raises_sigabrt)
+{
+    MIR_EXPECT_EXIT(mir::fatal_error("Hello world"),
+                    KilledBySignal(SIGABRT),
+                    "Hello world");
+}

--- a/tests/unit-tests/test_fatal.cpp
+++ b/tests/unit-tests/test_fatal.cpp
@@ -22,38 +22,9 @@
 
 using namespace testing;
 
-TEST(FatalErrorDeathTest, abort_formats_message_to_stderr)
+TEST(FatalErrorDeathTest, fatal_error_formats_message_to_stderr)
 {
-    mir::FatalErrorStrategy on_error{mir::fatal_error_abort};
-
     MIR_EXPECT_DEATH(mir::fatal_error("%s had %d %s %s",
                                       "Mary", 1, "little", "lamb"),
                      "Mary had 1 little lamb");
-}
-
-TEST(FatalErrorDeathTest, abort_raises_sigabrt)
-{
-    mir::FatalErrorStrategy on_error{mir::fatal_error_abort};
-
-    MIR_EXPECT_EXIT(mir::fatal_error("Hello world"),
-                    KilledBySignal(SIGABRT),
-                    "Hello world");
-}
-
-TEST(FatalErrorTest, throw_formats_message_to_what)
-{
-    mir::FatalErrorStrategy on_error{mir::fatal_error_except};
-
-    EXPECT_THROW(
-        mir::fatal_error("%s had %d %s %s", "Mary", 1, "little", "lamb"),
-        std::runtime_error);
-
-    try
-    {
-        mir::fatal_error("%s had %d %s %s", "Mary", 1, "little", "lamb");
-    }
-    catch (std::exception const& x)
-    {
-        EXPECT_THAT(x.what(), StrEq("Mary had 1 little lamb"));
-    }
 }


### PR DESCRIPTION
Simplify the "fatal_error()" design

A follow-up will switch to C++ formatters (and grab std::source_location - that is awkward right now since varargs and defaulted std::source_location don’t play nice)