### PR TITLE
Deduplicate gl renderer logs

### DIFF
--- a/include/platform/mir/renderers/gl/renderer.h
+++ b/include/platform/mir/renderers/gl/renderer.h
@@ -36,13 +36,19 @@ namespace renderer
 {
 namespace gl
 {
-
+class Logger;
 class Renderer : public renderer::Renderer
 {
 public:
     Renderer(
         std::shared_ptr<graphics::GLRenderingProvider> gl_interface,
         std::unique_ptr<graphics::gl::OutputSurface> output);
+
+    Renderer(
+        std::shared_ptr<graphics::GLRenderingProvider> gl_interface,
+        std::unique_ptr<graphics::gl::OutputSurface> output,
+        std::shared_ptr<Logger> const& logger);
+
     virtual ~Renderer();
 
     // These are called with a valid GL context:

--- a/include/platform/mir/renderers/gl/renderer_factory.h
+++ b/include/platform/mir/renderers/gl/renderer_factory.h
@@ -35,6 +35,7 @@ public:
         std::unique_ptr<graphics::gl::OutputSurface> output_surface,
         std::shared_ptr<graphics::GLRenderingProvider> gl_provider) const
         -> std::unique_ptr<renderer::Renderer> override;
+
 private:
     struct Self;
     std::shared_ptr<Self> const self;

--- a/include/platform/mir/renderers/gl/renderer_factory.h
+++ b/include/platform/mir/renderers/gl/renderer_factory.h
@@ -26,14 +26,18 @@ namespace renderer
 {
 namespace gl
 {
-
 class RendererFactory : public renderer::RendererFactory
 {
 public:
+    RendererFactory();
+
     auto create_renderer_for(
         std::unique_ptr<graphics::gl::OutputSurface> output_surface,
         std::shared_ptr<graphics::GLRenderingProvider> gl_provider) const
         -> std::unique_ptr<renderer::Renderer> override;
+private:
+    struct Self;
+    std::shared_ptr<Self> const self;
 };
 
 }

--- a/src/include/server/mir/recent_items.h
+++ b/src/include/server/mir/recent_items.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_RECENT_ITEMS_H_
+#define MIR_RECENT_ITEMS_H_
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <optional>
+
+namespace mir
+{
+/// A fixed-capacity circular buffer of recently added items.
+template<typename T, std::size_t Capacity>
+    requires(Capacity > 0)
+class RecentItems
+{
+public:
+    static constexpr auto capacity = Capacity;
+
+    void add(T const& item)
+    {
+        *next = item;
+
+        if (++next == items.end())
+            next = items.begin();
+    }
+
+    auto contains(T const& item) const -> bool
+    {
+        return std::ranges::any_of(items, [&item](auto const& current)
+            {
+                return current && *current == item;
+            });
+    }
+
+private:
+    std::array<std::optional<T>, Capacity> items;
+    decltype(items)::iterator next{items.begin()};
+};
+}
+
+
+#endif // MIR_RECENT_ITEMS_H_

--- a/src/platform/renderers/gl/CMakeLists.txt
+++ b/src/platform/renderers/gl/CMakeLists.txt
@@ -2,6 +2,7 @@ ADD_LIBRARY(mirrenderergl OBJECT
 
   renderer.cpp
   renderer_factory.cpp
+  renderer_logger.cpp
 )
 
 target_include_directories(

--- a/src/platform/renderers/gl/renderer.cpp
+++ b/src/platform/renderers/gl/renderer.cpp
@@ -16,6 +16,9 @@
 #define MIR_LOG_COMPONENT "GLRenderer"
 
 #include <mir/renderers/gl/renderer.h>
+
+#include "renderer_logger.h"
+
 #include <mir/graphics/renderable.h>
 #include <mir/graphics/transformation.h>
 #include <mir/graphics/display_sink.h>
@@ -28,6 +31,8 @@
 #include <mir/graphics/program_factory.h>
 #include <mir/graphics/program.h>
 #include <mir/renderer/gl/gl_surface.h>
+#include <mir/recent_items.h>
+#include <mir/synchronised.h>
 
 #define GLM_FORCE_RADIANS
 #include <glm/gtc/matrix_transform.hpp>
@@ -558,6 +563,39 @@ auto make_output_current(std::unique_ptr<mg::gl::OutputSurface> output) -> std::
     output->make_current();
     return output;
 }
+
+auto log_capabilities_legacy(auto const& capabilities)
+{
+
+    EGLDisplay disp = eglGetCurrentDisplay();
+    if (disp != EGL_NO_DISPLAY)
+    {
+        for (auto i = 0u; i != std::size(mrg::Capabilities::eglstrings); ++i)
+        {
+            auto const label = mrg::Capabilities::eglstrings[i].label.data();
+            auto const val = capabilities.egl_strings[i].data();
+            mir::log_info("%s: %s", label, val ? val : "");
+        }
+    }
+
+    for (auto i = 0u; i != std::size(mrg::Capabilities::glstrings); ++i)
+    {
+        auto const label = mrg::Capabilities::glstrings[i].label.data();
+        auto const val = capabilities.gl_strings[i].data();
+        mir::log_info("%s: %s", label, val ? val : "");
+    }
+
+    mir::log_info("GL max texture size = %d", capabilities.max_texture_size);
+
+    mir::log_info(
+        "GL framebuffer bits: RGBA=%d%d%d%d, depth=%d, stencil=%d",
+        capabilities.framebuffer_bits[0],
+        capabilities.framebuffer_bits[1],
+        capabilities.framebuffer_bits[2],
+        capabilities.framebuffer_bits[3],
+        capabilities.framebuffer_bits[4],
+        capabilities.framebuffer_bits[5]);
+}
 }
 
 mrg::Renderer::Renderer(
@@ -571,52 +609,23 @@ mrg::Renderer::Renderer(
       gl_interface{std::move(gl_interface)}
 {
     eglBindAPI(EGL_OPENGL_ES_API);
-    EGLDisplay disp = eglGetCurrentDisplay();
-    if (disp != EGL_NO_DISPLAY)
-    {
-        struct {GLint id; char const* label;} const eglstrings[] =
-        {
-            {EGL_VENDOR,      "EGL vendor"},
-            {EGL_VERSION,     "EGL version"},
-            {EGL_CLIENT_APIS, "EGL client APIs"},
-            {EGL_EXTENSIONS,  "EGL extensions"},
-        };
-        for (auto& s : eglstrings)
-        {
-            auto val = eglQueryString(disp, s.id);
-            mir::log_info(std::string(s.label) + ": " + (val ? val : ""));
-        }
-    }
+    log_capabilities_legacy(collect_capabilities());
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
 
-    struct {GLenum id; char const* label;} const glstrings[] =
-    {
-        {GL_VENDOR,   "GL vendor"},
-        {GL_RENDERER, "GL renderer"},
-        {GL_VERSION,  "GL version"},
-        {GL_SHADING_LANGUAGE_VERSION,  "GLSL version"},
-        {GL_EXTENSIONS, "GL extensions"},
-    };
-
-    for (auto& s : glstrings)
-    {
-        auto val = reinterpret_cast<char const*>(glGetString(s.id)); //TICS !cppcoreguidelines-pro-type-reinterpret-cast: glGetString returns an ASCII string, guaranteed not to have the high-bit set, so it's representationally-identical to signed char
-        mir::log_info(std::string(s.label) + ": " + (val ? val : ""));
-    }
-
-    GLint max_texture_size = 0;
-    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size);
-    mir::log_info("GL max texture size = %d", max_texture_size);
-
-    GLint rbits = 0, gbits = 0, bbits = 0, abits = 0, dbits = 0, sbits = 0;
-    glGetIntegerv(GL_RED_BITS, &rbits);
-    glGetIntegerv(GL_GREEN_BITS, &gbits);
-    glGetIntegerv(GL_BLUE_BITS, &bbits);
-    glGetIntegerv(GL_ALPHA_BITS, &abits);
-    glGetIntegerv(GL_DEPTH_BITS, &dbits);
-    glGetIntegerv(GL_STENCIL_BITS, &sbits);
-    mir::log_info("GL framebuffer bits: RGBA=%d%d%d%d, depth=%d, stencil=%d",
-                  rbits, gbits, bbits, abits, dbits, sbits);
-
+mrg::Renderer::Renderer(
+    std::shared_ptr<graphics::GLRenderingProvider> gl_interface,
+    std::unique_ptr<graphics::gl::OutputSurface> output,
+    std::shared_ptr<mrg::Logger> const& logger) :
+    output_surface{std::make_unique<OutputFilter>(make_output_current(std::move(output)))},
+    clear_color{0.0f, 0.0f, 0.0f, 1.0f},
+    program_factory{std::make_unique<ProgramFactory>()},
+    screen_to_gl_coords(0),
+    display_transform(1),
+    gl_interface{std::move(gl_interface)}
+{
+    eglBindAPI(EGL_OPENGL_ES_API);
+    logger->maybe_log_capabilities();
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 

--- a/src/platform/renderers/gl/renderer_factory.cpp
+++ b/src/platform/renderers/gl/renderer_factory.cpp
@@ -15,15 +15,31 @@
  */
 
 #include <mir/renderers/gl/renderer_factory.h>
+
+#include "renderer_logger.h"
+
+
 #include <mir/renderers/gl/renderer.h>
 #include <mir/graphics/platform.h>
 #include <mir/renderer/gl/gl_surface.h>
 
 namespace mrg = mir::renderer::gl;
 
+struct mrg::RendererFactory::Self
+{
+    Self() : logger{std::make_shared<Logger>()} {}
+
+    std::shared_ptr<Logger> const logger;
+};
+
+mrg::RendererFactory::RendererFactory()
+    : self{std::make_shared<mrg::RendererFactory::Self>()}
+{
+}
+
 auto mrg::RendererFactory::create_renderer_for(
     std::unique_ptr<graphics::gl::OutputSurface> output_surface,
     std::shared_ptr<graphics::GLRenderingProvider> gl_provider) const -> std::unique_ptr<mir::renderer::Renderer>
 {
-    return std::make_unique<Renderer>(std::move(gl_provider), std::move(output_surface));
+    return std::make_unique<Renderer>(std::move(gl_provider), std::move(output_surface), self->logger);
 }

--- a/src/platform/renderers/gl/renderer_logger.cpp
+++ b/src/platform/renderers/gl/renderer_logger.cpp
@@ -1,0 +1,90 @@
+/* Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "renderer_logger.h"
+
+#include <ranges>
+
+auto mir::renderer::gl::collect_capabilities() -> Capabilities
+{
+    Capabilities capabilities{
+        eglGetCurrentDisplay(),
+        {},
+        {},
+        0,
+        {},
+    };
+
+    if (capabilities.display != EGL_NO_DISPLAY)
+    {
+        for (auto const& [index, eglstring] : Capabilities::eglstrings | std::views::enumerate)
+        {
+            auto const egl_string = eglQueryString(capabilities.display, eglstring.id);
+            capabilities.egl_strings[index] = egl_string ? egl_string : "";
+        }
+    }
+
+    for (auto const& [index, glstring] : Capabilities::glstrings | std::views::enumerate)
+    {
+        // TICS !cppcoreguidelines-pro-type-reinterpret-cast: glGetString returns an ASCII string,
+        // guaranteed not to have the high-bit set, so it is representationally-identical to signed char.
+        auto const gl_string = reinterpret_cast<char const*>(glGetString(glstring.id));
+        capabilities.gl_strings[index] = gl_string ? gl_string : "";
+    }
+
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &capabilities.max_texture_size);
+
+    std::array const framebuffer_queries{
+        GL_RED_BITS,
+        GL_GREEN_BITS,
+        GL_BLUE_BITS,
+        GL_ALPHA_BITS,
+        GL_DEPTH_BITS,
+        GL_STENCIL_BITS,
+    };
+    for (auto index = 0u; index != framebuffer_queries.size(); ++index)
+        glGetIntegerv(framebuffer_queries[index], &capabilities.framebuffer_bits[index]);
+
+    return capabilities;
+}
+
+void mir::renderer::gl::Logger::maybe_log_capabilities()
+{
+    auto const capabilities = collect_capabilities();
+
+    if (!reported_capabilities.insert(capabilities))
+        return;
+
+
+    if (capabilities.display != EGL_NO_DISPLAY)
+    {
+        for (auto const& [index, eglstring] : Capabilities::eglstrings | std::views::enumerate)
+            mir::log_info({mir::logging::graphics()}, "{}: {}", eglstring.label, capabilities.egl_strings[index]);
+    }
+
+    for (auto const& [index, glstring] : Capabilities::glstrings | std::views::enumerate)
+        mir::log_info({mir::logging::graphics()}, "{}: {}", glstring.label, capabilities.gl_strings[index]);
+
+    mir::log_info({mir::logging::graphics()}, "GL max texture size = {}", capabilities.max_texture_size);
+    mir::log_info(
+        {mir::logging::graphics()},
+        "GL framebuffer bits: RGBA={}{}{}{}, depth={}, stencil={}",
+        capabilities.framebuffer_bits[0],
+        capabilities.framebuffer_bits[1],
+        capabilities.framebuffer_bits[2],
+        capabilities.framebuffer_bits[3],
+        capabilities.framebuffer_bits[4],
+        capabilities.framebuffer_bits[5]);
+}

--- a/src/platform/renderers/gl/renderer_logger.h
+++ b/src/platform/renderers/gl/renderer_logger.h
@@ -1,0 +1,104 @@
+/* Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_RENDERER_GL_RENDERER_LOGGER_H_
+#define MIR_RENDERER_GL_RENDERER_LOGGER_H_
+
+#include <mir/recent_items.h>
+#include <mir/synchronised.h>
+#include <mir/log.h>
+
+#include <GL/gl.h>
+#include <EGL/egl.h>
+
+
+namespace mir
+{
+namespace renderer
+{
+namespace gl
+{
+
+struct Capabilities
+{
+    struct
+    {
+        GLint id;
+        std::string_view label;
+    } static constexpr eglstrings[] = {
+        {EGL_VENDOR, "EGL vendor"},
+        {EGL_VERSION, "EGL version"},
+        {EGL_CLIENT_APIS, "EGL client APIs"},
+        {EGL_EXTENSIONS, "EGL extensions"},
+    };
+
+    struct
+    {
+        GLenum id;
+        std::string_view label;
+    } static constexpr glstrings[] = {
+        {GL_VENDOR, "GL vendor"},
+        {GL_RENDERER, "GL renderer"},
+        {GL_VERSION, "GL version"},
+        {GL_SHADING_LANGUAGE_VERSION, "GLSL version"},
+        {GL_EXTENSIONS, "GL extensions"},
+    };
+
+    EGLDisplay display;
+    std::array<std::string, 4> egl_strings;
+    std::array<std::string, 5> gl_strings;
+    GLint max_texture_size;
+    std::array<GLint, 6> framebuffer_bits;
+
+    auto operator==(Capabilities const&) const -> bool = default;
+};
+
+auto collect_capabilities() -> Capabilities;
+
+class Logger
+{
+public:
+    Logger() = default;
+
+    // Logs GL and EGL capabilities only if the current capabilities have not been logged before.
+    void maybe_log_capabilities();
+
+private:
+    template<typename T, std::size_t Capacity>
+    class BoundedSet
+    {
+    public:
+        auto insert(T const& value) -> bool
+        {
+            auto values = items.lock();
+
+            if (values->contains(value))
+                return false;
+
+            values->add(value);
+            return true;
+        }
+
+    private:
+        mir::Synchronised<mir::RecentItems<T, Capacity>> items;
+    };
+
+    BoundedSet<Capabilities, 32> reported_capabilities;
+};
+}
+}
+}
+
+#endif

--- a/src/server/frontend_wayland/input_trigger_registry.cpp
+++ b/src/server/frontend_wayland/input_trigger_registry.cpp
@@ -37,24 +37,6 @@ using ActionGroupManager = mf::InputTriggerRegistry::ActionGroupManager;
 using Trigger = mf::InputTriggerRegistry::Trigger;
 
 
-void mf::RecentTokens::add(std::string_view token)
-{
-    *current = token;
-
-    if (++current == tokens.end())
-    {
-        current = tokens.begin();
-    }
-}
-
-auto mf::RecentTokens::contains(std::string_view token) const -> bool
-{
-    if(token.empty())
-        return false;
-
-    return std::find(tokens.begin(), tokens.end(), token) != tokens.end();
-}
-
 template <typename T>
 void iterate_and_erase_expired(
     std::vector<mir::wayland::Weak<T>>& vec, auto&& callback)

--- a/src/server/frontend_wayland/input_trigger_registry.h
+++ b/src/server/frontend_wayland/input_trigger_registry.h
@@ -20,16 +20,15 @@
 
 #include <mir/events/event.h>
 #include <mir/executor.h>
+#include <mir/recent_items.h>
 #include <mir/shell/token_authority.h>
 #include <mir/wayland/lifetime_tracker.h>
 #include <mir/wayland/weak.h>
 
-#include <array>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -41,23 +40,7 @@ namespace frontend
 class KeyboardSymTrigger;
 class KeyboardCodeTrigger;
 
-/// A fixed-capacity circular buffer of recently seen tokens.
-///
-/// Tracks the last \c capacity tokens added, allowing efficient membership
-/// checks. Older tokens are evicted as new ones are inserted once the buffer
-/// is full.
-class RecentTokens
-{
-public:
-    void add(std::string_view token);
-
-    auto contains(std::string_view token) const -> bool;
-
-    static constexpr auto capacity = 32;
-private:
-    std::array<std::string, capacity> tokens;
-    decltype(tokens)::iterator current{tokens.begin()};
-};
+using RecentTokens = RecentItems<std::string, 32>;
 
 class InputTriggerRegistry
 {

--- a/tests/unit-tests/renderers/gl/CMakeLists.txt
+++ b/tests/unit-tests/renderers/gl/CMakeLists.txt
@@ -1,5 +1,7 @@
 list(APPEND UNIT_TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_gl_renderer.cpp
+  ${PROJECT_SOURCE_DIR}/src/platform/renderers/gl/renderer_factory.cpp
+  ${PROJECT_SOURCE_DIR}/src/platform/renderers/gl/renderer_logger.cpp
 )
 
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
+++ b/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
@@ -31,6 +31,9 @@
 #include <mir/test/doubles/mock_output_surface.h>
 
 #include <mir/graphics/transformation.h>
+#include <mir/logging/logger.h>
+#include <mir/logging/tag.h>
+#include <mir/renderers/gl/renderer_factory.h>
 
 using testing::SetArgPointee;
 using testing::InSequence;
@@ -173,11 +176,43 @@ public:
     StubProgram prog;
 };
 
+class MockRendererLogger : public mir::logging::Logger
+{
+public:
+    MOCK_METHOD(void, log, (mir::logging::Severity, std::string const&, std::string const&), (override));
+};
+
 auto make_output_surface() -> std::unique_ptr<mtd::MockOutputSurface>
 {
     return std::make_unique<testing::NiceMock<mtd::MockOutputSurface>>();
 }
 
+}
+
+TEST_F(GLRenderer, logs_renderer_capabilities_only_once_for_successive_renderer_creation)
+{
+    auto logger = std::make_shared<testing::StrictMock<MockRendererLogger>>();
+    mir::logging::set_logger(logger);
+    mir::logging::tag::set_severity("graphics", mir::logging::Severity::debug);
+
+    auto initial_log_count = 0u;
+    EXPECT_CALL(*logger, log(mir::logging::Severity::informational, testing::_, "graphics"))
+        .WillRepeatedly([&] { initial_log_count++; });
+
+    mrg::RendererFactory factory;
+
+    auto first_renderer = factory.create_renderer_for(make_output_surface(), gl_platform);
+    auto const log_count_after_first_renderer = initial_log_count;
+
+    auto second_renderer = factory.create_renderer_for(make_output_surface(), gl_platform);
+    auto const log_count_after_second_renderer = initial_log_count;
+
+    ASSERT_EQ(log_count_after_first_renderer, log_count_after_second_renderer)
+        << "Renderer capabilities should only be logged once for successive renderer creation";
+
+    // Clear out any references to the logger so its destroyed.
+    mir::logging::set_logger(std::make_shared<MockRendererLogger>());
+    logger.reset();
 }
 
 TEST_F(GLRenderer, disables_blending_for_rgbx_surfaces)


### PR DESCRIPTION
Addresses: https://github.com/canonical/mir/pull/5071#discussion_r3640766671

## What's new?

- De-duplicates `gl::Renderer` logs by capabilities such that when renderers are repeatedly re-created, our logging sinks aren't flooded with identical logs.

## How to test

```
<path/to/build>/bin/mir_unit_tests --gtest_filter=GLRenderer.logs_renderer_capabilities_only_once_for_successive_renderer_creation
```
