### PR TITLE
modernize fatal_error()

### DIFF
--- a/debian/libmircore3.symbols
+++ b/debian/libmircore3.symbols
@@ -8,6 +8,7 @@ libmircore.so.3 libmircore3 #MINVER#
  (c++)"mir::Fd::operator=(mir::Fd)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::fatal_error(char const*, ...)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::fatal_error(std::source_location, std::basic_string_view<char, std::char_traits<char> >)@MIR_CORE_2.29" 2.29.0
+ (c++)"mir::fatal_error(std::basic_string_view<char, std::char_traits<char> >, std::basic_format_args<std::basic_format_context<std::__format::_Sink_iter<char>, char> >, std::source_location)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::geometry::Rectangles::Rectangles()@MIR_CORE_2.29" 2.29.0
  (c++)"mir::geometry::Rectangles::Rectangles(std::initializer_list<mir::geometry::generic::Rectangle<int> > const&)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::geometry::Rectangles::add(mir::geometry::generic::Rectangle<int> const&)@MIR_CORE_2.29" 2.29.0

--- a/debian/libmircore3.symbols
+++ b/debian/libmircore3.symbols
@@ -7,6 +7,7 @@ libmircore.so.3 libmircore3 #MINVER#
  (c++)"mir::Fd::operator int() const@MIR_CORE_2.29" 2.29.0
  (c++)"mir::Fd::operator=(mir::Fd)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::fatal_error(char const*, ...)@MIR_CORE_2.29" 2.29.0
+ (c++)"mir::fatal_error(std::source_location, std::basic_string_view<char, std::char_traits<char> >)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::geometry::Rectangles::Rectangles()@MIR_CORE_2.29" 2.29.0
  (c++)"mir::geometry::Rectangles::Rectangles(std::initializer_list<mir::geometry::generic::Rectangle<int> > const&)@MIR_CORE_2.29" 2.29.0
  (c++)"mir::geometry::Rectangles::add(mir::geometry::generic::Rectangle<int> const&)@MIR_CORE_2.29" 2.29.0

--- a/examples/example-server-lib/wayland_shm.cpp
+++ b/examples/example-server-lib/wayland_shm.cpp
@@ -137,7 +137,7 @@ auto WaylandShmBuffer::use() -> wl_buffer*
 {
     if (self_ptr)
     {
-        mir::fatal_error("WaylandShmBuffer used multiple times");
+        MIR_FATAL_ERROR("WaylandShmBuffer used multiple times");
     }
     self_ptr = shared_from_this();
     return buffer;

--- a/include/common/mir/events/event_type_formatter.h
+++ b/include/common/mir/events/event_type_formatter.h
@@ -14,16 +14,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_EVENT_TYPE_TO_STRING_H_
-#define MIR_EVENT_TYPE_TO_STRING_H_
+#ifndef MIR_EVENT_TYPE_FORMATTER_H_
+#define MIR_EVENT_TYPE_FORMATTER_H_
 
-#include <string>
-#include <mir_toolkit/client_types.h>
+#include <mir_toolkit/events/enums.h>
 
-namespace mir
+#include <format>
+
+template<>
+struct std::formatter<MirEventType>
 {
-std::string event_type_to_string(MirEventType t);
-char const* event_type_to_c_str(MirEventType t);
-}
+    constexpr auto parse(std::format_parse_context& ctx) { return ctx.begin(); }
 
-#endif // MIR_EVENT_TYPE_TO_STRING_H_
+    auto format(MirEventType type, std::format_context& ctx) const -> std::format_context::iterator;
+};
+
+#endif // MIR_EVENT_TYPE_FORMATTER_H_

--- a/include/common/mir/events/input_event.h
+++ b/include/common/mir/events/input_event.h
@@ -19,6 +19,8 @@
 
 #include <mir/events/event.h>
 
+#include <format>
+
 struct MirInputEvent : MirEvent
 {
     MirInputEventType input_type() const;
@@ -61,6 +63,14 @@ private:
     MirInputDeviceId device_id_ = 0;
     std::chrono::nanoseconds event_time_ = {};
     MirInputEventModifiers modifiers_ = 0;
+};
+
+template<>
+struct std::formatter<MirInputEventType>
+{
+    constexpr auto parse(std::format_parse_context& ctx) { return ctx.begin(); }
+
+    auto format(MirInputEventType type, std::format_context& ctx) const -> std::format_context::iterator;
 };
 
 #endif /* MIR_COMMON_INPUT_EVENT_H_ */

--- a/include/core/mir/fatal.h
+++ b/include/core/mir/fatal.h
@@ -47,9 +47,22 @@ void fatal_error(char const* reason, ...) __attribute__((format(printf, 1, 2)));
 [[noreturn]]
 void fatal_error(std::source_location const loc, std::string_view message);
 
+/**
+ * fatal_error() is strictly for "this should never happen" situations that you
+ * cannot recover from. Kills the program and dump core as cleanly as possible.
+ *   \param [in] fmt  A std::format-style format string.
+ *   \param [in] args  Type-erased format arguments.
+ *   \param [in] loc  The source location where the fatal error occurred.
+ */
+[[noreturn]]
+void fatal_error(std::string_view fmt, std::format_args args, std::source_location const loc);
+
 template<typename... Args>
-[[noreturn]] inline void fatal_error(std::source_location const loc, std::format_string<Args...> reason, Args&&... args)
-{ fatal_error(loc, std::format(reason, std::forward<Args>(args)...)); }
+[[noreturn]] inline void fatal_error(
+    std::source_location const loc,
+    std::format_string<Args...> reason,
+    Args const&... args)
+{ fatal_error(reason.get(), std::make_format_args(args...), loc); }
 } // namespace mir
 
 #define MIR_FATAL_ERROR(...) ::mir::fatal_error(::std::source_location::current(), __VA_ARGS__)

--- a/include/core/mir/fatal.h
+++ b/include/core/mir/fatal.h
@@ -36,7 +36,7 @@ namespace mir
  *   \param [in] reason  A printf-style format string.
  */
 [[noreturn, deprecated("Use MIR_FATAL_ERROR() instead")]]
-void fatal_error(char const* reason, ...) __attribute__((format(printf, 1, 2)));
+void fatal_error(char const* reason, ...) noexcept __attribute__((format(printf, 1, 2)));
 
 /**
  * fatal_error() is strictly for "this should never happen" situations that you
@@ -45,7 +45,7 @@ void fatal_error(char const* reason, ...) __attribute__((format(printf, 1, 2)));
  *   \param [in] message  A message describing the fatal error.
  */
 [[noreturn]]
-void fatal_error(std::source_location const loc, std::string_view message);
+void fatal_error(std::source_location const loc, std::string_view message) noexcept;
 
 /**
  * fatal_error() is strictly for "this should never happen" situations that you
@@ -55,13 +55,13 @@ void fatal_error(std::source_location const loc, std::string_view message);
  *   \param [in] loc  The source location where the fatal error occurred.
  */
 [[noreturn]]
-void fatal_error(std::string_view fmt, std::format_args args, std::source_location const loc);
+void fatal_error(std::string_view fmt, std::format_args args, std::source_location const loc) noexcept;
 
 template<typename... Args>
 [[noreturn]] inline void fatal_error(
     std::source_location const loc,
     std::format_string<Args...> reason,
-    Args const&... args)
+    Args const&... args) noexcept
 { fatal_error(reason.get(), std::make_format_args(args...), loc); }
 } // namespace mir
 

--- a/include/core/mir/fatal.h
+++ b/include/core/mir/fatal.h
@@ -32,7 +32,7 @@ namespace mir
 {
 /**
  * fatal_error() is strictly for "this should never happen" situations that you
- * cannot recover from. Kills the program and dump core as cleanly as possible.
+ * cannot recover from. Kills the program and dumps core as cleanly as possible.
  *   \param [in] reason  A printf-style format string.
  */
 [[noreturn, deprecated("Use MIR_FATAL_ERROR() instead")]]
@@ -40,7 +40,7 @@ void fatal_error(char const* reason, ...) noexcept __attribute__((format(printf,
 
 /**
  * fatal_error() is strictly for "this should never happen" situations that you
- * cannot recover from. Kills the program and dump core as cleanly as possible.
+ * cannot recover from. Kills the program and dumps core as cleanly as possible.
  *   \param [in] loc  The source location where the fatal error occurred.
  *   \param [in] message  A message describing the fatal error.
  */
@@ -49,7 +49,7 @@ void fatal_error(std::source_location const loc, std::string_view message) noexc
 
 /**
  * fatal_error() is strictly for "this should never happen" situations that you
- * cannot recover from. Kills the program and dump core as cleanly as possible.
+ * cannot recover from. Kills the program and dumps core as cleanly as possible.
  *   \param [in] fmt  A std::format-style format string.
  *   \param [in] args  Type-erased format arguments.
  *   \param [in] loc  The source location where the fatal error occurred.

--- a/include/core/mir/fatal.h
+++ b/include/core/mir/fatal.h
@@ -35,7 +35,7 @@ namespace mir
  * cannot recover from. Kills the program and dump core as cleanly as possible.
  *   \param [in] reason  A printf-style format string.
  */
-[[noreturn]]
+[[noreturn, deprecated("Use MIR_FATAL_ERROR() instead")]]
 void fatal_error(char const* reason, ...) __attribute__((format(printf, 1, 2)));
 
 /**

--- a/include/core/mir/fatal.h
+++ b/include/core/mir/fatal.h
@@ -23,6 +23,11 @@
 #ifndef MIR_FATAL_H_
 #define MIR_FATAL_H_
 
+#include <format>
+#include <source_location>
+#include <string_view>
+#include <utility>
+
 namespace mir
 {
 /**
@@ -32,6 +37,21 @@ namespace mir
  */
 [[noreturn]]
 void fatal_error(char const* reason, ...) __attribute__((format(printf, 1, 2)));
+
+/**
+ * fatal_error() is strictly for "this should never happen" situations that you
+ * cannot recover from. Kills the program and dump core as cleanly as possible.
+ *   \param [in] loc  The source location where the fatal error occurred.
+ *   \param [in] message  A message describing the fatal error.
+ */
+[[noreturn]]
+void fatal_error(std::source_location const loc, std::string_view message);
+
+template<typename... Args>
+[[noreturn]] inline void fatal_error(std::source_location const loc, std::format_string<Args...> reason, Args&&... args)
+{ fatal_error(loc, std::format(reason, std::forward<Args>(args)...)); }
 } // namespace mir
+
+#define MIR_FATAL_ERROR(...) ::mir::fatal_error(::std::source_location::current(), __VA_ARGS__)
 
 #endif // MIR_FATAL_H_

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -20,7 +20,7 @@
 
 #include "events/event_private.h"
 
-#include <mir/events/event_type_to_string.h>
+#include <mir/events/event_type_formatter.h>
 #include <mir/fatal.h>
 
 #include <mir_toolkit/events/event.h>
@@ -41,8 +41,7 @@ void expect_event_type(EventType const* ev, MirEventType t) MIR_HANDLE_EVENT_EXC
     auto type = ev->type();
     if (type != t)
     {
-        MIR_FATAL_ERROR("Expected {} but event is of type {}",
-            mir::event_type_to_c_str(t), mir::event_type_to_c_str(type));
+        MIR_FATAL_ERROR("Expected {} but event is of type {}", t, type);
     }
 })
 
@@ -55,36 +54,35 @@ void expect_index_in_range(size_t size, size_t index)
 }
 }
 
-char const* mir::event_type_to_c_str(MirEventType t)
+auto std::formatter<MirEventType>::format(MirEventType type, std::format_context& ctx) const -> std::format_context::iterator
 {
-    switch (t)
+    auto to_c_str = [](MirEventType t)
     {
-    case mir_event_type_window:
-        return "mir_event_type_window";
-    case mir_event_type_resize:
-        return "mir_event_type_resize";
-    case mir_event_type_orientation:
-        return "mir_event_type_orientation";
-    case mir_event_type_close_window:
-        return "mir_event_type_close_window";
-    case mir_event_type_input:
-        return "mir_event_type_input";
-    case mir_event_type_input_device_state:
-        return "mir_event_type_input_device_state";
-    case mir_event_type_window_output:
-        return "mir_event_type_window_output";
-    case mir_event_type_window_placement:
-        return "mir_event_type_window_placement";
-    }
+        switch (t)
+        {
+        case mir_event_type_window:
+            return "mir_event_type_window";
+        case mir_event_type_resize:
+            return "mir_event_type_resize";
+        case mir_event_type_orientation:
+            return "mir_event_type_orientation";
+        case mir_event_type_close_window:
+            return "mir_event_type_close_window";
+        case mir_event_type_input:
+            return "mir_event_type_input";
+        case mir_event_type_input_device_state:
+            return "mir_event_type_input_device_state";
+        case mir_event_type_window_output:
+            return "mir_event_type_window_output";
+        case mir_event_type_window_placement:
+            return "mir_event_type_window_placement";
+        }
 
-    std::unreachable();
+        std::unreachable();
+    };
+
+    return std::format_to(ctx.out(), "{}", to_c_str(type));
 }
-
-std::string mir::event_type_to_string(MirEventType t)
-{
-    return event_type_to_c_str(t);
-}
-
 
 MirEventType mir_event_get_type(MirEvent const* ev) MIR_HANDLE_EVENT_EXCEPTION(
 {
@@ -96,7 +94,7 @@ MirInputEvent const* mir_event_get_input_event(MirEvent const* ev) MIR_HANDLE_EV
     auto const type = ev->type();
     if (type != mir_event_type_input)
     {
-        MIR_FATAL_ERROR("Expected input event but event is of type {}", mir::event_type_to_c_str(type));
+        MIR_FATAL_ERROR("Expected input event but event is of type {}", type);
     }
 
     return ev->to_input();

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -41,7 +41,7 @@ void expect_event_type(EventType const* ev, MirEventType t) MIR_HANDLE_EVENT_EXC
     auto type = ev->type();
     if (type != t)
     {
-        mir::fatal_error("Expected %s but event is of type %s",
+        MIR_FATAL_ERROR("Expected {} but event is of type {}",
             mir::event_type_to_c_str(t), mir::event_type_to_c_str(type));
     }
 })
@@ -50,7 +50,7 @@ void expect_index_in_range(size_t size, size_t index)
 {
     if (index >= size)
     {
-        mir::fatal_error("Index out of range in event data access");
+        MIR_FATAL_ERROR("Index out of range in event data access");
     }
 }
 }
@@ -96,7 +96,7 @@ MirInputEvent const* mir_event_get_input_event(MirEvent const* ev) MIR_HANDLE_EV
     auto const type = ev->type();
     if (type != mir_event_type_input)
     {
-        mir::fatal_error("Expected input event but event is of type %s", mir::event_type_to_c_str(type));
+        MIR_FATAL_ERROR("Expected input event but event is of type {}", mir::event_type_to_c_str(type));
     }
 
     return ev->to_input();

--- a/src/common/input/input_event.cpp
+++ b/src/common/input/input_event.cpp
@@ -299,9 +299,9 @@ float mir_pointer_event_axis_value(MirPointerEvent const* pev, MirPointerAxis ax
        return pev->v_scroll().value120.as_value();
    case mir_pointer_axis_hscroll_value120:
        return pev->h_scroll().value120.as_value();
-    default:
-        MIR_FATAL_ERROR("Invalid axis enumeration {}", static_cast<int>(axis));
-    }
+   default:
+       MIR_FATAL_ERROR("Invalid axis enumeration {}", static_cast<int>(axis));
+   }
 })
 
 bool mir_pointer_event_axis_stop(MirPointerEvent const* pev, MirPointerAxis axis) MIR_HANDLE_EVENT_EXCEPTION(

--- a/src/common/input/input_event.cpp
+++ b/src/common/input/input_event.cpp
@@ -53,7 +53,7 @@ char const* input_event_type_to_c_str(MirInputEventType input_event_type)
     case mir_input_event_type_keyboard_resync:
         return "mir_input_event_type_keyboard_resync";
     case mir_input_event_types:
-        mir::fatal_error("Sentinel value 'mir_input_event_types' not supported");
+        MIR_FATAL_ERROR("Sentinel value 'mir_input_event_types' not supported");
     }
 }
 
@@ -66,7 +66,7 @@ void expect_event_type(EventType const* ev, MirEventType expect)
 {
     if (auto const actual = ev->type(); actual != expect)
     {
-        mir::fatal_error("Expected %s but event is of type %s",
+        MIR_FATAL_ERROR("Expected {} but event is of type {}",
             mir::event_type_to_c_str(expect), mir::event_type_to_c_str(actual));
     }
 }
@@ -123,7 +123,7 @@ MirKeyboardEvent const* mir_input_event_get_keyboard_event(MirInputEvent const* 
 {
     if (ev->input_type() != mir_input_event_type_key)
     {
-        mir::fatal_error("expected key input event but event was of type %s",
+        MIR_FATAL_ERROR("expected key input event but event was of type {}",
             input_event_type_to_c_str(ev->input_type()));
     }
 
@@ -166,7 +166,7 @@ MirTouchEvent const* mir_input_event_get_touch_event(MirInputEvent const* ev) MI
 {
     if(ev->input_type() != mir_input_event_type_touch)
     {
-        mir::fatal_error("expected touch input event but event was of type %s",
+        MIR_FATAL_ERROR("expected touch input event but event was of type {}",
             input_event_type_to_c_str(ev->input_type()));
     }
 
@@ -182,7 +182,7 @@ MirTouchId mir_touch_event_id(MirTouchEvent const* event, size_t touch_index) MI
 {
     if (touch_index >= event->pointer_count())
     {
-        mir::fatal_error("touch index is greater than pointer count");
+        MIR_FATAL_ERROR("touch index is greater than pointer count");
     }
     return event->id(touch_index);
 
@@ -192,7 +192,7 @@ MirTouchAction mir_touch_event_action(MirTouchEvent const* event, size_t touch_i
 {
     if(touch_index > event->pointer_count())
     {
-        mir::fatal_error("touch index is greater than pointer count");
+        MIR_FATAL_ERROR("touch index is greater than pointer count");
     }
 
     return static_cast<MirTouchAction>(event->action(touch_index));
@@ -203,7 +203,7 @@ MirTouchTooltype mir_touch_event_tooltype(MirTouchEvent const* event,
 {
     if(touch_index > event->pointer_count())
     {
-        mir::fatal_error("touch index is greater than pointer count");
+        MIR_FATAL_ERROR("touch index is greater than pointer count");
     }
 
     return event->tool_type(touch_index);
@@ -214,7 +214,7 @@ float mir_touch_event_axis_value(MirTouchEvent const* event,
 {
     if(touch_index > event->pointer_count())
     {
-        mir::fatal_error("touch index is greater than pointer count");
+        MIR_FATAL_ERROR("touch index is greater than pointer count");
     }
 
     switch (axis)
@@ -244,7 +244,7 @@ MirPointerEvent const* mir_input_event_get_pointer_event(MirInputEvent const* ev
 {
     if(ev->input_type() != mir_input_event_type_pointer)
     {
-        mir::fatal_error("expected pointer input event but event was of type %s",
+        MIR_FATAL_ERROR("expected pointer input event but event was of type {}",
             input_event_type_to_c_str(ev->input_type()));
     }
 
@@ -307,9 +307,9 @@ float mir_pointer_event_axis_value(MirPointerEvent const* pev, MirPointerAxis ax
        return pev->v_scroll().value120.as_value();
    case mir_pointer_axis_hscroll_value120:
        return pev->h_scroll().value120.as_value();
-   default:
-       mir::fatal_error("Invalid axis enumeration %d", axis);
-   }
+    default:
+        MIR_FATAL_ERROR("Invalid axis enumeration {}", static_cast<int>(axis));
+    }
 })
 
 bool mir_pointer_event_axis_stop(MirPointerEvent const* pev, MirPointerAxis axis) MIR_HANDLE_EVENT_EXCEPTION(
@@ -330,6 +330,6 @@ bool mir_pointer_event_axis_stop(MirPointerEvent const* pev, MirPointerAxis axis
    case mir_pointer_axis_hscroll_value120:
        return false;
    default:
-       mir::fatal_error("Invalid axis enumeration %d", axis);
+       MIR_FATAL_ERROR("Invalid axis enumeration {}", static_cast<int>(axis));
    }
 })

--- a/src/common/input/input_event.cpp
+++ b/src/common/input/input_event.cpp
@@ -18,56 +18,51 @@
 
 #include "../events/event_private.h"
 
-#include <mir/events/event_type_to_string.h>
+#include <mir/events/event_type_formatter.h>
 #include <mir/fatal.h>
 #include <mir/log.h>
 #include <mir_toolkit/events/input/pointer_event.h>
 
 #include "../handle_event_exception.h"
 
+#include <format>
 
 
 namespace ml = mir::logging;
 namespace geom = mir::geometry;
 
+auto std::formatter<MirInputEventType>::format(MirInputEventType type, std::format_context& ctx) const -> std::format_context::iterator
+{
+    auto to_c_str = [](MirInputEventType input_event_type)
+    {
+        switch (input_event_type)
+        {
+        case mir_input_event_type_key:
+            return "mir_input_event_type_key";
+        case mir_input_event_type_touch:
+            return "mir_input_event_type_touch";
+        case mir_input_event_type_pointer:
+            return "mir_input_event_type_pointer";
+        case mir_input_event_type_keyboard_resync:
+            return "mir_input_event_type_keyboard_resync";
+        case mir_input_event_types:
+            MIR_FATAL_ERROR("Sentinel value 'mir_input_event_types' not supported");
+        }
+        std::unreachable();
+    };
+
+    return std::format_to(ctx.out(), "{}", to_c_str(type));
+}
 
 namespace
 {
-// GCC and Clang both ensure the switch is exhaustive.
-// GCC, however, gets a "control reaches end of non-void function" warning without this
-#ifndef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wreturn-type"
-#endif
-
-char const* input_event_type_to_c_str(MirInputEventType input_event_type)
-{
-    switch (input_event_type)
-    {
-    case mir_input_event_type_key:
-        return "mir_input_event_type_key";
-    case mir_input_event_type_touch:
-        return "mir_input_event_type_touch";
-    case mir_input_event_type_pointer:
-        return "mir_input_event_type_pointer";
-    case mir_input_event_type_keyboard_resync:
-        return "mir_input_event_type_keyboard_resync";
-    case mir_input_event_types:
-        MIR_FATAL_ERROR("Sentinel value 'mir_input_event_types' not supported");
-    }
-}
-
-#ifndef __clang__
-#pragma GCC diagnostic pop
-#endif
 
 template <typename EventType>
 void expect_event_type(EventType const* ev, MirEventType expect)
 {
     if (auto const actual = ev->type(); actual != expect)
     {
-        MIR_FATAL_ERROR("Expected {} but event is of type {}",
-            mir::event_type_to_c_str(expect), mir::event_type_to_c_str(actual));
+        MIR_FATAL_ERROR("Expected {} but event is of type {}", expect, actual);
     }
 }
 }
@@ -123,8 +118,7 @@ MirKeyboardEvent const* mir_input_event_get_keyboard_event(MirInputEvent const* 
 {
     if (ev->input_type() != mir_input_event_type_key)
     {
-        MIR_FATAL_ERROR("expected key input event but event was of type {}",
-            input_event_type_to_c_str(ev->input_type()));
+        MIR_FATAL_ERROR("expected key input event but event was of type {}", ev->input_type());
     }
 
     return reinterpret_cast<MirKeyboardEvent const*>(ev);
@@ -166,8 +160,7 @@ MirTouchEvent const* mir_input_event_get_touch_event(MirInputEvent const* ev) MI
 {
     if(ev->input_type() != mir_input_event_type_touch)
     {
-        MIR_FATAL_ERROR("expected touch input event but event was of type {}",
-            input_event_type_to_c_str(ev->input_type()));
+        MIR_FATAL_ERROR("expected touch input event but event was of type {}", ev->input_type());
     }
 
     return reinterpret_cast<MirTouchEvent const*>(ev);
@@ -244,8 +237,7 @@ MirPointerEvent const* mir_input_event_get_pointer_event(MirInputEvent const* ev
 {
     if(ev->input_type() != mir_input_event_type_pointer)
     {
-        MIR_FATAL_ERROR("expected pointer input event but event was of type {}",
-            input_event_type_to_c_str(ev->input_type()));
+        MIR_FATAL_ERROR("expected pointer input event but event was of type {}", ev->input_type());
     }
 
     return reinterpret_cast<MirPointerEvent const*>(ev);

--- a/src/common/input/mir_input_config.cpp
+++ b/src/common/input/mir_input_config.cpp
@@ -113,14 +113,14 @@ MirTouchpadConfig& MirInputDevice::touchpad_config()
 {
     if (auto& tmp = impl->touchpad)
         return tmp.value();
-    mir::fatal_error("Touchpad config not available");
+    MIR_FATAL_ERROR("Touchpad config not available");
 }
 
 MirTouchpadConfig const& MirInputDevice::touchpad_config() const
 {
     if (auto const& tmp = impl->touchpad)
         return tmp.value();
-    mir::fatal_error("Touchpad config not available");
+    MIR_FATAL_ERROR("Touchpad config not available");
 }
 
 void MirInputDevice::set_touchpad_config(MirTouchpadConfig const& conf)
@@ -137,14 +137,14 @@ MirTouchscreenConfig& MirInputDevice::touchscreen_config()
 {
     if (auto& tmp = impl->touchscreen)
         return tmp.value();
-    mir::fatal_error("Touchscreen config not available");
+    MIR_FATAL_ERROR("Touchscreen config not available");
 }
 
 MirTouchscreenConfig const& MirInputDevice::touchscreen_config() const
 {
     if (auto const& tmp = impl->touchscreen)
         return tmp.value();
-    mir::fatal_error("Touchscreen config not available");
+    MIR_FATAL_ERROR("Touchscreen config not available");
 }
 
 void MirInputDevice::set_touchscreen_config(MirTouchscreenConfig const& conf)
@@ -161,14 +161,14 @@ MirKeyboardConfig& MirInputDevice::keyboard_config()
 {
     if (auto& tmp = impl->keyboard)
         return tmp.value();
-    mir::fatal_error("Keyboard config not available");
+    MIR_FATAL_ERROR("Keyboard config not available");
 }
 
 MirKeyboardConfig const& MirInputDevice::keyboard_config() const
 {
     if (auto const& tmp = impl->keyboard)
         return tmp.value();
-    mir::fatal_error("Keyboard config not available");
+    MIR_FATAL_ERROR("Keyboard config not available");
 }
 
 void MirInputDevice::set_keyboard_config(MirKeyboardConfig const& conf)
@@ -185,14 +185,14 @@ MirPointerConfig& MirInputDevice::pointer_config()
 {
     if (auto& tmp = impl->pointer)
         return tmp.value();
-    mir::fatal_error("Pointer config not available");
+    MIR_FATAL_ERROR("Pointer config not available");
 }
 
 MirPointerConfig const& MirInputDevice::pointer_config() const
 {
     if (auto const& tmp = impl->pointer)
         return tmp.value();
-    mir::fatal_error("Pointer config not available");
+    MIR_FATAL_ERROR("Pointer config not available");
 }
 
 void MirInputDevice::set_pointer_config(MirPointerConfig const& conf)

--- a/src/common/input/xkb_mapper.cpp
+++ b/src/common/input/xkb_mapper.cpp
@@ -123,7 +123,7 @@ mi::XKBContextPtr mi::make_unique_context()
     auto context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (!context)
     {
-        fatal_error("Failed to create XKB context");
+        MIR_FATAL_ERROR("Failed to create XKB context");
     }
     return {context, &xkb_context_unref};
 }

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -63,6 +63,8 @@ global:
   mir_window_event_get_attribute_value;
 
   extern "C++" {
+    "std::formatter<MirEventType, char>::format(MirEventType, std::basic_format_context<std::__format::_Sink_iter<char>, char>&) const";
+    "std::formatter<MirInputEventType, char>::format(MirInputEventType, std::basic_format_context<std::__format::_Sink_iter<char>, char>&) const";
     ?MirCloseWindowEvent*;
     ?MirKeyboardEvent*;
     ?MirPointerEvent*;
@@ -395,8 +397,6 @@ global:
     mir::dispatch::epoll_to_fd_event*;
     mir::dispatch::fd_event_to_epoll*;
     mir::errno_to_cstr*;
-    mir::event_type_to_c_str*;
-    mir::event_type_to_string*;
     mir::events::TouchContactV2::TouchContactV2*;
     mir::events::TouchContactV2::operator*;
     mir::events::add_touch*;

--- a/src/core/fatal.cpp
+++ b/src/core/fatal.cpp
@@ -19,6 +19,8 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstdarg>
+#include <iostream>
+#include <print>
 
 [[noreturn]]
 void mir::fatal_error(char const* reason, ...)
@@ -33,6 +35,18 @@ void mir::fatal_error(char const* reason, ...)
     std::vfprintf(stderr, reason, args);
     std::fprintf(stderr, "\n");
     va_end(args);
+
+    std::abort();
+}
+
+[[noreturn]]
+void mir::fatal_error(std::source_location const loc, std::string_view message)
+{
+    std::println(std::cerr, "Mir fatal error: {} ({}:{} in {})",
+        message,
+        loc.file_name(),
+        loc.line(),
+        loc.function_name());
 
     std::abort();
 }

--- a/src/core/fatal.cpp
+++ b/src/core/fatal.cpp
@@ -50,3 +50,18 @@ void mir::fatal_error(std::source_location const loc, std::string_view message)
 
     std::abort();
 }
+
+[[noreturn]]
+void mir::fatal_error(std::string_view fmt, std::format_args args, std::source_location const loc)
+{
+    std::string message;
+    try
+    {
+        message = std::vformat(fmt, args);
+    }
+    catch (...)
+    {
+        message = fmt;
+    }
+    fatal_error(loc, std::string_view{message});
+}

--- a/src/core/fatal.cpp
+++ b/src/core/fatal.cpp
@@ -19,11 +19,9 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstdarg>
-#include <iostream>
-#include <print>
 
 [[noreturn]]
-void mir::fatal_error(char const* reason, ...)
+void mir::fatal_error(char const* reason, ...) noexcept
 {
     va_list args;
 
@@ -40,28 +38,27 @@ void mir::fatal_error(char const* reason, ...)
 }
 
 [[noreturn]]
-void mir::fatal_error(std::source_location const loc, std::string_view message)
+void mir::fatal_error(std::source_location const loc, std::string_view message) noexcept
 {
-    std::println(std::cerr, "Mir fatal error: {} ({}:{} in {})",
-        message,
-        loc.file_name(),
-        loc.line(),
-        loc.function_name());
+    // Use fprintf(), avoiding any object construction and minimizing the
+    // potential for heap operations between the error location and the abort().
+    std::fprintf(stderr, "Mir fatal error: %.*s (%s:%u in %s)\n",
+        static_cast<int>(message.size()), message.data(),
+        loc.file_name(), loc.line(), loc.function_name());
 
     std::abort();
 }
 
 [[noreturn]]
-void mir::fatal_error(std::string_view fmt, std::format_args args, std::source_location const loc)
+void mir::fatal_error(std::string_view fmt, std::format_args args, std::source_location const loc) noexcept
 {
-    std::string message;
     try
     {
-        message = std::vformat(fmt, args);
+        fatal_error(loc, std::vformat(fmt, args));
     }
     catch (...)
     {
-        message = fmt;
+        // Formatting failed with an exception! Just report what we can
+        fatal_error(loc, fmt);
     }
-    fatal_error(loc, std::string_view{message});
 }

--- a/src/core/logging/logger.cpp
+++ b/src/core/logging/logger.cpp
@@ -143,7 +143,7 @@ void ml::format_message(std::ostream& out, Severity severity, std::string const&
     }
     catch (std::runtime_error const& e)
     {
-        mir::fatal_error("Cannot format log message: %s", e.what());
+        MIR_FATAL_ERROR("Cannot format log message: {}", e.what());
     }
 }
 

--- a/src/include/server/mir/proof_of_mutex_lock.h
+++ b/src/include/server/mir/proof_of_mutex_lock.h
@@ -31,7 +31,7 @@ public:
     {
         if (!lock.owns_lock())
         {
-            fatal_error("ProofOfMutexLock created with unlocked unique_lock");
+            MIR_FATAL_ERROR("ProofOfMutexLock created with unlocked unique_lock");
         }
     }
     ProofOfMutexLock(ProofOfMutexLock const&) = delete;

--- a/src/miral/application_selector.cpp
+++ b/src/miral/application_selector.cpp
@@ -83,7 +83,7 @@ void ApplicationSelector::advise_focus_gained(WindowInfo const& window_info)
     auto window = window_info.window();
     if (!window)
     {
-        mir::fatal_error("advise_focus_gained: window_info did not reference a window");
+        MIR_FATAL_ERROR("advise_focus_gained: window_info did not reference a window");
     }
 
     auto it = find(window);
@@ -93,7 +93,7 @@ void ApplicationSelector::advise_focus_gained(WindowInfo const& window_info)
         if (it != focus_list.end())
             std::rotate(focus_list.begin(), it, it + 1);
         else
-            mir::fatal_error("advise_focus_gained: window was not found in the list");
+            MIR_FATAL_ERROR("advise_focus_gained: window was not found in the list");
     }
 
     select(window);
@@ -104,7 +104,7 @@ void ApplicationSelector::advise_focus_lost(miral::WindowInfo const& window_info
     auto window = window_info.window();
     if (!window)
     {
-        mir::fatal_error("advise_focus_lost: window_info did not reference a window");
+        MIR_FATAL_ERROR("advise_focus_lost: window_info did not reference a window");
         return;
     }
 

--- a/src/miral/application_switcher.cpp
+++ b/src/miral/application_switcher.cpp
@@ -420,11 +420,11 @@ public:
     {
         wayland_init(display);
         if (!layer_shell())
-            mir::fatal_error("The %s interface is required for the application switcher to run. "
+            MIR_FATAL_ERROR("The {} interface is required for the application switcher to run. "
                 "Please enable it using miral::WaylandExtensions.", miral::WaylandExtensions::zwlr_layer_shell_v1);
 
         if (!toplevel_manager)
-            mir::fatal_error("The %s interface is required for the application switcher to run. "
+            MIR_FATAL_ERROR("The {} interface is required for the application switcher to run. "
                 "Please enable it using miral::WaylandExtensions.", miral::WaylandExtensions::zwlr_foreign_toplevel_manager_v1);
 
         shm_ = std::make_shared<miral::tk::WaylandShmPool>(shm());

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1286,7 +1286,7 @@ void miral::BasicWindowManager::place_attached_to_zone(
     }
 
     default:
-        fatal_error("BasicWindowManager::place_attached_to_zone() called for window not in a maximized or attached state");
+        MIR_FATAL_ERROR("BasicWindowManager::place_attached_to_zone() called for window not in a maximized or attached state");
     }
 
     // TODO: Maybe remove update_window and update only if the rect has changed?
@@ -2950,7 +2950,7 @@ void miral::BasicWindowManager::update_application_zones_and_attached_windows()
                 })
                 .or_else([&]()-> decltype(info.exclusive_rect())
                 {
-                    fatal_error("Attached window has no exclusive rect");
+                    MIR_FATAL_ERROR("Attached window has no exclusive rect");
                     std::unreachable();
                 });
         }
@@ -2969,7 +2969,7 @@ void miral::BasicWindowManager::update_application_zones_and_attached_windows()
                 })
                 .or_else([&]()-> decltype(info.exclusive_rect())
                 {
-                    fatal_error("Attached window has no exclusive rect");
+                    MIR_FATAL_ERROR("Attached window has no exclusive rect");
                     std::unreachable();
                 });
         }

--- a/src/miral/display_configuration.cpp
+++ b/src/miral/display_configuration.cpp
@@ -209,7 +209,7 @@ auto miral::DisplayConfiguration::Node::type() const -> Type
 auto miral::DisplayConfiguration::Node::as_string() const -> std::string
 {
     if (type() != Type::string)
-        mir::fatal_error("Attempting to access a Node of type %s as a string", node_type_to_string(type()));
+        MIR_FATAL_ERROR("Attempting to access a Node of type {} as a string", node_type_to_string(type()));
 
     return self->as<std::string>();
 }
@@ -217,7 +217,7 @@ auto miral::DisplayConfiguration::Node::as_string() const -> std::string
 auto miral::DisplayConfiguration::Node::as_int() const -> int
 {
     if (type() != Type::integer)
-        mir::fatal_error("Attempting to access a Node of type %s as an integer", node_type_to_string(type()));
+        MIR_FATAL_ERROR("Attempting to access a Node of type {} as an integer", node_type_to_string(type()));
 
     return self->as<int>();
 }
@@ -225,7 +225,7 @@ auto miral::DisplayConfiguration::Node::as_int() const -> int
 void miral::DisplayConfiguration::Node::for_each(std::function<void(Node const&)> const& f) const
 {
     if (type() != Type::sequence)
-        mir::fatal_error("Attempting to access a Node of type %s as a sequence", node_type_to_string(type()));
+        MIR_FATAL_ERROR("Attempting to access a Node of type {} as a sequence", node_type_to_string(type()));
 
     for (auto const& item : self->node)
         f(Node(std::make_unique<Self>(item)));
@@ -234,7 +234,7 @@ void miral::DisplayConfiguration::Node::for_each(std::function<void(Node const&)
 auto miral::DisplayConfiguration::Node::has(std::string const& key) const -> bool
 {
     if (type() != Type::map)
-        mir::fatal_error("Attempting to access a Node of type %s as a map", node_type_to_string(type()));
+        MIR_FATAL_ERROR("Attempting to access a Node of type {} as a map", node_type_to_string(type()));
 
     if (self->node[key])
         return true;

--- a/src/miral/display_configuration_option.cpp
+++ b/src/miral/display_configuration_option.cpp
@@ -211,11 +211,11 @@ void miral::display_configuration_options(mir::Server& server)
             }
             catch (std::invalid_argument const&)
             {
-                mir::fatal_error("Failed to parse scale '%s' as double", scale_str.c_str());
+                MIR_FATAL_ERROR("Failed to parse scale '{}' as double", scale_str);
             }
             if (scale < scale_min || scale > scale_max)
             {
-                mir::fatal_error("Invalid scale %f, must be between %f and %f", scale, scale_min, scale_max);
+                MIR_FATAL_ERROR("Invalid scale {}, must be between {} and {}", scale, scale_min, scale_max);
             }
 
             auto layout_selector = wrapped;
@@ -232,7 +232,7 @@ void miral::display_configuration_options(mir::Server& server)
             {
                 if (scale != 1.0)
                 {
-                    mir::fatal_error("Display scale option can't be used with static display configuration");
+                    MIR_FATAL_ERROR("Display scale option can't be used with static display configuration");
                 }
                 auto sdc = std::make_shared<StaticDisplayConfig>(display_layout.substr(mir::strlen_c(static_opt_val)));
                 server.add_init_callback([sdc, &server]{ sdc->init_auto_reload(server); });
@@ -248,12 +248,12 @@ void miral::display_configuration_options(mir::Server& server)
             {
                 if (scale != 1.0)
                 {
-                    mir::fatal_error("Display scale option can't be used with autoscale");
+                    MIR_FATAL_ERROR("Display scale option can't be used with autoscale");
                 }
 
                 if (display_layout.compare(0, mir::strlen_c(static_opt_val), static_opt_val) == 0)
                 {
-                    mir::fatal_error("Display autoscale option can't be used with static display configuration");
+                    MIR_FATAL_ERROR("Display autoscale option can't be used with static display configuration");
                 }
 
                 auto const auto_scale_target = options->get<int>(display_autoscale_opt);

--- a/src/miral/launch_app.cpp
+++ b/src/miral/launch_app.cpp
@@ -132,7 +132,7 @@ auto execute_with_environment(std::vector<std::string> const app, Environment& a
     posix_spawnattr_t attr;
     if (auto const error = posix_spawnattr_init(&attr))
     {
-        mir::fatal_error("Failed to init spawn attributes: %s", std::strerror(error));
+        MIR_FATAL_ERROR("Failed to init spawn attributes: {}", std::strerror(error));
     }
 
     // Unblock all signals in the child, preserving their existing dispositions
@@ -144,7 +144,7 @@ auto execute_with_environment(std::vector<std::string> const app, Environment& a
         if (result != 0)
         {
             posix_spawnattr_destroy(&attr);
-            mir::fatal_error("%s: %s", what, std::strerror(result));
+            MIR_FATAL_ERROR("{}: {}", what, std::strerror(result));
         }
     };
 
@@ -175,7 +175,7 @@ auto execute_with_environment(std::vector<std::string> const app, Environment& a
         // The child calls _exit() immediately, avoiding any non-async-signal-safe work.
         pid_t const placeholder = fork();
         if (placeholder < 0)
-            mir::fatal_error("Failed to fork placeholder process: %s", std::strerror(errno));
+            MIR_FATAL_ERROR("Failed to fork placeholder process: {}", std::strerror(errno));
         if (placeholder == 0)
             _exit(EXIT_FAILURE);
         return placeholder;

--- a/src/miral/live_config_overrides_list.cpp
+++ b/src/miral/live_config_overrides_list.cpp
@@ -51,9 +51,9 @@ void mlc::OverridesList::for_each(Loader unchanged, Loader fresh, Loader modifie
         }
         catch (std::exception const& e)
         {
-            mir::fatal_error(
-                "Openers must not throw exceptions. Failed to open '%s' with exception '%s'",
-                event.path.string().c_str(),
+            MIR_FATAL_ERROR(
+                "Openers must not throw exceptions. Failed to open '{}' with exception '{}'",
+                event.path.string(),
                 e.what());
         }
 

--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -726,7 +726,7 @@ void miral::ReloadingYamlFileDisplayConfig::init_auto_reload(mir::Server& server
         std::lock_guard lock{mutex};
         if (the_display_configuration_controller_.use_count() || the_main_loop_.use_count())
         {
-            mir::fatal_error("Init function should only be called once: %s", __PRETTY_FUNCTION__);
+            MIR_FATAL_ERROR("Init function should only be called once: {}", __PRETTY_FUNCTION__);
         }
 
         the_display_configuration_controller_ = server.the_display_configuration_controller();

--- a/src/miral/wayland_shm.cpp
+++ b/src/miral/wayland_shm.cpp
@@ -122,7 +122,7 @@ auto miral::tk::WaylandShmBuffer::use() -> wl_buffer*
 {
     if (self_ptr)
     {
-        mir::fatal_error("WaylandShmBuffer used multiple times");
+        MIR_FATAL_ERROR("WaylandShmBuffer used multiple times");
     }
     self_ptr = shared_from_this();
     return buffer;

--- a/src/miral/x11_support.cpp
+++ b/src/miral/x11_support.cpp
@@ -88,7 +88,7 @@ void miral::X11Support::operator()(mir::Server& server) const
 
                             if (write(fd, display.c_str(), display.size()) != static_cast<ssize_t>(display.size()))
                             {
-                                mir::fatal_error("Cannot write X11 display number to fd %d\n", static_cast<int>(fd));
+                                MIR_FATAL_ERROR("Cannot write X11 display number to fd {}", static_cast<int>(fd));
                             }
                         }
                     });

--- a/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
+++ b/src/platforms/atomic-kms/server/kms/atomic_kms_output.cpp
@@ -259,7 +259,7 @@ void mga::AtomicKMSOutput::reset()
     }
     catch (std::exception const& e)
     {
-        fatal_error("%s", e.what());
+        MIR_FATAL_ERROR("{}", e.what());
     }
 
     /* Discard previously current crtc */
@@ -407,8 +407,8 @@ void mga::AtomicKMSOutput::clear_crtc()
         }
         else
         {
-            fatal_error("Couldn't clear output %s (drmModeSetCrtc = %d)",
-                        mgk::connector_name(conf->connector).c_str(), result);
+            MIR_FATAL_ERROR("Couldn't clear output {} (drmModeSetCrtc = {})",
+                        mgk::connector_name(conf->connector), result);
         }
     }
 

--- a/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
+++ b/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
@@ -101,7 +101,7 @@ void mgg::RealKMSOutput::reset()
     }
     catch (std::exception const& e)
     {
-        fatal_error("%s", e.what());
+        MIR_FATAL_ERROR("{}", e.what());
     }
 
     // TODO: What if we can't locate the DPMS property?
@@ -219,8 +219,8 @@ void mgg::RealKMSOutput::clear_crtc()
         }
         else
         {
-            fatal_error("Couldn't clear output %s (drmModeSetCrtc = %d)",
-                        mgk::connector_name(connector).c_str(), result);
+            MIR_FATAL_ERROR("Couldn't clear output {} (drmModeSetCrtc = {})",
+                        mgk::connector_name(connector), result);
         }
     }
 
@@ -251,8 +251,8 @@ void mgg::RealKMSOutput::wait_for_page_flip()
         return;
     if (!current_crtc)
     {
-        fatal_error("Output %s has no associated CRTC to wait on",
-                   mgk::connector_name(connector).c_str());
+        MIR_FATAL_ERROR("Output {} has no associated CRTC to wait on",
+                   mgk::connector_name(connector));
     }
     page_flipper->wait_for_flip(current_crtc->crtc_id);
 }

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -163,7 +163,7 @@ void mgw::Display::set_keyboard_sink(std::shared_ptr<input::wayland::KeyboardInp
 {
 
     std::lock_guard display_lock{the_display_mtx};
-    if (!the_display) fatal_error("mir::graphics::wayland::Display not initialized");
+    if (!the_display) MIR_FATAL_ERROR("mir::graphics::wayland::Display not initialized");
 
     std::lock_guard lock{the_display->sink_mutex};
     if (keyboard_sink)
@@ -279,7 +279,7 @@ try
 }
 catch (std::exception const& e)
 {
-    fatal_error("Critical error in Wayland platform: %s\n", boost::diagnostic_information(e).c_str());
+    MIR_FATAL_ERROR("Critical error in Wayland platform: {}", boost::diagnostic_information(e));
 }
 
 void mir::graphics::wayland::Display::flush_wl() const
@@ -317,7 +317,7 @@ mir::graphics::wayland::Display::~Display()
 void mgw::Display::set_pointer_sink(std::shared_ptr<input::wayland::PointerInput> const& pointer_sink)
 {
     std::lock_guard display_lock{the_display_mtx};
-    if (!the_display) fatal_error("mir::graphics::wayland::Display not initialized");
+    if (!the_display) MIR_FATAL_ERROR("mir::graphics::wayland::Display not initialized");
 
     std::lock_guard lock{the_display->sink_mutex};
     if (pointer_sink)
@@ -517,7 +517,7 @@ void mir::graphics::wayland::Display::touch_orientation(wl_touch* touch, int32_t
 void mir::graphics::wayland::Display::set_touch_sink(std::shared_ptr<input::wayland::TouchInput> const& touch_sink)
 {
     std::lock_guard display_lock{the_display_mtx};
-    if (!the_display) fatal_error("mir::graphics::wayland::Display not initialized");
+    if (!the_display) MIR_FATAL_ERROR("mir::graphics::wayland::Display not initialized");
 
     std::lock_guard lock{the_display->sink_mutex};
     if (touch_sink)

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -469,7 +469,7 @@ mgw::DisplayClient::DisplayClient(
 {
     if (!keyboard_context_)
     {
-        fatal_error("Failed to create XKB context");
+        MIR_FATAL_ERROR("Failed to create XKB context");
     }
 
     registry = {wl_display_get_registry(display), &wl_registry_destroy};

--- a/src/platforms/wayland/wayland_display.cpp
+++ b/src/platforms/wayland/wayland_display.cpp
@@ -50,7 +50,7 @@ auto mpw::connection(options::Option const& options) -> struct wl_display*
 {
     if (!options.is_set(wayland_host_option_name))
     {
-        fatal_error("%s option required for Wayland platform", wayland_host_option_name);
+        MIR_FATAL_ERROR("{} option required for Wayland platform", wayland_host_option_name);
     }
 
     auto const wayland_host = options.get<std::string>(wayland_host_option_name);

--- a/src/server/display_server.cpp
+++ b/src/server/display_server.cpp
@@ -150,7 +150,7 @@ struct mir::DisplayServer::Private
                     catch(std::runtime_error const& e)
                     {
                         if (std::chrono::steady_clock::now() > deadline)
-                            fatal_error("Failed to resume display:\n%s", boost::diagnostic_information(e).c_str());
+                            MIR_FATAL_ERROR("Failed to resume display:\n{}", boost::diagnostic_information(e));
 
                         std::this_thread::sleep_for(std::chrono::milliseconds{50});
                         goto retry;

--- a/src/server/frontend_wayland/ext_foreign_toplevel_image_capture_source_v1.cpp
+++ b/src/server/frontend_wayland/ext_foreign_toplevel_image_capture_source_v1.cpp
@@ -231,7 +231,7 @@ void mf::ExtForeignToplevelImageCopyBackend::begin_capture(
     {
     case DamageAmount::none:
         // This should never happen as maybe_capture_frame() checks has_damage() before calling begin_capture()
-        fatal_error("begin_capture() called with no damage - this is a precondition violation");
+        MIR_FATAL_ERROR("begin_capture() called with no damage - this is a precondition violation");
         break;
 
     case DamageAmount::partial:

--- a/src/server/frontend_wayland/ext_output_image_capture_source_v1.cpp
+++ b/src/server/frontend_wayland/ext_output_image_capture_source_v1.cpp
@@ -216,7 +216,7 @@ void mf::ExtOutputImageCopyBackend::begin_capture(
     {
     case DamageAmount::none:
         // This should never happen as maybe_capture_frame() checks has_damage() before calling begin_capture()
-        fatal_error("begin_capture() called with no damage - this is a precondition violation");
+        MIR_FATAL_ERROR("begin_capture() called with no damage - this is a precondition violation");
         break;
 
     case DamageAmount::partial:

--- a/src/server/frontend_wayland/keyboard_helper.cpp
+++ b/src/server/frontend_wayland/keyboard_helper.cpp
@@ -44,7 +44,7 @@ mf::KeyboardHelper::KeyboardHelper(
 {
     if (!context)
     {
-        fatal_error("Failed to create XKB context");
+        MIR_FATAL_ERROR("Failed to create XKB context");
     }
 
     /* The wayland::Keyboard constructor has already run, creating the keyboard

--- a/src/server/frontend_wayland/keyboard_state_tracker.cpp
+++ b/src/server/frontend_wayland/keyboard_state_tracker.cpp
@@ -95,7 +95,7 @@ mf::KeyboardStateTracker::KeyboardStateTracker()
     : context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), xkb_context_unref}
 {
     if (!context)
-        fatal_error("KeyboardStateTracker: failed to create XKB context");
+        MIR_FATAL_ERROR("KeyboardStateTracker: failed to create XKB context");
 }
 
 bool mf::KeyboardStateTracker::process(MirEvent const& event)

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -433,7 +433,7 @@ mf::WaylandConnector::WaylandConnector(
     }
     else
     {
-        fatal_error("Unable to bind Wayland socket");
+        MIR_FATAL_ERROR("Unable to bind Wayland socket");
     }
 
     auto wayland_loop = wl_display_get_event_loop(display.get());

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -122,7 +122,7 @@ auto wayland_axis_source(MirPointerAxisSource mir_source) -> std::optional<uint3
         return mw::Pointer::AxisSource::wheel_tilt;
     }
 
-    mir::fatal_error("Invalid MirPointerAxisSource %d", mir_source);
+    MIR_FATAL_ERROR("Invalid MirPointerAxisSource {}", static_cast<int>(mir_source));
     return std::nullopt;
 }
 }

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -374,7 +374,7 @@ private:
     {
         if (src_len > dest_len)
         {
-            fatal_error("%zu elements of data does not fit in %zu element long array", src_len, dest_len);
+            MIR_FATAL_ERROR("{} elements of data does not fit in {} element long array", src_len, dest_len);
         }
         for (unsigned i = 0; i < src_len; i++)
         {

--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -44,7 +44,7 @@ mf::XWaylandConnector::XWaylandConnector(
 {
     if (access(xwayland_path.c_str(), F_OK | X_OK) != 0)
     {
-        fatal_error("Cannot execute Xwayland: --xwayland-path %s", xwayland_path.c_str());
+        MIR_FATAL_ERROR("Cannot execute Xwayland: --xwayland-path {}", xwayland_path);
     }
 }
 
@@ -52,9 +52,9 @@ mf::XWaylandConnector::~XWaylandConnector()
 {
     if (is_started || spawner || server || wm || wm_event_thread)
     {
-        fatal_error(
+        MIR_FATAL_ERROR(
             "XWaylandConnector was not stopped before being destroyed "
-            "(is_started: %s, spawner: %s, server: %s, wm: %s, wm_event_thread: %s)",
+            "(is_started: {}, spawner: {}, server: {}, wm: {}, wm_event_thread: {})",
             is_started ? "yes" : "no",
             spawner ? "exists" : "null",
             wm ? "exists" : "null",
@@ -119,7 +119,7 @@ void mf::XWaylandConnector::maybe_create_spawner(std::unique_lock<std::mutex> co
 {
     if (!lock.owns_lock())
     {
-        fatal_error("XWaylandConnector::maybe_create_spawner() given unlocked lock");
+        MIR_FATAL_ERROR("XWaylandConnector::maybe_create_spawner() given unlocked lock");
     }
 
     if (is_started && !spawner)
@@ -133,7 +133,7 @@ void mf::XWaylandConnector::clean_up(std::unique_lock<std::mutex> lock)
 {
     if (!lock.owns_lock())
     {
-        fatal_error("XWaylandConnector::clean_up() given unlocked lock");
+        MIR_FATAL_ERROR("XWaylandConnector::clean_up() given unlocked lock");
     }
 
     auto local_server{std::move(server)};

--- a/src/server/frontend_xwayland/xwayland_default_configuration.cpp
+++ b/src/server/frontend_xwayland/xwayland_default_configuration.cpp
@@ -87,11 +87,11 @@ std::shared_ptr<mf::Connector> mir::DefaultServerConfiguration::the_xwayland_con
             }
             catch (std::exception& x)
             {
-                mir::fatal_error(
-                    "Failed to start XWaylandConnector: %s\n  (xwayland-path is '%s', x11-scale is '%s')",
+                MIR_FATAL_ERROR(
+                    "Failed to start XWaylandConnector: {}\n  (xwayland-path is '{}', x11-scale is '{}')",
                     x.what(),
-                    options->get<std::string>("xwayland-path").c_str(),
-                    options->get<std::string>(mo::x11_scale_opt).c_str());
+                    options->get<std::string>("xwayland-path"),
+                    options->get<std::string>(mo::x11_scale_opt));
             }
         }
 

--- a/src/server/frontend_xwayland/xwayland_spawner.cpp
+++ b/src/server/frontend_xwayland/xwayland_spawner.cpp
@@ -152,7 +152,7 @@ mf::XWaylandSpawner::XWaylandSpawner(
     if (dispatcher_fd.empty())
     {
         // To get here, we were configured with "enable-x11". So this is fatal.
-        mir::fatal_error("Cannot open any X11 socket (abstract or not)");
+        MIR_FATAL_ERROR("Cannot open any X11 socket (abstract or not)");
     }
 
     for (auto const& fd_dispatcher : dispatcher_fd)
@@ -205,7 +205,7 @@ auto mf::XWaylandSpawner::choose_display() -> XDisplayPaths
         if (create_lockfile(xp) == 0) return xp;
     }
 
-    mir::fatal_error("Cannot create X11 lockfile!");
+    MIR_FATAL_ERROR("Cannot create X11 lockfile!");
     return XDisplayPaths();
 }
 
@@ -223,7 +223,7 @@ bool mf::XWaylandSpawner::set_cloexec(mir::Fd const& fd, bool cloexec)
 {
     int flags = fcntl(fd, F_GETFD);
     if (flags == -1) {
-        mir::fatal_error("fcntl failed");
+        MIR_FATAL_ERROR("fcntl failed");
         return false;
     }
     if (cloexec) {
@@ -232,7 +232,7 @@ bool mf::XWaylandSpawner::set_cloexec(mir::Fd const& fd, bool cloexec)
         flags = flags & ~FD_CLOEXEC;
     }
     if (fcntl(fd, F_SETFD, flags) == -1) {
-        mir::fatal_error("fcntl failed");
+        MIR_FATAL_ERROR("fcntl failed");
         return false;
     }
     return true;

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -776,7 +776,7 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
 
     if (!session)
     {
-        fatal_error("Property handlers did not set a valid session");
+        MIR_FATAL_ERROR("Property handlers did not set a valid session");
     }
 
     // property_handlers will have updated the pending spec. Use it.

--- a/src/server/input/xkb_mapper_registrar.cpp
+++ b/src/server/input/xkb_mapper_registrar.cpp
@@ -103,7 +103,7 @@ mi::XKBContextPtr mi::make_unique_context()
     auto context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (!context)
     {
-        fatal_error("Failed to create XKB context");
+        MIR_FATAL_ERROR("Failed to create XKB context");
     }
     return {context, &xkb_context_unref};
 }

--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -67,7 +67,7 @@ public:
                 return handlers[i];
             }
         }
-        mir::fatal_error("Attempted to access signal handler for signal %i not in intercepted list", sig);
+        MIR_FATAL_ERROR("Attempted to access signal handler for signal {} not in intercepted list", sig);
     }
 
     /**
@@ -114,7 +114,7 @@ public:
                 return AtomicOutPtr{handlers[i]};
             }
         }
-        mir::fatal_error("Attempted to access signal handler for signal %i not in intercepted list", sig);
+        MIR_FATAL_ERROR("Attempted to access signal handler for signal {} not in intercepted list", sig);
     }
 
 private:
@@ -198,6 +198,8 @@ extern "C" [[noreturn]] void fatal_signal_cleanup(int sig, siginfo_t* info, void
          * Re-raising the signal will destroy this context, so call the handler directly.
          */
         (*old_handler->sa_sigaction)(sig, info, ucontext);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         /* We don't *expect* to get here - fatal signal handlers will *generally* re-raise the signal,
          * and so don't return.
          *
@@ -210,6 +212,7 @@ extern "C" [[noreturn]] void fatal_signal_cleanup(int sig, siginfo_t* info, void
     std::raise(sig);
     // We definitely can't continue, though, even if their handler tries.
     mir::fatal_error("Unsupported attempt to continue after a fatal signal: %s", signum_to_string(sig).c_str());
+#pragma GCC diagnostic pop
 }
 }
 
@@ -233,7 +236,7 @@ void mir::run_mir(
         [&server_ptr](int)
         {
             if (!server_ptr)
-                fatal_error("Logic error in mir::run_mir() server_ptr is nullptr");
+                MIR_FATAL_ERROR("Logic error in mir::run_mir() server_ptr is nullptr");
             server_ptr->stop();
         };
 

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -74,7 +74,7 @@ auto ms::ApplicationSession::create_surface(
     Executor* observer_executor) -> std::shared_ptr<Surface>
 {
     if (session && session.get() != this)
-        fatal_error("Incorrect session");
+        MIR_FATAL_ERROR("Incorrect session");
 
     //TODO: we take the first stream's content for now. Once the surface factory interface takes more than one stream,
     //      we can take all the streams as content.

--- a/src/server/scene/basic_clipboard.cpp
+++ b/src/server/scene/basic_clipboard.cpp
@@ -37,7 +37,7 @@ void ms::BasicClipboard::set_paste_source(std::shared_ptr<DataExchangeSource> co
 {
     if (!source)
     {
-        fatal_error("BasicClipboard::set_paste_source(nullptr)");
+        MIR_FATAL_ERROR("BasicClipboard::set_paste_source(nullptr)");
     }
     bool notify{false};
     {
@@ -93,7 +93,7 @@ void mir::scene::BasicClipboard::set_drag_n_drop_source(std::shared_ptr<DataExch
 {
     if (!source)
     {
-        fatal_error("BasicClipboard::start_drag_n_drop_gesture(nullptr)");
+        MIR_FATAL_ERROR("BasicClipboard::start_drag_n_drop_gesture(nullptr)");
     }
     bool notify{false};
     {
@@ -114,7 +114,7 @@ void mir::scene::BasicClipboard::clear_drag_n_drop_source(std::shared_ptr<DataEx
 {
     if (!source)
     {
-        fatal_error("BasicClipboard::clear_drag_n_drop_source(nullptr)");
+        MIR_FATAL_ERROR("BasicClipboard::clear_drag_n_drop_source(nullptr)");
     }
     bool notify{false};
     {

--- a/src/server/scene/basic_idle_hub.cpp
+++ b/src/server/scene/basic_idle_hub.cpp
@@ -42,7 +42,7 @@ public:
     {
         if (!locked)
         {
-            mir::fatal_error("AlarmCallback called while unlocked");
+            MIR_FATAL_ERROR("AlarmCallback called while unlocked");
         }
         func(*locked.value());
     }

--- a/src/server/scene/surface_state_tracker.cpp
+++ b/src/server/scene/surface_state_tracker.cpp
@@ -170,7 +170,7 @@ ms::SurfaceStateTracker::SurfaceStateTracker(SurfaceStateTracker base, MirWindow
         break;
 
     default:
-        fatal_error("Invalid window state: %d", active);
+        MIR_FATAL_ERROR("Invalid window state: {}", static_cast<int>(active));
     }
 }
 
@@ -209,10 +209,10 @@ ms::SurfaceStateTracker::SurfaceStateTracker(SurfaceStateTracker base, MirWindow
         break;
 
     case mir_window_state_restored:
-        fatal_error("Sending mir_window_state_restored to SurfaceStateTracker::with()/without() is not allowed");
+        MIR_FATAL_ERROR("Sending mir_window_state_restored to SurfaceStateTracker::with()/without() is not allowed");
         break;
 
     default:
-        fatal_error("Invalid window state: %d", state);
+        MIR_FATAL_ERROR("Invalid window state: {}", static_cast<int>(state));
     }
 }

--- a/src/server/shell/basic_idle_handler.cpp
+++ b/src/server/shell/basic_idle_handler.cpp
@@ -288,7 +288,7 @@ void msh::BasicIdleHandler::register_observers(ProofOfMutexLock const&)
     {
         if (*off_timeout <= time::Duration{0})
         {
-            fatal_error("BasicIdleHandler given invalid timeout %" PRId64 ", should be >0", static_cast<int64_t>(off_timeout->count()));
+            MIR_FATAL_ERROR("BasicIdleHandler given invalid timeout {}, should be >0", off_timeout->count());
         }
         if (*off_timeout >= dim_time_before_off * 2)
         {

--- a/src/server/shell/decoration/decoration_strategy.cpp
+++ b/src/server/shell/decoration/decoration_strategy.cpp
@@ -416,8 +416,7 @@ auto msd::border_type_for(MirWindowType type, MirWindowState state) -> msd::Bord
         return BorderType::None;
     }
 
-    mir::fatal_error("%s:%d: should be unreachable", __FILE__, __LINE__);
-    return {};
+    MIR_FATAL_ERROR("should be unreachable");
 }
 
 auto msd::DecorationStrategy::default_decoration_strategy(std::shared_ptr<mir::graphics::GraphicBufferAllocator> const& allocator) -> std::shared_ptr<DecorationStrategy>

--- a/src/server/shell/decoration/input.cpp
+++ b/src/server/shell/decoration/input.cpp
@@ -169,7 +169,7 @@ void msd::InputManager::update_window_state(WindowState const& window_state)
         }
         else
         {
-            fatal_error("Invalid widget");
+            MIR_FATAL_ERROR("Invalid widget");
         }
     }
 

--- a/src/server/shell/decoration/threadsafe_access.h
+++ b/src/server/shell/decoration/threadsafe_access.h
@@ -44,14 +44,14 @@ public:
     ~ThreadsafeAccess()
     {
         if (target)
-            fatal_error("ThreadsafeAccess never invalidated");
+            MIR_FATAL_ERROR("ThreadsafeAccess never invalidated");
     }
 
     void initialize(T* t)
     {
         std::lock_guard lock{mutex};
         if (target)
-            fatal_error("ThreadsafeAccess initialized multiple times");
+            MIR_FATAL_ERROR("ThreadsafeAccess initialized multiple times");
         target = t;
     }
 

--- a/src/server/shell/decoration/window.cpp
+++ b/src/server/shell/decoration/window.cpp
@@ -111,7 +111,7 @@ auto msd::WindowState::titlebar_width() const -> geom::Width
         return {};
     }
 
-    mir::fatal_error("%s:%d: should be unreachable", __FILE__, __LINE__);
+    MIR_FATAL_ERROR("should be unreachable");
     return {};
 }
 
@@ -126,7 +126,7 @@ auto msd::WindowState::titlebar_height() const -> geom::Height
         return {};
     }
 
-    mir::fatal_error("%s:%d: should be unreachable", __FILE__, __LINE__);
+    MIR_FATAL_ERROR("should be unreachable");
     return {};
 }
 
@@ -141,7 +141,7 @@ auto msd::WindowState::side_border_width() const -> geom::Width
         return {};
     }
 
-    mir::fatal_error("%s:%d: should be unreachable", __FILE__, __LINE__);
+    MIR_FATAL_ERROR("should be unreachable");
     return {};
 }
 
@@ -156,7 +156,7 @@ auto msd::WindowState::side_border_height() const -> geom::Height
         return {};
     }
 
-    mir::fatal_error("%s:%d: should be unreachable", __FILE__, __LINE__);
+    MIR_FATAL_ERROR("should be unreachable");
     return {};
 }
 
@@ -176,7 +176,7 @@ auto msd::WindowState::bottom_border_height() const -> geom::Height
         return {};
     }
 
-    mir::fatal_error("%s:%d: should be unreachable", __FILE__, __LINE__);
+    MIR_FATAL_ERROR("should be unreachable");
     return {};
 }
 

--- a/src/wayland/client.cpp
+++ b/src/wayland/client.cpp
@@ -59,12 +59,11 @@ auto mw::Client::shared_from(wl_client const* client) -> std::shared_ptr<Client>
             }
             else
             {
-                // The client should remove itself from the map in it's destructor and should be destroyed/accessed on a
+                // The client should remove itself from the map in its destructor and should be destroyed/accessed on a
                 // single thread, so this should never happen
-                mir::fatal_error("client_map has stale entry for wl_client %p", static_cast<void const*>(client));
+                MIR_FATAL_ERROR("client_map has stale entry for wl_client {}", static_cast<void const*>(client));
             }
         }
     }
-    mir::fatal_error("wl_client %p is %s", static_cast<void const*>(client), client ? "unknown" : "null");
-    abort(); // Make compiler happy
+    MIR_FATAL_ERROR("wl_client {} is {}", static_cast<void const*>(client), client ? "unknown" : "null");
 }

--- a/tests/mir_test_framework/executable_path.cpp
+++ b/tests/mir_test_framework/executable_path.cpp
@@ -47,7 +47,7 @@ std::string mir_test_framework::library_path()
     if (libpath.empty())
     {
         // Try to find the location of libmircore.so
-        void (*fn_in_mircore)(char const*, ...) = mir::fatal_error;
+        void (&fn_in_mircore)(std::source_location const loc, std::string_view) = mir::fatal_error;
         Dl_info library_info{nullptr, nullptr, nullptr, nullptr};
         dladdr(reinterpret_cast<void*>(&fn_in_mircore), &library_info);
 

--- a/tests/mir_test_framework/executable_path.cpp
+++ b/tests/mir_test_framework/executable_path.cpp
@@ -46,9 +46,10 @@ std::string mir_test_framework::library_path()
 
     if (libpath.empty())
     {
-        // Try to find the location of libmircommon.so
+        // Try to find the location of libmircore.so
+        void (*fn_in_mircore)(char const*, ...) = mir::fatal_error;
         Dl_info library_info{nullptr, nullptr, nullptr, nullptr};
-        dladdr(reinterpret_cast<void*>(&mir::fatal_error), &library_info);
+        dladdr(reinterpret_cast<void*>(&fn_in_mircore), &library_info);
 
         std::unique_ptr<char, decltype(&std::free)> const tmp{strdup(library_info.dli_fname), &std::free};
         libpath = dirname(tmp.get());

--- a/tests/mir_test_framework/test_display_server.cpp
+++ b/tests/mir_test_framework/test_display_server.cpp
@@ -146,7 +146,7 @@ void miral::TestDisplayServer::start_server()
             }
             catch (std::exception const& e)
             {
-                mir::fatal_error("%s", e.what());
+                MIR_FATAL_ERROR("{}", e.what());
             }
 
             {

--- a/tests/mir_test_framework/test_wlcs_display_server_internals.h
+++ b/tests/mir_test_framework/test_wlcs_display_server_internals.h
@@ -46,7 +46,7 @@ void emit_mir_event(
     emitter->emit_event(event.with_event_time(event_time));
 
     if (!event_sent->wait_for(a_long_time))
-        mir::fatal_error("fake event failed to go through");
+        MIR_FATAL_ERROR("fake event failed to go through");
 }
 
 } // namespace

--- a/tests/unit-tests/test_fatal.cpp
+++ b/tests/unit-tests/test_fatal.cpp
@@ -24,20 +24,27 @@ using namespace testing;
 
 TEST(FatalErrorDeathTest, fatal_error_formats_message_to_stderr)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     MIR_EXPECT_DEATH(mir::fatal_error("%s had %d %s %s",
                                       "Mary", 1, "little", "lamb"),
                      "Mary had 1 little lamb");
+#pragma GCC diagnostic pop
 }
 
 TEST(FatalErrorDeathTest, fatal_error_raises_sigabrt)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     MIR_EXPECT_EXIT(mir::fatal_error("Hello world"),
                     KilledBySignal(SIGABRT),
                     "Hello world");
+#pragma GCC diagnostic pop
 }
 
 TEST(FatalErrorDeathTest, mir_fatal_error_formats_message_and_source_location)
 {
-    MIR_EXPECT_DEATH(MIR_FATAL_ERROR("{} had {} {} {}", "Mary", 1, "little", "lamb"),
-                     "Mary had 1 little lamb .*test_fatal.cpp:[0-9]+ in .*mir_fatal_error_formats_message_and_source_location");
+    MIR_EXPECT_EXIT(MIR_FATAL_ERROR("{} had {} {} {}", "Mary", 1, "little", "lamb"),
+                    KilledBySignal(SIGABRT),
+                    "Mary had 1 little lamb .*test_fatal.cpp:[0-9]+ in .*mir_fatal_error_formats_message_and_source_location");
 }

--- a/tests/unit-tests/test_fatal.cpp
+++ b/tests/unit-tests/test_fatal.cpp
@@ -35,3 +35,9 @@ TEST(FatalErrorDeathTest, fatal_error_raises_sigabrt)
                     KilledBySignal(SIGABRT),
                     "Hello world");
 }
+
+TEST(FatalErrorDeathTest, mir_fatal_error_formats_message_and_source_location)
+{
+    MIR_EXPECT_DEATH(MIR_FATAL_ERROR("{} had {} {} {}", "Mary", 1, "little", "lamb"),
+                     "Mary had 1 little lamb .*test_fatal.cpp:[0-9]+ in .*mir_fatal_error_formats_message_and_source_location");
+}


### PR DESCRIPTION
Replaces a printf-style fatal_error with a std::formatter style fatal_error 