### PR TITLE
Plumb std::source_location through the `mir::log{,_debug,_info,_warning,_error,_critical}` paths.

### DIFF
--- a/debian/libmircore3.symbols
+++ b/debian/libmircore3.symbols
@@ -26,11 +26,9 @@ libmircore.so.3 libmircore3 #MINVER#
  (c++)"mir::input::MouseKeysKeymap::for_each_key_action_pair(std::function<void (unsigned int, mir::input::MouseKeysKeymap::Action)>&&) const@MIR_CORE_2.29" 2.29.0
  (c++)"mir::input::MouseKeysKeymap::get_action(unsigned int) const@MIR_CORE_2.29" 2.29.0
  (c++)"mir::input::MouseKeysKeymap::set_action(unsigned int, std::optional<mir::input::MouseKeysKeymap::Action>)@MIR_CORE_2.29" 2.29.0
- (c++)"mir::log(mir::logging::Severity, char const*, char const*, ...)@MIR_CORE_2.29" 2.29.0
- (c++)"mir::log(mir::logging::Severity, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIR_CORE_2.29" 2.29.0
- (c++)"mir::log(mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIR_CORE_2.29" 2.29.0
- (c++)"mir::log(mir::logging::Severity, std::initializer_list<std::reference_wrapper<mir::logging::Tag const> const>, std::basic_string_view<char, std::char_traits<char> >)@MIR_CORE_2.29" 2.29.0
- (c++)"mir::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >)@MIR_CORE_2.29" 2.29.0
+ (c++)"mir::log<mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location)@MIR_CORE_2.29" 2.29.0
+ (c++)"mir::log<mir::logging::Severity, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location)@MIR_CORE_2.29" 2.29.0
+ (c++)"mir::log<mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >, std::basic_format_args<std::basic_format_context<std::__format::_Sink_iter<char>, char> > >::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >, std::basic_format_args<std::basic_format_context<std::__format::_Sink_iter<char>, char> >, std::source_location)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::logging::DumbConsoleLogger::log(mir::logging::Event const&)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::logging::DumbConsoleLogger::log(mir::logging::Severity, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::logging::DumbConsoleLogger::~DumbConsoleLogger()@MIR_CORE_2.29" 2.29.0
@@ -73,7 +71,7 @@ libmircore.so.3 libmircore3 #MINVER#
  (c++)"typeinfo for mir::logging::DumbConsoleLogger@MIR_CORE_2.29" 2.29.0
  (c++)"typeinfo for mir::logging::Logger@MIR_CORE_2.29" 2.29.0
  (c++)"vtable for mir::logging::DumbConsoleLogger@MIR_CORE_2.29" 2.29.0
- (c++)"vtable for mir::logging::Logger@MIR_CORE_2.29" 2.29.0
+ (c++)"vtable for mir::logging::Logger@MIR_CORE_2.29" 2.29.0 mir::log<mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location)@MIR_CORE_2.29 2.29.0
  (c++|optional)"mir::logv(mir::logging::Severity, char const*, char const*, __va_list_tag*)@MIR_CORE_2.29" 2.29.0
  (c++|optional)"mir::logv(mir::logging::Severity, char const*, char const*, char*)@MIR_CORE_2.29" 2.29.0
  (c++|optional)"mir::logv(mir::logging::Severity, char const*, char const*, std::__va_list)@MIR_CORE_2.29" 2.29.0

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -228,56 +228,163 @@ template<typename ...Args>
 log_debug(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_debug<logging::Tags, std::format_string<Args...>, Args...>;
 
-inline void log_info(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::informational, tags, message); }
+template<typename... Args>
+struct log_info;
+
+template<>
+struct log_info<logging::Tags, std::string_view>
+{
+    log_info(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::informational, tags, message, loc);
+    }
+};
+log_info(logging::Tags, std::string_view) -> log_info<logging::Tags, std::string_view>;
+log_info(logging::Tags, std::string_view, std::source_location)
+    -> log_info<logging::Tags, std::string_view>;
 
 template<typename... Args>
-void log_info(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log_info(tags, std::format(fmt, std::forward<Args>(args)...)); }
-
-inline void log_warning(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::warning, tags, message); }
+struct log_info<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_info(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::informational,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_info(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_info<logging::Tags, std::format_string<Args...>, Args...>;
 
 template<typename... Args>
-void log_warning(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log(logging::Severity::warning, tags, fmt, std::forward<Args>(args)...); }
+struct log_warning;
 
-inline void log_error(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::error, tags, message); }
+template<>
+struct log_warning<logging::Tags, std::string_view>
+{
+    log_warning(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::warning, tags, message, loc);
+    }
+};
+log_warning(logging::Tags, std::string_view) -> log_warning<logging::Tags, std::string_view>;
+log_warning(logging::Tags, std::string_view, std::source_location)
+    -> log_warning<logging::Tags, std::string_view>;
 
 template<typename... Args>
-void log_error(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log(logging::Severity::error, tags, fmt, std::forward<Args>(args)...); }
-
-inline void log_critical(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::critical, tags, message); }
+struct log_warning<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_warning(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::warning,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_warning(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_warning<logging::Tags, std::format_string<Args...>, Args...>;
 
 template<typename... Args>
-void log_critical(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log(logging::Severity::critical, tags, fmt, std::forward<Args>(args)...); }
+struct log_error;
+
+template<>
+struct log_error<logging::Tags, std::string_view>
+{
+    log_error(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::error, tags, message, loc);
+    }
+};
+log_error(logging::Tags, std::string_view) -> log_error<logging::Tags, std::string_view>;
+log_error(logging::Tags, std::string_view, std::source_location)
+    -> log_error<logging::Tags, std::string_view>;
+
+template<typename... Args>
+struct log_error<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_error(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::error,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_error(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_error<logging::Tags, std::format_string<Args...>, Args...>;
+
+template<typename... Args>
+struct log_critical;
+
+template<>
+struct log_critical<logging::Tags, std::string_view>
+{
+    log_critical(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::critical, tags, message, loc);
+    }
+};
+log_critical(logging::Tags, std::string_view) -> log_critical<logging::Tags, std::string_view>;
+log_critical(logging::Tags, std::string_view, std::source_location)
+    -> log_critical<logging::Tags, std::string_view>;
+
+template<typename... Args>
+struct log_critical<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_critical(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::critical,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_critical(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_critical<logging::Tags, std::format_string<Args...>, Args...>;
 
 #ifdef MIR_LOG_COMPONENT
-
-inline void log_info(std::string const& message)
-{ ::mir::log(::mir::logging::Severity::informational, MIR_LOG_COMPONENT, message); }
-
-[[gnu::format(printf, 1, 2)]]
-inline void log_info(char const* fmt, ...)
-{
-    va_list va;
-    ::mir::logv(::mir::logging::Severity::informational, MIR_LOG_COMPONENT, fmt, va);
-    va_start(va, fmt);
-    va_end(va);
-}
-
-[[gnu::format(printf, 1, 2)]]
-inline void log_error(char const* fmt, ...)
-{
-    va_list va;
-    va_start(va, fmt);
-    ::mir::logv(::mir::logging::Severity::error, MIR_LOG_COMPONENT, fmt, va);
-    va_end(va);
-}
 
 template<typename... Args>
 struct log_debug<char const*, Args...>
@@ -298,32 +405,142 @@ struct log_debug<char const*, Args...>
 template<typename ...Args>
 log_debug(char const*, Args...) -> log_debug<char const*, Args...>;
 
-inline void log_critical(std::string const& message)
-{ ::mir::log(::mir::logging::Severity::critical, MIR_LOG_COMPONENT, message); }
-
-[[gnu::format(printf, 1, 2)]]
-inline void log_critical(char const* fmt, ...)
+template<>
+struct log_debug<std::string const&>
 {
-    va_list va;
-    va_start(va, fmt);
-    ::mir::logv(::mir::logging::Severity::critical, MIR_LOG_COMPONENT, fmt, va);
-    va_end(va);
-}
+    log_debug(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::debug, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_debug(std::string const&) -> log_debug<std::string const&>;
 
-inline void log_error(std::string const& message)
-{ ::mir::log(::mir::logging::Severity::error, MIR_LOG_COMPONENT, message); }
-
-inline void log_warning(std::string const& message)
-{ ::mir::log(::mir::logging::Severity::warning, MIR_LOG_COMPONENT, message); }
-
-[[gnu::format(printf, 1, 2)]]
-inline void log_warning(char const* fmt, ...)
+template<>
+struct log_info<std::string const&>
 {
-    va_list va;
-    va_start(va, fmt);
-    ::mir::logv(::mir::logging::Severity::warning, MIR_LOG_COMPONENT, fmt, va);
-    va_end(va);
-}
+    log_info(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::informational, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_info(std::string const&) -> log_info<std::string const&>;
+
+template<typename... Args>
+struct log_info<char const*, Args...>
+{
+    log_info(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::informational,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_info(char const*, Args...) -> log_info<char const*, Args...>;
+
+template<typename... Args>
+struct log_warning<char const*, Args...>
+{
+    log_warning(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::warning,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_warning(char const*, Args...) -> log_warning<char const*, Args...>;
+
+template<>
+struct log_warning<std::string const&>
+{
+    log_warning(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::warning, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_warning(std::string const&) -> log_warning<std::string const&>;
+
+template<typename... Args>
+struct log_error<char const*, Args...>
+{
+    log_error(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::error,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_error(char const*, Args...) -> log_error<char const*, Args...>;
+
+template<>
+struct log_error<std::string const&>
+{
+    log_error(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::error, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_error(std::string const&) -> log_error<std::string const&>;
+
+template<typename... Args>
+struct log_critical<char const*, Args...>
+{
+    log_critical(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::critical,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_critical(char const*, Args...) -> log_critical<char const*, Args...>;
+
+template<>
+struct log_critical<std::string const&>
+{
+    log_critical(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::critical, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_critical(std::string const&) -> log_critical<std::string const&>;
+
 #endif
 } // (nested anonymous) namespace
 

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -77,53 +77,47 @@ void logv(
  *    mir::log<logging::Severity, char const*, char const*, Args...>::log(..., loc);
  * ```
  */
-template<typename ...Args>
+template<typename... Args>
 struct log;
 
-template<typename ...Args>
+template<typename... Args>
 struct log<logging::Severity, char const*, char const*, Args...> final
 {
-    log(
-        logging::Severity sev,
+    log(logging::Severity sev,
         char const* component,
         char const* fmt,
         Args... args,
         std::source_location loc = std::source_location::current())
     {
-        auto const forwarder =
-            [sev, component, loc](char const* fmt, ...)
-            {
-                va_list va;
-                va_start(va, fmt);
-                mir::logv(sev, component, fmt, va, loc);
-                va_end(va);
-            };
+        auto const forwarder = [sev, component, loc](char const* fmt, ...)
+        {
+            va_list va;
+            va_start(va, fmt);
+            mir::logv(sev, component, fmt, va, loc);
+            va_end(va);
+        };
         forwarder(fmt, args...);
     }
 };
-template<typename ...Args>
-log(logging::Severity, char const*, char const*, Args...)
-    -> log<logging::Severity, char const*, char const*, Args...>;
+template<typename... Args>
+log(logging::Severity, char const*, char const*, Args...) -> log<logging::Severity, char const*, char const*, Args...>;
 
 template<>
 struct log<logging::Severity, char const*, std::string const&> final
 {
-    log(
-        logging::Severity sev,
+    log(logging::Severity sev,
         char const* component,
         std::string const& message,
         std::source_location loc = std::source_location::current());
 };
-log(logging::Severity, char const*, std::string const&)
-    -> log<logging::Severity, char const*, std::string const&>;
+log(logging::Severity, char const*, std::string const&) -> log<logging::Severity, char const*, std::string const&>;
 log(logging::Severity, char const*, std::string const&, std::source_location)
     -> log<logging::Severity, char const*, std::string const&>;
 
 template<>
 struct log<logging::Severity, char const*, std::exception_ptr const&, std::string const&> final
 {
-    log(
-        logging::Severity sev,
+    log(logging::Severity sev,
         char const* component,
         std::exception_ptr const& exception,
         std::string const& message,
@@ -134,18 +128,17 @@ log(logging::Severity, char const*, std::exception_ptr const&, std::string const
 log(logging::Severity, char const*, std::exception_ptr const&, std::string const&, std::source_location)
     -> log<logging::Severity, char const*, std::exception_ptr const&, std::string const&>;
 
-
 template<typename... Args>
 struct log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...> final
 {
-    log(
-        logging::Severity severity,
+    log(logging::Severity severity,
         logging::Tags tags,
         std::format_string<Args...> fmt,
         Args&&... args,
         std::source_location loc = std::source_location::current())
     {
-        log<logging::Severity, logging::Tags, std::string_view>(severity, tags, std::format(fmt, std::forward<Args>(args)...), loc);
+        log<logging::Severity, logging::Tags, std::string_view>(
+            severity, tags, std::format(fmt, std::forward<Args>(args)...), loc);
     }
 };
 template<typename... Args>
@@ -162,7 +155,7 @@ struct log<logging::Severity, logging::Tags, std::string_view> final
 };
 log(logging::Severity, logging::Tags, std::string_view) -> log<logging::Severity, logging::Tags, std::string_view>;
 log(logging::Severity, logging::Tags, std::string_view, std::source_location)
-        -> log<logging::Severity, logging::Tags, std::string_view>;
+    -> log<logging::Severity, logging::Tags, std::string_view>;
 
 /// Log a security event according to the OWASP specification
 ///
@@ -195,17 +188,11 @@ struct log_debug;
 template<>
 struct log_debug<logging::Tags, std::string_view>
 {
-    log_debug(
-        logging::Tags tags,
-        std::string_view message,
-        std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::debug, tags, message, loc);
-    }
+    log_debug(logging::Tags tags, std::string_view message, std::source_location loc = std::source_location::current())
+    { mir::log(logging::Severity::debug, tags, message, loc); }
 };
 log_debug(logging::Tags, std::string_view) -> log_debug<logging::Tags, std::string_view>;
-log_debug(logging::Tags, std::string_view, std::source_location)
-    -> log_debug<logging::Tags, std::string_view>;
+log_debug(logging::Tags, std::string_view, std::source_location) -> log_debug<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_debug<logging::Tags, std::format_string<Args...>, Args...>
@@ -217,14 +204,10 @@ struct log_debug<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::debug,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::debug, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_debug(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_debug<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -234,17 +217,11 @@ struct log_info;
 template<>
 struct log_info<logging::Tags, std::string_view>
 {
-    log_info(
-        logging::Tags tags,
-        std::string_view message,
-        std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::informational, tags, message, loc);
-    }
+    log_info(logging::Tags tags, std::string_view message, std::source_location loc = std::source_location::current())
+    { mir::log(logging::Severity::informational, tags, message, loc); }
 };
 log_info(logging::Tags, std::string_view) -> log_info<logging::Tags, std::string_view>;
-log_info(logging::Tags, std::string_view, std::source_location)
-    -> log_info<logging::Tags, std::string_view>;
+log_info(logging::Tags, std::string_view, std::source_location) -> log_info<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_info<logging::Tags, std::format_string<Args...>, Args...>
@@ -256,14 +233,10 @@ struct log_info<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::informational,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::informational, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_info(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_info<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -277,13 +250,10 @@ struct log_warning<logging::Tags, std::string_view>
         logging::Tags tags,
         std::string_view message,
         std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::warning, tags, message, loc);
-    }
+    { mir::log(logging::Severity::warning, tags, message, loc); }
 };
 log_warning(logging::Tags, std::string_view) -> log_warning<logging::Tags, std::string_view>;
-log_warning(logging::Tags, std::string_view, std::source_location)
-    -> log_warning<logging::Tags, std::string_view>;
+log_warning(logging::Tags, std::string_view, std::source_location) -> log_warning<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_warning<logging::Tags, std::format_string<Args...>, Args...>
@@ -295,14 +265,10 @@ struct log_warning<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::warning,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::warning, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_warning(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_warning<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -312,17 +278,11 @@ struct log_error;
 template<>
 struct log_error<logging::Tags, std::string_view>
 {
-    log_error(
-        logging::Tags tags,
-        std::string_view message,
-        std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::error, tags, message, loc);
-    }
+    log_error(logging::Tags tags, std::string_view message, std::source_location loc = std::source_location::current())
+    { mir::log(logging::Severity::error, tags, message, loc); }
 };
 log_error(logging::Tags, std::string_view) -> log_error<logging::Tags, std::string_view>;
-log_error(logging::Tags, std::string_view, std::source_location)
-    -> log_error<logging::Tags, std::string_view>;
+log_error(logging::Tags, std::string_view, std::source_location) -> log_error<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_error<logging::Tags, std::format_string<Args...>, Args...>
@@ -334,14 +294,10 @@ struct log_error<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::error,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::error, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_error(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_error<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -355,13 +311,10 @@ struct log_critical<logging::Tags, std::string_view>
         logging::Tags tags,
         std::string_view message,
         std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::critical, tags, message, loc);
-    }
+    { mir::log(logging::Severity::critical, tags, message, loc); }
 };
 log_critical(logging::Tags, std::string_view) -> log_critical<logging::Tags, std::string_view>;
-log_critical(logging::Tags, std::string_view, std::source_location)
-    -> log_critical<logging::Tags, std::string_view>;
+log_critical(logging::Tags, std::string_view, std::source_location) -> log_critical<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_critical<logging::Tags, std::format_string<Args...>, Args...>
@@ -373,14 +326,10 @@ struct log_critical<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::critical,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::critical, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_critical(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_critical<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -389,155 +338,100 @@ log_critical(logging::Tags, std::format_string<Args...>, Args&&...)
 template<typename... Args>
 struct log_debug<char const*, Args...>
 {
-    log_debug(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_debug(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::debug,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::debug, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_debug(char const*, Args...) -> log_debug<char const*, Args...>;
 
 template<>
 struct log_debug<std::string const&>
 {
-    log_debug(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::debug, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_debug(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::debug, MIR_LOG_COMPONENT, msg, location); }
 };
 log_debug(std::string const&) -> log_debug<std::string const&>;
 
 template<>
 struct log_info<std::string const&>
 {
-    log_info(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::informational, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_info(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::informational, MIR_LOG_COMPONENT, msg, location); }
 };
 log_info(std::string const&) -> log_info<std::string const&>;
 
 template<typename... Args>
 struct log_info<char const*, Args...>
 {
-    log_info(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_info(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::informational,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::informational, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_info(char const*, Args...) -> log_info<char const*, Args...>;
 
 template<typename... Args>
 struct log_warning<char const*, Args...>
 {
-    log_warning(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_warning(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::warning,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::warning, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_warning(char const*, Args...) -> log_warning<char const*, Args...>;
 
 template<>
 struct log_warning<std::string const&>
 {
-    log_warning(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::warning, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_warning(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::warning, MIR_LOG_COMPONENT, msg, location); }
 };
 log_warning(std::string const&) -> log_warning<std::string const&>;
 
 template<typename... Args>
 struct log_error<char const*, Args...>
 {
-    log_error(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_error(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::error,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::error, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_error(char const*, Args...) -> log_error<char const*, Args...>;
 
 template<>
 struct log_error<std::string const&>
 {
-    log_error(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::error, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_error(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::error, MIR_LOG_COMPONENT, msg, location); }
 };
 log_error(std::string const&) -> log_error<std::string const&>;
 
 template<typename... Args>
 struct log_critical<char const*, Args...>
 {
-    log_critical(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_critical(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::critical,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::critical, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_critical(char const*, Args...) -> log_critical<char const*, Args...>;
 
 template<>
 struct log_critical<std::string const&>
 {
-    log_critical(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::critical, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_critical(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::critical, MIR_LOG_COMPONENT, msg, location); }
 };
 log_critical(std::string const&) -> log_critical<std::string const&>;
 

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -185,12 +185,48 @@ namespace
 // For C++-overload-resolution reasons these always-available functions need to be
 // defined in the same namespace as the conditionally-available ones below.
 
-inline void log_debug(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::debug, tags, message); }
+/*
+ * As above, the log_{debug,info,warn,error,critical} family need to be
+ * types-with-deduction-guides
+ */
+template<typename... Args>
+struct log_debug;
+
+template<>
+struct log_debug<logging::Tags, std::string_view>
+{
+    log_debug(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::debug, tags, message, loc);
+    }
+};
+log_debug(logging::Tags, std::string_view) -> log_debug<logging::Tags, std::string_view>;
+log_debug(logging::Tags, std::string_view, std::source_location)
+    -> log_debug<logging::Tags, std::string_view>;
 
 template<typename... Args>
-void log_debug(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log_debug(tags, std::format(fmt, std::forward<Args>(args)...)); }
+struct log_debug<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_debug(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::debug,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_debug(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_debug<logging::Tags, std::format_string<Args...>, Args...>;
 
 inline void log_info(logging::Tags tags, std::string_view message)
 { mir::log(logging::Severity::informational, tags, message); }
@@ -229,8 +265,8 @@ inline void log_info(std::string const& message)
 inline void log_info(char const* fmt, ...)
 {
     va_list va;
-    va_start(va, fmt);
     ::mir::logv(::mir::logging::Severity::informational, MIR_LOG_COMPONENT, fmt, va);
+    va_start(va, fmt);
     va_end(va);
 }
 
@@ -243,14 +279,24 @@ inline void log_error(char const* fmt, ...)
     va_end(va);
 }
 
-[[gnu::format(printf, 1, 2)]]
-inline void log_debug(char const* fmt, ...)
+template<typename... Args>
+struct log_debug<char const*, Args...>
 {
-    va_list va;
-    va_start(va, fmt);
-    ::mir::logv(::mir::logging::Severity::debug, MIR_LOG_COMPONENT, fmt, va);
-    va_end(va);
-}
+    log_debug(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::debug,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_debug(char const*, Args...) -> log_debug<char const*, Args...>;
 
 inline void log_critical(std::string const& message)
 { ::mir::log(::mir::logging::Severity::critical, MIR_LOG_COMPONENT, message); }

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -22,6 +22,7 @@
 #include <mir/logging/logger.h> // for Severity
 
 #include <format>
+#include <source_location>
 #include <string>
 #include <cstdarg>
 #include <exception>
@@ -30,17 +31,138 @@
 namespace mir
 {
 [[gnu::format(printf, 3, 0)]]
-void logv(logging::Severity sev, char const* component, char const* fmt, va_list va);
-[[gnu::format(printf, 3, 4)]]
-void log(logging::Severity sev, char const* component, char const* fmt, ...);
-void log(logging::Severity sev, char const* component, std::string const& message);
-void log(logging::Severity sev, char const* component, std::exception_ptr const& exception, std::string const& message);
+void logv(
+    logging::Severity sev,
+    char const* component,
+    char const* fmt,
+    va_list va,
+    std::source_location loc = std::source_location::current());
+
+/*
+ * The following is a bit weird because we want to have both a variadic
+ * logging API (both the older printf-style and the new std::format-style),
+ * but we also want to capture a std::source_location for each of the log sites
+ * and the idiomatic way to do *that* is with a default
+ * `std::source_location loc = std::source_location::current()` argument.
+ * (This use of ::current() is defined in the C++ spec as resolving to the call site).
+ *
+ * That combination plays badly: you can't have both variadics and default arguments,
+ * because how can the compiler tell what argument should be variadic and what should be
+ * defaulted?
+ *
+ * We *can* resolve this for the compiler by using a user-provided template deduction
+ * guide.
+ *
+ * Unfortunately, template deduction guides only apply to templated *types*, not
+ * templated *functions*.
+ *
+ * So: mir::log becomes a templated *type* with a family of partial- and
+ * complete-specialisations, and mir::log(...) becomes calls to the constructors
+ * of those types.
+ *
+ * Each of the old overloads of mir::log() becomes a (partial-)specialisation,
+ * with a deduction guide to direct the compiler to the correct specialisation.
+ *
+ * The non-variadic APIs get two deduction guides - one with an explicit
+ * std::source_location parameter and one without. That lets callers either omit
+ * the std::source_location if they *are* the site that should be recorded as the
+ * source of the log, or accept a std::source_location themselves and pass that on
+ * if they're proxying for a different call-site.
+ *
+ * The variadic APIs can only have the single deduction guide; if a caller wants
+ * to pass an explicit source_location they will need to manually select the
+ * correct specialisation. For example:
+ * ```
+ *    std::source_location loc;
+ *    mir::log<logging::Severity, char const*, char const*, Args...>::log(..., loc);
+ * ```
+ */
+template<typename ...Args>
+struct log;
+
+template<typename ...Args>
+struct log<logging::Severity, char const*, char const*, Args...> final
+{
+    log(
+        logging::Severity sev,
+        char const* component,
+        char const* fmt,
+        Args... args,
+        std::source_location loc = std::source_location::current())
+    {
+        auto const forwarder =
+            [sev, component, loc](char const* fmt, ...)
+            {
+                va_list va;
+                va_start(va, fmt);
+                mir::logv(sev, component, fmt, va, loc);
+                va_end(va);
+            };
+        forwarder(fmt, args...);
+    }
+};
+template<typename ...Args>
+log(logging::Severity, char const*, char const*, Args...)
+    -> log<logging::Severity, char const*, char const*, Args...>;
+
+template<>
+struct log<logging::Severity, char const*, std::string const&> final
+{
+    log(
+        logging::Severity sev,
+        char const* component,
+        std::string const& message,
+        std::source_location loc = std::source_location::current());
+};
+log(logging::Severity, char const*, std::string const&)
+    -> log<logging::Severity, char const*, std::string const&>;
+log(logging::Severity, char const*, std::string const&, std::source_location)
+    -> log<logging::Severity, char const*, std::string const&>;
+
+template<>
+struct log<logging::Severity, char const*, std::exception_ptr const&, std::string const&> final
+{
+    log(
+        logging::Severity sev,
+        char const* component,
+        std::exception_ptr const& exception,
+        std::string const& message,
+        std::source_location log = std::source_location::current());
+};
+log(logging::Severity, char const*, std::exception_ptr const&, std::string const&)
+    -> log<logging::Severity, char const*, std::exception_ptr const&, std::string const&>;
+log(logging::Severity, char const*, std::exception_ptr const&, std::string const&, std::source_location)
+    -> log<logging::Severity, char const*, std::exception_ptr const&, std::string const&>;
+
 
 template<typename... Args>
-void log(logging::Severity severity, logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log(severity, tags, std::format(fmt, std::forward<Args>(args)...)); }
+struct log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...> final
+{
+    log(
+        logging::Severity severity,
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location loc = std::source_location::current())
+    {
+        log<logging::Severity, logging::Tags, std::string_view>(severity, tags, std::format(fmt, std::forward<Args>(args)...), loc);
+    }
+};
+template<typename... Args>
+log(logging::Severity, logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>;
 
-void log(logging::Severity sev, logging::Tags tags, std::string_view message);
+template<>
+struct log<logging::Severity, logging::Tags, std::string_view> final
+{
+    log(logging::Severity sev,
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current());
+};
+log(logging::Severity, logging::Tags, std::string_view) -> log<logging::Severity, logging::Tags, std::string_view>;
+log(logging::Severity, logging::Tags, std::string_view, std::source_location)
+        -> log<logging::Severity, logging::Tags, std::string_view>;
 
 /// Log a security event according to the OWASP specification
 ///

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -187,7 +187,15 @@ struct log<logging::Severity, logging::Tags, std::string_view> final
     log(logging::Severity sev,
         logging::Tags tags,
         std::string_view message,
-        std::source_location loc = std::source_location::current());
+        std::source_location loc = std::source_location::current())
+    {
+        log<logging::Severity, logging::Tags, std::format_string<std::string_view>, std::string_view>(
+            sev,
+            tags,
+            "{}",
+            message,
+            loc);
+    }
 };
 log(logging::Severity, logging::Tags, std::string_view) -> log<logging::Severity, logging::Tags, std::string_view>;
 log(logging::Severity, logging::Tags, std::string_view, std::source_location)

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -114,7 +114,15 @@ struct log<logging::Severity, char const*, char const*, Args...> final
     {
         char message[1024];
 
+#if !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+#endif
         std::snprintf(message, sizeof(message), fmt, args...);
+#if !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
         log<logging::Severity, std::string const&, std::string const&>(
             sev,
             component,

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -28,6 +28,18 @@
 #include <exception>
 #include <string_view>
 
+#if defined(__clang__)
+#pragma GCC diagnostic push
+// [[gnu::format]] on non-variadic functions is a clang extension
+#pragma GCC diagnostic ignored "-Wgcc-compat"
+// Clang likes to warn about the unused log_{debug,info,etc} templates & functions
+#pragma GCC diagnostic ignored "-Wunused-template"
+#pragma GCC diagnostic ignored "-Wunused-function"
+#define FORMAT_ATTRIB(fmt, args) [[gnu::format(printf, fmt, args)]]
+#else
+#define FORMAT_ATTRIB(fmt, args)
+#endif
+
 namespace mir
 {
 /*
@@ -105,6 +117,8 @@ log(logging::Severity, logging::Tags, std::string_view, std::format_args, std::s
 template<typename ...Args>
 struct log<logging::Severity, char const*, char const*, Args...> final
 {
+    // fmt is the 4th argument because there's an implicit "this" as the first argument
+    FORMAT_ATTRIB(4, 5)
     log(
         logging::Severity sev,
         char const* component,
@@ -404,6 +418,8 @@ log_critical(logging::Tags, std::format_string<Args...>, Args&&...)
 template<typename... Args>
 struct log_debug<char const*, Args...>
 {
+    // fmt is the *second* argument, because the implicit "this" pointer is the first.
+    FORMAT_ATTRIB(2, 3)
     log_debug(
         char const* fmt,
         Args... args,
@@ -447,6 +463,8 @@ log_info(std::string const&) -> log_info<std::string const&>;
 template<typename... Args>
 struct log_info<char const*, Args...>
 {
+    // fmt is the *second* argument, because the implicit "this" pointer is the first.
+    FORMAT_ATTRIB(2, 3)
     log_info(
         char const* fmt,
         Args... args,
@@ -466,6 +484,8 @@ log_info(char const*, Args...) -> log_info<char const*, Args...>;
 template<typename... Args>
 struct log_warning<char const*, Args...>
 {
+    // fmt is the *second* argument, because the implicit "this" pointer is the first.
+    FORMAT_ATTRIB(2, 3)
     log_warning(
         char const* fmt,
         Args... args,
@@ -497,6 +517,8 @@ log_warning(std::string const&) -> log_warning<std::string const&>;
 template<typename... Args>
 struct log_error<char const*, Args...>
 {
+    // fmt is the *second* argument, because the implicit "this" pointer is the first.
+    FORMAT_ATTRIB(2, 3)
     log_error(
         char const* fmt,
         Args... args,
@@ -528,6 +550,8 @@ log_error(std::string const&) -> log_error<std::string const&>;
 template<typename... Args>
 struct log_critical<char const*, Args...>
 {
+    // fmt is the *second* argument, because the implicit "this" pointer is the first.
+    FORMAT_ATTRIB(2, 3)
     log_critical(
         char const* fmt,
         Args... args,
@@ -560,5 +584,9 @@ log_critical(std::string const&) -> log_critical<std::string const&>;
 } // (nested anonymous) namespace
 
 } // namespace mir
+
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif // MIR_LOG_H_

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -221,12 +221,48 @@ namespace
 // For C++-overload-resolution reasons these always-available functions need to be
 // defined in the same namespace as the conditionally-available ones below.
 
-inline void log_debug(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::debug, tags, message); }
+/*
+ * As above, the log_{debug,info,warn,error,critical} family need to be
+ * types-with-deduction-guides
+ */
+template<typename... Args>
+struct log_debug;
+
+template<>
+struct log_debug<logging::Tags, std::string_view>
+{
+    log_debug(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::debug, tags, message, loc);
+    }
+};
+log_debug(logging::Tags, std::string_view) -> log_debug<logging::Tags, std::string_view>;
+log_debug(logging::Tags, std::string_view, std::source_location)
+    -> log_debug<logging::Tags, std::string_view>;
 
 template<typename... Args>
-void log_debug(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log_debug(tags, std::format(fmt, std::forward<Args>(args)...)); }
+struct log_debug<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_debug(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::debug,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_debug(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_debug<logging::Tags, std::format_string<Args...>, Args...>;
 
 inline void log_info(logging::Tags tags, std::string_view message)
 { mir::log(logging::Severity::informational, tags, "{}", message); }
@@ -265,8 +301,8 @@ inline void log_info(std::string const& message)
 inline void log_info(char const* fmt, ...)
 {
     va_list va;
-    va_start(va, fmt);
     ::mir::logv(::mir::logging::Severity::informational, MIR_LOG_COMPONENT, fmt, va);
+    va_start(va, fmt);
     va_end(va);
 }
 
@@ -279,14 +315,24 @@ inline void log_error(char const* fmt, ...)
     va_end(va);
 }
 
-[[gnu::format(printf, 1, 2)]]
-inline void log_debug(char const* fmt, ...)
+template<typename... Args>
+struct log_debug<char const*, Args...>
 {
-    va_list va;
-    va_start(va, fmt);
-    ::mir::logv(::mir::logging::Severity::debug, MIR_LOG_COMPONENT, fmt, va);
-    va_end(va);
-}
+    log_debug(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::debug,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_debug(char const*, Args...) -> log_debug<char const*, Args...>;
 
 inline void log_critical(std::string const& message)
 { ::mir::log(::mir::logging::Severity::critical, MIR_LOG_COMPONENT, message); }

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -264,56 +264,163 @@ template<typename ...Args>
 log_debug(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_debug<logging::Tags, std::format_string<Args...>, Args...>;
 
-inline void log_info(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::informational, tags, "{}", message); }
+template<typename... Args>
+struct log_info;
+
+template<>
+struct log_info<logging::Tags, std::string_view>
+{
+    log_info(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::informational, tags, message, loc);
+    }
+};
+log_info(logging::Tags, std::string_view) -> log_info<logging::Tags, std::string_view>;
+log_info(logging::Tags, std::string_view, std::source_location)
+    -> log_info<logging::Tags, std::string_view>;
 
 template<typename... Args>
-void log_info(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log_info(tags, std::format(fmt, std::forward<Args>(args)...)); }
-
-inline void log_warning(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::warning, tags, "{}", message); }
+struct log_info<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_info(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::informational,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_info(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_info<logging::Tags, std::format_string<Args...>, Args...>;
 
 template<typename... Args>
-void log_warning(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log(logging::Severity::warning, tags, fmt, std::forward<Args>(args)...); }
+struct log_warning;
 
-inline void log_error(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::error, tags, "{}", message); }
+template<>
+struct log_warning<logging::Tags, std::string_view>
+{
+    log_warning(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::warning, tags, message, loc);
+    }
+};
+log_warning(logging::Tags, std::string_view) -> log_warning<logging::Tags, std::string_view>;
+log_warning(logging::Tags, std::string_view, std::source_location)
+    -> log_warning<logging::Tags, std::string_view>;
 
 template<typename... Args>
-void log_error(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log(logging::Severity::error, tags, fmt, std::forward<Args>(args)...); }
-
-inline void log_critical(logging::Tags tags, std::string_view message)
-{ mir::log(logging::Severity::critical, tags, "{}", message); }
+struct log_warning<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_warning(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::warning,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_warning(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_warning<logging::Tags, std::format_string<Args...>, Args...>;
 
 template<typename... Args>
-void log_critical(logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ log(logging::Severity::critical, tags, fmt, std::forward<Args>(args)...); }
+struct log_error;
+
+template<>
+struct log_error<logging::Tags, std::string_view>
+{
+    log_error(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::error, tags, message, loc);
+    }
+};
+log_error(logging::Tags, std::string_view) -> log_error<logging::Tags, std::string_view>;
+log_error(logging::Tags, std::string_view, std::source_location)
+    -> log_error<logging::Tags, std::string_view>;
+
+template<typename... Args>
+struct log_error<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_error(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::error,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_error(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_error<logging::Tags, std::format_string<Args...>, Args...>;
+
+template<typename... Args>
+struct log_critical;
+
+template<>
+struct log_critical<logging::Tags, std::string_view>
+{
+    log_critical(
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current())
+    {
+        mir::log(logging::Severity::critical, tags, message, loc);
+    }
+};
+log_critical(logging::Tags, std::string_view) -> log_critical<logging::Tags, std::string_view>;
+log_critical(logging::Tags, std::string_view, std::source_location)
+    -> log_critical<logging::Tags, std::string_view>;
+
+template<typename... Args>
+struct log_critical<logging::Tags, std::format_string<Args...>, Args...>
+{
+    log_critical(
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
+            logging::Severity::critical,
+            tags,
+            fmt,
+            std::forward<Args>(args)...,
+            location);
+    }
+};
+template<typename ...Args>
+log_critical(logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log_critical<logging::Tags, std::format_string<Args...>, Args...>;
 
 #ifdef MIR_LOG_COMPONENT
-
-inline void log_info(std::string const& message)
-{ ::mir::log(::mir::logging::Severity::informational, MIR_LOG_COMPONENT, message); }
-
-[[gnu::format(printf, 1, 2)]]
-inline void log_info(char const* fmt, ...)
-{
-    va_list va;
-    ::mir::logv(::mir::logging::Severity::informational, MIR_LOG_COMPONENT, fmt, va);
-    va_start(va, fmt);
-    va_end(va);
-}
-
-[[gnu::format(printf, 1, 2)]]
-inline void log_error(char const* fmt, ...)
-{
-    va_list va;
-    va_start(va, fmt);
-    ::mir::logv(::mir::logging::Severity::error, MIR_LOG_COMPONENT, fmt, va);
-    va_end(va);
-}
 
 template<typename... Args>
 struct log_debug<char const*, Args...>
@@ -334,32 +441,142 @@ struct log_debug<char const*, Args...>
 template<typename ...Args>
 log_debug(char const*, Args...) -> log_debug<char const*, Args...>;
 
-inline void log_critical(std::string const& message)
-{ ::mir::log(::mir::logging::Severity::critical, MIR_LOG_COMPONENT, message); }
-
-[[gnu::format(printf, 1, 2)]]
-inline void log_critical(char const* fmt, ...)
+template<>
+struct log_debug<std::string const&>
 {
-    va_list va;
-    va_start(va, fmt);
-    ::mir::logv(::mir::logging::Severity::critical, MIR_LOG_COMPONENT, fmt, va);
-    va_end(va);
-}
+    log_debug(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::debug, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_debug(std::string const&) -> log_debug<std::string const&>;
 
-inline void log_error(std::string const& message)
-{ ::mir::log(::mir::logging::Severity::error, MIR_LOG_COMPONENT, message); }
-
-inline void log_warning(std::string const& message)
-{ ::mir::log(::mir::logging::Severity::warning, MIR_LOG_COMPONENT, message); }
-
-[[gnu::format(printf, 1, 2)]]
-inline void log_warning(char const* fmt, ...)
+template<>
+struct log_info<std::string const&>
 {
-    va_list va;
-    va_start(va, fmt);
-    ::mir::logv(::mir::logging::Severity::warning, MIR_LOG_COMPONENT, fmt, va);
-    va_end(va);
-}
+    log_info(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::informational, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_info(std::string const&) -> log_info<std::string const&>;
+
+template<typename... Args>
+struct log_info<char const*, Args...>
+{
+    log_info(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::informational,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_info(char const*, Args...) -> log_info<char const*, Args...>;
+
+template<typename... Args>
+struct log_warning<char const*, Args...>
+{
+    log_warning(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::warning,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_warning(char const*, Args...) -> log_warning<char const*, Args...>;
+
+template<>
+struct log_warning<std::string const&>
+{
+    log_warning(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::warning, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_warning(std::string const&) -> log_warning<std::string const&>;
+
+template<typename... Args>
+struct log_error<char const*, Args...>
+{
+    log_error(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::error,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_error(char const*, Args...) -> log_error<char const*, Args...>;
+
+template<>
+struct log_error<std::string const&>
+{
+    log_error(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::error, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_error(std::string const&) -> log_error<std::string const&>;
+
+template<typename... Args>
+struct log_critical<char const*, Args...>
+{
+    log_critical(
+        char const* fmt,
+        Args... args,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log<logging::Severity, char const*, char const*, Args...>(
+            logging::Severity::critical,
+            MIR_LOG_COMPONENT,
+            fmt,
+            args...,
+            location);
+    }
+};
+template<typename ...Args>
+log_critical(char const*, Args...) -> log_critical<char const*, Args...>;
+
+template<>
+struct log_critical<std::string const&>
+{
+    log_critical(
+        std::string const& msg,
+        std::source_location const& location = std::source_location::current())
+    {
+        mir::log(logging::Severity::critical, MIR_LOG_COMPONENT, msg, location);
+    }
+};
+log_critical(std::string const&) -> log_critical<std::string const&>;
+
 #endif
 } // (nested anonymous) namespace
 

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -29,15 +29,15 @@
 #include <string_view>
 
 #if defined(__clang__)
-#pragma GCC diagnostic push
-// [[gnu::format]] on non-variadic functions is a clang extension
-#pragma GCC diagnostic ignored "-Wgcc-compat"
-// Clang likes to warn about the unused log_{debug,info,etc} templates & functions
-#pragma GCC diagnostic ignored "-Wunused-template"
-#pragma GCC diagnostic ignored "-Wunused-function"
-#define FORMAT_ATTRIB(fmt, args) [[gnu::format(printf, fmt, args)]]
+  #pragma GCC diagnostic push
+  // [[gnu::format]] on non-variadic functions is a clang extension
+  #pragma GCC diagnostic ignored "-Wgcc-compat"
+  // Clang likes to warn about the unused log_{debug,info,etc} templates & functions
+  #pragma GCC diagnostic ignored "-Wunused-template"
+  #pragma GCC diagnostic ignored "-Wunused-function"
+  #define FORMAT_ATTRIB(fmt, args) [[gnu::format(printf, fmt, args)]]
 #else
-#define FORMAT_ATTRIB(fmt, args)
+  #define FORMAT_ATTRIB(fmt, args)
 #endif
 
 namespace mir
@@ -81,15 +81,14 @@ namespace mir
  *    mir::log<logging::Severity, char const*, char const*, Args...>::log(..., loc);
  * ```
  */
-template<typename ...Args>
+template<typename... Args>
 struct log;
 
 /* Legacy component/message pair */
 template<>
 struct log<logging::Severity, std::string const&, std::string const&> final
 {
-    log(
-        logging::Severity sev,
+    log(logging::Severity sev,
         std::string const& component,
         std::string const& message,
         std::source_location location = std::source_location::current());
@@ -102,8 +101,7 @@ log(logging::Severity, std::string const&, std::string const&, std::source_locat
 template<>
 struct log<logging::Severity, logging::Tags, std::string_view, std::format_args> final
 {
-    log(
-        logging::Severity sev,
+    log(logging::Severity sev,
         logging::Tags tags,
         std::string_view fmt,
         std::format_args args,
@@ -114,13 +112,12 @@ log(logging::Severity, logging::Tags, std::string_view, std::format_args)
 log(logging::Severity, logging::Tags, std::string_view, std::format_args, std::source_location)
     -> log<logging::Severity, logging::Tags, std::string_view, std::format_args>;
 
-template<typename ...Args>
+template<typename... Args>
 struct log<logging::Severity, char const*, char const*, Args...> final
 {
     // fmt is the 4th argument because there's an implicit "this" as the first argument
     FORMAT_ATTRIB(4, 5)
-    log(
-        logging::Severity sev,
+    log(logging::Severity sev,
         char const* component,
         char const* fmt,
         Args... args,
@@ -129,30 +126,24 @@ struct log<logging::Severity, char const*, char const*, Args...> final
         char message[1024];
 
 #if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-security"
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
         std::snprintf(message, sizeof(message), fmt, args...);
 #if !defined(__clang__)
-#pragma GCC diagnostic pop
+  #pragma GCC diagnostic pop
 #endif
 
-        log<logging::Severity, std::string const&, std::string const&>(
-            sev,
-            component,
-            message,
-            loc);
+        log<logging::Severity, std::string const&, std::string const&>(sev, component, message, loc);
     }
 };
-template<typename ...Args>
-log(logging::Severity, char const*, char const*, Args...)
-    -> log<logging::Severity, char const*, char const*, Args...>;
+template<typename... Args>
+log(logging::Severity, char const*, char const*, Args...) -> log<logging::Severity, char const*, char const*, Args...>;
 
 template<>
 struct log<logging::Severity, char const*, std::exception_ptr const&, std::string const&> final
 {
-    log(
-        logging::Severity sev,
+    log(logging::Severity sev,
         char const* component,
         std::exception_ptr const& exception,
         std::string const& message,
@@ -163,23 +154,17 @@ log(logging::Severity, char const*, std::exception_ptr const&, std::string const
 log(logging::Severity, char const*, std::exception_ptr const&, std::string const&, std::source_location)
     -> log<logging::Severity, char const*, std::exception_ptr const&, std::string const&>;
 
-
 template<typename... Args>
 struct log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...> final
 {
-    log(
-        logging::Severity severity,
+    log(logging::Severity severity,
         logging::Tags tags,
         std::format_string<Args...> fmt,
         Args... args,
         std::source_location loc = std::source_location::current())
     {
         log<logging::Severity, logging::Tags, std::string_view, std::format_args>(
-            severity,
-            tags,
-            fmt.get(),
-            std::make_format_args(args...),
-            loc);
+            severity, tags, fmt.get(), std::make_format_args(args...), loc);
     }
 };
 template<typename... Args>
@@ -195,16 +180,12 @@ struct log<logging::Severity, logging::Tags, std::string_view> final
         std::source_location loc = std::source_location::current())
     {
         log<logging::Severity, logging::Tags, std::format_string<std::string_view>, std::string_view>(
-            sev,
-            tags,
-            "{}",
-            message,
-            loc);
+            sev, tags, "{}", message, loc);
     }
 };
 log(logging::Severity, logging::Tags, std::string_view) -> log<logging::Severity, logging::Tags, std::string_view>;
 log(logging::Severity, logging::Tags, std::string_view, std::source_location)
-        -> log<logging::Severity, logging::Tags, std::string_view>;
+    -> log<logging::Severity, logging::Tags, std::string_view>;
 
 /// Log a security event according to the OWASP specification
 ///
@@ -237,17 +218,11 @@ struct log_debug;
 template<>
 struct log_debug<logging::Tags, std::string_view>
 {
-    log_debug(
-        logging::Tags tags,
-        std::string_view message,
-        std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::debug, tags, message, loc);
-    }
+    log_debug(logging::Tags tags, std::string_view message, std::source_location loc = std::source_location::current())
+    { mir::log(logging::Severity::debug, tags, message, loc); }
 };
 log_debug(logging::Tags, std::string_view) -> log_debug<logging::Tags, std::string_view>;
-log_debug(logging::Tags, std::string_view, std::source_location)
-    -> log_debug<logging::Tags, std::string_view>;
+log_debug(logging::Tags, std::string_view, std::source_location) -> log_debug<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_debug<logging::Tags, std::format_string<Args...>, Args...>
@@ -259,14 +234,10 @@ struct log_debug<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::debug,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::debug, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_debug(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_debug<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -276,17 +247,11 @@ struct log_info;
 template<>
 struct log_info<logging::Tags, std::string_view>
 {
-    log_info(
-        logging::Tags tags,
-        std::string_view message,
-        std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::informational, tags, message, loc);
-    }
+    log_info(logging::Tags tags, std::string_view message, std::source_location loc = std::source_location::current())
+    { mir::log(logging::Severity::informational, tags, message, loc); }
 };
 log_info(logging::Tags, std::string_view) -> log_info<logging::Tags, std::string_view>;
-log_info(logging::Tags, std::string_view, std::source_location)
-    -> log_info<logging::Tags, std::string_view>;
+log_info(logging::Tags, std::string_view, std::source_location) -> log_info<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_info<logging::Tags, std::format_string<Args...>, Args...>
@@ -298,14 +263,10 @@ struct log_info<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::informational,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::informational, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_info(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_info<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -319,13 +280,10 @@ struct log_warning<logging::Tags, std::string_view>
         logging::Tags tags,
         std::string_view message,
         std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::warning, tags, message, loc);
-    }
+    { mir::log(logging::Severity::warning, tags, message, loc); }
 };
 log_warning(logging::Tags, std::string_view) -> log_warning<logging::Tags, std::string_view>;
-log_warning(logging::Tags, std::string_view, std::source_location)
-    -> log_warning<logging::Tags, std::string_view>;
+log_warning(logging::Tags, std::string_view, std::source_location) -> log_warning<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_warning<logging::Tags, std::format_string<Args...>, Args...>
@@ -337,14 +295,10 @@ struct log_warning<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::warning,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::warning, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_warning(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_warning<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -354,17 +308,11 @@ struct log_error;
 template<>
 struct log_error<logging::Tags, std::string_view>
 {
-    log_error(
-        logging::Tags tags,
-        std::string_view message,
-        std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::error, tags, message, loc);
-    }
+    log_error(logging::Tags tags, std::string_view message, std::source_location loc = std::source_location::current())
+    { mir::log(logging::Severity::error, tags, message, loc); }
 };
 log_error(logging::Tags, std::string_view) -> log_error<logging::Tags, std::string_view>;
-log_error(logging::Tags, std::string_view, std::source_location)
-    -> log_error<logging::Tags, std::string_view>;
+log_error(logging::Tags, std::string_view, std::source_location) -> log_error<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_error<logging::Tags, std::format_string<Args...>, Args...>
@@ -376,14 +324,10 @@ struct log_error<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::error,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::error, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_error(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_error<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -397,13 +341,10 @@ struct log_critical<logging::Tags, std::string_view>
         logging::Tags tags,
         std::string_view message,
         std::source_location loc = std::source_location::current())
-    {
-        mir::log(logging::Severity::critical, tags, message, loc);
-    }
+    { mir::log(logging::Severity::critical, tags, message, loc); }
 };
 log_critical(logging::Tags, std::string_view) -> log_critical<logging::Tags, std::string_view>;
-log_critical(logging::Tags, std::string_view, std::source_location)
-    -> log_critical<logging::Tags, std::string_view>;
+log_critical(logging::Tags, std::string_view, std::source_location) -> log_critical<logging::Tags, std::string_view>;
 
 template<typename... Args>
 struct log_critical<logging::Tags, std::format_string<Args...>, Args...>
@@ -415,14 +356,10 @@ struct log_critical<logging::Tags, std::format_string<Args...>, Args...>
         std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>(
-            logging::Severity::critical,
-            tags,
-            fmt,
-            std::forward<Args>(args)...,
-            location);
+            logging::Severity::critical, tags, fmt, std::forward<Args>(args)..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_critical(logging::Tags, std::format_string<Args...>, Args&&...)
     -> log_critical<logging::Tags, std::format_string<Args...>, Args...>;
 
@@ -433,43 +370,28 @@ struct log_debug<char const*, Args...>
 {
     // fmt is the *second* argument, because the implicit "this" pointer is the first.
     FORMAT_ATTRIB(2, 3)
-    log_debug(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_debug(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::debug,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::debug, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_debug(char const*, Args...) -> log_debug<char const*, Args...>;
 
 template<>
 struct log_debug<std::string const&>
 {
-    log_debug(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::debug, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_debug(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::debug, MIR_LOG_COMPONENT, msg, location); }
 };
 log_debug(std::string const&) -> log_debug<std::string const&>;
 
 template<>
 struct log_info<std::string const&>
 {
-    log_info(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::informational, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_info(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::informational, MIR_LOG_COMPONENT, msg, location); }
 };
 log_info(std::string const&) -> log_info<std::string const&>;
 
@@ -478,20 +400,13 @@ struct log_info<char const*, Args...>
 {
     // fmt is the *second* argument, because the implicit "this" pointer is the first.
     FORMAT_ATTRIB(2, 3)
-    log_info(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_info(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::informational,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::informational, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_info(char const*, Args...) -> log_info<char const*, Args...>;
 
 template<typename... Args>
@@ -499,31 +414,20 @@ struct log_warning<char const*, Args...>
 {
     // fmt is the *second* argument, because the implicit "this" pointer is the first.
     FORMAT_ATTRIB(2, 3)
-    log_warning(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_warning(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::warning,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::warning, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_warning(char const*, Args...) -> log_warning<char const*, Args...>;
 
 template<>
 struct log_warning<std::string const&>
 {
-    log_warning(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::warning, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_warning(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::warning, MIR_LOG_COMPONENT, msg, location); }
 };
 log_warning(std::string const&) -> log_warning<std::string const&>;
 
@@ -532,31 +436,20 @@ struct log_error<char const*, Args...>
 {
     // fmt is the *second* argument, because the implicit "this" pointer is the first.
     FORMAT_ATTRIB(2, 3)
-    log_error(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_error(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::error,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::error, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_error(char const*, Args...) -> log_error<char const*, Args...>;
 
 template<>
 struct log_error<std::string const&>
 {
-    log_error(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::error, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_error(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::error, MIR_LOG_COMPONENT, msg, location); }
 };
 log_error(std::string const&) -> log_error<std::string const&>;
 
@@ -565,31 +458,20 @@ struct log_critical<char const*, Args...>
 {
     // fmt is the *second* argument, because the implicit "this" pointer is the first.
     FORMAT_ATTRIB(2, 3)
-    log_critical(
-        char const* fmt,
-        Args... args,
-        std::source_location const& location = std::source_location::current())
+    log_critical(char const* fmt, Args... args, std::source_location const& location = std::source_location::current())
     {
         mir::log<logging::Severity, char const*, char const*, Args...>(
-            logging::Severity::critical,
-            MIR_LOG_COMPONENT,
-            fmt,
-            args...,
-            location);
+            logging::Severity::critical, MIR_LOG_COMPONENT, fmt, args..., location);
     }
 };
-template<typename ...Args>
+template<typename... Args>
 log_critical(char const*, Args...) -> log_critical<char const*, Args...>;
 
 template<>
 struct log_critical<std::string const&>
 {
-    log_critical(
-        std::string const& msg,
-        std::source_location const& location = std::source_location::current())
-    {
-        mir::log(logging::Severity::critical, MIR_LOG_COMPONENT, msg, location);
-    }
+    log_critical(std::string const& msg, std::source_location const& location = std::source_location::current())
+    { mir::log(logging::Severity::critical, MIR_LOG_COMPONENT, msg, location); }
 };
 log_critical(std::string const&) -> log_critical<std::string const&>;
 
@@ -599,7 +481,7 @@ log_critical(std::string const&) -> log_critical<std::string const&>;
 } // namespace mir
 
 #if defined(__clang__)
-#pragma GCC diagnostic pop
+  #pragma GCC diagnostic pop
 #endif
 
 #endif // MIR_LOG_H_

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -127,27 +127,6 @@ log(logging::Severity, char const*, char const*, Args...)
     -> log<logging::Severity, char const*, char const*, Args...>;
 
 template<>
-struct log<logging::Severity, char const*, std::string const&> final
-{
-    log(
-        logging::Severity sev,
-        char const* component,
-        std::string const& message,
-        std::source_location loc = std::source_location::current())
-    {
-        log<logging::Severity, std::string const&, std::string const&>(
-            sev,
-            component,
-            message,
-            loc);
-    }
-};
-log(logging::Severity, char const*, std::string const&)
-    -> log<logging::Severity, char const*, std::string const&>;
-log(logging::Severity, char const*, std::string const&, std::source_location)
-    -> log<logging::Severity, char const*, std::string const&>;
-
-template<>
 struct log<logging::Severity, char const*, std::exception_ptr const&, std::string const&> final
 {
     log(

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -30,14 +30,6 @@
 
 namespace mir
 {
-[[gnu::format(printf, 3, 0)]]
-void logv(
-    logging::Severity sev,
-    char const* component,
-    char const* fmt,
-    va_list va,
-    std::source_location loc = std::source_location::current());
-
 /*
  * The following is a bit weird because we want to have both a variadic
  * logging API (both the older printf-style and the new std::format-style),

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -171,10 +171,15 @@ struct log<logging::Severity, logging::Tags, std::format_string<Args...>, Args..
         logging::Severity severity,
         logging::Tags tags,
         std::format_string<Args...> fmt,
-        Args&&... args,
+        Args... args,
         std::source_location loc = std::source_location::current())
     {
-        log<logging::Severity, logging::Tags, std::string_view>(severity, tags, std::format(fmt, std::forward<Args>(args)...), loc);
+        log<logging::Severity, logging::Tags, std::string_view, std::format_args>(
+            severity,
+            tags,
+            fmt.get(),
+            std::make_format_args(args...),
+            loc);
     }
 };
 template<typename... Args>

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -22,6 +22,7 @@
 #include <mir/logging/logger.h> // for Severity
 
 #include <format>
+#include <source_location>
 #include <string>
 #include <cstdarg>
 #include <exception>
@@ -30,17 +31,174 @@
 namespace mir
 {
 [[gnu::format(printf, 3, 0)]]
-void logv(logging::Severity sev, char const* component, char const* fmt, va_list va);
-[[gnu::format(printf, 3, 4)]]
-void log(logging::Severity sev, char const* component, char const* fmt, ...);
-void log(logging::Severity sev, char const* component, std::string const& message);
-void log(logging::Severity sev, char const* component, std::exception_ptr const& exception, std::string const& message);
+void logv(
+    logging::Severity sev,
+    char const* component,
+    char const* fmt,
+    va_list va,
+    std::source_location loc = std::source_location::current());
 
-void log(logging::Severity severity, logging::Tags tags, std::string_view msg);
+/*
+ * The following is a bit weird because we want to have both a variadic
+ * logging API (both the older printf-style and the new std::format-style),
+ * but we also want to capture a std::source_location for each of the log sites
+ * and the idiomatic way to do *that* is with a default
+ * `std::source_location loc = std::source_location::current()` argument.
+ * (This use of ::current() is defined in the C++ spec as resolving to the call site).
+ *
+ * That combination plays badly: you can't have both variadics and default arguments,
+ * because how can the compiler tell what argument should be variadic and what should be
+ * defaulted?
+ *
+ * We *can* resolve this for the compiler by using a user-provided template deduction
+ * guide.
+ *
+ * Unfortunately, template deduction guides only apply to templated *types*, not
+ * templated *functions*.
+ *
+ * So: mir::log becomes a templated *type* with a family of partial- and
+ * complete-specialisations, and mir::log(...) becomes calls to the constructors
+ * of those types.
+ *
+ * Each of the old overloads of mir::log() becomes a (partial-)specialisation,
+ * with a deduction guide to direct the compiler to the correct specialisation.
+ *
+ * The non-variadic APIs get two deduction guides - one with an explicit
+ * std::source_location parameter and one without. That lets callers either omit
+ * the std::source_location if they *are* the site that should be recorded as the
+ * source of the log, or accept a std::source_location themselves and pass that on
+ * if they're proxying for a different call-site.
+ *
+ * The variadic APIs can only have the single deduction guide; if a caller wants
+ * to pass an explicit source_location they will need to manually select the
+ * correct specialisation. For example:
+ * ```
+ *    std::source_location loc;
+ *    mir::log<logging::Severity, char const*, char const*, Args...>::log(..., loc);
+ * ```
+ */
+template<typename ...Args>
+struct log;
+
+/* Legacy component/message pair */
+template<>
+struct log<logging::Severity, std::string const&, std::string const&> final
+{
+    log(
+        logging::Severity sev,
+        std::string const& component,
+        std::string const& message,
+        std::source_location location = std::source_location::current());
+};
+log(logging::Severity, std::string const&, std::string const&)
+    -> log<logging::Severity, std::string const&, std::string const&>;
+log(logging::Severity, std::string const&, std::string const&, std::source_location)
+    -> log<logging::Severity, std::string const&, std::string const&>;
+
+template<>
+struct log<logging::Severity, logging::Tags, std::string_view, std::format_args> final
+{
+    log(
+        logging::Severity sev,
+        logging::Tags tags,
+        std::string_view fmt,
+        std::format_args args,
+        std::source_location loc = std::source_location::current());
+};
+log(logging::Severity, logging::Tags, std::string_view, std::format_args)
+    -> log<logging::Severity, std::string_view, std::format_args>;
+log(logging::Severity, logging::Tags, std::string_view, std::format_args, std::source_location)
+    -> log<logging::Severity, std::string_view, std::format_args>;
+
+template<typename ...Args>
+struct log<logging::Severity, char const*, char const*, Args...> final
+{
+    log(
+        logging::Severity sev,
+        char const* component,
+        char const* fmt,
+        Args... args,
+        std::source_location loc = std::source_location::current())
+    {
+        char message[1024];
+
+        std::snprintf(message, sizeof(message), fmt, args...);
+        log<logging::Severity, std::string const&, std::string const&>(
+            sev,
+            component,
+            message,
+            loc);
+    }
+};
+template<typename ...Args>
+log(logging::Severity, char const*, char const*, Args...)
+    -> log<logging::Severity, char const*, char const*, Args...>;
+
+template<>
+struct log<logging::Severity, char const*, std::string const&> final
+{
+    log(
+        logging::Severity sev,
+        char const* component,
+        std::string const& message,
+        std::source_location loc = std::source_location::current())
+    {
+        log<logging::Severity, std::string const&, std::string const&>(
+            sev,
+            component,
+            message,
+            loc);
+    }
+};
+log(logging::Severity, char const*, std::string const&)
+    -> log<logging::Severity, char const*, std::string const&>;
+log(logging::Severity, char const*, std::string const&, std::source_location)
+    -> log<logging::Severity, char const*, std::string const&>;
+
+template<>
+struct log<logging::Severity, char const*, std::exception_ptr const&, std::string const&> final
+{
+    log(
+        logging::Severity sev,
+        char const* component,
+        std::exception_ptr const& exception,
+        std::string const& message,
+        std::source_location log = std::source_location::current());
+};
+log(logging::Severity, char const*, std::exception_ptr const&, std::string const&)
+    -> log<logging::Severity, char const*, std::exception_ptr const&, std::string const&>;
+log(logging::Severity, char const*, std::exception_ptr const&, std::string const&, std::source_location)
+    -> log<logging::Severity, char const*, std::exception_ptr const&, std::string const&>;
+
 
 template<typename... Args>
-void log(logging::Severity severity, logging::Tags tags, std::format_string<Args...> fmt, Args&&... args)
-{ logging::log(severity, tags, fmt.get(), std::make_format_args(std::forward<Args>(args)...)); }
+struct log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...> final
+{
+    log(
+        logging::Severity severity,
+        logging::Tags tags,
+        std::format_string<Args...> fmt,
+        Args&&... args,
+        std::source_location loc = std::source_location::current())
+    {
+        log<logging::Severity, logging::Tags, std::string_view>(severity, tags, std::format(fmt, std::forward<Args>(args)...), loc);
+    }
+};
+template<typename... Args>
+log(logging::Severity, logging::Tags, std::format_string<Args...>, Args&&...)
+    -> log<logging::Severity, logging::Tags, std::format_string<Args...>, Args...>;
+
+template<>
+struct log<logging::Severity, logging::Tags, std::string_view> final
+{
+    log(logging::Severity sev,
+        logging::Tags tags,
+        std::string_view message,
+        std::source_location loc = std::source_location::current());
+};
+log(logging::Severity, logging::Tags, std::string_view) -> log<logging::Severity, logging::Tags, std::string_view>;
+log(logging::Severity, logging::Tags, std::string_view, std::source_location)
+        -> log<logging::Severity, logging::Tags, std::string_view>;
 
 /// Log a security event according to the OWASP specification
 ///

--- a/include/core/mir/log.h
+++ b/include/core/mir/log.h
@@ -110,9 +110,9 @@ struct log<logging::Severity, logging::Tags, std::string_view, std::format_args>
         std::source_location loc = std::source_location::current());
 };
 log(logging::Severity, logging::Tags, std::string_view, std::format_args)
-    -> log<logging::Severity, std::string_view, std::format_args>;
+    -> log<logging::Severity, logging::Tags, std::string_view, std::format_args>;
 log(logging::Severity, logging::Tags, std::string_view, std::format_args, std::source_location)
-    -> log<logging::Severity, std::string_view, std::format_args>;
+    -> log<logging::Severity, logging::Tags, std::string_view, std::format_args>;
 
 template<typename ...Args>
 struct log<logging::Severity, char const*, char const*, Args...> final

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,6 +34,20 @@ add_library(mircore SHARED
     ${PROJECT_SOURCE_DIR}/include/core/mir/logging/event.h
 )
 
+# Our logging uses an extra, defaulted std::source_location argument
+# This (of course) doesn't appear in the format string, so the printf format machinery
+# warns that the function is being passed more arguments than the format string specifies.
+#
+# This warning needs to be suppressed for code *using* log.h,
+# so make it PUBLIC
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(
+    mircore
+    PUBLIC
+      -Wno-format-extra-args)
+endif()
+
+
 target_include_directories(mircore
   PUBLIC
     ${PROJECT_SOURCE_DIR}/include/core

--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -25,8 +25,12 @@
 
 namespace mir {
 
-void logv(logging::Severity sev, char const* component,
-          char const* fmt, va_list va)
+void logv(
+    logging::Severity sev,
+    char const* component,
+    char const* fmt,
+    va_list va,
+    std::source_location loc)
 {
     char message[1024];
     int max = sizeof(message) - 1;
@@ -36,30 +40,25 @@ void logv(logging::Severity sev, char const* component,
     message[len] = '\0';
 
     // Suboptimal: Constructing a std::string for message/component.
-    logging::log(sev, message, component);
+    logging::log(sev, message, component, loc);
 }
 
-void log(logging::Severity sev, char const* component,
-         char const* fmt, ...)
+log<logging::Severity, char const*, std::string const&>::log(
+    logging::Severity sev,
+    char const* component,
+    std::string const& message,
+    std::source_location loc)
 {
-    va_list va;
-    va_start(va, fmt);
-    logv(sev, component, fmt, va);
-    va_end(va);
-}
-
-void log(logging::Severity sev, char const* component,
-         std::string const& message)
-{
-    logging::log(sev, message, component);
+    logging::log(sev, message, component, loc);
 }
 
 
-void log(
+log<logging::Severity, char const*, std::exception_ptr const&, std::string const&>::log(
     logging::Severity severity,
     char const* component,
     std::exception_ptr const& ex,
-    std::string const& message)
+    std::string const& message,
+    std::source_location loc)
 {
     try
     {
@@ -69,29 +68,32 @@ void log(
     {
         // TODO: We can probably format this better by pulling out
         // the boost::errinfo's ourselves.
-        mir::log(
+        mir::log<logging::Severity, char const*, char const*, char const*, char const*>(
             severity,
             component,
             "%s: %s",
             message.c_str(),
-            boost::diagnostic_information(err).c_str());
+            boost::diagnostic_information(err).c_str(),
+            loc);
     }
     catch(...)
     {
-        mir::log(
+        mir::log<logging::Severity, char const*, char const*, char const*>(
             severity,
             component,
             "%s: unknown exception",
-            message.c_str());
+            message.c_str(),
+            loc);
     }
 }
 
-void log(
+log<logging::Severity, logging::Tags, std::string_view>::log(
     logging::Severity severity,
     logging::Tags tags,
-    std::string_view message)
+    std::string_view message,
+    std::source_location loc)
 {
-    logging::log(severity, tags, message);
+    logging::log(severity, tags, message, loc);
 }
 
 void security_log(

--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -17,7 +17,6 @@
 #include <mir/log.h>
 #include <mir/logging/logger.h>
 #include <chrono>
-#include <cstdio>
 #include <exception>
 #include <format>
 
@@ -25,24 +24,6 @@
 #include <source_location>
 
 namespace mir {
-
-void logv(
-    logging::Severity sev,
-    char const* component,
-    char const* fmt,
-    va_list va,
-    std::source_location loc)
-{
-    char message[1024];
-    int max = sizeof(message) - 1;
-    int len = std::vsnprintf(message, max, fmt, va);
-    if (len > max)
-        len = max;
-    message[len] = '\0';
-
-    // Suboptimal: Constructing a std::string for message/component.
-    logging::log(sev, message, component, loc);
-}
 
 log<logging::Severity, logging::Tags, std::string_view, std::format_args>::log(
     logging::Severity sev,

--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -22,6 +22,7 @@
 #include <format>
 
 #include <boost/exception/diagnostic_information.hpp>
+#include <source_location>
 
 namespace mir {
 
@@ -29,7 +30,8 @@ void logv(
     logging::Severity sev,
     char const* component,
     char const* fmt,
-    va_list va)
+    va_list va,
+    std::source_location loc)
 {
     char message[1024];
     int max = sizeof(message) - 1;
@@ -39,30 +41,34 @@ void logv(
     message[len] = '\0';
 
     // Suboptimal: Constructing a std::string for message/component.
-    logging::log(sev, message, component);
+    logging::log(sev, message, component, loc);
 }
 
-void log(logging::Severity sev, char const* component,
-         char const* fmt, ...)
+log<logging::Severity, logging::Tags, std::string_view, std::format_args>::log(
+    logging::Severity sev,
+    logging::Tags tags,
+    std::string_view fmt,
+    std::format_args args,
+    std::source_location loc)
 {
-    va_list va;
-    va_start(va, fmt);
-    logv(sev, component, fmt, va);
-    va_end(va);
+    logging::log(sev, tags, fmt, args, loc);
 }
 
-void log(logging::Severity sev, char const* component,
-         std::string const& message)
+log<logging::Severity, std::string const&, std::string const&>::log(
+    logging::Severity sev,
+    std::string const& component,
+    std::string const& message,
+    std::source_location loc)
 {
-    logging::log(sev, message, component);
+    logging::log(sev, component, message, loc);
 }
 
-
-void log(
+log<logging::Severity, char const*, std::exception_ptr const&, std::string const&>::log(
     logging::Severity severity,
     char const* component,
     std::exception_ptr const& ex,
-    std::string const& message)
+    std::string const& message,
+    std::source_location loc)
 {
     try
     {
@@ -72,29 +78,32 @@ void log(
     {
         // TODO: We can probably format this better by pulling out
         // the boost::errinfo's ourselves.
-        mir::log(
+        mir::log<logging::Severity, char const*, char const*, char const*, char const*>(
             severity,
             component,
             "%s: %s",
             message.c_str(),
-            boost::diagnostic_information(err).c_str());
+            boost::diagnostic_information(err).c_str(),
+            loc);
     }
     catch(...)
     {
-        mir::log(
+        mir::log<logging::Severity, char const*, char const*, char const*>(
             severity,
             component,
             "%s: unknown exception",
-            message.c_str());
+            message.c_str(),
+            loc);
     }
 }
 
-void log(
+log<logging::Severity, logging::Tags, std::string_view>::log(
     logging::Severity severity,
     logging::Tags tags,
-    std::string_view message)
+    std::string_view message,
+    std::source_location loc)
 {
-    logging::log(severity, tags, message, std::make_format_args());
+    logging::log(severity, tags, message, std::make_format_args(), loc);
 }
 
 void security_log(

--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -78,15 +78,6 @@ log<logging::Severity, char const*, std::exception_ptr const&, std::string const
     }
 }
 
-log<logging::Severity, logging::Tags, std::string_view>::log(
-    logging::Severity severity,
-    logging::Tags tags,
-    std::string_view message,
-    std::source_location loc)
-{
-    logging::log(severity, tags, message, std::make_format_args(), loc);
-}
-
 void security_log(
     logging::Severity severity,
     std::string const& event,

--- a/src/core/symbols.map
+++ b/src/core/symbols.map
@@ -3,18 +3,27 @@ MIR_CORE_2.29 {
     /* For some reason lld does not correctly identify these symbols if in an "extern C++" block. */
     /* Include the full, demangled symbols here instead to work around this */
 
-    /* mir::log(mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&); */
-    _ZN3mir3logENS_7logging8SeverityEPKcRKNSt15__exception_ptr13exception_ptrERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE;
-    /* mir::log(mir::logging::Severity, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&); */
-    _ZN3mir3logENS_7logging8SeverityEPKcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE;
-    /* mir::log(mir::logging::Severity, char const*, char const*, ...); */
-    _ZN3mir3logENS_7logging8SeverityEPKcS3_z;
-    /* mir::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const>, std::basic_string_view<char, std::char_traits<char> >); */
-    _ZN3mir3logENS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS0_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEE;
     /* mir::logging::log(mir::logging::Severity, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location) */
     _ZN3mir7logging3logENS0_8SeverityERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_St15source_location;
     /* mir::logging::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >, std::source_location) */
     _ZN3mir7logging3logENS0_8SeverityESt4spanIKSt17reference_wrapperIKNS0_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEESt15source_location;
+
+    /* The following symbols are constructors, for which the Itaniam ABI emits (up to) 3 different symbol names with the same demangled form
+     * (which makes for some *excellent* missing symbols errors of the form "couldn't find symbol foo::bar(), did you mean foo::bar()?")
+     * The eagle-eyed will notice the difference between these constructors is a "C1" vs "C2".
+     * Modern compilers only emit the C1 and C2 forms; C3 form is omitted from this list.
+     */
+    /* mir::log<mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> > >::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >, std::source_location) */
+    _ZN3mir3logIJNS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS1_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEEEEC1ES2_S9_SD_St15source_location;
+    _ZN3mir3logIJNS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS1_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEEEEC2ES2_S9_SD_St15source_location;
+
+    /* mir::log<mir::logging::Severity, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location) */
+    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC1ES2_S4_SC_St15source_location;
+    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC2ES2_S4_SC_St15source_location;
+
+    /* mir::log<mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location) */
+    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt15__exception_ptr13exception_ptrERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC1ES2_S4_S8_SG_St15source_location;
+    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt15__exception_ptr13exception_ptrERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC2ES2_S4_S8_SG_St15source_location;
 
   extern "C++" {
     "mir::logging::Logger::log(char const*, mir::logging::Severity, char const*, ...)";

--- a/src/core/symbols.map
+++ b/src/core/symbols.map
@@ -3,18 +3,35 @@ MIR_CORE_2.29 {
     /* For some reason lld does not correctly identify these symbols if in an "extern C++" block. */
     /* Include the full, demangled symbols here instead to work around this */
 
-    /* mir::log(mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&); */
-    _ZN3mir3logENS_7logging8SeverityEPKcRKNSt15__exception_ptr13exception_ptrERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE;
-    /* mir::log(mir::logging::Severity, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&); */
-    _ZN3mir3logENS_7logging8SeverityEPKcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE;
-    /* mir::log(mir::logging::Severity, char const*, char const*, ...); */
-    _ZN3mir3logENS_7logging8SeverityEPKcS3_z;
-    /* mir::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const>, std::basic_string_view<char, std::char_traits<char> >); */
-    _ZN3mir3logENS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS0_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEE;
     /* mir::logging::log(mir::logging::Severity, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location) */
     _ZN3mir7logging3logENS0_8SeverityERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_St15source_location;
     /* mir::logging::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >, std::basic_format_args<std::basic_format_context<std::__format::_Sink_iter<char>, char> >, std::source_location) */
     _ZN3mir7logging3logENS0_8SeverityESt4spanIKSt17reference_wrapperIKNS0_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEESt17basic_format_argsISt20basic_format_contextINSt8__format10_Sink_iterIcEEcEESt15source_location;
+
+    /* The following symbols are constructors, for which the Itaniam ABI emits (up to) 3 different symbol names with the same demangled form
+     * (which makes for some *excellent* missing symbols errors of the form "couldn't find symbol foo::bar(), did you mean foo::bar()?")
+     * The eagle-eyed will notice the difference between these constructors is a "C1" vs "C2".
+     * Modern compilers only emit the C1 and C2 forms; C3 form is omitted from this list.
+     */
+    /* mir::log<mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> > >::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >, std::source_location) */
+    _ZN3mir3logIJNS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS1_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEEEEC1ES2_S9_SD_St15source_location;
+    _ZN3mir3logIJNS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS1_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEEEEC2ES2_S9_SD_St15source_location;
+
+    /* mir::log<mir::logging::Severity, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location) */
+    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC1ES2_S4_SC_St15source_location;
+    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC2ES2_S4_SC_St15source_location;
+
+    /* mir::log<mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location) */
+    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt15__exception_ptr13exception_ptrERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC1ES2_S4_S8_SG_St15source_location;
+    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt15__exception_ptr13exception_ptrERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC2ES2_S4_S8_SG_St15source_location;
+
+    /* mir::log<mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >, std::basic_format_args<std::basic_format_context<std::__format::_Sink_iter<char>, char> > >::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >, std::basic_format_args<std::basic_format_context<std::__format::_Sink_iter<char>, char> >, std::source_location) */
+    _ZN3mir3logIJNS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS1_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEESt17basic_format_argsISt20basic_format_contextINSt8__format10_Sink_iterIcEEcEEEEC1ES2_S9_SD_SK_St15source_location;
+    _ZN3mir3logIJNS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS1_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEESt17basic_format_argsISt20basic_format_contextINSt8__format10_Sink_iterIcEEcEEEEC2ES2_S9_SD_SK_St15source_location;
+
+    /* mir::log<mir::logging::Severity, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location) */
+   _ZN3mir3logIJNS_7logging8SeverityERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESA_EEC1ES2_SA_SA_St15source_location;
+   _ZN3mir3logIJNS_7logging8SeverityERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESA_EEC2ES2_SA_SA_St15source_location;
 
   extern "C++" {
     "mir::logging::Logger::log(char const*, mir::logging::Severity, char const*, ...)";

--- a/src/core/symbols.map
+++ b/src/core/symbols.map
@@ -13,14 +13,6 @@ MIR_CORE_2.29 {
      * The eagle-eyed will notice the difference between these constructors is a "C1" vs "C2".
      * Modern compilers only emit the C1 and C2 forms; C3 form is omitted from this list.
      */
-    /* mir::log<mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> > >::log(mir::logging::Severity, std::span<std::reference_wrapper<mir::logging::Tag const> const, 18446744073709551615ul>, std::basic_string_view<char, std::char_traits<char> >, std::source_location) */
-    _ZN3mir3logIJNS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS1_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEEEEC1ES2_S9_SD_St15source_location;
-    _ZN3mir3logIJNS_7logging8SeverityESt4spanIKSt17reference_wrapperIKNS1_3TagEELm18446744073709551615EESt17basic_string_viewIcSt11char_traitsIcEEEEC2ES2_S9_SD_St15source_location;
-
-    /* mir::log<mir::logging::Severity, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location) */
-    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC1ES2_S4_SC_St15source_location;
-    _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC2ES2_S4_SC_St15source_location;
-
     /* mir::log<mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::log(mir::logging::Severity, char const*, std::__exception_ptr::exception_ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::source_location) */
     _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt15__exception_ptr13exception_ptrERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC1ES2_S4_S8_SG_St15source_location;
     _ZN3mir3logIJNS_7logging8SeverityEPKcRKNSt15__exception_ptr13exception_ptrERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEC2ES2_S4_S8_SG_St15source_location;

--- a/src/platforms/atomic-kms/server/kms/display.cpp
+++ b/src/platforms/atomic-kms/server/kms/display.cpp
@@ -116,7 +116,7 @@ void log_drm_details(mir::Fd const& drm_fd)
             for (auto i = 0; i < connector->count_modes; ++i)
             {
                 mir::log_info(
-                    "\t\tMode: %i×%i@%.2f",
+                    "\t\tMode: %hu×%hu@%.2f",
                     connector->modes[i].hdisplay,
                     connector->modes[i].vdisplay,
                     calculate_vrefresh_hz(connector->modes[i]));

--- a/src/platforms/gbm-kms/server/kms/display.cpp
+++ b/src/platforms/gbm-kms/server/kms/display.cpp
@@ -127,7 +127,7 @@ void log_drm_details(mir::Fd const& drm_fd)
             for (auto i = 0; i < connector->count_modes; ++i)
             {
                 mir::log_info(
-                    "\t\tMode: %i×%i@%.2f",
+                    "\t\tMode: %hu×%hu@%.2f",
                     connector->modes[i].hdisplay,
                     connector->modes[i].vdisplay,
                     calculate_vrefresh_hz(connector->modes[i]));

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -49,12 +49,6 @@ auto data_buffer_to_debug_string(
     return ss.str();
 }
 
-template<typename T, size_t length>
-constexpr size_t length_of(T(&)[length])
-{
-    return length;
-}
-
 auto xcb_error_to_string(int error) -> std::string
 {
     // see https://xcb.freedesktop.org/manual/group__XCB__Core__API.html#ga70a6bade94bd2824db552abcf5fbdbe3

--- a/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
@@ -388,7 +388,7 @@ void mf::XWaylandClipboardSource::create_source(xcb_timestamp_t timestamp, std::
         {
             msg += "\n    " + pair.first + ": " + connection.query_name(pair.second);
         }
-        log_info(msg);
+        log_info(std::string{msg});
     }
 
     auto const source = std::make_shared<ClipboardSource>(std::move(mime_types), this);

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -747,12 +747,12 @@ void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)
     {
         log_debug("XCB_CREATE_NOTIFY parent: %s", connection->window_debug_string(event->parent).c_str());
         log_debug("                  window: %s", connection->window_debug_string(event->window).c_str());
-        log_debug("                  position: %d, %d", event->x, event->y);
-        log_debug("                  size: %dx%d", event->width, event->height);
+        log_debug("                  position: %hd, %hd", event->x, event->y);
+        log_debug("                  size: %hux%hu", event->width, event->height);
         log_debug("                  override_redirect: %s", event->override_redirect ? "yes" : "no");
 
         if (event->border_width)
-            log_warning("border width unsupported (border width %d)", event->border_width);
+            log_warning("border width unsupported (border width %hu)", event->border_width);
     }
 
     if (!connection->is_ours(event->window))
@@ -771,8 +771,8 @@ void mf::XWaylandWM::handle_motion_notify(xcb_motion_notify_event_t *event)
         log_debug("XCB_MOTION_NOTIFY root: %s", connection->window_debug_string(event->root).c_str());
         log_debug("                  event: %s", connection->window_debug_string(event->event).c_str());
         log_debug("                  child: %s", connection->window_debug_string(event->child).c_str());
-        log_debug("                  root pos: %d, %d", event->root_x, event->root_y);
-        log_debug("                  event pos: %d, %d", event->event_x, event->event_y);
+        log_debug("                  root pos: %hd, %hd", event->root_x, event->root_y);
+        log_debug("                  event pos: %hd, %hd", event->event_x, event->event_y);
     }
 }
 
@@ -924,11 +924,11 @@ void mf::XWaylandWM::handle_configure_request(xcb_configure_request_event_t *eve
         log_debug("XCB_CONFIGURE_REQUEST parent: %s", connection->window_debug_string(event->parent).c_str());
         log_debug("                      window: %s", connection->window_debug_string(event->window).c_str());
         log_debug("                      sibling: %s", connection->window_debug_string(event->sibling).c_str());
-        log_debug("                      position: %d, %d", event->x, event->y);
-        log_debug("                      size: %dx%d", event->width, event->height);
+        log_debug("                      position: %hd, %hd", event->x, event->y);
+        log_debug("                      size: %hux%hu", event->width, event->height);
 
         if (event->border_width)
-            log_warning("border width unsupported (border width %d)", event->border_width);
+            log_warning("border width unsupported (border width %hu)", event->border_width);
     }
 
     if (auto const surface = get_wm_surface(event->window))
@@ -944,12 +944,12 @@ void mf::XWaylandWM::handle_configure_notify(xcb_configure_notify_event_t *event
         log_debug("XCB_CONFIGURE_NOTIFY event: %s", connection->window_debug_string(event->event).c_str());
         log_debug("                     window: %s", connection->window_debug_string(event->window).c_str());
         log_debug("                     above_sibling: %s", connection->window_debug_string(event->above_sibling).c_str());
-        log_debug("                     position: %d, %d", event->x, event->y);
-        log_debug("                     size: %dx%d", event->width, event->height);
+        log_debug("                     position: %hd, %hd", event->x, event->y);
+        log_debug("                     size: %hux%hu", event->width, event->height);
         log_debug("                     override_redirect: %s", event->override_redirect ? "yes" : "no");
 
         if (event->border_width)
-            log_warning("border width unsupported (border width %d)", event->border_width);
+            log_warning("border width unsupported (border width %hu)", event->border_width);
     }
 
     if (auto const surface = get_wm_surface(event->window))

--- a/tests/unit-tests/logging/test_logging.cpp
+++ b/tests/unit-tests/logging/test_logging.cpp
@@ -368,6 +368,24 @@ TEST_F(TestLog, log_info_captures_source_location)
 
     EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
     EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_info({tag}, "I take a {} string", "format");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_info("And the %s works, too", "printf API");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_info(std::string{"The string API works"});
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
 }
 
 TEST_F(TestLog, log_warning_captures_source_location)
@@ -388,6 +406,18 @@ TEST_F(TestLog, log_warning_captures_source_location)
                 }));
 
     mir::log_warning({tag}, "Hello");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_warning({tag}, "I take a {} string", "format");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_warning("And the %s works, too", "printf API");
     next_line = std::source_location::current();
 
     EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
@@ -416,6 +446,18 @@ TEST_F(TestLog, log_error_captures_source_location)
 
     EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
     EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_error({tag}, "I take a {} string", "format");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_error("And the %s works, too", "printf API");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
 }
 
 TEST_F(TestLog, log_critical_captures_source_location)
@@ -436,6 +478,18 @@ TEST_F(TestLog, log_critical_captures_source_location)
                 }));
 
     mir::log_critical({tag}, "Hello");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_critical({tag}, "I take a {} string", "format");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_critical("And the %s works, too", "printf API");
     next_line = std::source_location::current();
 
     EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));

--- a/tests/unit-tests/logging/test_logging.cpp
+++ b/tests/unit-tests/logging/test_logging.cpp
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <exception>
 #include <mir/logging/tag.h>
 #include <mir/options/program_option.h>
 #include <boost/program_options/detail/cmdline.hpp>
@@ -229,4 +230,200 @@ TEST_F(TestLog, can_set_severity_by_full_path_when_tag_name_is_the_same)
     ml::tag::set_severity(std::format("base/graphics/gbm-kms/bypass"), severity);
 
     EXPECT_TRUE(ml::logging_enabled_for(bypass_b, severity));
+}
+
+TEST_F(TestLog, logging_captures_source_location)
+{
+    auto const& tag = ml::base();
+
+    // Ensure that all log messages are propagated
+    ml::tag::set_severity(ml::tag::name(tag), ml::Severity::debug);
+
+    std::source_location logged_loc, next_line;
+
+    ON_CALL(*logger, log(_))
+        .WillByDefault(
+            Invoke(
+                [&logged_loc](ml::Event const& ev)
+                {
+                    logged_loc = ev.location();
+                }));
+
+    mir::log(ml::Severity::informational, {tag}, "Hello");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log(ml::Severity::informational, {tag}, "I take a {} string", "format");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log(ml::Severity::debug, MIR_LOG_COMPONENT, "And the %s works, too", "printf API");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    try
+    {
+        throw std::runtime_error{"Just to test"};
+    }
+    catch (std::exception const&)
+    {
+        auto prev_line = std::source_location::current();
+        mir::log(
+            ml::Severity::debug,
+            MIR_LOG_COMPONENT,
+            std::current_exception(),
+            "The exception_ptr API works");
+
+        EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+        EXPECT_THAT(logged_loc.line(), Eq(prev_line.line() + 1));
+    }
+
+    try
+    {
+        throw "Don't do this, but we need to check the non-std::exception path";
+    }
+    catch (...)
+    {
+        auto prev_line = std::source_location::current();
+        mir::log(
+            ml::Severity::debug,
+            MIR_LOG_COMPONENT,
+            std::current_exception(),
+            "The exception_ptr API works");
+
+        EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+        EXPECT_THAT(logged_loc.line(), Eq(prev_line.line() + 1));
+    }
+
+    mir::log(ml::Severity::debug, MIR_LOG_COMPONENT, std::string{"The string API works"});
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+}
+
+TEST_F(TestLog, log_debug_captures_source_location)
+{
+    auto const& tag = ml::base();
+
+    // Ensure that all log messages are propagated
+    ml::tag::set_severity(ml::tag::name(tag), ml::Severity::debug);
+
+    std::source_location logged_loc, next_line;
+
+    ON_CALL(*logger, log(_))
+        .WillByDefault(
+            Invoke(
+                [&logged_loc](ml::Event const& ev)
+                {
+                    logged_loc = ev.location();
+                }));
+
+    mir::log_debug({tag}, "Hello");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+}
+
+TEST_F(TestLog, log_info_captures_source_location)
+{
+    auto const& tag = ml::base();
+
+    // Ensure that all log messages are propagated
+    ml::tag::set_severity(ml::tag::name(tag), ml::Severity::debug);
+
+    std::source_location logged_loc, next_line;
+
+    ON_CALL(*logger, log(_))
+        .WillByDefault(
+            Invoke(
+                [&logged_loc](ml::Event const& ev)
+                {
+                    logged_loc = ev.location();
+                }));
+
+    mir::log_info({tag}, "Hello");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+}
+
+TEST_F(TestLog, log_warning_captures_source_location)
+{
+    auto const& tag = ml::base();
+
+    // Ensure that all log messages are propagated
+    ml::tag::set_severity(ml::tag::name(tag), ml::Severity::debug);
+
+    std::source_location logged_loc, next_line;
+
+    ON_CALL(*logger, log(_))
+        .WillByDefault(
+            Invoke(
+                [&logged_loc](ml::Event const& ev)
+                {
+                    logged_loc = ev.location();
+                }));
+
+    mir::log_warning({tag}, "Hello");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+}
+
+TEST_F(TestLog, log_error_captures_source_location)
+{
+    auto const& tag = ml::base();
+
+    // Ensure that all log messages are propagated
+    ml::tag::set_severity(ml::tag::name(tag), ml::Severity::debug);
+
+    std::source_location logged_loc, next_line;
+
+    ON_CALL(*logger, log(_))
+        .WillByDefault(
+            Invoke(
+                [&logged_loc](ml::Event const& ev)
+                {
+                    logged_loc = ev.location();
+                }));
+
+    mir::log_error({tag}, "Hello");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+}
+
+TEST_F(TestLog, log_critical_captures_source_location)
+{
+    auto const& tag = ml::base();
+
+    // Ensure that all log messages are propagated
+    ml::tag::set_severity(ml::tag::name(tag), ml::Severity::debug);
+
+    std::source_location logged_loc, next_line;
+
+    ON_CALL(*logger, log(_))
+        .WillByDefault(
+            Invoke(
+                [&logged_loc](ml::Event const& ev)
+                {
+                    logged_loc = ev.location();
+                }));
+
+    mir::log_critical({tag}, "Hello");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
 }

--- a/tests/unit-tests/logging/test_logging.cpp
+++ b/tests/unit-tests/logging/test_logging.cpp
@@ -20,6 +20,8 @@
 #include <boost/program_options/detail/cmdline.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <mir/logging/logger.h>
+
+#define MIR_LOG_COMPONENT "tests"
 #include <mir/log.h>
 
 #include <boost/program_options.hpp>
@@ -326,6 +328,18 @@ TEST_F(TestLog, log_debug_captures_source_location)
                 }));
 
     mir::log_debug({tag}, "Hello");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_debug({tag}, "I take a {} string", "format");
+    next_line = std::source_location::current();
+
+    EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
+    EXPECT_THAT(logged_loc.line(), Eq(next_line.line() - 1));
+
+    mir::log_debug("And the %s works, too", "printf API");
     next_line = std::source_location::current();
 
     EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));

--- a/tests/unit-tests/logging/test_logging.cpp
+++ b/tests/unit-tests/logging/test_logging.cpp
@@ -276,14 +276,13 @@ TEST_F(TestLog, logging_captures_source_location)
     catch (std::exception const&)
     {
         auto prev_line = std::source_location::current();
-        mir::log(
-            ml::Severity::debug,
-            MIR_LOG_COMPONENT,
-            std::current_exception(),
-            "The exception_ptr API works");
+        /* This log line needs to be on a single line, as clang and gcc disagree as to which line of a multi-line
+         * function call should be reported by source_location::current();
+         */
+        mir::log(ml::Severity::debug, MIR_LOG_COMPONENT, std::current_exception(), "The exception_ptr API works");
 
         EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
-        EXPECT_THAT(logged_loc.line(), Eq(prev_line.line() + 1));
+        EXPECT_THAT(logged_loc.line(), Eq(prev_line.line() + 4));
     }
 
     try
@@ -293,14 +292,13 @@ TEST_F(TestLog, logging_captures_source_location)
     catch (...)
     {
         auto prev_line = std::source_location::current();
-        mir::log(
-            ml::Severity::debug,
-            MIR_LOG_COMPONENT,
-            std::current_exception(),
-            "The exception_ptr API works");
+        /* This log line needs to be on a single line, as clang and gcc disagree as to which line of a multi-line
+         * function call should be reported by source_location::current();
+         */
+        mir::log(ml::Severity::debug, MIR_LOG_COMPONENT, std::current_exception(), "The exception_ptr API works");
 
         EXPECT_THAT(logged_loc.file_name(), StrEq(next_line.file_name()));
-        EXPECT_THAT(logged_loc.line(), Eq(prev_line.line() + 1));
+        EXPECT_THAT(logged_loc.line(), Eq(prev_line.line() + 4));
     }
 
     mir::log(ml::Severity::debug, MIR_LOG_COMPONENT, std::string{"The string API works"});


### PR DESCRIPTION
This means that all calls to `mir::log`, `mir::log_debug`, `mir::log_info`, etc will result in an `Event` with the correct `std::source_location` being passed to `Logger::log()`.