### PR TITLE
gbm-kms: DisplaySink: stop using OverlappingOutputGroupping

### DIFF
--- a/src/platforms/gbm-kms/server/kms/display.cpp
+++ b/src/platforms/gbm-kms/server/kms/display.cpp
@@ -381,46 +381,37 @@ void mgg::Display::configure_locked(
             });
     }
 
-    /* Set up used outputs */
-    OverlappingOutputGrouping grouping{kms_conf};
-    auto group_idx = 0;
-
-    grouping.for_each_group(
-        [&](OverlappingOutputGroup const& group)
+    size_t output_idx{0};
+    kms_conf.for_each_output(
+        [&](DisplayConfigurationOutput const& out)
         {
-            auto bounding_rect = group.bounding_rectangle();
-            std::vector<std::shared_ptr<KMSOutput>> kms_outputs;
-            glm::mat2 transformation;
-            geom::Size current_mode_resolution;
+            if (!out.connected || !out.used ||
+                (out.power_mode != mir_power_mode_on) ||
+                (out.current_mode_index >= out.modes.size()))
+            {
+                // We don't need to do anything for unconfigured outputs
+                return;
+            }
 
-            group.for_each_output(
-                [&](DisplayConfigurationOutput const& conf_output)
-                {
-                    auto kms_output = current_display_configuration.get_output_for(conf_output.id);
+            auto kms_output = kms_conf.get_output_for(out.id);
+            auto const mode_index = kms_conf.get_kms_mode_index(out.id, out.current_mode_index);
 
-                    auto const mode_index = kms_conf.get_kms_mode_index(conf_output.id,
-                                                                  conf_output.current_mode_index);
-                    kms_output->configure(conf_output.top_left - bounding_rect.top_left, mode_index);
-                    if (!comp)
-                    {
-                        kms_output->set_power_mode(conf_output.power_mode);
-                        kms_output->set_gamma(conf_output.gamma);
-                        kms_outputs.push_back(std::move(kms_output));
-                    }
+            kms_output->configure({0, 0}, mode_index);
 
-                    /*
-                     * Presently OverlappingOutputGroup guarantees all grouped
-                     * outputs have the same transformation.
-                     */
-                    transformation = conf_output.transformation();
-                    if (conf_output.current_mode_index < conf_output.modes.size())
-                        current_mode_resolution = conf_output.modes[conf_output.current_mode_index].size;
-                });
+            if (!comp)
+            {
+                kms_output->set_power_mode(out.power_mode);
+                kms_output->set_gamma(out.gamma);
+            }
+
+            auto const transform = out.transformation();
 
             if (comp)
             {
-                display_sinks[group_idx++]->set_transformation(transformation,
-                                                                 bounding_rect);
+                display_sinks[output_idx]->set_transformation(
+                    transform,
+                    out.extents());
+                ++output_idx;
             }
             else
             {
@@ -429,9 +420,9 @@ void mgg::Display::configure_locked(
                     gbm,
                     bypass_option,
                     listener,
-                    kms_outputs,
-                    bounding_rect,
-                    transformation);
+                    std::move(kms_output),
+                    out.extents(),
+                    transform);
 
                 display_buffers_new.push_back(std::move(db));
             }

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -53,12 +53,12 @@ mgg::DisplaySink::DisplaySink(
     std::shared_ptr<struct gbm_device> gbm,
     mgg::BypassOption,
     std::shared_ptr<DisplayReport> const& listener,
-    std::vector<std::shared_ptr<KMSOutput>> const& outputs,
+    std::shared_ptr<KMSOutput> const& output,
     geom::Rectangle const& area,
     glm::mat2 const& transformation)
     : gbm{std::move(gbm)},
       listener(listener),
-      outputs(outputs),
+      output(output),
       area(area),
       transform{transformation},
       needs_set_crtc{false},
@@ -68,13 +68,7 @@ mgg::DisplaySink::DisplaySink(
 
     // If any of the outputs have a CRTC mismatch, we will want to set all of them
     // so that they're all showing the same buffer.
-    bool has_crtc_mismatch = false;
-    for (auto& output : outputs)
-    {
-        has_crtc_mismatch = output->has_crtc_mismatch();
-        if (has_crtc_mismatch)
-            break;
-    }
+    bool has_crtc_mismatch = output->has_crtc_mismatch();
 
     if (has_crtc_mismatch)
     {
@@ -90,9 +84,7 @@ mgg::DisplaySink::DisplaySink(
         ::memset(mapping->data(), 24, mapping->len());
 
         visible_fb = std::move(initial_fb);
-        for (auto &output: outputs) {
-            output->set_crtc(*visible_fb);
-        }
+        output->set_crtc(*visible_fb);
         listener->report_successful_drm_mode_set_crtc_on_construction();
     }
     listener->report_successful_display_construction();
@@ -151,7 +143,7 @@ void mgg::DisplaySink::for_each_display_sink(std::function<void(graphics::Displa
     // to all sorts of problems (e.g. an error during eglSwapBuffers
     // because the back buffer is empty). To avoid this, we don't iterate
     // over display sinks that refer to disconnected outputs.
-    if (!outputs.front()->connected())
+    if (!output->connected())
         return;
 
     f(*this);
@@ -159,32 +151,21 @@ void mgg::DisplaySink::for_each_display_sink(std::function<void(graphics::Displa
 
 void mgg::DisplaySink::set_crtc(FBHandle const& forced_frame)
 {
-    for (auto& output : outputs)
-    {
-        /*
-         * Note that failure to set the CRTC is not a fatal error. This can
-         * happen under normal conditions when resizing VirtualBox (which
-         * actually removes and replaces the virtual output each time so
-         * sometimes it's really not there). Xorg often reports similar
-         * errors, and it's not fatal.
-         */
-        if (!output->set_crtc(forced_frame))
-            mir::log_error("Failed to set DRM CRTC. "
-                "Screen contents may be incomplete. "
-                "Try plugging the monitor in again.");
-    }
+    /*
+     * Note that failure to set the CRTC is not a fatal error. This can
+     * happen under normal conditions when resizing VirtualBox (which
+     * actually removes and replaces the virtual output each time so
+     * sometimes it's really not there). Xorg often reports similar
+     * errors, and it's not fatal.
+     */
+    if (!output->set_crtc(forced_frame))
+        mir::log_error("Failed to set DRM CRTC. "
+            "Screen contents may be incomplete. "
+            "Try plugging the monitor in again.");
 }
 
 void mgg::DisplaySink::post()
 {
-    /*
-     * We might not have waited for the previous frame to page flip yet.
-     * This is good because it maximizes the time available to spend rendering
-     * each frame. Just remember wait_for_page_flip() must be called at some
-     * point before the next schedule_page_flip().
-     */
-    wait_for_page_flip();
-
     if (!next_swap)
     {
         // Hey! No one has given us a next frame yet, so we don't have to change what's onscreen.
@@ -223,50 +204,16 @@ void mgg::DisplaySink::post()
     // Predicted worst case render time for the next frame...
     auto predicted_render_time = 50ms;
 
-    if (holding_client_buffers)
-    {
-        /*
-         * For composited frames we defer wait_for_page_flip till just before
-         * the next frame, but not for bypass frames. Deferring the flip of
-         * bypass frames would increase the time we held
-         * visible_bypass_frame unacceptably, resulting in client stuttering
-         * unless we allocate more buffers (which I'm trying to avoid).
-         * Also, bypass does not need the deferred page flip because it has
-         * no compositing/rendering step for which to save time for.
-         */
-        wait_for_page_flip();
-
-        // It's very likely the next frame will be bypassed like this one so
-        // we only need time for kernel page flip scheduling...
-        predicted_render_time = 5ms;
-    }
-    else
-    {
-        /*
-         * Not in clone mode? We can afford to wait for the page flip then,
-         * making us double-buffered (noticeably less laggy than the triple
-         * buffering that clone mode requires).
-         */
-        if (outputs.size() == 1)
-            wait_for_page_flip();
-
-        /*
-         * TODO: If you're optimistic about your GPU performance and/or
-         *       measure it carefully you may wish to set predicted_render_time
-         *       to a lower value here for lower latency.
-         *
-         *predicted_render_time = 9ms; // e.g. about the same as Weston
-         */
-    }
-
     recommend_sleep = 0ms;
-    if (outputs.size() == 1)
-    {
-        auto const& output = outputs.front();
-        auto const min_frame_interval = 1000ms / output->max_refresh_rate();
-        if (predicted_render_time < min_frame_interval)
-            recommend_sleep = min_frame_interval - predicted_render_time;
-    }
+
+    // Wait for the frame to be displayed
+    // This makes us double-buffered; assuming we can reliably render within the frame deadline
+    // that minimises latency.
+    wait_for_page_flip();
+
+    auto const min_frame_interval = 1000ms / output->max_refresh_rate();
+    if (predicted_render_time < min_frame_interval)
+        recommend_sleep = min_frame_interval - predicted_render_time;
 }
 
 std::chrono::milliseconds mgg::DisplaySink::recommended_sleep() const
@@ -280,11 +227,8 @@ bool mgg::DisplaySink::schedule_page_flip(FBHandle const& bufobj)
      * Schedule the current front buffer object for display. Note that
      * the page flip is asynchronous and synchronized with vertical refresh.
      */
-    for (auto& output : outputs)
-    {
-        if (output->schedule_page_flip(bufobj))
-            page_flips_pending = true;
-    }
+    if (output->schedule_page_flip(bufobj))
+        page_flips_pending = true;
 
     return page_flips_pending;
 }
@@ -293,8 +237,7 @@ void mgg::DisplaySink::wait_for_page_flip()
 {
     if (page_flips_pending)
     {
-        for (auto& output : outputs)
-            output->wait_for_page_flip();
+        output->wait_for_page_flip();
 
         // The previously-scheduled FB has been page-flipped, and is now visible
         visible_fb = std::move(scheduled_fb);
@@ -311,7 +254,7 @@ void mgg::DisplaySink::schedule_set_crtc()
 
 auto mgg::DisplaySink::drm_fd() const -> mir::Fd
 {
-    return mir::Fd{mir::IntOwnedFd{outputs.front()->drm_fd()}};
+    return mir::Fd{mir::IntOwnedFd{output->drm_fd()}};
 }
 
 auto mgg::DisplaySink::gbm_device() const -> std::shared_ptr<struct gbm_device>
@@ -344,7 +287,7 @@ auto mgg::DisplaySink::maybe_create_allocator(DisplayAllocator::Tag const& type_
     {
         if (!kms_allocator)
         {
-            kms_allocator = kms::CPUAddressableDisplayAllocator::create_if_supported(drm_fd(), outputs.front()->size());
+            kms_allocator = kms::CPUAddressableDisplayAllocator::create_if_supported(drm_fd(), output->size());
         }
         return kms_allocator.get();
     }
@@ -352,7 +295,7 @@ auto mgg::DisplaySink::maybe_create_allocator(DisplayAllocator::Tag const& type_
     {
         if (!gbm_allocator)
         {
-            gbm_allocator = std::make_unique<GBMDisplayAllocator>(drm_fd(), gbm, outputs.front()->size());
+            gbm_allocator = std::make_unique<GBMDisplayAllocator>(drm_fd(), gbm, output->size());
         }
         return gbm_allocator.get();
     }

--- a/src/platforms/gbm-kms/server/kms/display_sink.h
+++ b/src/platforms/gbm-kms/server/kms/display_sink.h
@@ -52,7 +52,7 @@ public:
         std::shared_ptr<struct gbm_device> gbm,
         BypassOption bypass_options,
         std::shared_ptr<DisplayReport> const& listener,
-        std::vector<std::shared_ptr<KMSOutput>> const& outputs,
+        std::shared_ptr<KMSOutput> const& output,
         geometry::Rectangle const& area,
         glm::mat2 const& transformation);
     ~DisplaySink();
@@ -86,11 +86,10 @@ private:
     void set_crtc(FBHandle const&);
 
     std::shared_ptr<struct gbm_device> const gbm;
-    bool holding_client_buffers{false};
     std::shared_ptr<FBHandle const> bypass_bufobj{nullptr};
     std::shared_ptr<DisplayReport> const listener;
 
-    std::vector<std::shared_ptr<KMSOutput>> outputs;
+    std::shared_ptr<KMSOutput> const output;
 
     std::shared_ptr<CPUAddressableDisplayAllocator> kms_allocator;
     std::unique_ptr<GBMDisplayAllocator> gbm_allocator;

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
@@ -360,11 +360,15 @@ TEST_F(MesaDisplayMultiMonitorTest, flip_flips_all_connected_crtcs)
 
         /* Emit fake DRM page-flip events */
         mock_drm.generate_event_on(drm_device);
+        mock_drm.generate_event_on(drm_device);
     }
 
     /* Handle the events properly */
     EXPECT_CALL(mock_drm, drmHandleEvent(mtd::IsFdOfDevice(drm_device), _))
-        .Times(num_connected_outputs)
+        .Times(num_connected_outputs * 2)
+        .WillOnce(DoAll(InvokePageFlipHandler(&user_data[0]), Return(0)))
+        .WillOnce(DoAll(InvokePageFlipHandler(&user_data[1]), Return(0)))
+        .WillOnce(DoAll(InvokePageFlipHandler(&user_data[2]), Return(0)))
         .WillOnce(DoAll(InvokePageFlipHandler(&user_data[0]), Return(0)))
         .WillOnce(DoAll(InvokePageFlipHandler(&user_data[1]), Return(0)))
         .WillOnce(DoAll(InvokePageFlipHandler(&user_data[2]), Return(0)));


### PR DESCRIPTION
Fundamentally every DisplaySink should refer to an actual sink where a framebuffer can be rendered. With the previous approach, all displays with similar resolutions were getting grouped into one DisplaySink, which only works for clone mode and breaks otherwise. Therefore, revert back to the former approach to get multi-display back up.

## What's new?
Fixes broken multi-display without clone mode

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
