### PR TITLE
miral: extract `SoftwareBufferPool`

### DIFF
--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(miral-internal STATIC
     live_config_overrides_list_builder.cpp    live_config_overrides_list_builder.h
     override_watcher.cpp                 override_watcher.h
     render_scene_into_surface.cpp        render_scene_into_surface.h
+    software_buffer_pool.cpp             software_buffer_pool.h
     mru_window_list.cpp                  mru_window_list.h
     open_desktop_entry.cpp               open_desktop_entry.h
     static_display_config.cpp            static_display_config.h

--- a/src/miral/render_scene_into_surface.cpp
+++ b/src/miral/render_scene_into_surface.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "render_scene_into_surface.h"
+#include "./software_buffer_pool.h"
 
 #include <mir/executor.h>
 #include <mir/server.h>
@@ -40,112 +41,6 @@ namespace mi = mir::input;
 
 namespace
 {
-class ClaimedBuffer : public mg::Buffer
-{
-public:
-    explicit ClaimedBuffer(
-        std::shared_ptr<Buffer> const& buffer,
-        std::function<void()>&& release_callback)
-        : buffer(buffer), release_callback(std::move(release_callback))
-    {
-    }
-
-    ~ClaimedBuffer() override
-    {
-        release_callback();
-    }
-
-    std::unique_ptr<mrs::Mapping<std::byte const>> map_readable() const override
-    {
-        return buffer->map_readable();
-    }
-    mg::BufferID id() const override { return buffer->id(); }
-    geom::Size size() const override { return buffer->size(); }
-    MirPixelFormat pixel_format() const override { return buffer->pixel_format(); }
-    mg::NativeBufferBase* native_buffer_base() override { return buffer->native_buffer_base(); }
-
-private:
-    std::shared_ptr<Buffer> const buffer;
-    std::function<void()> const release_callback;
-};
-
-/// A simple buffer pool. Users provide the buffers that back the pool.
-/// These buffers may be claimed later.
-class BufferPool
-{
-public:
-    using BufferBuilder = std::function<std::shared_ptr<mg::Buffer>()>;
-
-    BufferPool(BufferBuilder&& builder_func, size_t default_size)
-        : data(std::make_shared<Self>(std::move(builder_func), default_size))
-    {
-    }
-
-    /// Claims the next free buffer from the pool. This may resize the buffer pool
-    /// if that is required to claim a buffer.
-    /// \returns A buffer from the pool
-    std::shared_ptr<mg::Buffer> claim()
-    {
-        std::lock_guard lock{data->mutex};
-        for (size_t i = 0; i < data->buffers.size(); ++i)
-        {
-            if (auto& [used, buffer] = data->buffers[i]; !used)
-            {
-                used = true;
-                std::weak_ptr weak_data = data;
-                return std::make_shared<ClaimedBuffer>(buffer, [weak_data=weak_data, i]
-                {
-                    if (auto const locked = weak_data.lock())
-                    {
-                        std::lock_guard lock{locked->mutex};
-                        locked->buffers[i].first = false;
-                    }
-                });
-            }
-        }
-
-        data->buffers.emplace_back(true, data->builder());
-        size_t i = data->buffers.size() - 1;
-
-        std::weak_ptr weak_data = data;
-        return std::make_shared<ClaimedBuffer>(data->buffers[i].second, [weak_data=weak_data, i]
-        {
-            if (auto const locked = weak_data.lock())
-            {
-                std::lock_guard lock{locked->mutex};
-                locked->buffers[i].first = false;
-            }
-        });
-    }
-
-    void set_builder(BufferBuilder&& in_builder)
-    {
-        std::lock_guard lock{data->mutex};
-        data->builder = std::move(in_builder);
-        for (auto& b: data->buffers)
-            b = { b.first, data->builder() };
-    }
-
-private:
-    struct Self
-    {
-        Self(BufferBuilder&& builder_func, size_t default_size)
-            : builder(std::move(builder_func))
-        {
-            for (size_t i = 0; i < default_size; ++i)
-                buffers.emplace_back(false, builder());
-        }
-
-        std::mutex mutex;
-        BufferBuilder builder;
-
-        /// List of available buffers along with their "claimed" status.
-        std::vector<std::pair<bool, std::shared_ptr<mg::Buffer>>> buffers;
-    };
-
-    std::shared_ptr<Self> data;
-};
-
 class AlwaysHasSubmittedBufferStream : public mc::Stream
 {
 public:
@@ -250,7 +145,7 @@ private:
     bool overlay_cursor = false;
     std::shared_ptr<mc::ScreenShooter> screen_shooter;
     std::shared_ptr<mg::GraphicBufferAllocator> allocator;
-    BufferPool mutable pool;
+    miral::SoftwareBufferPool mutable pool;
 };
 }
 

--- a/src/miral/software_buffer_pool.cpp
+++ b/src/miral/software_buffer_pool.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "software_buffer_pool.h"
+#include "mir/fatal.h"
+
+#include <mir/compositor/stream.h>
+#include <mir/geometry/displacement.h>
+#include <mir/graphics/buffer.h>
+#include <mir/renderer/sw/pixel_source.h>
+#include <mir/report_exception.h>
+
+namespace mg = mir::graphics;
+
+namespace
+{
+/// Wraps a buffer and calls a release callback when destroyed, returning it
+/// to its owning SoftwareBufferPool.
+class ClaimedBuffer : public mir::graphics::Buffer
+{
+public:
+    ClaimedBuffer(std::shared_ptr<mir::graphics::Buffer> const& buffer, std::function<void()>&& release_callback) :
+        buffer(buffer),
+        release_callback(std::move(release_callback))
+    {}
+
+    ~ClaimedBuffer() override
+    {
+        try
+        {
+            release_callback();
+        }
+        catch (std::exception const& e)
+        {
+            MIR_FATAL_ERROR("Exception thrown while releasing a buffer back to its pool: {}", e.what());
+        }
+    }
+
+    ClaimedBuffer(ClaimedBuffer const&) = delete;
+    ClaimedBuffer& operator=(ClaimedBuffer const&) = delete;
+    ClaimedBuffer(ClaimedBuffer&&) = delete;
+    ClaimedBuffer& operator=(ClaimedBuffer&&) = delete;
+
+    std::unique_ptr<mir::renderer::software::Mapping<std::byte const>> map_readable() const override
+    { return buffer->map_readable(); }
+
+    mir::graphics::BufferID id() const override { return buffer->id(); }
+    mir::geometry::Size size() const override { return buffer->size(); }
+    MirPixelFormat pixel_format() const override { return buffer->pixel_format(); }
+    mir::graphics::NativeBufferBase* native_buffer_base() override { return buffer->native_buffer_base(); }
+
+private:
+    std::shared_ptr<mir::graphics::Buffer> const buffer;
+    std::function<void()> const release_callback;
+};
+}
+
+struct miral::SoftwareBufferPool::Self
+{
+    Self(BufferBuilder&& builder_func, size_t initial_size);
+    std::mutex mutex;
+    BufferBuilder builder;
+    std::vector<std::pair<bool, std::shared_ptr<mir::graphics::Buffer>>> buffers;
+};
+
+miral::SoftwareBufferPool::Self::Self(BufferBuilder&& builder_func, size_t initial_size) : builder(std::move(builder_func))
+{
+    for (size_t i = 0; i < initial_size; ++i)
+        buffers.emplace_back(false, builder());
+}
+
+miral::SoftwareBufferPool::SoftwareBufferPool(BufferBuilder&& builder_func, size_t initial_size) :
+    data(std::make_shared<Self>(std::move(builder_func), initial_size))
+{}
+
+std::shared_ptr<mg::Buffer> miral::SoftwareBufferPool::claim()
+{
+    std::lock_guard lock{data->mutex};
+    for (size_t i = 0; i < data->buffers.size(); ++i)
+    {
+        if (auto& [used, buffer] = data->buffers[i]; !used)
+        {
+            used = true;
+            std::weak_ptr weak_data = data;
+            return std::make_shared<ClaimedBuffer>(
+                buffer,
+                [weak_data, i]
+                {
+                    if (auto const locked = weak_data.lock())
+                    {
+                        std::lock_guard l{locked->mutex};
+                        locked->buffers[i].first = false;
+                    }
+                });
+        }
+    }
+
+    // All slots in use — grow the pool.
+    data->buffers.emplace_back(true, data->builder());
+    size_t const i = data->buffers.size() - 1;
+    std::weak_ptr weak_data = data;
+    return std::make_shared<ClaimedBuffer>(
+        data->buffers[i].second,
+        [weak_data, i]
+        {
+            if (auto const locked = weak_data.lock())
+            {
+                std::lock_guard l{locked->mutex};
+                locked->buffers[i].first = false;
+            }
+        });
+}
+
+void miral::SoftwareBufferPool::set_builder(BufferBuilder&& builder)
+{
+    std::lock_guard lock{data->mutex};
+    data->builder = std::move(builder);
+    for (auto& b : data->buffers)
+        b = {b.first, data->builder()};
+}

--- a/src/miral/software_buffer_pool.h
+++ b/src/miral/software_buffer_pool.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_SOFTWARE_BUFFER_POOL_H
+#define MIRAL_SOFTWARE_BUFFER_POOL_H
+
+#include <mir/scene/surface.h>
+
+#include <functional>
+#include <memory>
+
+namespace mir::graphics { class Buffer; }
+
+namespace miral
+{
+
+/// Pool of reusable software buffers. Callers claim one buffer at a time via
+/// claim(); the buffer is returned to the pool when the claim is released by
+/// dropping the last reference to it. If every buffer is in use the pool
+/// grows automatically.
+class SoftwareBufferPool
+{
+public:
+    using BufferBuilder = std::function<std::shared_ptr<mir::graphics::Buffer>()>;
+
+    SoftwareBufferPool(BufferBuilder&& builder_func, size_t initial_size);
+
+    /// Claims the next free buffer, growing the pool if necessary.
+    std::shared_ptr<mir::graphics::Buffer> claim();
+
+    /// Replaces the buffer builder and rebuilds all existing buffers.
+    void set_builder(BufferBuilder&& builder);
+
+private:
+    struct Self;
+    std::shared_ptr<Self> const data;
+};
+} // namespace miral
+
+#endif // MIRAL_SOFTWARE_BUFFER_POOL_H


### PR DESCRIPTION
Split out of #5071, which was too large to review as one change.

## What's new?

- Pull the software buffer allocation, recycling and pixel-writing logic out of `render_scene_into_surface.cpp` into a reusable `miral::SoftwareBufferPool`. No behaviour change; `RenderSceneIntoSurface` now delegates to the pool.

## How to test

```sh
cmake --build build --target miral-test-internal
./build/bin/miral-test-internal --gtest_filter='RenderSceneIntoSurface*'
```

## Checklist

- [x] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos

Existing `RenderSceneIntoSurface` tests cover the refactored path; this is a pure extraction.
