### PR TITLE
avoid warnings from g++16.2 when inlining stuff excessively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ if(MIR_FATAL_COMPILE_WARNINGS)
   if ((CMAKE_CXX_COMPILER_ID MATCHES "GNU") AND NOT (CMAKE_BUILD_TYPE MATCHES "Debug"))
     add_compile_options(
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=maybe-uninitialized>
-        $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=array-bounds>
     )
   endif()
 endif()

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -356,6 +356,9 @@ private:
     geom::Size const size_;
 };
 
+#if !defined(__clang__) && (__GNUC__ == 16) && (__GNUC_MINOR__ == 2)
+    __attribute__((noinline))  // g++16.2 has trouble inlining this correctly
+#endif
 auto export_egl_image(
     mg::EGLExtensions::MESADmaBufExport const& ext,
     EGLDisplay dpy,

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_cursor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_cursor.cpp
@@ -809,7 +809,7 @@ TEST_F(MesaCursorTest, cursor_renderable_screen_position_is_expected)
 {
     using namespace testing;
 
-    auto image = std::make_shared<StubCursorImage>();
+    std::shared_ptr<mg::CursorImage> image = std::make_shared<StubCursorImage>();
     cursor.move_to(geom::Point{50, 50});
     cursor.show(image);
 
@@ -821,7 +821,7 @@ TEST_F(MesaCursorTest, cursor_renderable_src_bounds_is_expected)
 {
     using namespace testing;
 
-    auto image = std::make_shared<StubCursorImage>();
+    std::shared_ptr<mg::CursorImage> image = std::make_shared<StubCursorImage>();
     cursor.move_to(geom::Point{50, 50});
     cursor.show(image);
 


### PR DESCRIPTION
There are a bunch of spurious errors beginning with:

```plain
[ 26%] Building CXX object src/platform/graphics/CMakeFiles/mirplatformgraphicscommon.dir/linux_dmabuf.cpp.o
In member function ‘virtual std::optional<long unsigned int> {anonymous}::U::modifier() const’,
    inlined from ‘std::shared_ptr<mir::graphics::gl::Texture> mir::graphics::DMABufEGLProvider::as_texture(std::shared_ptr<mir::graphics::NativeBufferBase>)’ at /home/alan/mir/src/platform/graphics/linux_dmabuf.cpp:1638:48:
/home/alan/mir/src/platform/graphics/linux_dmabuf.cpp:1175:16: warning: array subscript 0 is outside array bounds of ‘void [72]’ [-Warray-bounds=]
 1175 |         return modifier_;
      |                ^~~~~~~~~
```