### PR TITLE
feat(wayland-rs): advertise wl_output as a dynamic per-monitor global

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -44,6 +44,7 @@ pub struct CppProtocolGenerationOutput {
 /// - A wayland server notification handler builder
 /// - A work callback builder
 /// - An fd-ready callback builder
+/// - An output global binder builder
 /// - An FFI forward-declaration builder
 pub fn generate_cpp_protocol_builders(
     protocols: &Vec<WaylandProtocol>,
@@ -52,6 +53,7 @@ pub fn generate_cpp_protocol_builders(
     let wayland_server_notification_handler_builder = create_wayland_server_notification_handler();
     let work_callback_builder = create_work_callback();
     let fd_ready_callback_builder = create_fd_ready_callback();
+    let output_global_binder_builder = create_output_global_binder();
     let ffi_fwd_builder = create_ffi_fwd_builder(protocols);
 
     // Interfaces that are created server-side and handed back to the client via an event
@@ -68,6 +70,7 @@ pub fn generate_cpp_protocol_builders(
     builders.push(wayland_server_notification_handler_builder);
     builders.push(work_callback_builder);
     builders.push(fd_ready_callback_builder);
+    builders.push(output_global_binder_builder);
 
     CppProtocolGenerationOutput {
         ffi_fwd_builder,
@@ -207,6 +210,65 @@ fn create_fd_ready_callback() -> CppBuilder {
 
     let ready_method = CppMethod::new("ready", None, true, false, true, true);
     class.add_method(ready_method);
+
+    namespace.add_class(class);
+    builder.add_namespace(namespace);
+    builder
+}
+
+/// Create the `OutputGlobalBinder` interface.
+///
+/// This is the per-monitor counterpart to the `GlobalFactory` for the
+/// dynamically-created `wl_output` globals. Where `GlobalFactory` owns the
+/// binding logic for every statically-registered global, an
+/// `OutputGlobalBinder` captures the state of a *single* monitor: it is passed
+/// to `WaylandServer::create_output_global` and invoked whenever a client binds
+/// that monitor's `wl_output` global.
+fn create_output_global_binder() -> CppBuilder {
+    let mut builder: CppBuilder =
+        CppBuilder::new("MIR_WAYLANDRS_OUTPUT_GLOBAL_BINDER", "output_global_binder");
+    builder.add_header_include("<memory>");
+    builder.add_header_include("<rust/cxx.h>");
+    let mut namespace = CppNamespace::new(vec!["mir", "wayland_rs"]);
+    namespace.add_forward_declaration_class("WaylandClient");
+    namespace.add_forward_declaration_class("WaylandClientId");
+    namespace.add_forward_declaration_class("Output");
+    namespace.add_forward_declaration_struct("OutputMiddleware");
+
+    let mut class = CppClass::new("OutputGlobalBinder");
+
+    // bind: construct the wl_output object for a client that has bound this
+    // monitor's global, mirroring GlobalFactory::create_wl_output.
+    let mut bind_method = CppMethod::new(
+        "bind",
+        Some(CppType::Object("Output".to_string())),
+        true,
+        false,
+        true,
+        true,
+    );
+    bind_method.add_arg(CppArg::new(
+        CppType::Box("WaylandClient".to_string()),
+        "client",
+        false,
+    ));
+    bind_method.add_arg(CppArg::new(
+        CppType::Box("OutputMiddleware".to_string()),
+        "instance",
+        false,
+    ));
+    bind_method.add_arg(CppArg::new(CppType::CppU32, "object_id", false));
+    class.add_method(bind_method);
+
+    // can_view: whether the given client may see this monitor's global.
+    let mut can_view_method =
+        CppMethod::new("can_view", Some(CppType::Bool), true, false, true, true);
+    can_view_method.add_arg(CppArg::new(
+        CppType::Box("WaylandClientId".to_string()),
+        "client_id",
+        false,
+    ));
+    class.add_method(can_view_method);
 
     namespace.add_class(class);
     builder.add_namespace(namespace);

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -90,7 +90,11 @@ fn create_global_factory(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
             .interfaces
             .iter()
             .filter(|interface| interface.is_global)
-            .filter(|interface| interface.name != "wl_display" && interface.name != "wl_registry")
+            .filter(|interface| {
+                interface.name != "wl_display"
+                    && interface.name != "wl_registry"
+                    && interface.name != "wl_output"
+            })
             .for_each(|global_interface| {
                 let class_name = format_wayland_interface_to_cpp_class(&global_interface.name);
                 let ext_name =
@@ -238,7 +242,8 @@ fn create_output_global_binder() -> CppBuilder {
     let mut class = CppClass::new("OutputGlobalBinder");
 
     // bind: construct the wl_output object for a client that has bound this
-    // monitor's global, mirroring GlobalFactory::create_wl_output.
+    // monitor's global, mirroring GlobalFactory::create_<interface> for the
+    // statically-registered globals.
     let mut bind_method = CppMethod::new(
         "bind",
         Some(CppType::Object("Output".to_string())),

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -729,6 +729,10 @@ fn generate_dispatch_implementations(protocol: &WaylandProtocol) -> TokenStream 
         .interfaces
         .iter()
         .filter(|interface| interface.is_global)
+        // `wl_output` gets its `GlobalDispatch` from `generate_output_dynamic_global`
+        // (per-monitor, `OutputGlobalData`), so it must not also get a static
+        // `SharedFactory` implementation here.
+        .filter(|interface| interface.name != "wl_output")
         .collect();
 
     let global_dispatch_impls = global_interfaces.iter().map(|interface| {

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -34,6 +34,8 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
 
     let server_side_factories = generate_server_side_factories(protocols);
 
+    let output_dynamic_global = generate_output_dynamic_global(protocols);
+
     quote! {
         #[allow(dead_code, unused_imports)]
         mod dispatch {
@@ -84,7 +86,63 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
             #(#generated_dispatch_implementations)*
 
             #server_side_factories
+
+            #output_dynamic_global
         }
+    }
+}
+
+/// Generate the machinery for dynamically-created `wl_output` globals.
+///
+/// Unlike every other global (which is registered once at startup and bound
+/// through the shared `GlobalFactory`), `wl_output` is advertised per-monitor
+/// and can come and go at runtime. To support this we use a distinct
+/// global-data type ([OutputGlobalData]) carrying a per-monitor C++
+/// [ffi::OutputGlobalBinder], and reuse [generate_global_dispatch_impl] to emit
+/// the `GlobalDispatch` implementation so that binding a `wl_output` follows
+/// exactly the same steps as binding any other global.
+///
+/// The binder is stored behind a `Mutex` because `GlobalDispatch::bind` and
+/// `can_view` only receive a shared reference to the global data, yet the C++
+/// binder methods (like the factory's) require a `Pin<&mut _>` to be invoked.
+fn generate_output_dynamic_global(protocols: &Vec<WaylandProtocol>) -> TokenStream {
+    let (protocol, interface) = protocols
+        .iter()
+        .find_map(|protocol| {
+            protocol
+                .interfaces
+                .iter()
+                .find(|interface| interface.name == "wl_output")
+                .map(|interface| (protocol, interface))
+        })
+        .expect("The wayland protocol must define wl_output");
+
+    let global_dispatch_impl = generate_global_dispatch_impl(
+        interface,
+        &generate_namespace(protocol),
+        GlobalBindSource::PerGlobalBinder,
+    );
+
+    quote! {
+        // A cxx opaque C++ type is not automatically `Send`/`Sync`. The binder
+        // is only ever accessed under the `Mutex` in `OutputGlobalData` (and,
+        // from C++, only on the event-loop thread), so this is sound.
+        unsafe impl Send for ffi::OutputGlobalBinder {}
+        unsafe impl Sync for ffi::OutputGlobalBinder {}
+
+        /// Per-global data for a dynamically-created `wl_output`, carrying the
+        /// C++ binder that builds the `wl_output` object for each client bind.
+        pub(crate) struct OutputGlobalData {
+            binder: Mutex<cxx::UniquePtr<ffi::OutputGlobalBinder>>,
+        }
+
+        impl OutputGlobalData {
+            pub(crate) fn new(binder: cxx::UniquePtr<ffi::OutputGlobalBinder>) -> Self {
+                OutputGlobalData { binder: Mutex::new(binder) }
+            }
+        }
+
+        #global_dispatch_impl
     }
 }
 
@@ -209,10 +267,72 @@ fn generate_server_side_factory(
     }
 }
 
+/// Where a `GlobalDispatch` implementation finds the C++ code that builds the
+/// object a client binds to.
+///
+/// Both variants produce the same `bind` body — create the wrapper, init the
+/// resource, wrap it in middleware, call into C++, store the result — and
+/// differ only in which C++ object is called and how it is reached from the
+/// global data.
+#[derive(Clone, Copy)]
+enum GlobalBindSource {
+    /// The single `GlobalFactory` shared by every statically-registered global.
+    /// Because one factory serves all interfaces, it exposes a
+    /// `create_<interface>` method per global and `can_view` is told which
+    /// interface is being queried.
+    SharedFactory,
+    /// A per-global `OutputGlobalBinder` carried by the global's own data, used
+    /// by the dynamically-created per-monitor `wl_output` globals. The binder
+    /// already *is* the monitor, so its methods need no interface name.
+    PerGlobalBinder,
+}
+
+impl GlobalBindSource {
+    /// The `GlobalDispatch` global-data type.
+    fn global_data_type(&self) -> TokenStream {
+        match self {
+            // An Arc<Mutex<...>> instead of just a UniquePtr because the factory
+            // has to be accessed mutably in order to call methods across the
+            // Rust -> C++ boundary.
+            Self::SharedFactory => quote! { Arc<Mutex<cxx::UniquePtr<ffi::GlobalFactory>>> },
+            Self::PerGlobalBinder => quote! { OutputGlobalData },
+        }
+    }
+
+    /// The expression, in terms of `global_data`, holding the `Mutex` guarding
+    /// the C++ object.
+    fn lock_target(&self) -> TokenStream {
+        match self {
+            Self::SharedFactory => quote! { global_data },
+            Self::PerGlobalBinder => quote! { global_data.binder },
+        }
+    }
+
+    /// The C++ method that builds the bound object.
+    fn bind_method(&self, interface_name: &str) -> Ident {
+        match self {
+            Self::SharedFactory => format_ident!("create_{}", interface_name),
+            Self::PerGlobalBinder => format_ident!("bind"),
+        }
+    }
+
+    /// The arguments passed to the C++ `can_view`, and any bindings they need.
+    fn can_view_args(&self, interface_name: &str) -> (TokenStream, TokenStream) {
+        match self {
+            Self::SharedFactory => (
+                quote! { let interface_name = #interface_name; },
+                quote! { interface_name, client_id },
+            ),
+            Self::PerGlobalBinder => (quote! {}, quote! { client_id }),
+        }
+    }
+}
+
 /// Generate a GlobalDispatch implementation for a single interface.
 fn generate_global_dispatch_impl(
     interface: &WaylandInterface,
     namespace_name: &TokenStream,
+    source: GlobalBindSource,
 ) -> TokenStream {
     let interface_name = dash_to_snake_ident(&interface.name);
 
@@ -227,10 +347,14 @@ fn generate_global_dispatch_impl(
         format_wayland_interface_to_rust_extension_struct(&interface.name)
     );
     let wrapper_struct_name = format_ident!("{}Wrapper", snake_to_pascal(&interface.name));
-    let create_global_method = format_ident!("create_{}", &interface.name);
-    let interface_name_str = &interface.name;
+
+    let global_data_type = source.global_data_type();
+    let lock_target = source.lock_target();
+    let bind_method = source.bind_method(&interface.name);
+    let (can_view_bindings, can_view_args) = source.can_view_args(&interface.name);
+
     quote! {
-        impl GlobalDispatch<#namespace_name::#interface_name::#interface_struct_name, Arc<Mutex<cxx::UniquePtr<ffi::GlobalFactory>>>>
+        impl GlobalDispatch<#namespace_name::#interface_name::#interface_struct_name, #global_data_type>
             for ServerState
         {
             fn bind(
@@ -238,10 +362,7 @@ fn generate_global_dispatch_impl(
                 handle: &wayland_server::DisplayHandle,
                 client: &wayland_server::Client,
                 resource: New<#namespace_name::#interface_name::#interface_struct_name>,
-                // The global data is an Arc<Mutex<...>> instead of just a UniquePtr because it
-                // has to be accessed mutability in order to call methods across the Rust -> C++
-                // boundary.
-                global_data: &Arc<Mutex<cxx::UniquePtr<ffi::GlobalFactory>>>,
+                global_data: &#global_data_type,
                 data_init: &mut wayland_server::DataInit<'_, Self>,
             ) {
                 use crate::ffi;
@@ -255,21 +376,21 @@ fn generate_global_dispatch_impl(
                 // Step 2: Create the middleware object wrapping the wayland resource.
                 let boxed = Box::new(crate::middleware::#ext_interface_struct_name{ wrapped: instance });
 
-                // Step 3: Call the C++ factory with client, middleware, and object_id
+                // Step 3: Call into C++ with client, middleware, and object_id
                 // so the C++ object is fully initialized from the start.
                 let wayland_client = Box::new(WaylandClient::new(client.clone(), handle.clone()));
-                let mut guard = global_data.lock().unwrap();
-                let global = (&mut *guard).pin_mut().#create_global_method(wayland_client, boxed, protocol_id);
+                let mut guard = #lock_target.lock().unwrap();
+                let global = (&mut *guard).pin_mut().#bind_method(wayland_client, boxed, protocol_id);
 
                 // Step 4: Store the fully-initialized C++ object in the wrapper.
                 wrapper.lock().unwrap().inner = Some(global);
             }
 
-            fn can_view(client: Client, global_data: &Arc<Mutex<cxx::UniquePtr<ffi::GlobalFactory>>>) -> bool {
-                let interface_name = #interface_name_str;
+            fn can_view(client: Client, global_data: &#global_data_type) -> bool {
+                #can_view_bindings
                 let client_id = Box::new(WaylandClientId::new(client.id()));
-                let mut guard = global_data.lock().unwrap();
-                (&mut *guard).pin_mut().can_view(interface_name, client_id)
+                let mut guard = #lock_target.lock().unwrap();
+                (&mut *guard).pin_mut().can_view(#can_view_args)
             }
         }
     }
@@ -610,9 +731,9 @@ fn generate_dispatch_implementations(protocol: &WaylandProtocol) -> TokenStream 
         .filter(|interface| interface.is_global)
         .collect();
 
-    let global_dispatch_impls = global_interfaces
-        .iter()
-        .map(|interface| generate_global_dispatch_impl(interface, &namespace_name));
+    let global_dispatch_impls = global_interfaces.iter().map(|interface| {
+        generate_global_dispatch_impl(interface, &namespace_name, GlobalBindSource::SharedFactory)
+    });
 
     let is_wayland_protocol = protocol.name == "wayland";
     let dispatch_impls = protocol

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -55,6 +55,9 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
                 fn stop(self: &WaylandServer);
                 fn drain_queue(self: &mut WaylandServer) -> bool;
                 fn register_fd_ready_listener(self: &WaylandServer, fd: i32, callback: UniquePtr<FdReadyCallback>);
+                fn create_output_global(self: &WaylandServer, binder: UniquePtr<OutputGlobalBinder>) -> Box<OutputGlobal>;
+
+                type OutputGlobal;
 
                 type WaylandClient;
                 fn pid(self: &WaylandClient) -> Result<i32>;

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -55,9 +55,9 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
                 fn stop(self: &WaylandServer);
                 fn drain_queue(self: &WaylandServer) -> bool;
                 fn register_fd_ready_listener(self: &WaylandServer, fd: i32, callback: UniquePtr<FdReadyCallback>);
-                fn create_output_global(self: &WaylandServer, binder: UniquePtr<OutputGlobalBinder>) -> Result<Box<OutputGlobal>>;
 
                 type OutputGlobal;
+                fn create_output_global(self: &WaylandServer, binder: UniquePtr<OutputGlobalBinder>) -> Result<Box<OutputGlobal>>;
 
                 type WaylandClient;
                 fn pid(self: &WaylandClient) -> Result<i32>;

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -55,7 +55,7 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
                 fn stop(self: &WaylandServer);
                 fn drain_queue(self: &WaylandServer) -> bool;
                 fn register_fd_ready_listener(self: &WaylandServer, fd: i32, callback: UniquePtr<FdReadyCallback>);
-                fn create_output_global(self: &WaylandServer, binder: UniquePtr<OutputGlobalBinder>) -> Box<OutputGlobal>;
+                fn create_output_global(self: &WaylandServer, binder: UniquePtr<OutputGlobalBinder>) -> Result<Box<OutputGlobal>>;
 
                 type OutputGlobal;
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -51,9 +51,9 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
             extern "Rust" {
                 type WaylandServer;
                 fn create_wayland_server() -> Box<WaylandServer>;
-                fn run(self: &mut WaylandServer, socket: &str, factory: UniquePtr<GlobalFactory>, notification_handler: UniquePtr<WaylandServerNotificationHandler>, work_callback: UniquePtr<WorkCallback>) -> Result<()>;
+                fn run(self: &WaylandServer, socket: &str, factory: UniquePtr<GlobalFactory>, notification_handler: UniquePtr<WaylandServerNotificationHandler>, work_callback: UniquePtr<WorkCallback>) -> Result<()>;
                 fn stop(self: &WaylandServer);
-                fn drain_queue(self: &mut WaylandServer) -> bool;
+                fn drain_queue(self: &WaylandServer) -> bool;
                 fn register_fd_ready_listener(self: &WaylandServer, fd: i32, callback: UniquePtr<FdReadyCallback>);
                 fn create_output_global(self: &WaylandServer, binder: UniquePtr<OutputGlobalBinder>) -> Box<OutputGlobal>;
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/wayland_server_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/wayland_server_generation.rs
@@ -48,6 +48,13 @@ fn generate_register_globals_impl(protocol: &WaylandProtocol) -> Vec<TokenStream
             return None;
         }
 
+        // `wl_output` is advertised dynamically (one global per monitor) via
+        // `WaylandServer::create_output_global`, so it must not be registered
+        // statically here. See `generate_output_dynamic_global`.
+        if interface.name == "wl_output" {
+            return None;
+        }
+
         let interface_name = format_ident!("{}", interface.name);
         let interface_struct_name = format_ident!("{}", snake_to_pascal(&interface.name));
         let version = interface.version;

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
@@ -43,9 +43,7 @@ pub struct WaylandServer {
     fd_listener_signal: Mutex<Option<Ping>>,
     pending_fd_listeners: Mutex<Vec<PendingFdListener>>,
     /// A clone of the running display's handle, populated for the duration of
-    /// [WaylandServer::run]. It lets C++ create and destroy dynamic globals
-    /// (e.g. one `wl_output` per monitor) from any thread; the handle is
-    /// internally synchronised by the backend.
+    /// [WaylandServer::run].
     display_handle: Mutex<Option<DisplayHandle>>,
 }
 

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
@@ -42,6 +42,11 @@ pub struct WaylandServer {
     work_signal: Mutex<Option<Ping>>,
     fd_listener_signal: Mutex<Option<Ping>>,
     pending_fd_listeners: Mutex<Vec<PendingFdListener>>,
+    /// A clone of the running display's handle, populated for the duration of
+    /// [WaylandServer::run]. It lets C++ create and destroy dynamic globals
+    /// (e.g. one `wl_output` per monitor) from any thread; the handle is
+    /// internally synchronised by the backend.
+    display_handle: Mutex<Option<DisplayHandle>>,
 }
 
 impl WaylandServer {
@@ -52,7 +57,49 @@ impl WaylandServer {
             work_signal: Mutex::new(None),
             fd_listener_signal: Mutex::new(None),
             pending_fd_listeners: Mutex::new(Vec::new()),
+            display_handle: Mutex::new(None),
         }
+    }
+
+    /// Create a `wl_output` global backed by the given per-output binder.
+    ///
+    /// Unlike the statically-registered globals, `wl_output` globals are
+    /// dynamic: Mir advertises one per connected monitor and withdraws it when
+    /// the monitor is unplugged. The `binder` captures the C++ state for a
+    /// single monitor and is invoked whenever a client binds this global.
+    ///
+    /// The returned [OutputGlobal] owns the global's lifetime: dropping it
+    /// (from C++, via the returned `Box`) removes the global from the display.
+    ///
+    /// # Panics
+    /// Panics if called while the server is not running (i.e. outside of an
+    /// active [WaylandServer::run]).
+    pub fn create_output_global(
+        &self,
+        binder: UniquePtr<crate::ffi::OutputGlobalBinder>,
+    ) -> Box<OutputGlobal> {
+        let handle = self
+            .display_handle
+            .lock()
+            .expect("No recovery from lock poisoning")
+            .as_ref()
+            .expect("create_output_global called while the server was not running")
+            .clone();
+
+        let data = crate::dispatch::OutputGlobalData::new(binder);
+
+        let version =
+            <wayland_server::protocol::wl_output::WlOutput as wayland_server::Resource>::interface(
+            )
+            .version;
+
+        let id = handle.create_global::<
+            ServerState,
+            wayland_server::protocol::wl_output::WlOutput,
+            crate::dispatch::OutputGlobalData,
+        >(version, data);
+
+        Box::new(OutputGlobal { id, handle })
     }
 
     /// Run the wayland server.
@@ -79,6 +126,14 @@ impl WaylandServer {
             work_callback,
             disconnect_rx,
         };
+
+        // Publish a clone of the display handle so that C++ can create and
+        // destroy dynamic globals (e.g. per-monitor `wl_output`s) while the
+        // server is running. Cleared again before `run` returns.
+        *self
+            .display_handle
+            .lock()
+            .expect("No recovery from lock poisoning") = Some(state.handle.clone());
 
         // First, add the listener to the event loop.
         let listener = ListeningSocket::bind(socket)?;
@@ -230,6 +285,13 @@ impl WaylandServer {
                 .flush_clients()
                 .map_err(|_| "Failed to flush clients")?;
         }
+
+        // The display handle is about to become inert; stop handing out clones
+        // for dynamic global creation.
+        *self
+            .display_handle
+            .lock()
+            .expect("No recovery from lock poisoning") = None;
 
         Ok(())
     }
@@ -388,6 +450,22 @@ impl FdReadyListener for CxxFdReadyListener {
 /// Create a new wayland server.
 pub fn create_wayland_server() -> Box<WaylandServer> {
     Box::new(WaylandServer::new())
+}
+
+/// An RAII handle owning the lifetime of a dynamically-created `wl_output`
+/// global (see [WaylandServer::create_output_global]).
+///
+/// Dropping it withdraws the global from the display. It is handed to C++ as a
+/// `Box<OutputGlobal>`; when C++ drops that box the global is removed.
+pub struct OutputGlobal {
+    id: wayland_server::backend::GlobalId,
+    handle: DisplayHandle,
+}
+
+impl Drop for OutputGlobal {
+    fn drop(&mut self) {
+        self.handle.remove_global::<ServerState>(self.id.clone());
+    }
 }
 
 /// The state of the wayland server.

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
@@ -109,7 +109,7 @@ impl WaylandServer {
     /// # Arguments
     /// * `socket` - The name of the socket to bind to (e.g. "wayland-0").
     pub fn run(
-        &mut self,
+        &self,
         socket: &str,
         factory: UniquePtr<GlobalFactory>,
         notification_handler: UniquePtr<WaylandServerNotificationHandler>,
@@ -134,6 +134,19 @@ impl WaylandServer {
             .display_handle
             .lock()
             .expect("No recovery from lock poisoning") = Some(state.handle.clone());
+
+        // This ensures that the display handle will be dropped when this method returns.
+        struct ClearDisplayHandleOnDrop<'a>(&'a WaylandServer);
+        impl Drop for ClearDisplayHandleOnDrop<'_> {
+            fn drop(&mut self) {
+                *self
+                    .0
+                    .display_handle
+                    .lock()
+                    .expect("No recovery from lock poisoning") = None;
+            }
+        }
+        let _clear_display_handle = ClearDisplayHandleOnDrop(self);
 
         // First, add the listener to the event loop.
         let listener = ListeningSocket::bind(socket)?;
@@ -285,13 +298,6 @@ impl WaylandServer {
                 .flush_clients()
                 .map_err(|_| "Failed to flush clients")?;
         }
-
-        // The display handle is about to become inert; stop handing out clones
-        // for dynamic global creation.
-        *self
-            .display_handle
-            .lock()
-            .expect("No recovery from lock poisoning") = None;
 
         Ok(())
     }

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
@@ -71,19 +71,19 @@ impl WaylandServer {
     /// The returned [OutputGlobal] owns the global's lifetime: dropping it
     /// (from C++, via the returned `Box`) removes the global from the display.
     ///
-    /// # Panics
-    /// Panics if called while the server is not running (i.e. outside of an
-    /// active [WaylandServer::run]).
+    /// # Errors
+    /// Returns an error if called while the server is not running (i.e. outside
+    /// of an active [WaylandServer::run]).
     pub fn create_output_global(
         &self,
         binder: UniquePtr<crate::ffi::OutputGlobalBinder>,
-    ) -> Box<OutputGlobal> {
+    ) -> Result<Box<OutputGlobal>, Box<dyn error::Error>> {
         let handle = self
             .display_handle
             .lock()
             .expect("No recovery from lock poisoning")
             .as_ref()
-            .expect("create_output_global called while the server was not running")
+            .ok_or("create_output_global called while the server was not running")?
             .clone();
 
         let data = crate::dispatch::OutputGlobalData::new(binder);
@@ -99,7 +99,7 @@ impl WaylandServer {
             crate::dispatch::OutputGlobalData,
         >(version, data);
 
-        Box::new(OutputGlobal { id, handle })
+        Ok(Box::new(OutputGlobal { id, handle }))
     }
 
     /// Run the wayland server.


### PR DESCRIPTION
This was discovered during the grand refactor from wayland_server.h to wayland-rs.

Every global in the generated wayland-rs frontend is registered once at startup and bound through the single, shared `GlobalFactory`. That model does not fit `wl_output`: a compositor advertises one `wl_output` global per connected monitor, creates them as monitors are plugged in, and withdraws them as monitors go away. A single statically-registered global has no way to say *which* monitor a client is binding, and no way to disappear.

Generate a parallel, per-monitor path for `wl_output`:

* A new `OutputGlobalBinder` C++ interface is generated alongside `GlobalFactory`. Where `GlobalFactory` owns the binding logic for every static global, an `OutputGlobalBinder` captures the state of exactly one monitor: `bind()` builds that monitor's `wl_output` object for a client, and `can_view()` decides whether a client may see the global at all.

* A dedicated `GlobalDispatch<WlOutput, OutputGlobalData>` implementation is generated, using a distinct global-data type that carries the per-monitor binder rather than the shared factory. The binder lives behind a `Mutex` because `GlobalDispatch` hands out only a shared reference to the global data, while the cxx-generated binder methods need `Pin<&mut _>`.

* `wl_output` is consequently excluded from the static global registration, since it is now advertised exclusively through this path.

* `WaylandServer::create_output_global()` is exposed over the bridge so C++ can create one global per monitor. It returns a `Box<OutputGlobal>` whose `Drop` removes the global from the display, giving C++ RAII control over the global's lifetime -- which is what makes monitor hotplug/unplug expressible.

To support creating and destroying globals while the server is running, `WaylandServer` now publishes a clone of the display handle for the duration of `run()`. The handle is internally synchronised by the backend, so globals may be created from any thread; it is cleared again before `run()` returns so that no one can hand out globals against an inert display.

This lands ahead of the wider wayland-rs frontend migration, which needs per-monitor outputs before Mir's `OutputManager` can be ported onto the new frontend.

## How to test
Check that the code is generated properly.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
