### PR TITLE
Reuse one resizable renderer in BasicScreenShooter

### DIFF
--- a/include/platform/mir/renderers/gl/renderer.h
+++ b/include/platform/mir/renderers/gl/renderer.h
@@ -106,11 +106,13 @@ protected:
     virtual void draw(graphics::Renderable const& renderable) const;
 
 private:
-    void update_gl_viewport();
+    void update_gl_viewport() const;
 
     class ProgramFactory;
     std::unique_ptr<ProgramFactory> program_factory;
     geometry::Rectangle viewport;
+    /// Size the GL viewport was last derived for; the output surface may resize under us.
+    geometry::Size mutable last_output_size;
     glm::mat4 screen_to_gl_coords;
     glm::mat4 display_transform;
     std::vector<mir::gl::Primitive> mutable primitives;

--- a/include/platform/mir/renderers/gl/renderer.h
+++ b/include/platform/mir/renderers/gl/renderer.h
@@ -106,13 +106,16 @@ protected:
     virtual void draw(graphics::Renderable const& renderable) const;
 
 private:
-    void update_gl_viewport() const;
+    void update_gl_viewport();
 
     class ProgramFactory;
     std::unique_ptr<ProgramFactory> program_factory;
     geometry::Rectangle viewport;
-    /// Size the GL viewport was last derived for; the output surface may resize under us.
-    geometry::Size mutable last_output_size;
+    /* Size the GL viewport was last derived for; the output surface may resize
+     * under us, so set_viewport() (which callers invoke before each render)
+     * re-derives the GL viewport when this no longer matches.
+     */
+    geometry::Size last_output_size;
     glm::mat4 screen_to_gl_coords;
     glm::mat4 display_transform;
     std::vector<mir::gl::Primitive> mutable primitives;

--- a/src/platform/graphics/cpu_copy_output_surface.cpp
+++ b/src/platform/graphics/cpu_copy_output_surface.cpp
@@ -157,6 +157,12 @@ public:
     auto layout() const -> Layout;
 
 private:
+    /* The size of the target buffer can change between commits (notably, the
+     * screen shooter captures to whatever buffer the client provides), so
+     * (re)specify our storage whenever it no longer matches.
+     */
+    void ensure_storage_for(geom::Size size);
+
     mg::CPUAddressableDisplayAllocator& allocator;
     EGLDisplay const dpy;
     EGLContext ctx;
@@ -164,6 +170,7 @@ private:
     RenderbufferHandle colour_buffer;
     std::shared_ptr<RenderbufferHandle> depth_stencil_buffer;
     FramebufferHandle fbo;
+    geom::Size allocated_size;
 };
 
 mgc::CPUCopyOutputSurface::CPUCopyOutputSurface(
@@ -215,16 +222,29 @@ mgc::CPUCopyOutputSurface::Impl::Impl(
     : allocator{allocator},
       dpy{dpy},
       ctx{create_current_context(dpy, share_ctx)},
-      format{select_format_from(allocator)}
+      format{select_format_from(allocator)},
+      depth_stencil_buffer{
+          (config.depth_buffer_bits() || config.stencil_buffer_bits())
+              ? std::make_shared<RenderbufferHandle>()
+              : nullptr}
 {
-    glBindRenderbuffer(GL_RENDERBUFFER, colour_buffer);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8_OES, size().width.as_int(), size().height.as_int());
+    ensure_storage_for(size());
+}
 
-    if (config.depth_buffer_bits() || config.stencil_buffer_bits())
+void mgc::CPUCopyOutputSurface::Impl::ensure_storage_for(geom::Size size)
+{
+    if (size == allocated_size)
     {
-        depth_stencil_buffer = std::make_shared<RenderbufferHandle>();
+        return;
+    }
+
+    glBindRenderbuffer(GL_RENDERBUFFER, colour_buffer);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8_OES, size.width.as_int(), size.height.as_int());
+
+    if (depth_stencil_buffer)
+    {
         glBindRenderbuffer(GL_RENDERBUFFER, depth_stencil_buffer->operator GLuint());
-        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size().width.as_int(), size().height.as_int());
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size.width.as_int(), size.height.as_int());
     }
 
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
@@ -267,6 +287,8 @@ mgc::CPUCopyOutputSurface::Impl::Impl(
                         std::string{"Unknown GL framebuffer error code: "} + std::to_string(status)}));
         }
     }
+
+    allocated_size = size;
 }
 
 mgc::CPUCopyOutputSurface::Impl::~Impl()
@@ -291,6 +313,7 @@ mgc::CPUCopyOutputSurface::Impl::~Impl()
     // We're the current EGL context; destroy our GL resources...
     fbo.reset();
     colour_buffer.reset();
+    depth_stencil_buffer.reset();
 
     // Now release our context, and delete it.
     release_current();
@@ -299,6 +322,7 @@ mgc::CPUCopyOutputSurface::Impl::~Impl()
 
 void mgc::CPUCopyOutputSurface::Impl::bind()
 {
+    ensure_storage_for(size());
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 }
 

--- a/src/platform/graphics/cpu_copy_output_surface.cpp
+++ b/src/platform/graphics/cpu_copy_output_surface.cpp
@@ -161,7 +161,7 @@ private:
      * screen shooter captures to whatever buffer the client provides), so
      * (re)specify our storage whenever it no longer matches.
      */
-    void ensure_storage_for(geom::Size size);
+    void ensure_storage_for_size();
 
     mg::CPUAddressableDisplayAllocator& allocator;
     EGLDisplay const dpy;
@@ -228,23 +228,24 @@ mgc::CPUCopyOutputSurface::Impl::Impl(
               ? std::make_shared<RenderbufferHandle>()
               : nullptr}
 {
-    ensure_storage_for(size());
+    ensure_storage_for_size();
 }
 
-void mgc::CPUCopyOutputSurface::Impl::ensure_storage_for(geom::Size size)
+void mgc::CPUCopyOutputSurface::Impl::ensure_storage_for_size()
 {
-    if (size == allocated_size)
+    auto const next_size = size();
+    if (next_size == allocated_size)
     {
         return;
     }
 
     glBindRenderbuffer(GL_RENDERBUFFER, colour_buffer);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8_OES, size.width.as_int(), size.height.as_int());
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8_OES, next_size.width.as_int(), next_size.height.as_int());
 
     if (depth_stencil_buffer)
     {
         glBindRenderbuffer(GL_RENDERBUFFER, depth_stencil_buffer->operator GLuint());
-        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size.width.as_int(), size.height.as_int());
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, next_size.width.as_int(), next_size.height.as_int());
     }
 
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
@@ -288,7 +289,7 @@ void mgc::CPUCopyOutputSurface::Impl::ensure_storage_for(geom::Size size)
         }
     }
 
-    allocated_size = size;
+    allocated_size = next_size;
 }
 
 mgc::CPUCopyOutputSurface::Impl::~Impl()
@@ -322,7 +323,7 @@ mgc::CPUCopyOutputSurface::Impl::~Impl()
 
 void mgc::CPUCopyOutputSurface::Impl::bind()
 {
-    ensure_storage_for(size());
+    ensure_storage_for_size();
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 }
 

--- a/src/platform/renderers/gl/renderer.cpp
+++ b/src/platform/renderers/gl/renderer.cpp
@@ -317,7 +317,7 @@ public:
     // NOTE: This must be called with a current GL context
     OutputFilter(std::unique_ptr<mg::gl::OutputSurface> output)
      : output{std::move(output)},
-        texture{make_texture(this->output->size())},
+        texture{make_texture()},
         framebuffer{make_framebuffer(texture)},
         filter{mir_output_filter_none},
         program{nullptr},
@@ -356,6 +356,8 @@ public:
             output->bind();
             return;
         }
+
+        ensure_texture_storage_for(output->size());
 
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, framebuffer);
 
@@ -490,12 +492,28 @@ private:
         return program;
     }
 
-   static GLuint make_texture(mir::geometry::Size size)
+   static GLuint make_texture()
     {
         GLuint tex{0};
         glGenTextures(1, &tex);
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, tex);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        return tex;
+    }
+
+    /* The output surface can be resized under us, so (re)specify the
+     * intermediate texture whenever it no longer matches. This is only ever
+     * reached with a filter active, so an unfiltered output never pays for it.
+     */
+    void ensure_texture_storage_for(mir::geometry::Size size)
+    {
+        if (size == texture_size)
+            return;
+
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, texture);
         glTexImage2D(GL_TEXTURE_2D, 0,
                      GL_RGBA,
                      size.width.as_value(),
@@ -504,9 +522,7 @@ private:
                      GL_RGBA,
                      GL_UNSIGNED_BYTE,
                      nullptr);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        return tex;
+        texture_size = size;
     }
 
     static GLuint make_framebuffer(GLuint tex)
@@ -522,6 +538,7 @@ private:
     std::unique_ptr<mg::gl::OutputSurface> output;
     TextureHandle const texture;
     FramebufferHandle const framebuffer;
+    mir::geometry::Size texture_size;
     MirOutputFilter filter;
     std::unique_ptr<ProgramHandle> program;
     GLint position_attrib;
@@ -657,6 +674,16 @@ auto mrg::Renderer::render(mg::RenderableList const& renderables) const -> std::
 {
     output_surface->make_current();
     output_surface->bind();
+
+    /* The output surface can change size between renders (the screen shooter
+     * captures to whatever buffer the client hands us), and set_viewport() is a
+     * no-op when the logical area is unchanged, so the GL viewport has to be
+     * re-derived here.
+     */
+    if (output_surface->size() != last_output_size)
+    {
+        update_gl_viewport();
+    }
 
     glClearColor(clear_color[0], clear_color[1], clear_color[2], clear_color[3]);
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
@@ -931,7 +958,7 @@ void mrg::Renderer::set_viewport(geometry::Rectangle const& rect)
     update_gl_viewport();
 }
 
-void mrg::Renderer::update_gl_viewport()
+void mrg::Renderer::update_gl_viewport() const
 {
     /*
      * Letterboxing: Move the glViewport to add black bars in the case that
@@ -947,6 +974,7 @@ void mrg::Renderer::update_gl_viewport()
     auto viewport_height = fabs(transformed_viewport[1]);
 
     auto const output_size = output_surface->size();
+    last_output_size = output_size;
     auto const output_width = output_size.width.as_value();
     auto const output_height = output_size.height.as_value();
 

--- a/src/platform/renderers/gl/renderer.cpp
+++ b/src/platform/renderers/gl/renderer.cpp
@@ -504,8 +504,9 @@ private:
     }
 
     /* The output surface can be resized under us, so (re)specify the
-     * intermediate texture whenever it no longer matches. This is only ever
-     * reached with a filter active, so an unfiltered output never pays for it.
+     * intermediate texture storage whenever it no longer matches. This is only
+     * reached with a filter active, so an unfiltered output never allocates
+     * texture storage.
      */
     void ensure_texture_storage_for(mir::geometry::Size size)
     {

--- a/src/platform/renderers/gl/renderer.cpp
+++ b/src/platform/renderers/gl/renderer.cpp
@@ -675,16 +675,6 @@ auto mrg::Renderer::render(mg::RenderableList const& renderables) const -> std::
     output_surface->make_current();
     output_surface->bind();
 
-    /* The output surface can change size between renders (the screen shooter
-     * captures to whatever buffer the client hands us), and set_viewport() is a
-     * no-op when the logical area is unchanged, so the GL viewport has to be
-     * re-derived here.
-     */
-    if (output_surface->size() != last_output_size)
-    {
-        update_gl_viewport();
-    }
-
     glClearColor(clear_color[0], clear_color[1], clear_color[2], clear_color[3]);
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     glClear(GL_COLOR_BUFFER_BIT);
@@ -917,8 +907,16 @@ void mrg::Renderer::draw(mg::Renderable const& renderable) const
 
 void mrg::Renderer::set_viewport(geometry::Rectangle const& rect)
 {
+    /* The output surface can change size under us (the screen shooter captures
+     * to whatever buffer the client hands us), which changes the GL viewport
+     * even when the logical area is unchanged.
+     */
     if (rect == viewport)
+    {
+        if (output_surface->size() != last_output_size)
+            update_gl_viewport();
         return;
+    }
 
     /*
      * Here we provide a 3D perspective projection with a default 30 degrees
@@ -958,7 +956,7 @@ void mrg::Renderer::set_viewport(geometry::Rectangle const& rect)
     update_gl_viewport();
 }
 
-void mrg::Renderer::update_gl_viewport() const
+void mrg::Renderer::update_gl_viewport()
 {
     /*
      * Letterboxing: Move the glViewport to add black bars in the case that

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -278,16 +278,7 @@ public:
 
     auto size() const -> geom::Size override
     {
-        EGLint width{0}, height{0};
-        if (eglQuerySurface(dpy, egl_surf, EGL_WIDTH, &width) != EGL_TRUE)
-        {
-            BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query surface width")));
-        }
-        if (eglQuerySurface(dpy, egl_surf, EGL_HEIGHT, &height) != EGL_TRUE)
-        {
-            BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query surface height")));
-        }
-        return geom::Size{width, height};
+        return surface_size;
     }
 
     auto layout() const -> Layout override
@@ -442,6 +433,20 @@ private:
         return std::make_tuple(std::move(surf), egl_ctx, egl_surf);
     }
 
+    static auto query_surface_size(EGLDisplay dpy, EGLSurface surf) -> geom::Size
+    {
+        EGLint width{0}, height{0};
+        if (eglQuerySurface(dpy, surf, EGL_WIDTH, &width) != EGL_TRUE)
+        {
+            BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query surface width")));
+        }
+        if (eglQuerySurface(dpy, surf, EGL_HEIGHT, &height) != EGL_TRUE)
+        {
+            BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query surface height")));
+        }
+        return geom::Size{width, height};
+    }
+
     GBMOutputSurface(
         EGLDisplay dpy,
         std::tuple<std::unique_ptr<mg::GBMDisplayAllocator::GBMSurface>, EGLContext, EGLSurface> renderables,
@@ -450,7 +455,8 @@ private:
           egl_surf{std::get<2>(renderables)},
           dpy{dpy},
           ctx{std::get<1>(renderables)},
-          quirks{quirks}
+          quirks{quirks},
+          surface_size{query_surface_size(dpy, egl_surf)}
     {
     }
 
@@ -459,6 +465,10 @@ private:
     EGLDisplay const dpy;
     EGLContext const ctx;
     std::shared_ptr<mgg::GbmQuirks> const quirks;
+    /* The EGL surface is created once, at a fixed size, and lives as long as we
+     * do, so querying EGL for it on every frame is pure overhead.
+     */
+    geom::Size const surface_size;
 };
 }
 

--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -71,11 +71,11 @@ public:
 
     auto supported_formats() const -> std::vector<graphics::DRMFormat> override
     {
-        if (!next_buffer)
+        if (current_format == mir_pixel_format_invalid)
         {
             BOOST_THROW_EXCEPTION((std::logic_error{"Attempted to query supported_formats before assigning a buffer"}));
         }
-        return {mg::DRMFormat::from_mir_format(next_buffer->format())};
+        return {mg::DRMFormat::from_mir_format(current_format)};
     }
 
     auto alloc_fb(mg::DRMFormat format) -> std::unique_ptr<MappableFB> override
@@ -89,11 +89,11 @@ public:
 
     auto output_size() const -> geom::Size override
     {
-        if (!next_buffer)
+        if (current_size == geom::Size{})
         {
             BOOST_THROW_EXCEPTION((std::logic_error{"Attempted to query buffer size before assigning a buffer"}));
         }
-        return next_buffer->size();
+        return current_size;
     }
 
     void set_next_buffer(std::shared_ptr<mrs::WriteMappable> buffer)
@@ -102,13 +102,27 @@ public:
         {
             BOOST_THROW_EXCEPTION((std::logic_error{"Attempt to set next buffer with a buffer already pending"}));
         }
+        current_size = buffer->size();
+        current_format = buffer->format();
         next_buffer = std::move(buffer);
+    }
+
+    /// Drop a pending buffer that we've turned out to be unable to render into.
+    void clear_next_buffer()
+    {
+        next_buffer = nullptr;
     }
 private:
     std::shared_ptr<mrs::WriteMappable> next_buffer;
+    /* The pending buffer is consumed by alloc_fb() during commit(), but the
+     * surface we render through outlives any individual capture and will still
+     * query us, so remember the geometry of the most recent buffer.
+     */
+    geom::Size current_size;
+    MirPixelFormat current_format{mir_pixel_format_invalid};
 };
 
-class OffscreenDisplaySink : public mg::DisplaySink
+class mc::BasicScreenShooter::Self::OffscreenDisplaySink : public mg::DisplaySink
 {
 public:
     OffscreenDisplaySink(
@@ -117,6 +131,11 @@ public:
         : provider {std::move(provider)},
           size{size}
     {
+    }
+
+    void set_size(geom::Size new_size)
+    {
+        size = new_size;
     }
 
     auto view_area() const -> mir::geometry::Rectangle override
@@ -150,7 +169,7 @@ protected:
     }
 private:
     std::shared_ptr<mg::CPUAddressableDisplayAllocator> const provider;
-    geom::Size const size;
+    geom::Size size;
 };
 
 mc::BasicScreenShooter::Self::Self(
@@ -165,7 +184,7 @@ mc::BasicScreenShooter::Self::Self(
       clock{clock},
       render_provider{std::move(render_provider)},
       renderer_factory{std::move(renderer_factory)},
-      last_rendered_size{0, 0},
+      last_rendered_format{mir_pixel_format_invalid},
       output{std::make_shared<OneShotBufferDisplayProvider>()},
       config{config},
       output_filter{output_filter},
@@ -221,15 +240,41 @@ auto mc::BasicScreenShooter::Self::renderer_for_buffer(std::shared_ptr<mrs::Writ
     {
         BOOST_THROW_EXCEPTION((std::runtime_error{"Attempt to capture to a zero-sized buffer"}));
     }
+
+    auto const buffer_format = buffer->format();
+    // The renderer is built from the pending buffer, so this has to come first
     output->set_next_buffer(std::move(buffer));
-    if (buffer_size != last_rendered_size)
+
+    try
     {
-        // We need to build a new Renderer, at the new size
-        offscreen_sink = std::make_unique<OffscreenDisplaySink>(output, buffer_size);
-        auto gl_surface = render_provider->surface_for_sink(*offscreen_sink, *config);
-        current_renderer = renderer_factory->create_renderer_for(std::move(gl_surface), render_provider);
-        last_rendered_size = buffer_size;
+        /* The Renderer's output surface resizes itself to whatever buffer is
+         * pending, but it binds a pixel format for its lifetime, so only a
+         * format change forces us to build a new one.
+         */
+        if (!current_renderer || buffer_format != last_rendered_format)
+        {
+            offscreen_sink = std::make_unique<OffscreenDisplaySink>(output, buffer_size);
+            auto gl_surface = render_provider->surface_for_sink(*offscreen_sink, *config);
+            current_renderer = renderer_factory->create_renderer_for(std::move(gl_surface), render_provider);
+            last_rendered_format = buffer_format;
+        }
+        else
+        {
+            offscreen_sink->set_size(buffer_size);
+        }
     }
+    catch (...)
+    {
+        /* We've taken ownership of the buffer but have no renderer to consume
+         * it. Drop it, so the next capture isn't rejected for having a buffer
+         * already pending, and force a rebuild on the next attempt.
+         */
+        output->clear_next_buffer();
+        current_renderer.reset();
+        last_rendered_format = mir_pixel_format_invalid;
+        throw;
+    }
+
     return *current_renderer;
 }
 
@@ -239,7 +284,7 @@ auto mc::BasicScreenShooter::select_provider(
     -> std::shared_ptr<mg::GLRenderingProvider>
 {
     auto display_provider = std::make_shared<Self::OneShotBufferDisplayProvider>();
-    OffscreenDisplaySink temp_db{display_provider, geom::Size{640, 480}};
+    Self::OffscreenDisplaySink temp_db{display_provider, geom::Size{640, 480}};
 
     std::pair<mg::probe::Result, std::shared_ptr<mg::GLRenderingProvider>> best_provider = std::make_pair(
         mg::probe::unsupported, nullptr);

--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -25,6 +25,7 @@
 #include <mir/log.h>
 #include <mir/executor.h>
 #include <mir/graphics/platform.h>
+#include <mir/raii.h>
 #include <mir/renderer/renderer_factory.h>
 #include <mir/renderer/sw/pixel_source.h>
 #include <mir/graphics/display_sink.h>
@@ -96,14 +97,19 @@ public:
         return current_size;
     }
 
+    /// Advertise the geometry the next capture will render into.
+    void set_output_geometry(geom::Size size, MirPixelFormat format)
+    {
+        current_size = size;
+        current_format = format;
+    }
+
     void set_next_buffer(std::shared_ptr<mrs::WriteMappable> buffer)
     {
         if (next_buffer)
         {
             BOOST_THROW_EXCEPTION((std::logic_error{"Attempt to set next buffer with a buffer already pending"}));
         }
-        current_size = buffer->size();
-        current_format = buffer->format();
         next_buffer = std::move(buffer);
     }
 
@@ -217,10 +223,29 @@ auto mc::BasicScreenShooter::Self::render(
 
     scene_elements.clear();
 
-    auto& renderer = renderer_for_buffer(buffer);
+    auto const buffer_size = buffer->size();
+    if (buffer_size.height == geom::Height{0} || buffer_size.width == geom::Width{0})
+    {
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Attempt to capture to a zero-sized buffer"}));
+    }
+
+    auto& renderer = renderer_for(buffer_size, buffer->format());
     renderer.set_output_transform(transform);
     renderer.set_viewport(area);
     renderer.set_output_filter(output_filter->filter());
+
+    /* Hand the buffer over only once we have a renderer to consume it, and make
+     * sure it can't outlive this capture: a buffer left pending would fail every
+     * subsequent capture. On success it has already been claimed by alloc_fb().
+     */
+    output->set_next_buffer(buffer);
+    auto const drop_unconsumed_buffer = mir::raii::paired_calls(
+        [](){},
+        [this]()
+        {
+            output->clear_next_buffer();
+        });
+
     /* We don't need the result of this `render` call, as we know it's
      * going into the buffer we just set
      */
@@ -232,47 +257,32 @@ auto mc::BasicScreenShooter::Self::render(
     return captured_time;
 }
 
-auto mc::BasicScreenShooter::Self::renderer_for_buffer(std::shared_ptr<mrs::WriteMappable> buffer)
+auto mc::BasicScreenShooter::Self::renderer_for(geom::Size buffer_size, MirPixelFormat buffer_format)
     -> mr::Renderer&
 {
-    auto const buffer_size = buffer->size();
-    if (buffer_size.height == geom::Height{0} || buffer_size.width == geom::Width{0})
-    {
-        BOOST_THROW_EXCEPTION((std::runtime_error{"Attempt to capture to a zero-sized buffer"}));
-    }
+    // The renderer is built from the buffer's geometry, so this has to come first
+    output->set_output_geometry(buffer_size, buffer_format);
 
-    auto const buffer_format = buffer->format();
-    // The renderer is built from the pending buffer, so this has to come first
-    output->set_next_buffer(std::move(buffer));
+    /* The Renderer's output surface resizes itself to whatever buffer is
+     * pending, but it binds a pixel format for its lifetime, so only a
+     * format change forces us to build a new one.
+     */
+    if (!current_renderer || buffer_format != last_rendered_format)
+    {
+        /* Build everything before touching any member, so that a failure leaves
+         * the (still perfectly usable) previous renderer in place.
+         */
+        auto sink = std::make_unique<OffscreenDisplaySink>(output, buffer_size);
+        auto gl_surface = render_provider->surface_for_sink(*sink, *config);
+        auto renderer = renderer_factory->create_renderer_for(std::move(gl_surface), render_provider);
 
-    try
-    {
-        /* The Renderer's output surface resizes itself to whatever buffer is
-         * pending, but it binds a pixel format for its lifetime, so only a
-         * format change forces us to build a new one.
-         */
-        if (!current_renderer || buffer_format != last_rendered_format)
-        {
-            offscreen_sink = std::make_unique<OffscreenDisplaySink>(output, buffer_size);
-            auto gl_surface = render_provider->surface_for_sink(*offscreen_sink, *config);
-            current_renderer = renderer_factory->create_renderer_for(std::move(gl_surface), render_provider);
-            last_rendered_format = buffer_format;
-        }
-        else
-        {
-            offscreen_sink->set_size(buffer_size);
-        }
+        offscreen_sink = std::move(sink);
+        current_renderer = std::move(renderer);
+        last_rendered_format = buffer_format;
     }
-    catch (...)
+    else
     {
-        /* We've taken ownership of the buffer but have no renderer to consume
-         * it. Drop it, so the next capture isn't rejected for having a buffer
-         * already pending, and force a rebuild on the next attempt.
-         */
-        output->clear_next_buffer();
-        current_renderer.reset();
-        last_rendered_format = mir_pixel_format_invalid;
-        throw;
+        offscreen_sink->set_size(buffer_size);
     }
 
     return *current_renderer;

--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -223,13 +223,7 @@ auto mc::BasicScreenShooter::Self::render(
 
     scene_elements.clear();
 
-    auto const buffer_size = buffer->size();
-    if (buffer_size.height == geom::Height{0} || buffer_size.width == geom::Width{0})
-    {
-        BOOST_THROW_EXCEPTION((std::runtime_error{"Attempt to capture to a zero-sized buffer"}));
-    }
-
-    auto& renderer = renderer_for(buffer_size, buffer->format());
+    auto& renderer = renderer_for(buffer->size(), buffer->format());
     renderer.set_output_transform(transform);
     renderer.set_viewport(area);
     renderer.set_output_filter(output_filter->filter());
@@ -260,6 +254,11 @@ auto mc::BasicScreenShooter::Self::render(
 auto mc::BasicScreenShooter::Self::renderer_for(geom::Size buffer_size, MirPixelFormat buffer_format)
     -> mr::Renderer&
 {
+    if (buffer_size.height == geom::Height{0} || buffer_size.width == geom::Width{0})
+    {
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Attempt to capture to a zero-sized buffer"}));
+    }
+
     // The renderer is built from the buffer's geometry, so this has to come first
     output->set_output_geometry(buffer_size, buffer_format);
 

--- a/src/server/compositor/basic_screen_shooter.h
+++ b/src/server/compositor/basic_screen_shooter.h
@@ -70,6 +70,7 @@ private:
     struct Self
     {
         class OneShotBufferDisplayProvider;
+        class OffscreenDisplaySink;
 
         Self(
             std::shared_ptr<Scene> const& scene,
@@ -95,14 +96,14 @@ std::shared_ptr<graphics::Cursor> const& cursor);
         std::shared_ptr<graphics::GLRenderingProvider> const render_provider;
         std::shared_ptr<renderer::RendererFactory> const renderer_factory;
 
-        /* The Renderer instantiation is tied to a particular output size, and
-         * requires enough setup to make it worth keeping around as a consumer
-         * is likely to be taking screenshots of consistent size
+        /* The Renderer resizes its output surface to match whatever buffer we're
+         * capturing into, so a single instance serves captures of any size.
+         * Only a change of pixel format requires building a new one.
          */
         std::unique_ptr<renderer::Renderer> current_renderer;
-        geometry::Size last_rendered_size;
+        MirPixelFormat last_rendered_format;
 
-        std::unique_ptr<graphics::DisplaySink> offscreen_sink;
+        std::unique_ptr<OffscreenDisplaySink> offscreen_sink;
         std::shared_ptr<OneShotBufferDisplayProvider> const output;
         std::shared_ptr<mir::graphics::GLConfig> config;
         std::shared_ptr<graphics::OutputFilter> const output_filter;

--- a/src/server/compositor/basic_screen_shooter.h
+++ b/src/server/compositor/basic_screen_shooter.h
@@ -87,7 +87,7 @@ std::shared_ptr<graphics::Cursor> const& cursor);
             glm::mat2 const& transform,
             bool overlay_cursor) -> time::Timestamp;
 
-        auto renderer_for_buffer(std::shared_ptr<renderer::software::WriteMappable> buffer)
+        auto renderer_for(geometry::Size buffer_size, MirPixelFormat buffer_format)
             -> renderer::Renderer&;
 
         std::mutex mutex;

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -53,28 +53,21 @@ struct BasicScreenShooter : Test
     BasicScreenShooter()
     {
         ON_CALL(*scene, scene_elements_for(_)).WillByDefault(Return(scene_elements));
-        ON_CALL(*renderer_factory, create_renderer_for(_,_)).WillByDefault(
+        ON_CALL(*renderer_factory, create_renderer_for(_, _))
+            .WillByDefault(
                 [this](auto output_surface, auto)
                 {
                     ON_CALL(*next_renderer, render(_))
-                        .WillByDefault(
-                            [surface = std::shared_ptr<mg::gl::OutputSurface>(std::move(output_surface))]()
-                            {
-                                return surface->commit();
-                            });
+                        .WillByDefault([surface = std::shared_ptr<mg::gl::OutputSurface>(std::move(output_surface))]()
+                                       { return surface->commit(); });
 
                     return std::move(next_renderer);
                 });
         ON_CALL(*gl_provider, as_texture(_))
-            .WillByDefault(
-                [this](auto buffer)
-                {
-                    return default_gl_behaviour_provider.as_texture(std::move(buffer));
-                });
+            .WillByDefault([this](auto buffer) { return default_gl_behaviour_provider.as_texture(std::move(buffer)); });
         ON_CALL(*gl_provider, surface_for_sink(_, _))
             .WillByDefault(
-                [this](mg::DisplaySink& sink, auto const&)
-                    -> std::unique_ptr<mg::gl::OutputSurface>
+                [this](mg::DisplaySink& sink, auto const&) -> std::unique_ptr<mg::gl::OutputSurface>
                 {
                     if (auto cpu_provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>())
                     {
@@ -83,25 +76,15 @@ struct BasicScreenShooter : Test
                         auto surface = std::make_unique<testing::NiceMock<mtd::MockOutputSurface>>();
                         auto format = cpu_provider->supported_formats().front();
                         ON_CALL(*surface, commit())
-                            .WillByDefault(
-                                [cpu_provider, format]()
-                                {
-                                    return cpu_provider->alloc_fb(format);
-                                });
+                            .WillByDefault([cpu_provider, format]() { return cpu_provider->alloc_fb(format); });
                         ON_CALL(*surface, size())
-                            .WillByDefault(
-                                [cpu_provider]()
-                                {
-                                    return cpu_provider->output_size();
-                                });
+                            .WillByDefault([cpu_provider]() { return cpu_provider->output_size(); });
                         return surface;
                     }
                     BOOST_THROW_EXCEPTION((std::runtime_error{"CPU output support not available?!"}));
                 });
-        ON_CALL(*gl_provider, suitability_for_allocator(_))
-            .WillByDefault(Return(mg::probe::supported));
-        ON_CALL(*gl_provider, suitability_for_display(_))
-            .WillByDefault(Return(mg::probe::supported));
+        ON_CALL(*gl_provider, suitability_for_allocator(_)).WillByDefault(Return(mg::probe::supported));
+        ON_CALL(*gl_provider, suitability_for_display(_)).WillByDefault(Return(mg::probe::supported));
 
         shooter = std::make_unique<mc::BasicScreenShooter>(
             scene,
@@ -122,27 +105,22 @@ struct BasicScreenShooter : Test
      */
     void supply_unlimited_renderers()
     {
-        ON_CALL(*renderer_factory, create_renderer_for(_, _)).WillByDefault(
-            [this](auto output_surface, auto)
-            {
-                ++renderers_created;
-                auto renderer = std::make_unique<testing::NiceMock<mtd::MockRenderer>>();
-                ON_CALL(*renderer, render(_))
-                    .WillByDefault(
-                        [surface = std::shared_ptr<mg::gl::OutputSurface>(std::move(output_surface))]()
-                        {
-                            return surface->commit();
-                        });
-                return renderer;
-            });
+        ON_CALL(*renderer_factory, create_renderer_for(_, _))
+            .WillByDefault(
+                [this](auto output_surface, auto)
+                {
+                    ++renderers_created;
+                    auto renderer = std::make_unique<testing::NiceMock<mtd::MockRenderer>>();
+                    ON_CALL(*renderer, render(_))
+                        .WillByDefault([surface = std::shared_ptr<mg::gl::OutputSurface>(std::move(output_surface))]()
+                                       { return surface->commit(); });
+                    return renderer;
+                });
     }
 
     void capture_and_run(std::shared_ptr<mtd::StubBuffer> const& target)
     {
-        shooter->capture(target, viewport_rect, viewport_transform, false, [&](auto time)
-            {
-                callback.Call(time);
-            });
+        shooter->capture(target, viewport_rect, viewport_transform, false, [&](auto time) { callback.Call(time); });
         executor.execute();
     }
 
@@ -153,15 +131,16 @@ struct BasicScreenShooter : Test
 
     std::shared_ptr<mtd::MockScene> scene{std::make_shared<NiceMock<mtd::MockScene>>()};
     mg::RenderableList renderables{[]()
-        {
-            mg::RenderableList renderables;
-            for (int i = 0; i < 6; i++)
-            {
-                renderables.push_back(std::make_shared<mtd::StubRenderable>());
-            }
-            return renderables;
-        }()};
-    mc::SceneElementSequence scene_elements{[&]()
+                                   {
+                                       mg::RenderableList renderables;
+                                       for (int i = 0; i < 6; i++)
+                                       {
+                                           renderables.push_back(std::make_shared<mtd::StubRenderable>());
+                                       }
+                                       return renderables;
+                                   }()};
+    mc::SceneElementSequence scene_elements{
+        [&]()
         {
             mc::SceneElementSequence elements;
             for (auto& renderable : renderables)
@@ -171,9 +150,11 @@ struct BasicScreenShooter : Test
             return elements;
         }()};
     mtd::StubGlRenderingProvider default_gl_behaviour_provider;
-    std::shared_ptr<mtd::MockGlRenderingProvider> gl_provider{std::make_shared<testing::NiceMock<mtd::MockGlRenderingProvider>>()};
+    std::shared_ptr<mtd::MockGlRenderingProvider> gl_provider{
+        std::make_shared<testing::NiceMock<mtd::MockGlRenderingProvider>>()};
     std::vector<std::shared_ptr<mg::GLRenderingProvider>> gl_providers{gl_provider};
-    std::shared_ptr<mtd::MockRendererFactory> renderer_factory{std::make_shared<testing::NiceMock<mtd::MockRendererFactory>>()};
+    std::shared_ptr<mtd::MockRendererFactory> renderer_factory{
+        std::make_shared<testing::NiceMock<mtd::MockRendererFactory>>()};
     std::shared_ptr<mtd::StubBufferAllocator> buffer_allocator;
     std::shared_ptr<mtd::AdvanceableClock> clock{std::make_shared<mtd::AdvanceableClock>()};
     std::shared_ptr<mtd::MockCursor> cursor{std::make_shared<mtd::MockCursor>()};
@@ -190,10 +171,7 @@ struct BasicScreenShooter : Test
 
 TEST_F(BasicScreenShooter, calls_callback_from_executor)
 {
-    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time)
-        {
-            callback.Call(time);
-        });
+    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time) { callback.Call(time); });
     clock->advance_by(1s);
     EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
     executor.execute();
@@ -201,10 +179,7 @@ TEST_F(BasicScreenShooter, calls_callback_from_executor)
 
 TEST_F(BasicScreenShooter, renders_scene_elements)
 {
-    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time)
-        {
-            callback.Call(time);
-        });
+    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time) { callback.Call(time); });
     InSequence seq;
     EXPECT_CALL(*scene, scene_elements_for(_)).WillOnce(Return(scene_elements));
     EXPECT_THAT(renderables.size(), Gt(0));
@@ -215,10 +190,7 @@ TEST_F(BasicScreenShooter, renders_scene_elements)
 
 TEST_F(BasicScreenShooter, render_curor_when_overlay_cursor_is_true)
 {
-    shooter->capture(buffer, viewport_rect, viewport_transform, true, [&](auto time)
-        {
-            callback.Call(time);
-        });
+    shooter->capture(buffer, viewport_rect, viewport_transform, true, [&](auto time) { callback.Call(time); });
     InSequence seq;
     EXPECT_CALL(*scene, scene_elements_for(_)).WillOnce(Return(scene_elements));
     auto const cursor_renderable = std::make_shared<mtd::StubRenderable>();
@@ -232,10 +204,7 @@ TEST_F(BasicScreenShooter, render_curor_when_overlay_cursor_is_true)
 
 TEST_F(BasicScreenShooter, sets_viewport_correctly_before_render)
 {
-    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time)
-        {
-            callback.Call(time);
-        });
+    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time) { callback.Call(time); });
     Sequence a, b;
     EXPECT_CALL(*next_renderer, set_viewport(Eq(viewport_rect))).InSequence(b);
     EXPECT_CALL(*next_renderer, render(_)).InSequence(a, b);
@@ -246,53 +215,37 @@ TEST_F(BasicScreenShooter, sets_viewport_correctly_before_render)
 TEST_F(BasicScreenShooter, graceful_failure_on_zero_sized_buffer)
 {
     auto broken_buffer = std::make_shared<mtd::StubBuffer>(geom::Size{0, 0});
-    shooter->capture(broken_buffer, viewport_rect, viewport_transform, false, [&](auto time)
-        {
-            callback.Call(time);
-        });
+    shooter->capture(broken_buffer, viewport_rect, viewport_transform, false, [&](auto time) { callback.Call(time); });
     EXPECT_CALL(callback, Call(nullopt_time));
     executor.execute();
 }
 
 TEST_F(BasicScreenShooter, throw_in_scene_elements_for_causes_graceful_failure)
 {
-    ON_CALL(*scene, scene_elements_for(_)).WillByDefault(Invoke([](auto) -> mc::SceneElementSequence
-        {
-            throw std::runtime_error{"throw in scene_elements_for()!"};
-        }));
-    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time)
-        {
-            callback.Call(time);
-        });
+    ON_CALL(*scene, scene_elements_for(_))
+        .WillByDefault(Invoke(
+            [](auto) -> mc::SceneElementSequence { throw std::runtime_error{"throw in scene_elements_for()!"}; }));
+    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time) { callback.Call(time); });
     EXPECT_CALL(callback, Call(nullopt_time));
     executor.execute();
 }
 
 TEST_F(BasicScreenShooter, throw_in_surface_for_output_handled_gracefully)
 {
-    ON_CALL(*gl_provider, surface_for_sink).WillByDefault(
-        [](auto&, auto&) -> std::unique_ptr<mg::gl::OutputSurface>
-        {
-            BOOST_THROW_EXCEPTION((std::runtime_error{"Throw in surface_for_sink"}));
-        });
-    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time)
-        {
-            callback.Call(time);
-        });
+    ON_CALL(*gl_provider, surface_for_sink)
+        .WillByDefault(
+            [](auto&, auto&) -> std::unique_ptr<mg::gl::OutputSurface>
+            { BOOST_THROW_EXCEPTION((std::runtime_error{"Throw in surface_for_sink"})); });
+    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time) { callback.Call(time); });
     EXPECT_CALL(callback, Call(nullopt_time));
     executor.execute();
 }
 
 TEST_F(BasicScreenShooter, throw_in_render_causes_graceful_failure)
 {
-    EXPECT_CALL(*next_renderer, render(_)).WillOnce([](auto) -> std::unique_ptr<mg::Framebuffer>
-        {
-            throw std::runtime_error{"throw in render()!"};
-        });
-    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time)
-        {
-            callback.Call(time);
-        });
+    EXPECT_CALL(*next_renderer, render(_))
+        .WillOnce([](auto) -> std::unique_ptr<mg::Framebuffer> { throw std::runtime_error{"throw in render()!"}; });
+    shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto time) { callback.Call(time); });
     EXPECT_CALL(callback, Call(nullopt_time));
     executor.execute();
 }
@@ -338,11 +291,8 @@ TEST_F(BasicScreenShooter, ensures_renderer_is_current_on_only_one_thread)
 
     // This doesn't actually have to be atomic
     std::atomic<int> call_count = 0;
-    auto const spawn_a_capture =
-        [&]()
-        {
-            shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto) { call_count++; });
-        };
+    auto const spawn_a_capture = [&]()
+    { shooter->capture(buffer, viewport_rect, viewport_transform, false, [&](auto) { call_count++; }); };
 
     auto const expected_call_count = 20;
     for (auto i = 0; i < expected_call_count; ++i)
@@ -354,10 +304,7 @@ TEST_F(BasicScreenShooter, ensures_renderer_is_current_on_only_one_thread)
     EXPECT_THAT(call_count, Eq(expected_call_count));
 }
 
-TEST_F(BasicScreenShooter, compositor_id_is_not_null)
-{
-    EXPECT_THAT(shooter->id(), NotNull());
-}
+TEST_F(BasicScreenShooter, compositor_id_is_not_null) { EXPECT_THAT(shooter->id(), NotNull()); }
 
 TEST_F(BasicScreenShooter, reuses_a_single_renderer_across_differently_sized_buffers)
 {
@@ -365,7 +312,8 @@ TEST_F(BasicScreenShooter, reuses_a_single_renderer_across_differently_sized_buf
 
     EXPECT_CALL(callback, Call(std::make_optional(clock->now()))).Times(4);
 
-    for (auto const& size : {geom::Size{800, 600}, geom::Size{1920, 1080}, geom::Size{640, 480}, geom::Size{1920, 1080}})
+    for (auto const& size :
+         {geom::Size{800, 600}, geom::Size{1920, 1080}, geom::Size{640, 480}, geom::Size{1920, 1080}})
     {
         capture_and_run(std::make_shared<mtd::StubBuffer>(size));
     }
@@ -418,45 +366,10 @@ TEST_F(BasicScreenShooter, builds_a_new_renderer_when_the_pixel_format_changes)
     EXPECT_THAT(renderers_created, Eq(3));
 }
 
-TEST_F(BasicScreenShooter, recovers_from_a_failure_to_build_a_renderer)
-{
-    supply_unlimited_renderers();
-
-    ON_CALL(*gl_provider, surface_for_sink).WillByDefault(
-        [](auto&, auto&) -> std::unique_ptr<mg::gl::OutputSurface>
-        {
-            BOOST_THROW_EXCEPTION((std::runtime_error{"Throw in surface_for_sink"}));
-        });
-
-    EXPECT_CALL(callback, Call(nullopt_time));
-    capture_and_run(buffer);
-    Mock::VerifyAndClearExpectations(&callback);
-
-    // The failed attempt must not leave a buffer pending on the display
-    // provider, or every subsequent capture fails too.
-    ON_CALL(*gl_provider, surface_for_sink(_, _))
-        .WillByDefault(
-            [](mg::DisplaySink& sink, auto const&) -> std::unique_ptr<mg::gl::OutputSurface>
-            {
-                auto cpu_provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>();
-                auto surface = std::make_unique<testing::NiceMock<mtd::MockOutputSurface>>();
-                auto format = cpu_provider->supported_formats().front();
-                ON_CALL(*surface, commit())
-                    .WillByDefault([cpu_provider, format]() { return cpu_provider->alloc_fb(format); });
-                return surface;
-            });
-
-    EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
-    capture_and_run(buffer);
-}
-
 TEST_F(BasicScreenShooter, recovers_from_a_failure_in_render)
 {
     EXPECT_CALL(*next_renderer, render(_))
-        .WillOnce([](auto) -> std::unique_ptr<mg::Framebuffer>
-            {
-                throw std::runtime_error{"throw in render()!"};
-            })
+        .WillOnce([](auto) -> std::unique_ptr<mg::Framebuffer> { throw std::runtime_error{"throw in render()!"}; })
         .WillRepeatedly(DoDefault());
 
     EXPECT_CALL(callback, Call(nullopt_time));

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -69,10 +69,6 @@ struct BasicScreenShooter : Test
             .WillByDefault(
                 [this](mg::DisplaySink& sink, auto const&) -> std::unique_ptr<mg::gl::OutputSurface>
                 {
-                    if (fail_surface_for_sink)
-                    {
-                        BOOST_THROW_EXCEPTION((std::runtime_error{"Throw in surface_for_sink"}));
-                    }
                     if (auto cpu_provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>())
                     {
                         captured_sink = &sink;
@@ -129,7 +125,6 @@ struct BasicScreenShooter : Test
     }
 
     int renderers_created{0};
-    bool fail_surface_for_sink{false};
     std::vector<geom::Size> sink_sizes;
     mg::DisplaySink* captured_sink{nullptr};
     mg::CPUAddressableDisplayAllocator* captured_allocator{nullptr};

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -381,7 +381,9 @@ TEST_F(BasicScreenShooter, only_acquires_one_output_surface_across_differently_s
 
     for (auto const& size : {geom::Size{800, 600}, geom::Size{1024, 768}, geom::Size{800, 600}})
     {
+        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
         capture_and_run(std::make_shared<mtd::StubBuffer>(size));
+        Mock::VerifyAndClearExpectations(&callback);
     }
 }
 
@@ -391,7 +393,9 @@ TEST_F(BasicScreenShooter, output_geometry_tracks_the_current_buffer)
 
     for (auto const& size : {geom::Size{800, 600}, geom::Size{1920, 1080}, geom::Size{640, 480}})
     {
+        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
         capture_and_run(std::make_shared<mtd::StubBuffer>(size));
+        Mock::VerifyAndClearExpectations(&callback);
 
         ASSERT_THAT(captured_sink, NotNull());
         ASSERT_THAT(captured_allocator, NotNull());

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -76,6 +76,10 @@ struct BasicScreenShooter : Test
                 [this](mg::DisplaySink& sink, auto const&)
                     -> std::unique_ptr<mg::gl::OutputSurface>
                 {
+                    if (fail_surface_for_sink)
+                    {
+                        BOOST_THROW_EXCEPTION((std::runtime_error{"Throw in surface_for_sink"}));
+                    }
                     if (auto cpu_provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>())
                     {
                         captured_sink = &sink;
@@ -147,6 +151,7 @@ struct BasicScreenShooter : Test
     }
 
     int renderers_created{0};
+    bool fail_surface_for_sink{false};
     std::vector<geom::Size> sink_sizes;
     mg::DisplaySink* captured_sink{nullptr};
     mg::CPUAddressableDisplayAllocator* captured_allocator{nullptr};
@@ -422,32 +427,51 @@ TEST_F(BasicScreenShooter, recovers_from_a_failure_to_build_a_renderer)
 {
     supply_unlimited_renderers();
 
-    ON_CALL(*gl_provider, surface_for_sink).WillByDefault(
-        [](auto&, auto&) -> std::unique_ptr<mg::gl::OutputSurface>
-        {
-            BOOST_THROW_EXCEPTION((std::runtime_error{"Throw in surface_for_sink"}));
-        });
-
+    fail_surface_for_sink = true;
     EXPECT_CALL(callback, Call(nullopt_time));
     capture_and_run(buffer);
     Mock::VerifyAndClearExpectations(&callback);
 
-    // The failed attempt must not leave a buffer pending on the display
-    // provider, or every subsequent capture fails too.
-    ON_CALL(*gl_provider, surface_for_sink(_, _))
-        .WillByDefault(
-            [](mg::DisplaySink& sink, auto const&) -> std::unique_ptr<mg::gl::OutputSurface>
-            {
-                auto cpu_provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>();
-                auto surface = std::make_unique<testing::NiceMock<mtd::MockOutputSurface>>();
-                auto format = cpu_provider->supported_formats().front();
-                ON_CALL(*surface, commit())
-                    .WillByDefault([cpu_provider, format]() { return cpu_provider->alloc_fb(format); });
-                return surface;
-            });
-
+    // A build that failed before we ever had a renderer must not wedge the
+    // shooter; the next capture has to try again from scratch.
+    fail_surface_for_sink = false;
     EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
     capture_and_run(buffer);
+
+    EXPECT_THAT(renderers_created, Eq(1));
+}
+
+TEST_F(BasicScreenShooter, retains_the_previous_renderer_when_a_rebuild_fails)
+{
+    supply_unlimited_renderers();
+
+    EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
+    capture_and_run(std::make_shared<mtd::StubBuffer>(geom::Size{800, 600}, mir_pixel_format_abgr_8888));
+    Mock::VerifyAndClearExpectations(&callback);
+
+    auto const* const original_sink = captured_sink;
+    ASSERT_THAT(original_sink, NotNull());
+
+    // Only a format change forces a rebuild, and a failed rebuild must leave
+    // the renderer we already have (and the sink it was built from) untouched.
+    fail_surface_for_sink = true;
+    EXPECT_CALL(callback, Call(nullopt_time));
+    capture_and_run(std::make_shared<mtd::StubBuffer>(geom::Size{1024, 768}, mir_pixel_format_argb_8888));
+    Mock::VerifyAndClearExpectations(&callback);
+
+    fail_surface_for_sink = false;
+    EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
+    capture_and_run(std::make_shared<mtd::StubBuffer>(geom::Size{1280, 720}, mir_pixel_format_abgr_8888));
+
+    // Back on the original format, so the surviving renderer must be reused
+    EXPECT_THAT(renderers_created, Eq(1));
+    /* Reading through this pointer is well defined precisely because the failed
+     * rebuild kept the original sink alive; a build that assigned to the
+     * members before it could succeed would have freed it (and left the
+     * surviving renderer built from a destroyed sink), which the sanitiser
+     * builds catch as a use-after-free.
+     */
+    EXPECT_THAT(original_sink->view_area(), Eq(geom::Rectangle{{0, 0}, geom::Size{1280, 720}}));
 }
 
 TEST_F(BasicScreenShooter, recovers_from_a_failure_in_render)

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -73,11 +73,13 @@ struct BasicScreenShooter : Test
                 });
         ON_CALL(*gl_provider, surface_for_sink(_, _))
             .WillByDefault(
-                [](mg::DisplaySink& sink, auto const&)
+                [this](mg::DisplaySink& sink, auto const&)
                     -> std::unique_ptr<mg::gl::OutputSurface>
                 {
                     if (auto cpu_provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>())
                     {
+                        captured_sink = &sink;
+                        captured_allocator = cpu_provider;
                         auto surface = std::make_unique<testing::NiceMock<mtd::MockOutputSurface>>();
                         auto format = cpu_provider->supported_formats().front();
                         ON_CALL(*surface, commit())
@@ -85,6 +87,12 @@ struct BasicScreenShooter : Test
                                 [cpu_provider, format]()
                                 {
                                     return cpu_provider->alloc_fb(format);
+                                });
+                        ON_CALL(*surface, size())
+                            .WillByDefault(
+                                [cpu_provider]()
+                                {
+                                    return cpu_provider->output_size();
                                 });
                         return surface;
                     }
@@ -108,6 +116,40 @@ struct BasicScreenShooter : Test
     }
 
     std::unique_ptr<mtd::MockRenderer> next_renderer{std::make_unique<testing::NiceMock<mtd::MockRenderer>>()};
+
+    /* The default create_renderer_for() hands out the single `next_renderer`;
+     * tests that expect more than one Renderer need a fresh one each time.
+     */
+    void supply_unlimited_renderers()
+    {
+        ON_CALL(*renderer_factory, create_renderer_for(_, _)).WillByDefault(
+            [this](auto output_surface, auto)
+            {
+                ++renderers_created;
+                auto renderer = std::make_unique<testing::NiceMock<mtd::MockRenderer>>();
+                ON_CALL(*renderer, render(_))
+                    .WillByDefault(
+                        [surface = std::shared_ptr<mg::gl::OutputSurface>(std::move(output_surface))]()
+                        {
+                            return surface->commit();
+                        });
+                return renderer;
+            });
+    }
+
+    void capture_and_run(std::shared_ptr<mtd::StubBuffer> const& target)
+    {
+        shooter->capture(target, viewport_rect, viewport_transform, false, [&](auto time)
+            {
+                callback.Call(time);
+            });
+        executor.execute();
+    }
+
+    int renderers_created{0};
+    std::vector<geom::Size> sink_sizes;
+    mg::DisplaySink* captured_sink{nullptr};
+    mg::CPUAddressableDisplayAllocator* captured_allocator{nullptr};
 
     std::shared_ptr<mtd::MockScene> scene{std::make_shared<NiceMock<mtd::MockScene>>()};
     mg::RenderableList renderables{[]()
@@ -315,4 +357,97 @@ TEST_F(BasicScreenShooter, ensures_renderer_is_current_on_only_one_thread)
 TEST_F(BasicScreenShooter, compositor_id_is_not_null)
 {
     EXPECT_THAT(shooter->id(), NotNull());
+}
+
+TEST_F(BasicScreenShooter, reuses_a_single_renderer_across_differently_sized_buffers)
+{
+    supply_unlimited_renderers();
+
+    for (auto const& size : {geom::Size{800, 600}, geom::Size{1920, 1080}, geom::Size{640, 480}, geom::Size{1920, 1080}})
+    {
+        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
+        capture_and_run(std::make_shared<mtd::StubBuffer>(size));
+        Mock::VerifyAndClearExpectations(&callback);
+    }
+
+    EXPECT_THAT(renderers_created, Eq(1));
+}
+
+TEST_F(BasicScreenShooter, only_acquires_one_output_surface_across_differently_sized_buffers)
+{
+    supply_unlimited_renderers();
+
+    EXPECT_CALL(*gl_provider, surface_for_sink(_, _)).Times(1);
+
+    for (auto const& size : {geom::Size{800, 600}, geom::Size{1024, 768}, geom::Size{800, 600}})
+    {
+        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
+        capture_and_run(std::make_shared<mtd::StubBuffer>(size));
+        Mock::VerifyAndClearExpectations(&callback);
+    }
+}
+
+TEST_F(BasicScreenShooter, output_geometry_tracks_the_current_buffer)
+{
+    supply_unlimited_renderers();
+
+    for (auto const& size : {geom::Size{800, 600}, geom::Size{1920, 1080}, geom::Size{640, 480}})
+    {
+        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
+        capture_and_run(std::make_shared<mtd::StubBuffer>(size));
+        Mock::VerifyAndClearExpectations(&callback);
+
+        ASSERT_THAT(captured_sink, NotNull());
+        ASSERT_THAT(captured_allocator, NotNull());
+        // Both must report the buffer we just captured into, not the one we started with
+        EXPECT_THAT(captured_sink->view_area(), Eq(geom::Rectangle{{0, 0}, size}));
+        EXPECT_THAT(captured_allocator->output_size(), Eq(size));
+    }
+}
+
+TEST_F(BasicScreenShooter, builds_a_new_renderer_when_the_pixel_format_changes)
+{
+    supply_unlimited_renderers();
+
+    for (auto const format : {mir_pixel_format_abgr_8888, mir_pixel_format_argb_8888, mir_pixel_format_abgr_8888})
+    {
+        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
+        capture_and_run(std::make_shared<mtd::StubBuffer>(geom::Size{800, 600}, format));
+        Mock::VerifyAndClearExpectations(&callback);
+    }
+
+    EXPECT_THAT(renderers_created, Eq(3));
+}
+
+TEST_F(BasicScreenShooter, recovers_from_a_failure_to_build_a_renderer)
+{
+    supply_unlimited_renderers();
+
+    ON_CALL(*gl_provider, surface_for_sink).WillByDefault(
+        [](auto&, auto&) -> std::unique_ptr<mg::gl::OutputSurface>
+        {
+            BOOST_THROW_EXCEPTION((std::runtime_error{"Throw in surface_for_sink"}));
+        });
+
+    EXPECT_CALL(callback, Call(nullopt_time));
+    capture_and_run(buffer);
+    Mock::VerifyAndClearExpectations(&callback);
+
+    /* The failed attempt must not leave a buffer pending on the display
+     * provider, or every subsequent capture fails too.
+     */
+    ON_CALL(*gl_provider, surface_for_sink(_, _))
+        .WillByDefault(
+            [](mg::DisplaySink& sink, auto const&) -> std::unique_ptr<mg::gl::OutputSurface>
+            {
+                auto cpu_provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>();
+                auto surface = std::make_unique<testing::NiceMock<mtd::MockOutputSurface>>();
+                auto format = cpu_provider->supported_formats().front();
+                ON_CALL(*surface, commit())
+                    .WillByDefault([cpu_provider, format]() { return cpu_provider->alloc_fb(format); });
+                return surface;
+            });
+
+    EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
+    capture_and_run(buffer);
 }

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -363,11 +363,11 @@ TEST_F(BasicScreenShooter, reuses_a_single_renderer_across_differently_sized_buf
 {
     supply_unlimited_renderers();
 
+    EXPECT_CALL(callback, Call(std::make_optional(clock->now()))).Times(4);
+
     for (auto const& size : {geom::Size{800, 600}, geom::Size{1920, 1080}, geom::Size{640, 480}, geom::Size{1920, 1080}})
     {
-        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
         capture_and_run(std::make_shared<mtd::StubBuffer>(size));
-        Mock::VerifyAndClearExpectations(&callback);
     }
 
     EXPECT_THAT(renderers_created, Eq(1));
@@ -378,12 +378,11 @@ TEST_F(BasicScreenShooter, only_acquires_one_output_surface_across_differently_s
     supply_unlimited_renderers();
 
     EXPECT_CALL(*gl_provider, surface_for_sink(_, _)).Times(1);
+    EXPECT_CALL(callback, Call(std::make_optional(clock->now()))).Times(3);
 
     for (auto const& size : {geom::Size{800, 600}, geom::Size{1024, 768}, geom::Size{800, 600}})
     {
-        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
         capture_and_run(std::make_shared<mtd::StubBuffer>(size));
-        Mock::VerifyAndClearExpectations(&callback);
     }
 }
 
@@ -391,11 +390,11 @@ TEST_F(BasicScreenShooter, output_geometry_tracks_the_current_buffer)
 {
     supply_unlimited_renderers();
 
+    EXPECT_CALL(callback, Call(std::make_optional(clock->now()))).Times(3);
+
     for (auto const& size : {geom::Size{800, 600}, geom::Size{1920, 1080}, geom::Size{640, 480}})
     {
-        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
         capture_and_run(std::make_shared<mtd::StubBuffer>(size));
-        Mock::VerifyAndClearExpectations(&callback);
 
         ASSERT_THAT(captured_sink, NotNull());
         ASSERT_THAT(captured_allocator, NotNull());
@@ -409,11 +408,11 @@ TEST_F(BasicScreenShooter, builds_a_new_renderer_when_the_pixel_format_changes)
 {
     supply_unlimited_renderers();
 
+    EXPECT_CALL(callback, Call(std::make_optional(clock->now()))).Times(3);
+
     for (auto const format : {mir_pixel_format_abgr_8888, mir_pixel_format_argb_8888, mir_pixel_format_abgr_8888})
     {
-        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
         capture_and_run(std::make_shared<mtd::StubBuffer>(geom::Size{800, 600}, format));
-        Mock::VerifyAndClearExpectations(&callback);
     }
 
     EXPECT_THAT(renderers_created, Eq(3));

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -381,9 +381,7 @@ TEST_F(BasicScreenShooter, only_acquires_one_output_surface_across_differently_s
 
     for (auto const& size : {geom::Size{800, 600}, geom::Size{1024, 768}, geom::Size{800, 600}})
     {
-        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
         capture_and_run(std::make_shared<mtd::StubBuffer>(size));
-        Mock::VerifyAndClearExpectations(&callback);
     }
 }
 
@@ -393,9 +391,7 @@ TEST_F(BasicScreenShooter, output_geometry_tracks_the_current_buffer)
 
     for (auto const& size : {geom::Size{800, 600}, geom::Size{1920, 1080}, geom::Size{640, 480}})
     {
-        EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
         capture_and_run(std::make_shared<mtd::StubBuffer>(size));
-        Mock::VerifyAndClearExpectations(&callback);
 
         ASSERT_THAT(captured_sink, NotNull());
         ASSERT_THAT(captured_allocator, NotNull());
@@ -433,9 +429,8 @@ TEST_F(BasicScreenShooter, recovers_from_a_failure_to_build_a_renderer)
     capture_and_run(buffer);
     Mock::VerifyAndClearExpectations(&callback);
 
-    /* The failed attempt must not leave a buffer pending on the display
-     * provider, or every subsequent capture fails too.
-     */
+    // The failed attempt must not leave a buffer pending on the display
+    // provider, or every subsequent capture fails too.
     ON_CALL(*gl_provider, surface_for_sink(_, _))
         .WillByDefault(
             [](mg::DisplaySink& sink, auto const&) -> std::unique_ptr<mg::gl::OutputSurface>
@@ -465,9 +460,8 @@ TEST_F(BasicScreenShooter, recovers_from_a_failure_in_render)
     capture_and_run(buffer);
     Mock::VerifyAndClearExpectations(&callback);
 
-    /* The buffer handed to the failed render must not be left pending on the
-     * display provider, or every subsequent capture fails too.
-     */
+    // The buffer handed to the failed render must not be left pending on the
+    // display provider, or every subsequent capture fails too.
     EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
     capture_and_run(buffer);
 }

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -451,3 +451,23 @@ TEST_F(BasicScreenShooter, recovers_from_a_failure_to_build_a_renderer)
     EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
     capture_and_run(buffer);
 }
+
+TEST_F(BasicScreenShooter, recovers_from_a_failure_in_render)
+{
+    EXPECT_CALL(*next_renderer, render(_))
+        .WillOnce([](auto) -> std::unique_ptr<mg::Framebuffer>
+            {
+                throw std::runtime_error{"throw in render()!"};
+            })
+        .WillRepeatedly(DoDefault());
+
+    EXPECT_CALL(callback, Call(nullopt_time));
+    capture_and_run(buffer);
+    Mock::VerifyAndClearExpectations(&callback);
+
+    /* The buffer handed to the failed render must not be left pending on the
+     * display provider, or every subsequent capture fails too.
+     */
+    EXPECT_CALL(callback, Call(std::make_optional(clock->now())));
+    capture_and_run(buffer);
+}

--- a/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
+++ b/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
@@ -436,6 +436,7 @@ TEST_F(GLRenderer, unchanged_viewport_updates_gl_if_output_resized)
         .WillByDefault([]() { return std::unique_ptr<mg::Framebuffer>(); });
 
     mrg::Renderer renderer(gl_platform, std::move(output_surface));
+    EXPECT_CALL(mock_gl, glViewport(0, 0, 1920, 1080));
     renderer.set_viewport(view_area);
     renderer.render(renderable_list);
 

--- a/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
+++ b/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
@@ -420,6 +420,50 @@ TEST_F(GLRenderer, unchanged_viewport_avoids_gl_calls)
     renderer.set_viewport(view_area);
 }
 
+TEST_F(GLRenderer, unchanged_viewport_updates_gl_if_output_resized)
+{   /* The screen shooter renders through an output surface that resizes itself
+     * to whatever buffer it's capturing into, so the logical viewport can stay
+     * put while the output underneath changes size.
+     */
+    mir::geometry::Rectangle const view_area{{0, 0}, {1920, 1080}};
+
+    auto output_surface = make_output_surface();
+    auto* const output_surface_ptr = output_surface.get();
+
+    ON_CALL(*output_surface, size())
+        .WillByDefault(Return(mir::geometry::Size{1920, 1080}));
+    ON_CALL(*output_surface, commit())
+        .WillByDefault([]() { return std::unique_ptr<mg::Framebuffer>(); });
+
+    mrg::Renderer renderer(gl_platform, std::move(output_surface));
+    renderer.set_viewport(view_area);
+    renderer.render(renderable_list);
+
+    ON_CALL(*output_surface_ptr, size())
+        .WillByDefault(Return(mir::geometry::Size{1280, 720}));
+
+    EXPECT_CALL(mock_gl, glViewport(0, 0, 1280, 720));
+    renderer.render(renderable_list);
+}
+
+TEST_F(GLRenderer, unchanged_viewport_and_output_size_avoids_gl_viewport_calls)
+{
+    mir::geometry::Rectangle const view_area{{0, 0}, {1920, 1080}};
+
+    auto output_surface = make_output_surface();
+    ON_CALL(*output_surface, size())
+        .WillByDefault(Return(mir::geometry::Size{1920, 1080}));
+    ON_CALL(*output_surface, commit())
+        .WillByDefault([]() { return std::unique_ptr<mg::Framebuffer>(); });
+
+    mrg::Renderer renderer(gl_platform, std::move(output_surface));
+    renderer.set_viewport(view_area);
+    renderer.render(renderable_list);
+
+    EXPECT_CALL(mock_gl, glViewport(_, _, _, _)).Times(0);
+    renderer.render(renderable_list);
+}
+
 TEST_F(GLRenderer, unchanged_viewport_updates_gl_if_rotated)
 {   // Regression test for LP: #1672269
     int const screen_width = 1920;

--- a/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
+++ b/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
@@ -443,6 +443,7 @@ TEST_F(GLRenderer, unchanged_viewport_updates_gl_if_output_resized)
         .WillByDefault(Return(mir::geometry::Size{1280, 720}));
 
     EXPECT_CALL(mock_gl, glViewport(0, 0, 1280, 720));
+    renderer.set_viewport(view_area);
     renderer.render(renderable_list);
 }
 
@@ -461,6 +462,7 @@ TEST_F(GLRenderer, unchanged_viewport_and_output_size_avoids_gl_viewport_calls)
     renderer.render(renderable_list);
 
     EXPECT_CALL(mock_gl, glViewport(_, _, _, _)).Times(0);
+    renderer.set_viewport(view_area);
     renderer.render(renderable_list);
 }
 


### PR DESCRIPTION
This is a response to https://github.com/canonical/mir/pull/5111

## The Problem
`BasicScreenShooter` rebuilt its entire rendering stack whenever the capture buffer size changed. Because `WlrScreencopyManagerV1` owns a single `ScreenShooter` per client binding ([`wlr_screencopy_v1.cpp:365`](https://github.com/canonical/mir/blob/main/src/server/frontend_wayland/wlr_screencopy_v1.cpp#L365)), a client capturing two differently-sized outputs alternates sizes every frame, so `last_rendered_size` never stabilises and *every* capture paid for a fresh EGL context, renderbuffer, FBO, `OutputFilter` texture, `ProgramFactory` (all shaders recompiled and relinked) and ~10 `log_info()` lines dumping multi-kB EGL/GL extension strings.


Micro-benchmark on Mesa/radeonsi (AMD RX 7800 XT), alternating 1920x1080 ↔ 1280x720, 200 iterations:

| Path | per capture |
| --- | --- |
| Recreate context + storage + FBOs + programs (before) | **6.367 ms** |
| Reuse context, re-specify storage only (after) | **0.095 ms** |
| **Saving** | **6.27 ms (~67x)** |

Component breakdown on a warm context at 1920x1080: `eglCreateContext` + make current + destroy 1.238 ms; compile + link 2 programs 0.217 ms; `glRenderbufferStorage` 0.057 ms; `glTexImage2D` 0.040 ms. The parts only sum to ~1.5 ms — the remaining ~4.9 ms is the cost of allocating FBOs/renderbuffers/textures on a *cold* context, where the driver cannot reuse its buffer-object pools.

6.4 ms is ~38% of a 60Hz frame budget, burned per capture before any actual rendering, on a discrete GPU. On integrated/software GL (sanitiser and VM CI targets, low-end devices) it will be materially worse.

## What's new?
- `CPUCopyOutputSurface` now respecifies its storage size in `bind` to ensure that it has a properly sized texture
- `Renderer` now calls `ensure_texture_storage_for` on `bind` to ensure that it has a properly sized texture
- `BasicScreenShooter` builds its sink, surface and renderer once and resizes to match the new size after (thus avoiding the cost of rebuilding, unless the format changes)

## How to test
1. Run `miral-app`
2. Enable the magnifier
3. Resize it how you please and see that it still functions correctly.

## Notes for reviewers
- `BasicScreenShooter`'s sink only offers `CPUAddressableDisplayAllocator`, so `surface_for_sink` always lands on `CPUCopyOutputSurface` for both gbm-kms and renderer-generic-egl.

## Checklist

- [x] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos

