### PR TITLE
Use `std::experimental::scope_exit` instead of a dtor only `paired_calls`

### DIFF
--- a/src/server/compositor/multi_threaded_compositor.cpp
+++ b/src/server/compositor/multi_threaded_compositor.cpp
@@ -37,6 +37,7 @@
 #include <thread>
 #include <chrono>
 #include <future>
+#include <experimental/scope>
 #include <boost/throw_exception.hpp>
 
 using namespace std::literals::chrono_literals;
@@ -106,8 +107,7 @@ public:
     try
     {
         mir::set_thread_name("Mir/Comp");
-        auto const signal_when_stopped = mir::raii::paired_calls(
-            [](){},
+        auto const signal_when_stopped = std::experimental::scope_exit(
             [this]()
             {
                 stopped.set_value();

--- a/src/server/console/linux_virtual_terminal.cpp
+++ b/src/server/console/linux_virtual_terminal.cpp
@@ -41,6 +41,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <csignal>
+#include <experimental/scope>
 
 #include <linux/vt.h>
 #include <linux/kd.h>
@@ -456,8 +457,7 @@ void mir::LinuxVirtualTerminal::register_switch_handlers(
                      * Otherwise we leave the VT subsystem in a glorious state of
                      * waiting forever for us to ACK the switch.
                      */
-                    auto ack_when_done = mir::raii::paired_calls(
-                        [](){},
+                    auto ack_when_done = std::experimental::scope_exit(
                         [this]()
                         {
                             fops->ioctl(vt_fd.fd(), VT_RELDISP, VT_ACKACQ);
@@ -491,8 +491,7 @@ void mir::LinuxVirtualTerminal::register_switch_handlers(
                      * Otherwise we leave the VT subsystem in a glorious state of
                      * waiting forever for us to ACK the switch.
                      */
-                    auto ack_when_done = mir::raii::paired_calls(
-                        [](){},
+                    auto ack_when_done = std::experimental::scope_exit(
                         [this, &action]()
                         {
                             fops->ioctl(vt_fd.fd(), VT_RELDISP, action);


### PR DESCRIPTION
Does what it says on the tin.