### PR TITLE
refactor(x11): isolate xcb XKB include workaround

### DIFF
--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -35,17 +35,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-x11.h>
 
-// xcb/xkb.h has a struct member named "explicit", which C++ does not like
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
-#endif
-#define explicit explicit_
-#include <xcb/xkb.h>
-#undef explicit
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include "../xcb_xkb_compat.h"
 
 // Due to a bug in Unity when keyboard is grabbed,
 // client cannot be resized. This helps in debugging.

--- a/src/platforms/x11/xcb_xkb_compat.h
+++ b/src/platforms/x11/xcb_xkb_compat.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_X11_XCB_XKB_COMPAT_H_
+#define MIR_X11_XCB_XKB_COMPAT_H_
+
+// xcb/xkb.h has a struct member named "explicit", which C++ does not like.
+#if defined(__clang__)
+#define MIR_XKB_DIAGNOSTIC_PUSH \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wkeyword-macro\"")
+#define MIR_XKB_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__) && (__GNUC__ >= 16)
+#define MIR_XKB_DIAGNOSTIC_PUSH \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wkeyword-macro\"")
+#define MIR_XKB_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
+#else
+#define MIR_XKB_DIAGNOSTIC_PUSH
+#define MIR_XKB_DIAGNOSTIC_POP
+#endif
+
+MIR_XKB_DIAGNOSTIC_PUSH
+#define explicit explicit_
+#include <xcb/xkb.h>
+#undef explicit
+MIR_XKB_DIAGNOSTIC_POP
+
+#undef MIR_XKB_DIAGNOSTIC_PUSH
+#undef MIR_XKB_DIAGNOSTIC_POP
+
+#endif

--- a/tests/mir_test_doubles/CMakeLists.txt
+++ b/tests/mir_test_doubles/CMakeLists.txt
@@ -76,7 +76,8 @@ if (MIR_BUILD_PLATFORM_X11)
       ${CMAKE_CURRENT_SOURCE_DIR}/mock_x11.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/mock_xkb.cpp
     PROPERTIES
-      INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/src/platforms/gbm-kms/server
+        INCLUDE_DIRECTORIES
+          "${PROJECT_SOURCE_DIR}/src/platforms/gbm-kms/server;${PROJECT_SOURCE_DIR}/src/platforms/x11"
   )
 endif()
 

--- a/tests/mir_test_doubles/mock_xkb.cpp
+++ b/tests/mir_test_doubles/mock_xkb.cpp
@@ -17,17 +17,7 @@
 #include <mir/test/doubles/mock_xkb.h>
 #include <gtest/gtest.h>
 
-// xcb/xkb.h has a struct member named "explicit", which C++ does not like
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
-#endif
-#define explicit explicit_
-#include <xcb/xkb.h>
-#undef explicit
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include <xcb_xkb_compat.h>
 
 namespace mtd=mir::test::doubles;
 


### PR DESCRIPTION
Spun off from: #5113 

Fixes building on Debian Sid and extracts duplicated macro wizardry into a common header.