### PR TITLE
ci: add ubuntu-26.04 as a custom runner label so actionlint stops complaining

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,6 @@
 self-hosted-runner:
   labels:
     - self-hosted-linux-amd64-resolute-large-tiobe
+    # actionlint v1.7.12 doesn't know about ubuntu-26.04:
+    #    https://github.com/rhysd/actionlint/pull/683
+    - ubuntu-26.04

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -26,9 +26,6 @@ jobs:
       with:
         python-version: 3.x
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-      if: always()
-      with:
-        extra_args: --files $(find ./include ./spread ./crates ./tests ./tools ./wayland-protocols ./assets ./debian ./rpm ./.workshop ./examples ./.github ./snap ./.git ./doc ./src -type f -not -name spread.yml -and -not -name symbols-check.yml)
     - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
       if: always()
       with:


### PR DESCRIPTION
This is a slightly cleaner version of #5099. The underlying problem is that [actionlint v1.7.12](https://github.com/rhysd/actionlint) includes a hard coded list of runner images it believes that Github provides, and ubuntu-26.04 is not on that list. Ideally we could move to a newer version in our pre-commit configuration, but no newer versions have been released (there is https://github.com/rhysd/actionlint/pull/683 open to add it though).

We can augment the list of runner images actionlint will treat as valid through it's configuration file though, so that's what this PR does. This has the benefit that we'll be linting the `spread.yml` and `symbols-check.yml` workflows again, and no change will be necessary if we start using ubuntu-26.04 in other workflows.

Closes #5097

## How to test

Check if the PreCommit actions workflow succeeds.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
