### PR TITLE
Modify a bunch of `miral::*::operator()(mir::Server&)`s to be const

### DIFF
--- a/debian/libmiral8.symbols
+++ b/debian/libmiral8.symbols
@@ -4,9 +4,9 @@ libmiral.so.8 libmiral8 #MINVER#
  (c++)"miral::AddInitCallback::operator()(mir::Server&) const@MIRAL_6.0" 6.0.0
  (c++)"miral::AddInitCallback::~AddInitCallback()@MIRAL_6.0" 6.0.0
  (c++)"miral::AppendEventFilter::AppendEventFilter(std::function<bool (MirEvent const*)> const&)@MIRAL_6.0" 6.0.0
- (c++)"miral::AppendEventFilter::operator()(mir::Server&)@MIRAL_6.0" 6.0.0
+ (c++)"miral::AppendEventFilter::operator()(mir::Server&) const@MIRAL_6.0" 6.0.0
  (c++)"miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter(std::function<bool (MirKeyboardEvent const*)> const&)@MIRAL_6.0" 6.0.0
- (c++)"miral::AppendKeyboardEventFilter::operator()(mir::Server&)@MIRAL_6.0" 6.0.0
+ (c++)"miral::AppendKeyboardEventFilter::operator()(mir::Server&) const@MIRAL_6.0" 6.0.0
  (c++)"miral::ApplicationCredentials::ApplicationCredentials(mir::frontend::SessionCredentials const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::ApplicationCredentials::gid() const@MIRAL_6.0" 6.0.0
  (c++)"miral::ApplicationCredentials::pid() const@MIRAL_6.0" 6.0.0
@@ -333,7 +333,7 @@ libmiral.so.8 libmiral8 #MINVER#
  (c++)"miral::OutputFilter::operator()(mir::Server&) const@MIRAL_6.0" 6.0.0
  (c++)"miral::OutputFilter::~OutputFilter()@MIRAL_6.0" 6.0.0
  (c++)"miral::PrependEventFilter::PrependEventFilter(std::function<bool (MirEvent const*)> const&)@MIRAL_6.0" 6.0.0
- (c++)"miral::PrependEventFilter::operator()(mir::Server&)@MIRAL_6.0" 6.0.0
+ (c++)"miral::PrependEventFilter::operator()(mir::Server&) const@MIRAL_6.0" 6.0.0
  (c++)"miral::PrintTo(miral::Window const&, std::basic_ostream<char, std::char_traits<char> >*)@MIRAL_6.0" 6.0.0
  (c++)"miral::SessionLockListener::SessionLockListener(std::function<void ()> const&, std::function<void ()> const&)@MIRAL_6.0" 6.0.0
  (c++)"miral::SessionLockListener::operator()(mir::Server&) const@MIRAL_6.0" 6.0.0

--- a/include/miral/miral/append_event_filter.h
+++ b/include/miral/miral/append_event_filter.h
@@ -44,7 +44,7 @@ public:
     ///               Returning `true` prevents later filters from seeing the event.
     explicit AppendEventFilter(std::function<bool(MirEvent const* event)> const& filter);
 
-    void operator()(mir::Server& server);
+    void operator()(mir::Server& server) const;
 
 private:
     class Filter;

--- a/include/miral/miral/append_keyboard_event_filter.h
+++ b/include/miral/miral/append_keyboard_event_filter.h
@@ -46,7 +46,7 @@ public:
     ///               Returning `true` prevents later filters from seeing the event.
     explicit AppendKeyboardEventFilter(std::function<bool(MirKeyboardEvent const* event)> const& filter);
 
-    void operator()(mir::Server& server);
+    void operator()(mir::Server& server) const;
 
 private:
     class Filter;

--- a/include/miral/miral/prepend_event_filter.h
+++ b/include/miral/miral/prepend_event_filter.h
@@ -44,7 +44,7 @@ public:
     ///               Returning `true` prevents later filters from seeing the event.
     explicit PrependEventFilter(std::function<bool(MirEvent const* event)> const& filter);
 
-    void operator()(mir::Server& server);
+    void operator()(mir::Server& server) const;
 
 private:
     class Filter;

--- a/src/miral/append_event_filter.cpp
+++ b/src/miral/append_event_filter.cpp
@@ -40,7 +40,7 @@ miral::AppendEventFilter::AppendEventFilter(std::function<bool(MirEvent const* e
 {
 }
 
-void miral::AppendEventFilter::operator()(mir::Server& server)
+void miral::AppendEventFilter::operator()(mir::Server& server) const
 {
     server.add_init_callback([this, &server] { server.the_composite_event_filter()->append(filter); });
 }

--- a/src/miral/append_keyboard_event_filter.cpp
+++ b/src/miral/append_keyboard_event_filter.cpp
@@ -50,7 +50,7 @@ miral::AppendKeyboardEventFilter::AppendKeyboardEventFilter(std::function<bool(M
 {
 }
 
-void miral::AppendKeyboardEventFilter::operator()(mir::Server& server)
+void miral::AppendKeyboardEventFilter::operator()(mir::Server& server) const
 {
     server.add_init_callback([this, &server] { server.the_composite_event_filter()->append(filter); });
 }

--- a/src/miral/prepend_event_filter.cpp
+++ b/src/miral/prepend_event_filter.cpp
@@ -40,7 +40,7 @@ miral::PrependEventFilter::PrependEventFilter(std::function<bool(MirEvent const*
 {
 }
 
-void miral::PrependEventFilter::operator()(mir::Server& server)
+void miral::PrependEventFilter::operator()(mir::Server& server) const
 {
     server.add_init_callback([this, &server] { server.the_composite_event_filter()->prepend(filter); });
 }


### PR DESCRIPTION
Related: https://github.com/canonical/mir/pull/5091#discussion_r3613532891


## What's new?

- What it says on the tin: If the operator doesn't modify the object, it should be `const`.

## How to test

- The code should stay compiling.
