### PR TITLE
Handle unmanaged scene surfaces consistently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_GCOV gcov)
 
 project(
   Mir
-  VERSION 2.29.0
+  VERSION 2.30.0
   DESCRIPTION "Mir compositor library"
   LANGUAGES C CXX
 )

--- a/debian/control
+++ b/debian/control
@@ -56,7 +56,7 @@ Vcs-Git: https://github.com/canonical/mir
 
 #TODO: Packaging infrastructure for better dependency generation,
 #      ala pkg-xorg's xviddriver:Provides and ABI detection.
-Package: libmirserver68
+Package: libmirserver69
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -144,7 +144,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirserver68 (= ${binary:Version}),
+Depends: libmirserver69 (= ${binary:Version}),
          libmirplatform-dev (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libglm-dev,
@@ -161,7 +161,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirserver68 (= ${binary:Version}),
+Depends: libmirserver69 (= ${binary:Version}),
       libmirplatform-dev (= ${binary:Version}),
       libmircommon-dev (= ${binary:Version}),
       libmircore-dev (= ${binary:Version}),

--- a/debian/libmiroil10.symbols
+++ b/debian/libmiroil10.symbols
@@ -1,5 +1,4 @@
 libmiroil.so.10 libmiroil10 #MINVER#
- MIROIL_10.0@MIROIL_10.0 2.29.0
  (c++)"miroil::Compositor::~Compositor()@MIROIL_10.0" 2.29.0
  (c++)"miroil::DisplayConfigurationControllerWrapper::DisplayConfigurationControllerWrapper(std::shared_ptr<mir::shell::DisplayConfigurationController> const&)@MIROIL_10.0" 2.29.0
  (c++)"miroil::DisplayConfigurationControllerWrapper::set_base_configuration(std::shared_ptr<mir::graphics::DisplayConfiguration> const&)@MIROIL_10.0" 2.29.0

--- a/debian/libmiroil10.symbols
+++ b/debian/libmiroil10.symbols
@@ -1,4 +1,5 @@
 libmiroil.so.10 libmiroil10 #MINVER#
+ MIROIL_10.0@MIROIL_10.0 2.29.0
  (c++)"miroil::Compositor::~Compositor()@MIROIL_10.0" 2.29.0
  (c++)"miroil::DisplayConfigurationControllerWrapper::DisplayConfigurationControllerWrapper(std::shared_ptr<mir::shell::DisplayConfigurationController> const&)@MIROIL_10.0" 2.29.0
  (c++)"miroil::DisplayConfigurationControllerWrapper::set_base_configuration(std::shared_ptr<mir::graphics::DisplayConfiguration> const&)@MIROIL_10.0" 2.29.0

--- a/debian/libmirserver68.install
+++ b/debian/libmirserver68.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirserver.so.68

--- a/debian/libmirserver69.install
+++ b/debian/libmirserver69.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirserver.so.69

--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -18,11 +18,11 @@
 #define MIR_SHELL_ABSTRACT_SHELL_H_
 
 #include <mir/shell/shell.h>
+#include <mir/shell/managed_window_membership.h>
 #include <mir/shell/window_manager_builder.h>
 #include <mir/scene/surface_observer.h>
 
 #include <mutex>
-#include <unordered_set>
 
 namespace mir
 {
@@ -177,7 +177,7 @@ private:
     void update_confinement_for(std::shared_ptr<scene::Surface> const& surface) const;
 
     std::shared_ptr<decoration::Manager> decoration_manager;
-    std::unordered_set<std::shared_ptr<scene::Surface>> managed_surfaces;
+    std::shared_ptr<ManagedWindowMembership const> const managed_window_membership;
 };
 }
 }

--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -22,6 +22,7 @@
 #include <mir/scene/surface_observer.h>
 
 #include <mutex>
+#include <unordered_set>
 
 namespace mir
 {
@@ -176,6 +177,7 @@ private:
     void update_confinement_for(std::shared_ptr<scene::Surface> const& surface) const;
 
     std::shared_ptr<decoration::Manager> decoration_manager;
+    std::unordered_set<std::shared_ptr<scene::Surface>> managed_surfaces;
 };
 }
 }

--- a/src/include/server/mir/shell/managed_window_membership.h
+++ b/src/include/server/mir/shell/managed_window_membership.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_SHELL_MANAGED_WINDOW_MEMBERSHIP_H_
+#define MIR_SHELL_MANAGED_WINDOW_MEMBERSHIP_H_
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace mir
+{
+namespace scene { class Surface; }
+namespace shell
+{
+class ManagedWindowMembership
+{
+public:
+    virtual auto contains(std::shared_ptr<scene::Surface> const& surface) const -> bool = 0;
+
+    virtual ~ManagedWindowMembership() = default;
+    ManagedWindowMembership() = default;
+    ManagedWindowMembership(ManagedWindowMembership const&) = delete;
+    ManagedWindowMembership& operator=(ManagedWindowMembership const&) = delete;
+};
+
+/// A synchronised window registry whose values are owned by the window manager.
+template<typename Value>
+class ManagedWindowRegistry : public ManagedWindowMembership
+{
+public:
+    using Map = std::map<std::weak_ptr<scene::Surface>, Value, std::owner_less<std::weak_ptr<scene::Surface>>>;
+
+    auto contains(std::shared_ptr<scene::Surface> const& surface) const -> bool override
+    {
+        std::lock_guard lock{mutex};
+        return windows.contains(surface);
+    }
+
+    template<typename... Args>
+    auto emplace(std::shared_ptr<scene::Surface> const& surface, Args&&... args) -> Value&
+    {
+        std::lock_guard lock{mutex};
+        return windows.emplace(surface, std::forward<Args>(args)...).first->second;
+    }
+
+    template<typename ValueLike>
+    void insert_or_assign(std::shared_ptr<scene::Surface> const& surface, ValueLike&& value)
+    {
+        std::lock_guard lock{mutex};
+        windows.insert_or_assign(surface, std::forward<ValueLike>(value));
+    }
+
+    template<typename Key>
+    void erase(Key const& key)
+    {
+        std::lock_guard lock{mutex};
+        windows.erase(key);
+    }
+
+    auto find(std::weak_ptr<scene::Surface> const& surface) -> std::optional<std::reference_wrapper<Value>>
+    {
+        std::lock_guard lock{mutex};
+        if (auto found = windows.find(surface); found != windows.end())
+            return found->second;
+
+        return {};
+    }
+
+    auto snapshot() const -> std::vector<std::pair<std::weak_ptr<scene::Surface>, Value>>
+    {
+        std::lock_guard lock{mutex};
+        return {windows.begin(), windows.end()};
+    }
+private:
+    mutable std::mutex mutex;
+    Map windows;
+};
+}
+}
+
+#endif /* MIR_SHELL_MANAGED_WINDOW_MEMBERSHIP_H_ */

--- a/src/include/server/mir/shell/system_compositor_window_manager.h
+++ b/src/include/server/mir/shell/system_compositor_window_manager.h
@@ -20,9 +20,6 @@
 #include <mir/shell/window_manager.h>
 #include <mir/graphics/display_configuration.h>
 
-#include <map>
-#include <mutex>
-
 namespace mir
 {
 namespace scene { class SessionCoordinator; }
@@ -104,10 +101,10 @@ private:
         MirInputEvent const* event,
         MirResizeEdge edge) override;
 
-    using OutputMap = std::map<std::weak_ptr<scene::Surface>, graphics::DisplayConfigurationOutputId, std::owner_less<std::weak_ptr<scene::Surface>>>;
+    auto managed_window_membership() const -> std::shared_ptr<ManagedWindowMembership const> override;
 
-    std::mutex mutable mutex;
-    OutputMap output_map;
+    std::shared_ptr<ManagedWindowRegistry<graphics::DisplayConfigurationOutputId>> const output_map{
+        std::make_shared<ManagedWindowRegistry<graphics::DisplayConfigurationOutputId>>()};
 };
 
 /**

--- a/src/include/server/mir/shell/window_manager.h
+++ b/src/include/server/mir/shell/window_manager.h
@@ -18,6 +18,7 @@
 #define MIR_SHELL_WINDOW_MANAGER_H_
 
 #include <mir/frontend/surface_id.h>
+#include <mir/shell/managed_window_membership.h>
 #include <mir_toolkit/common.h>
 #include <mir_toolkit/event.h>
 #include <mir/geometry/forward.h>
@@ -78,6 +79,8 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         MirInputEvent const* event,
         MirResizeEdge edge) = 0;
+
+    virtual auto managed_window_membership() const -> std::shared_ptr<ManagedWindowMembership const> = 0;
 
     virtual ~WindowManager() = default;
     WindowManager() = default;

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -36,6 +36,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <stdexcept>
 
 using namespace mir;
 using namespace mir::geometry;
@@ -163,7 +164,7 @@ auto miral::BasicWindowManager::add_surface(
 
     auto const surface = build(session, make_surface_spec(spec));
     Window const window{session, surface};
-    auto& window_info = this->window_info.emplace(window, WindowInfo{window, spec}).first->second;
+    auto& window_info = this->window_info->emplace(surface, WindowInfo{window, spec});
 
     session_info.add_window(window);
 
@@ -359,7 +360,7 @@ void miral::BasicWindowManager::erase(miral::WindowInfo const& info)
     for (auto& child : info.children())
         info_for(child).parent({});
 
-    window_info.erase(info.window());
+    window_info->erase(std::shared_ptr<scene::Surface>{info.window()});
 }
 
 bool miral::BasicWindowManager::handle_keyboard_event(MirKeyboardEvent const* event)
@@ -435,6 +436,12 @@ void miral::BasicWindowManager::handle_request_resize(
     }
 }
 
+auto miral::BasicWindowManager::managed_window_membership() const
+-> std::shared_ptr<mir::shell::ManagedWindowMembership const>
+{
+    return window_info;
+}
+
 auto miral::BasicWindowManager::count_applications() const
 -> unsigned int
 {
@@ -473,7 +480,14 @@ auto miral::BasicWindowManager::info_for(std::weak_ptr<scene::Session> const& se
 auto miral::BasicWindowManager::info_for(std::weak_ptr<scene::Surface> const& surface) const
 -> WindowInfo&
 {
-    return const_cast<WindowInfo&>(window_info.at(surface));
+    auto const found = window_info->find(surface);
+    if (!found)
+    {
+        // Keep std::out_of_range here to preserve the old map::at() behavior.
+        throw std::out_of_range{"BasicWindowManager::info_for(): unknown surface"};
+    }
+
+    return found->get();
 }
 
 auto miral::BasicWindowManager::info_for(Window const& window) const
@@ -1749,7 +1763,7 @@ auto miral::BasicWindowManager::surface_known(
     std::weak_ptr<scene::Surface> const& surface,
     std::string const& action) -> bool
 {
-    if (window_info.find(surface) != window_info.end())
+    if (window_info->find(surface))
     {
         return true;
     }

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -117,6 +117,8 @@ public:
         MirInputEvent const* event,
         ::MirResizeEdge edge) override;
 
+    auto managed_window_membership() const -> std::shared_ptr<mir::shell::ManagedWindowMembership const> override;
+
     auto create_workspace() -> std::shared_ptr<Workspace> override;
 
     void add_tree_to_workspace(Window const& window, std::shared_ptr<Workspace> const& workspace) override;
@@ -221,7 +223,6 @@ private:
         std::set<Window> attached_windows; ///< Maximized/anchored/etc windows attached to this area
     };
 
-    using SurfaceInfoMap = std::map<std::weak_ptr<mir::scene::Surface>, WindowInfo, std::owner_less<std::weak_ptr<mir::scene::Surface>>>;
     using SessionInfoMap = std::map<std::weak_ptr<mir::scene::Session>, ApplicationInfo, std::owner_less<std::weak_ptr<mir::scene::Session>>>;
 
     mir::shell::FocusController* const focus_controller;
@@ -237,11 +238,13 @@ private:
 
     std::shared_ptr<DeadWorkspaces> const dead_workspaces{std::make_shared<DeadWorkspaces>()};
 
+    std::shared_ptr<mir::shell::ManagedWindowRegistry<WindowInfo>> const window_info{
+        std::make_shared<mir::shell::ManagedWindowRegistry<WindowInfo>>()};
+
     std::unique_ptr<WindowManagementPolicy> const policy;
 
     std::mutex mutex;
     SessionInfoMap app_info;
-    SurfaceInfoMap window_info;
     mir::geometry::Rectangles outputs;
     mir::geometry::Point cursor;
     uint64_t last_input_event_timestamp{0};

--- a/src/miral/system_compositor_window_manager.cpp
+++ b/src/miral/system_compositor_window_manager.cpp
@@ -96,8 +96,7 @@ auto miral::SystemCompositorWindowManager::add_surface(
 
     auto const surface = build(session, placed_parameters);
 
-    std::lock_guard lock{mutex};
-    output_map[surface] = params.output_id.value();
+    output_map->emplace(surface, params.output_id.value());
 
     return surface;
 }
@@ -130,8 +129,7 @@ void miral::SystemCompositorWindowManager::modify_surface(
             surface->resize(rect.size);
         }
 
-        std::lock_guard lock{mutex};
-        output_map[surface] = output_id;
+        output_map->insert_or_assign(surface, output_id);
     }
 
     if (modifications.input_shape.has_value())
@@ -147,8 +145,7 @@ void miral::SystemCompositorWindowManager::remove_surface(
     if (auto const locked = surface.lock())
         session->destroy_surface(locked);
 
-    std::lock_guard lock{mutex};
-    output_map.erase(surface);
+    output_map->erase(surface);
 }
 
 bool miral::SystemCompositorWindowManager::handle_keyboard_event(MirKeyboardEvent const* event)
@@ -248,10 +245,16 @@ void miral::SystemCompositorWindowManager::handle_request_resize(
 {
 }
 
+auto miral::SystemCompositorWindowManager::managed_window_membership() const
+-> std::shared_ptr<mir::shell::ManagedWindowMembership const>
+{
+    return output_map;
+}
+
 void miral::SystemCompositorWindowManager::advise_output_create(const miral::Output &/*output*/)
 {
     // When a display gets added, we reposition all surfaces across their outputs, most likely to fit them to the screen.
-    for (auto const& surface_output_pair : output_map)
+    for (auto const& surface_output_pair : output_map->snapshot())
     {
         if (auto surface = surface_output_pair.first.lock())
         {
@@ -263,10 +266,8 @@ void miral::SystemCompositorWindowManager::advise_output_create(const miral::Out
 
 void miral::SystemCompositorWindowManager::advise_output_update(const miral::Output & updated, const miral::Output &/*original*/)
 {
-    std::lock_guard lock{mutex};
-
     // When a display gets updated, we reposition any surface that is on the updated Output.
-    for (auto const& surface_output_pair : output_map)
+    for (auto const& surface_output_pair : output_map->snapshot())
     {
         if (auto surface = surface_output_pair.first.lock())
         {

--- a/src/miral/system_compositor_window_manager.h
+++ b/src/miral/system_compositor_window_manager.h
@@ -23,9 +23,6 @@
 #include <mir/graphics/display_configuration.h>
 #include <mir/observer_registrar.h>
 
-#include <map>
-#include <mutex>
-
 namespace mir
 {
 namespace shell { class DisplayLayout; class FocusController; }
@@ -69,11 +66,10 @@ public:
 /** @} */
 
 private:
-    using OutputMap = std::map<std::weak_ptr<mir::scene::Surface>, mir::graphics::DisplayConfigurationOutputId, std::owner_less<std::weak_ptr<mir::scene::Surface>>>;
     using MirSurfaceCreator = std::function<std::shared_ptr<mir::scene::Surface>(std::shared_ptr<mir::scene::Session> const& session, mir::shell::SurfaceSpecification const& params)>;
 
-    std::mutex mutable mutex;
-    OutputMap output_map;
+    std::shared_ptr<mir::shell::ManagedWindowRegistry<mir::graphics::DisplayConfigurationOutputId>> const output_map{
+        std::make_shared<mir::shell::ManagedWindowRegistry<mir::graphics::DisplayConfigurationOutputId>>()};
     mir::shell::FocusController* const focus_controller;
     std::shared_ptr<mir::shell::DisplayLayout> const display_layout;
     std::shared_ptr<mir::scene::SessionCoordinator> const session_coordinator;
@@ -120,6 +116,8 @@ private:
         std::shared_ptr<mir::scene::Surface> const& surface,
         MirInputEvent const* event,
         MirResizeEdge edge) override;
+
+    auto managed_window_membership() const -> std::shared_ptr<mir::shell::ManagedWindowMembership const> override;
 
     void advise_output_create(Output const& output) override;
     void advise_output_update(Output const& updated, Output const& original) override;

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -120,7 +120,7 @@ install(DIRECTORY
     ${CMAKE_SOURCE_DIR}/src/include/server/mir DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mirserver-internal"
 )
 
-set(MIRSERVER_ABI 68) # Be sure to increment PROJECT_VERSION_MINOR at the same time
+set(MIRSERVER_ABI 69) # Be sure to increment PROJECT_VERSION_MINOR at the same time
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 
 set_target_properties(

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -27,6 +27,8 @@
 #include <mir/scene/surface.h>
 #include <mir/input/seat.h>
 #include <mir/wayland/weak.h>
+#include <mir/log.h>
+
 #include "decoration/manager.h"
 
 #include <iterator>
@@ -252,6 +254,7 @@ auto msh::AbstractShell::create_surface(
         };
 
     auto const result = window_manager->add_surface(session, wm_visible_spec, build);
+    managed_surfaces.insert(result);
     report->created_surface(*session, *result);
 
     if (*should_decorate)
@@ -372,6 +375,7 @@ void msh::AbstractShell::destroy_surface(
 {
     report->destroying_surface(*session, *surface);
     decoration_manager->undecorate(surface);
+    managed_surfaces.erase(surface);
     window_manager->remove_surface(session, surface);
 }
 
@@ -689,7 +693,11 @@ bool msh::AbstractShell::handle(MirEvent const& event)
 auto msh::AbstractShell::surface_at(geometry::Point cursor) const
 -> std::shared_ptr<scene::Surface>
 {
-    return surface_stack->surface_at(cursor);
+    auto const surface = surface_stack->surface_at(cursor);
+    if(!managed_surfaces.contains(surface))
+        return nullptr;
+
+    return surface;
 }
 
 void msh::AbstractShell::raise(SurfaceSet const& surfaces)

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -168,7 +168,8 @@ msh::AbstractShell::AbstractShell(
     seat(seat),
     report(report),
     surface_confinement_updater(std::make_shared<SurfaceConfinementUpdater>(seat.get())),
-    decoration_manager(decoration_manager)
+    decoration_manager(decoration_manager),
+    managed_window_membership(window_manager->managed_window_membership())
 {
 }
 
@@ -254,7 +255,6 @@ auto msh::AbstractShell::create_surface(
         };
 
     auto const result = window_manager->add_surface(session, wm_visible_spec, build);
-    managed_surfaces.insert(result);
     report->created_surface(*session, *result);
 
     if (*should_decorate)
@@ -375,7 +375,6 @@ void msh::AbstractShell::destroy_surface(
 {
     report->destroying_surface(*session, *surface);
     decoration_manager->undecorate(surface);
-    managed_surfaces.erase(surface);
     window_manager->remove_surface(session, surface);
 }
 
@@ -694,7 +693,7 @@ auto msh::AbstractShell::surface_at(geometry::Point cursor) const
 -> std::shared_ptr<scene::Surface>
 {
     auto const surface = surface_stack->surface_at(cursor);
-    if(!managed_surfaces.contains(surface))
+    if (!managed_window_membership->contains(surface))
         return nullptr;
 
     return surface;

--- a/src/server/shell/system_compositor_window_manager.cpp
+++ b/src/server/shell/system_compositor_window_manager.cpp
@@ -87,8 +87,7 @@ auto msh::SystemCompositorWindowManager::add_surface(
 
     auto const surface = build(session, placed_parameters);
 
-    std::lock_guard lock{mutex};
-    output_map[surface] = params.output_id.value();
+    output_map->emplace(surface, params.output_id.value());
 
     return surface;
 }
@@ -121,8 +120,7 @@ void msh::SystemCompositorWindowManager::modify_surface(
             surface->resize(rect.size);
         }
 
-        std::lock_guard lock{mutex};
-        output_map[surface] = output_id;
+        output_map->insert_or_assign(surface, output_id);
     }
 
     if (modifications.input_shape.has_value())
@@ -138,8 +136,7 @@ void msh::SystemCompositorWindowManager::remove_surface(
     if (auto const locked = surface.lock())
         session->destroy_surface(locked);
 
-    std::lock_guard lock{mutex};
-    output_map.erase(surface);
+    output_map->erase(surface);
 }
 
 bool msh::SystemCompositorWindowManager::handle_keyboard_event(MirKeyboardEvent const* /*event*/)
@@ -198,6 +195,12 @@ void msh::SystemCompositorWindowManager::handle_request_resize(
     MirInputEvent const* /*event*/,
     MirResizeEdge /*edge*/)
 {
+}
+
+auto msh::SystemCompositorWindowManager::managed_window_membership() const
+-> std::shared_ptr<ManagedWindowMembership const>
+{
+    return output_map;
 }
 
 bool mir::shell::DefaultWindowManager::handle_keyboard_event(MirKeyboardEvent const* event)

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1,4 +1,4 @@
-MIR_SERVER_INTERNAL_2.29 {
+MIR_SERVER_INTERNAL_2.30 {
 global:
   extern "C++" {
     VTT?for?mir::DefaultServerConfiguration;

--- a/tests/include/mir/test/doubles/mock_window_manager.h
+++ b/tests/include/mir/test/doubles/mock_window_manager.h
@@ -57,6 +57,7 @@ struct MockWindowManager : shell::WindowManager
     MOCK_METHOD(void, handle_raise_surface, (std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t), (override));
     MOCK_METHOD(void, handle_request_move, (std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, MirInputEvent const*), (override));
     MOCK_METHOD(void, handle_request_resize, (std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, MirInputEvent const*, MirResizeEdge), (override));
+    MOCK_METHOD(std::shared_ptr<shell::ManagedWindowMembership const>, managed_window_membership, (), (const, override));
 
     static auto add_surface_default(
         std::shared_ptr<scene::Session> const& session,

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -37,6 +37,7 @@
 #include <gmock/gmock.h>
 
 #include <atomic>
+#include <stdexcept>
 
 namespace
 {
@@ -58,8 +59,10 @@ struct StubFocusController : mir::shell::FocusController
 
     void raise(mir::shell::SurfaceSet const& /*windows*/) override {}
 
-    virtual auto surface_at(mir::geometry::Point /*cursor*/) const -> std::shared_ptr<mir::scene::Surface> override
-        { return {}; }
+    auto surface_at(mir::geometry::Point cursor) const -> std::shared_ptr<mir::scene::Surface> override
+    {
+        return surface_at_callback ? surface_at_callback(cursor) : nullptr;
+    }
 
     void swap_z_order(mir::shell::SurfaceSet const& /*first*/, mir::shell::SurfaceSet const& /*second*/) override {}
 
@@ -69,6 +72,8 @@ struct StubFocusController : mir::shell::FocusController
     {
         return false;
     }
+
+    std::function<std::shared_ptr<mir::scene::Surface>(mir::geometry::Point)> surface_at_callback;
 };
 
 struct StubDisplayLayout : mir::shell::DisplayLayout
@@ -285,6 +290,80 @@ mt::TestWindowManagerTools::TestWindowManagerTools()
 }
 
 mt::TestWindowManagerTools::~TestWindowManagerTools() = default;
+
+void mt::TestWindowManagerTools::set_surface_at_callback(
+    std::function<std::shared_ptr<mir::scene::Surface>(mir::geometry::Point)> callback)
+{
+    self->focus_controller.surface_at_callback = std::move(callback);
+}
+
+namespace
+{
+struct ManagedWindowRegistry : mt::TestWindowManagerTools
+{
+};
+}
+
+TEST_F(ManagedWindowRegistry, tracks_surface_lifecycle)
+{
+    auto const membership = basic_window_manager.managed_window_membership();
+    auto const foreign_surface = create_surface(session, {});
+
+    EXPECT_FALSE(membership->contains({}));
+    EXPECT_FALSE(membership->contains(foreign_surface));
+
+    basic_window_manager.add_session(session);
+    auto const surface = basic_window_manager.add_surface(session, {}, &create_surface);
+
+    EXPECT_TRUE(membership->contains(surface));
+    EXPECT_FALSE(membership->contains(foreign_surface));
+
+    basic_window_manager.remove_surface(session, surface);
+    EXPECT_FALSE(membership->contains(surface));
+
+    basic_window_manager.remove_session(session);
+    EXPECT_FALSE(membership->contains(surface));
+}
+
+// This isolates registry access while BWM's mutex is held. AbstractShell's delegation is covered
+// by the tests in tests/unit-tests/scene/test_abstract_shell.cpp.
+TEST_F(ManagedWindowRegistry, policy_window_lookup_queries_registry_without_relocking_window_manager)
+{
+    auto const membership = basic_window_manager.managed_window_membership();
+    std::shared_ptr<mir::scene::Surface> surface;
+
+    set_surface_at_callback(
+        [&membership, &surface](mir::geometry::Point)
+        {
+            return membership->contains(surface) ? surface : nullptr;
+        });
+
+    EXPECT_CALL(*window_manager_policy, advise_new_window(testing::_)).
+        WillOnce(
+            [&]
+            (miral::WindowInfo const&)
+            {
+                EXPECT_THAT(
+                    std::shared_ptr<mir::scene::Surface>{window_manager_tools.window_at({})},
+                    testing::Eq(surface));
+            });
+
+    basic_window_manager.add_session(session);
+    basic_window_manager.add_surface(
+        session,
+        {},
+        [&](std::shared_ptr<mir::scene::Session> const& session, mir::shell::SurfaceSpecification const& specification)
+        {
+            return surface = create_surface(session, specification);
+        });
+}
+
+TEST_F(ManagedWindowRegistry, info_for_unknown_surface_throws_out_of_range)
+{
+    auto const foreign_surface = create_surface(session, {});
+
+    EXPECT_THROW(basic_window_manager.info_for(foreign_surface), std::out_of_range);
+}
 
 auto mt::TestWindowManagerTools::create_surface(
     std::shared_ptr<mir::scene::Session> const& session,

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -81,6 +81,9 @@ public:
     miral::WindowManagerTools window_manager_tools;
     miral::BasicWindowManager basic_window_manager;
 
+    void set_surface_at_callback(
+        std::function<std::shared_ptr<mir::scene::Surface>(mir::geometry::Point)> callback);
+
     static auto create_surface(
         std::shared_ptr<mir::scene::Session> const& session,
         mir::shell::SurfaceSpecification const& params) -> std::shared_ptr<mir::scene::Surface>;

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -133,6 +133,11 @@ struct MockDecorationManager : public msh::decoration::NullManager
 
 using NiceMockWindowManager = NiceMock<mtd::MockWindowManager>;
 
+struct MockManagedWindowMembership : msh::ManagedWindowMembership
+{
+    MOCK_METHOD(bool, contains, (std::shared_ptr<ms::Surface> const&), (const, override));
+};
+
 struct AbstractShell : Test
 {
     NiceMock<mtd::MockSurface> mock_surface;
@@ -156,13 +161,20 @@ struct AbstractShell : Test
 
     mtd::StubInputTargeter input_targeter;
     std::shared_ptr<NiceMockWindowManager> wm;
+    std::shared_ptr<NiceMock<MockManagedWindowMembership>> managed_window_membership{
+        std::make_shared<NiceMock<MockManagedWindowMembership>>()};
 
     msh::AbstractShell shell{
         mt::fake_shared(input_targeter),
         mt::fake_shared(surface_stack),
         mt::fake_shared(session_manager),
         std::make_shared<mir::report::null::ShellReport>(),
-        [this](msh::FocusController*) { return wm = std::make_shared<NiceMockWindowManager>(); },
+        [this](msh::FocusController*)
+        {
+            wm = std::make_shared<NiceMockWindowManager>();
+            ON_CALL(*wm, managed_window_membership()).WillByDefault(Return(managed_window_membership));
+            return wm;
+        },
         mt::fake_shared(seat),
         mt::fake_shared(decoration_manager)};
 
@@ -170,6 +182,8 @@ struct AbstractShell : Test
     {
         ON_CALL(session_manager, set_focus_to(_)).
             WillByDefault(Invoke(&session_manager, &MockSessionManager::unmocked_set_focus_to));
+        ON_CALL(*managed_window_membership, contains(_))
+            .WillByDefault(Return(true));
         ON_CALL(mock_surface, size())
             .WillByDefault(Return(geom::Size{}));
         ON_CALL(surface_factory, create_surface(_, _, _))
@@ -541,6 +555,35 @@ TEST_F(AbstractShell, as_focus_controller_delegates_surface_at_to_surface_stack)
     msh::FocusController& focus_controller = shell;
 
     EXPECT_THAT(focus_controller.surface_at(cursor), Eq(surface));
+}
+
+TEST_F(AbstractShell, as_focus_controller_does_not_return_unknown_surface)
+{
+    auto const surface = create_surface(mock_surface);
+    geom::Point const cursor{__LINE__, __LINE__};
+
+    EXPECT_CALL(surface_stack, surface_at(cursor)).
+        WillOnce(Return(surface));
+    EXPECT_CALL(*managed_window_membership, contains(surface)).
+        WillOnce(Return(false));
+
+    msh::FocusController& focus_controller = shell;
+
+    EXPECT_THAT(focus_controller.surface_at(cursor), IsNull());
+}
+
+TEST_F(AbstractShell, as_focus_controller_checks_null_surface_with_shared_membership_view)
+{
+    geom::Point const cursor{__LINE__, __LINE__};
+
+    EXPECT_CALL(surface_stack, surface_at(cursor)).
+        WillOnce(Return(nullptr));
+    EXPECT_CALL(*managed_window_membership, contains(std::shared_ptr<ms::Surface>{})).
+        WillOnce(Return(false));
+
+    msh::FocusController& focus_controller = shell;
+
+    EXPECT_THAT(focus_controller.surface_at(cursor), IsNull());
 }
 
 TEST_F(AbstractShell, as_focus_controller_focus_next_session_skips_surfaceless_sessions)

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -532,7 +532,7 @@ TEST_F(AbstractShell, as_focus_controller_focused_surface_follows_focus)
 
 TEST_F(AbstractShell, as_focus_controller_delegates_surface_at_to_surface_stack)
 {
-    auto const surface = mt::fake_shared(mock_surface);
+    auto const surface = create_surface(mock_surface);
     geom::Point const cursor{__LINE__, __LINE__};
 
     EXPECT_CALL(surface_stack, surface_at(cursor)).


### PR DESCRIPTION
Related: #5071

Split out of #5071, which was too large to review as one change.

## What's new?

- Prevent crashes when scene surfaces are present but are not managed by the window manager.
- Preserve established behavior for managed and unmanaged surfaces, with regression coverage for lifecycle and lookup edge cases.

## How to test

- Build and run the MirAL internal tests:
  ```sh
  cmake --build build --target miral-test-internal
  ./build/bin/miral-test-internal
  ```
- Run the server unit tests and the registered `miral-test` suite.

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
