### PR TITLE
cmake: drop incorrect stringop-overflow suppression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,6 @@ if(MIR_FATAL_COMPILE_WARNINGS)
     add_compile_options(
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=maybe-uninitialized>
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=array-bounds>
-        $<$<COMPILE_LANGUAGE:C>:-Wno-error=stringop-overflow>
     )
   endif()
 endif()


### PR DESCRIPTION
## What's new?

This is in the `CXX` compiler section, no point setting `C` compile flags.

## How to test

CI

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
