### PR TITLE
miral: add magnifier layout geometry helpers

### DIFF
--- a/include/core/mir/geometry/rectangle.h
+++ b/include/core/mir/geometry/rectangle.h
@@ -82,6 +82,7 @@ struct Rectangle
     X<T> right() const { return bottom_right().x; }
     Y<T> top() const { return top_left.y; }
     Y<T> bottom() const { return bottom_right().y; }
+    Point<T> centre() const { return top_left + as_displacement(size / static_cast<T>(2)); }
 
     friend bool operator==(Rectangle const& lhs, Rectangle const& rhs) = default;
 

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(miral-internal STATIC
     live_config_ini_file_common.cpp      live_config_ini_file_common.h
     live_config_watcher.cpp               live_config_watcher.h
     version_compare.cpp                   version_compare.h
+    magnifier_layout.cpp                 magnifier_layout.h magnifier_geometry.h
+    magnifier_controls.cpp               magnifier_controls.h
 )
 
 # Already implied by the linker's symbol version script, but can avoid accidents

--- a/src/miral/magnifier_controls.cpp
+++ b/src/miral/magnifier_controls.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "magnifier_controls.h"
+
+#include "magnifier_geometry.h"
+
+#include <algorithm>
+#include <initializer_list>
+#include <utility>
+
+namespace geom = mir::geometry;
+namespace controls = miral::magnifier_controls;
+
+auto controls::Positions::for_kind(HandleKind const kind) const -> geom::Point
+{
+    switch (kind)
+    {
+    case HandleKind::drag:
+        return drag;
+    case HandleKind::resize:
+        return resize;
+    case HandleKind::zoom_in:
+        return zoom_in;
+    case HandleKind::zoom_out:
+        return zoom_out;
+    }
+
+    std::unreachable();
+}
+
+auto controls::positions_for(miral::magnifier_layout::FreePlacement const& placement, double const magnification)
+    -> Positions
+{
+    auto const bounds = miral::magnifier_geometry::visual_bounds(
+        placement.surface_top_left, placement.capture_area.size, magnification);
+
+    auto const left = geom::X{bounds.left()};
+    auto const right = geom::X{bounds.right()};
+    auto const top = geom::Y{bounds.top()};
+    auto const bottom = geom::Y{bounds.bottom()};
+
+    auto const handle_width = geom::DeltaX{handle_diameter};
+    auto const handle_height = geom::DeltaY{handle_diameter};
+    auto const control_stack_offset = geom::DeltaY{handle_diameter + zoom_stack_padding};
+
+    return {
+        .drag = {right - handle_width, bottom - handle_height},
+        .resize = {left, top},
+        .zoom_in = {right - handle_width, top},
+        .zoom_out = {right - handle_width, top + control_stack_offset}};
+}
+
+auto controls::contains_content(
+    miral::magnifier_layout::FreePlacement const& placement,
+    double const magnification,
+    geom::PointD const& point) -> bool
+{
+    auto const bounds = miral::magnifier_geometry::visual_bounds(
+        placement.surface_top_left, placement.capture_area.size, magnification);
+
+    if (!bounds.contains(point))
+        return false;
+
+    // Make sure the point is not in any of the handles, which are drawn on top of the content.
+    auto const positions = positions_for(placement, magnification);
+    return std::ranges::none_of(
+        std::initializer_list{positions.drag, positions.resize, positions.zoom_in, positions.zoom_out},
+        [&point](auto const& handle)
+        {
+            auto const handle_rect =
+                geom::RectangleD{geom::PointD{handle}, geom::SizeD{handle_diameter, handle_diameter}};
+            return handle_rect.contains(point);
+        });
+}

--- a/src/miral/magnifier_controls.h
+++ b/src/miral/magnifier_controls.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_MAGNIFIER_CONTROLS_H
+#define MIRAL_MAGNIFIER_CONTROLS_H
+
+#include "magnifier_layout.h"
+
+#include <mir/geometry/point.h>
+#include <mir/geometry/size.h>
+
+namespace miral::magnifier_controls
+{
+constexpr int handle_diameter{48};
+constexpr int zoom_stack_padding{8};
+constexpr int visual_edge_clearance{handle_diameter};
+constexpr mir::geometry::Size minimum_visual_size{
+    2 * handle_diameter,
+    3 * handle_diameter + zoom_stack_padding};
+
+enum class HandleKind
+{
+    drag,
+    resize,
+    zoom_in,
+    zoom_out
+};
+
+struct Positions
+{
+    mir::geometry::Point drag;
+    mir::geometry::Point resize;
+    mir::geometry::Point zoom_in;
+    mir::geometry::Point zoom_out;
+
+    auto for_kind(HandleKind kind) const -> mir::geometry::Point;
+
+    bool operator==(Positions const&) const = default;
+};
+
+auto positions_for(
+    miral::magnifier_layout::FreePlacement const& placement,
+    double magnification) -> Positions;
+
+auto contains_content(
+    miral::magnifier_layout::FreePlacement const& placement,
+    double magnification,
+    mir::geometry::PointD const& point) -> bool;
+}
+
+#endif

--- a/src/miral/magnifier_geometry.h
+++ b/src/miral/magnifier_geometry.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_MAGNIFIER_GEOMETRY_H
+#define MIRAL_MAGNIFIER_GEOMETRY_H
+
+#include <mir/geometry/point.h>
+#include <mir/geometry/rectangle.h>
+#include <mir/geometry/size.h>
+
+namespace miral::magnifier_geometry
+{
+inline auto visual_bounds(
+    mir::geometry::Point const& surface_top_left,
+    mir::geometry::Size const& capture_size,
+    double const magnification) -> mir::geometry::RectangleD
+{
+    auto const center = mir::geometry::PointD{
+        surface_top_left.x.as_value() + capture_size.width.as_value() / 2.0,
+        surface_top_left.y.as_value() + capture_size.height.as_value() / 2.0,
+    };
+
+    auto const visual_size = mir::geometry::SizeD{
+        capture_size.width.as_value() * magnification,
+        capture_size.height.as_value() * magnification,
+    };
+
+    return {
+        {
+            center.x.as_value() - visual_size.width.as_value() / 2.0,
+            center.y.as_value() - visual_size.height.as_value() / 2.0,
+        },
+        visual_size,
+    };
+}
+}
+
+#endif

--- a/src/miral/magnifier_layout.cpp
+++ b/src/miral/magnifier_layout.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "magnifier_layout.h"
+
+#include "magnifier_controls.h"
+#include "magnifier_geometry.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace geom = mir::geometry;
+namespace controls = miral::magnifier_controls;
+namespace layout = miral::magnifier_layout;
+using namespace miral::magnifier_geometry;
+
+namespace
+{
+template<typename RectangleType>
+inline auto as_rectangle_d(RectangleType rectangle) -> mir::geometry::RectangleD
+{
+    return {
+        mir::geometry::PointD{rectangle.top_left},
+        mir::geometry::SizeD{rectangle.size},
+    };
+}
+
+auto squared_distance_between(geom::PointD point, geom::Rectangle rectangle) -> double
+{
+    auto const rectangle_d = as_rectangle_d(rectangle);
+    auto const dx = std::max({
+        0.0,
+        (rectangle_d.left() - point.x).as_value(),
+        (point.x - rectangle_d.right()).as_value(),
+    });
+    auto const dy = std::max({
+        0.0,
+        (rectangle_d.top() - point.y).as_value(),
+        (point.y - rectangle_d.bottom()).as_value(),
+    });
+    return dx * dx + dy * dy;
+}
+
+auto selected_output(geom::Rectangles const& outputs, geom::PointD desired_center)
+    -> geom::Rectangle const&
+{
+    auto const first_containing = std::ranges::find_if(
+        outputs, [desired_center](auto const& output) { return as_rectangle_d(output).contains(desired_center); });
+
+    if (first_containing != outputs.end())
+        return *first_containing;
+
+    auto const nearest = std::ranges::min_element(
+        outputs,
+        std::less{},
+        [desired_center](auto const& output) { return squared_distance_between(desired_center, output); });
+
+    return *nearest;
+}
+
+auto clamp(geom::SizeD value, geom::SizeD min_value, geom::SizeD max_value) -> geom::SizeD
+{
+    return {
+        std::clamp(value.width, min_value.width, max_value.width),
+        std::clamp(value.height, min_value.height, max_value.height),
+    };
+}
+
+auto floor(geom::SizeD value) -> geom::Size
+{
+    return {
+        geom::Width{std::floor(value.width.as_value())},
+        geom::Height{std::floor(value.height.as_value())}};
+}
+
+auto capture_size_for(
+    geom::SizeD requested_visual_size,
+    geom::Rectangle output,
+    double magnification) -> geom::Size
+{
+    auto const maximum_visual = 0.8 * geom::SizeD{output.size};
+
+    auto const clamped_visual = clamp(requested_visual_size, geom::SizeD{controls::minimum_visual_size}, geom::SizeD{maximum_visual});
+    auto const requested_capture = geom::Size{clamped_visual / magnification};
+    auto const maximum_capture = floor(maximum_visual / magnification);
+    return {
+        std::min(requested_capture.width, maximum_capture.width),
+        std::min(requested_capture.height, maximum_capture.height)};
+}
+
+auto surface_top_left_centered_on(geom::PointD center, geom::Size capture_size) -> geom::Point
+{
+    return {
+        geom::X{center.x.as_value() - capture_size.width.as_value() / 2.0},
+        geom::Y{center.y.as_value() - capture_size.height.as_value() / 2.0}};
+}
+
+auto contains_point(geom::Rectangles const& outputs, double x, double y) -> bool
+{
+    return std::ranges::any_of(
+        outputs, [point = geom::PointD{x, y}](auto const& output) { return as_rectangle_d(output).contains(point); });
+}
+
+auto contains_corners(geom::Rectangles const& outputs, geom::RectangleD const& bounds) -> bool
+{
+    auto const left = bounds.left().as_value();
+    auto const right = bounds.right().as_value();
+    auto const top = bounds.top().as_value();
+    auto const bottom = bounds.bottom().as_value();
+    return contains_point(outputs, left, top) &&
+           contains_point(outputs, right, top) &&
+           contains_point(outputs, left, bottom) &&
+           contains_point(outputs, right, bottom);
+}
+
+auto confinement_for(geom::RectangleD const& bounds, geom::Rectangle output) -> geom::Displacement
+{
+    auto dx = 0;
+    auto const output_d = as_rectangle_d(output);
+    if (bounds.left() < output_d.left())
+        dx = static_cast<int>(std::ceil((output_d.left() - bounds.left()).as_value()));
+    else if (bounds.right() > output_d.right())
+        dx = static_cast<int>(std::floor((output_d.right() - bounds.right()).as_value()));
+
+    auto dy = 0;
+    if (bounds.top() < output_d.top())
+        dy = static_cast<int>(std::ceil((output_d.top() - bounds.top()).as_value()));
+    else if (bounds.bottom() > output_d.bottom())
+        dy = static_cast<int>(std::floor((output_d.bottom() - bounds.bottom()).as_value()));
+
+    return {dx, dy};
+}
+
+auto map_axis(
+    double clearance,
+    double visual_center,
+    double visual_extent,
+    int capture_extent,
+    int output_start,
+    int output_extent)
+{
+    auto const output_center = output_start + output_extent / 2.0;
+    auto const progress =
+        std::clamp((visual_center - output_center) / ((output_extent - visual_extent) / 2.0), -1.0, 1.0);
+    auto const capture_center = output_center + progress * ((output_extent - capture_extent) / 2.0 + clearance);
+    return static_cast<int>(capture_center - capture_extent / 2.0);
+}
+
+auto capture_top_left_for(
+    geom::RectangleD const& visual_bounds,
+    geom::Size capture_size,
+    geom::Rectangle output,
+    double magnification) -> geom::Point
+{
+    auto const clearance = std::ceil(controls::visual_edge_clearance / magnification);
+    auto const visual_center = visual_bounds.centre();
+    return {
+        map_axis(
+            clearance,
+            visual_center.x.as_value(),
+            visual_bounds.size.width.as_value(),
+            capture_size.width.as_value(),
+            output.left().as_value(),
+            output.size.width.as_value()),
+        map_axis(
+            clearance,
+            visual_center.y.as_value(),
+            visual_bounds.size.height.as_value(),
+            capture_size.height.as_value(),
+            output.top().as_value(),
+            output.size.height.as_value())};
+}
+
+// Places the magnifier capture area and confines its visual area when necessary.
+//
+// First, the visual area is calculated from the given surface top left and
+// capture size. If the visual area's corners are not all covered by the
+// outputs, the surface top left is adjusted to confine it to the selected output.
+// Then, the capture area is placed to center on the visual area, while
+// ensuring that it does not extend beyond the output more than a handle's diameter.
+auto free_placement(
+    geom::Rectangle output,
+    geom::Size capture_size,
+    geom::Point surface_top_left,
+    geom::Rectangles const& outputs,
+    double magnification) -> layout::FreePlacement
+{
+    auto bounds = miral::magnifier_geometry::visual_bounds(
+        surface_top_left, capture_size, magnification);
+    auto confinement = geom::Displacement{0, 0};
+    if (!contains_corners(outputs, bounds))
+    {
+        confinement = confinement_for(bounds, output);
+        surface_top_left += confinement;
+        bounds.top_left += geom::DisplacementD{confinement};
+    }
+
+    return {
+        layout::Placement{{capture_top_left_for(bounds, capture_size, output, magnification), capture_size}},
+        surface_top_left};
+}
+}
+
+auto layout::place_following_cursor(
+    geom::PointD cursor,
+    geom::SizeD requested_visual_size,
+    geom::Rectangles const& outputs,
+    double magnification) -> Placement
+{
+    auto const output = selected_output(outputs, cursor);
+    auto const capture_size = capture_size_for(requested_visual_size, output, magnification);
+    auto const surface_top_left = surface_top_left_centered_on(cursor, capture_size);
+
+    return {
+        .capture_area = {surface_top_left, capture_size},
+    };
+}
+
+auto layout::place_freely(
+    geom::PointD desired_center,
+    geom::SizeD requested_visual_size,
+    geom::Rectangles const& outputs,
+    double magnification) -> FreePlacement
+{
+    auto const output = selected_output(outputs, desired_center);
+    auto const capture_size = capture_size_for(requested_visual_size, output, magnification);
+    return free_placement(
+        output,
+        capture_size,
+        surface_top_left_centered_on(desired_center, capture_size),
+        outputs,
+        magnification);
+}
+
+auto layout::resize_freely(
+    geom::PointD dragged_visual_top_left,
+    geom::PointD pinned_visual_bottom_right,
+    geom::Rectangles const& outputs,
+    double magnification) -> FreePlacement
+{
+    auto const requested_visual_size = geom::SizeD{
+        (pinned_visual_bottom_right.x - dragged_visual_top_left.x).as_value(),
+        (pinned_visual_bottom_right.y - dragged_visual_top_left.y).as_value()};
+
+    auto const temp_x = dragged_visual_top_left.x.as_value() + pinned_visual_bottom_right.x.as_value();
+    auto const temp_y = dragged_visual_top_left.y.as_value() + pinned_visual_bottom_right.y.as_value();
+    auto const intended_center = geom::PointD{(temp_x) / 2.0, (temp_y) / 2.0};
+
+    auto const output = selected_output(outputs, intended_center);
+    auto const capture_size = capture_size_for(requested_visual_size, output, magnification);
+    auto const surface_top_left = geom::Point{
+        geom::X{
+            pinned_visual_bottom_right.x.as_value() -
+            (1.0 + magnification) * capture_size.width.as_value() / 2.0},
+        geom::Y{
+            pinned_visual_bottom_right.y.as_value() -
+            (1.0 + magnification) * capture_size.height.as_value() / 2.0}};
+
+    return free_placement(output, capture_size, surface_top_left, outputs, magnification);
+}

--- a/src/miral/magnifier_layout.h
+++ b/src/miral/magnifier_layout.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_MAGNIFIER_LAYOUT_H
+#define MIRAL_MAGNIFIER_LAYOUT_H
+
+#include <mir/geometry/point.h>
+#include <mir/geometry/rectangle.h>
+#include <mir/geometry/rectangles.h>
+#include <mir/geometry/size.h>
+
+namespace miral::magnifier_layout
+{
+struct Placement
+{
+    mir::geometry::Rectangle capture_area;
+
+    bool operator==(Placement const&) const = default;
+};
+
+struct FreePlacement : Placement
+{
+    /// Top-left of the untransformed surface. Its size is always
+    /// `capture_area.size`.
+    mir::geometry::Point surface_top_left;
+
+    bool operator==(FreePlacement const&) const = default;
+};
+
+auto place_following_cursor(
+    mir::geometry::PointD cursor,
+    mir::geometry::SizeD requested_visual_size,
+    mir::geometry::Rectangles const& outputs,
+    double magnification) -> Placement;
+
+auto place_freely(
+    mir::geometry::PointD desired_center,
+    mir::geometry::SizeD requested_visual_size,
+    mir::geometry::Rectangles const& outputs,
+    double magnification) -> FreePlacement;
+
+auto resize_freely(
+    mir::geometry::PointD dragged_visual_top_left,
+    mir::geometry::PointD pinned_visual_bottom_right,
+    mir::geometry::Rectangles const& outputs,
+    double magnification) -> FreePlacement;
+}
+
+#endif

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -55,6 +55,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     ini_file_with_overrides.cpp
     override_watcher.cpp
     version_compare.cpp
+    magnifier_layout.cpp
     ${MIRAL_TEST_SOURCES}
 )
 

--- a/tests/miral/magnifier_layout.cpp
+++ b/tests/miral/magnifier_layout.cpp
@@ -1,0 +1,567 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "magnifier_controls.h"
+#include "magnifier_geometry.h"
+#include "magnifier_layout.h"
+
+#include <mir/flags.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <tuple>
+
+namespace geom = mir::geometry;
+namespace controls = miral::magnifier_controls;
+namespace layout = miral::magnifier_layout;
+using namespace testing;
+
+namespace
+{
+enum class ExpectedEdge
+{
+    left = 1 << 0,
+    right = 1 << 1,
+    top = 1 << 2,
+    bottom = 1 << 3,
+};
+
+constexpr auto mir_enable_enum_bit_operators(ExpectedEdge edge) -> ExpectedEdge
+{
+    return edge;
+}
+
+using ExpectedEdges = mir::Flags<ExpectedEdge>;
+
+constexpr std::array test_magnifications{1.25, 1.5, 2.0, 3.5, 8.0};
+
+auto single_output(geom::Rectangle const& output = {{0, 0}, {800, 600}}) -> geom::Rectangles
+{
+    return {output};
+}
+
+auto surface_top_left(layout::Placement const& placement) -> geom::Point
+{
+    return placement.capture_area.top_left;
+}
+
+auto surface_top_left(layout::FreePlacement const& placement) -> geom::Point
+{
+    return placement.surface_top_left;
+}
+
+auto visual_bounds(auto const& placement, double const magnification) -> geom::RectangleD
+{
+    return miral::magnifier_geometry::visual_bounds(
+        surface_top_left(placement),
+        placement.capture_area.size,
+        magnification);
+}
+
+auto surface_center(auto const& placement) -> geom::PointD
+{
+    return {
+        surface_top_left(placement).x.as_value() +
+            placement.capture_area.size.width.as_value() / 2.0,
+        surface_top_left(placement).y.as_value() +
+            placement.capture_area.size.height.as_value() / 2.0};
+}
+
+auto capture_center(layout::Placement const& placement) -> geom::PointD
+{
+    return {
+        placement.capture_area.left().as_value() + placement.capture_area.size.width.as_value() / 2.0,
+        placement.capture_area.top().as_value() + placement.capture_area.size.height.as_value() / 2.0};
+}
+
+void expect_center_near(geom::PointD const& actual, geom::PointD const& expected, double const tolerance = 1.0)
+{
+    EXPECT_THAT(actual.x.as_value(), DoubleNear(expected.x.as_value(), tolerance));
+    EXPECT_THAT(actual.y.as_value(), DoubleNear(expected.y.as_value(), tolerance));
+}
+
+class FollowingCursorPlacement : public TestWithParam<std::tuple<double, geom::SizeD>>
+{
+};
+
+class IntegralTranslation : public TestWithParam<double>
+{
+};
+
+class PinnedResize : public TestWithParam<double>
+{
+};
+
+class ContentHitTestingForHandle : public TestWithParam<controls::HandleKind>
+{
+};
+
+struct OutputSelectionParameters
+{
+    geom::PointD desired_center;
+    geom::Size expected_capture_size;
+};
+
+class OutputSelection : public TestWithParam<std::tuple<geom::Rectangles, OutputSelectionParameters>>
+{
+};
+
+struct EdgeAndCornerPlacementParameters
+{
+    geom::PointD center;
+    ExpectedEdges expected_edges;
+};
+
+class EdgeAndCornerPlacement : public TestWithParam<EdgeAndCornerPlacementParameters>
+{
+};
+}
+
+TEST_P(FollowingCursorPlacement, couples_capture_and_surface_with_bounded_center_error)
+{
+    auto const outputs = single_output({{-1000, -700}, {1800, 1300}});
+    auto const& [magnification, size] = GetParam();
+
+    auto const cursor = geom::PointD{-123.5, 47.25};
+    auto const placement =
+        layout::place_following_cursor(cursor, size, outputs, magnification);
+
+    EXPECT_THAT(
+        placement.capture_area,
+        Eq(geom::Rectangle{
+            surface_top_left(placement),
+            placement.capture_area.size}));
+    expect_center_near(surface_center(placement), cursor);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MagnificationsAndSizes,
+    FollowingCursorPlacement,
+    Combine(
+        ValuesIn(test_magnifications),
+        Values(geom::SizeD{201.0, 213.0}, geom::SizeD{240.0, 200.0})));
+
+TEST(MagnifierLayout, following_cursor_is_not_confined_at_output_edges)
+{
+    auto const outputs = single_output();
+
+    auto const placement =
+        layout::place_following_cursor({0.0, 0.0}, {200.0, 200.0}, outputs, 2.0);
+
+    auto const bounds = visual_bounds(placement, 2.0);
+    EXPECT_THAT(bounds.left().as_value(), DoubleEq(-100.0));
+    EXPECT_THAT(bounds.top().as_value(), DoubleEq(-100.0));
+}
+
+TEST(MagnifierLayout, free_placement_at_output_center_aligns_capture_and_surface_centers)
+{
+    auto const outputs = single_output();
+
+    auto const placement =
+        layout::place_freely({400.0, 300.0}, {240.0, 200.0}, outputs, 2.0);
+
+    expect_center_near(surface_center(placement), {400.0, 300.0}, 0.0);
+    expect_center_near(capture_center(placement), surface_center(placement), 0.0);
+}
+
+TEST_P(EdgeAndCornerPlacement, preserves_handle_width_of_source_clearance)
+{
+    auto const output = geom::Rectangle{{0, 0}, {800, 600}};
+    auto const outputs = single_output(output);
+    auto const requested_size = geom::SizeD{240.0, 200.0};
+    auto const magnification = 2.0;
+    auto const [center, expected_edges] = GetParam();
+
+    auto const placement = layout::place_freely(center, requested_size, outputs, magnification);
+    auto const bounds = visual_bounds(placement, magnification);
+
+    auto const left_visual_clearance =
+        (output.left() - placement.capture_area.left()).as_value() * magnification;
+    auto const right_visual_clearance =
+        (placement.capture_area.right() - output.right()).as_value() * magnification;
+    auto const top_visual_clearance =
+        (output.top() - placement.capture_area.top()).as_value() * magnification;
+    auto const bottom_visual_clearance =
+        (placement.capture_area.bottom() - output.bottom()).as_value() * magnification;
+
+    expect_center_near(surface_center(placement), center, 0.0);
+
+    if (contains(expected_edges, ExpectedEdge::left))
+    {
+        EXPECT_THAT(bounds.left().as_value(), DoubleEq(output.left().as_value()));
+        EXPECT_GE(left_visual_clearance, controls::handle_diameter);
+    }
+
+    if (contains(expected_edges, ExpectedEdge::right))
+    {
+        EXPECT_THAT(bounds.right().as_value(), DoubleEq(output.right().as_value()));
+        EXPECT_GE(right_visual_clearance, controls::handle_diameter);
+    }
+
+    if (contains(expected_edges, ExpectedEdge::top))
+    {
+        EXPECT_THAT(bounds.top().as_value(), DoubleEq(output.top().as_value()));
+        EXPECT_GE(top_visual_clearance, controls::handle_diameter);
+    }
+
+    if (contains(expected_edges, ExpectedEdge::bottom))
+    {
+        EXPECT_THAT(bounds.bottom().as_value(), DoubleEq(output.bottom().as_value()));
+        EXPECT_GE(bottom_visual_clearance, controls::handle_diameter);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OutputEdgesAndCorners,
+    EdgeAndCornerPlacement,
+    Values(
+        EdgeAndCornerPlacementParameters{.center = {120.0, 300.0}, .expected_edges = ExpectedEdge::left},
+        EdgeAndCornerPlacementParameters{.center = {680.0, 300.0}, .expected_edges = ExpectedEdge::right},
+        EdgeAndCornerPlacementParameters{.center = {400.0, 100.0}, .expected_edges = ExpectedEdge::top},
+        EdgeAndCornerPlacementParameters{.center = {400.0, 500.0}, .expected_edges = ExpectedEdge::bottom},
+        EdgeAndCornerPlacementParameters{
+            .center = {120.0, 100.0},
+            .expected_edges = ExpectedEdge::left | ExpectedEdge::top},
+        EdgeAndCornerPlacementParameters{
+            .center = {680.0, 500.0},
+            .expected_edges = ExpectedEdge::right | ExpectedEdge::bottom}));
+
+TEST(MagnifierLayout, source_clearance_is_capped_to_less_than_half_the_capture)
+{
+    auto const outputs = single_output();
+    auto const magnification = 3.5;
+    auto const placement = layout::place_freely(
+        {47.25, 300.0},
+        geom::SizeD{96.0, 152.0},
+        outputs,
+        magnification);
+    auto const bounds = visual_bounds(placement, magnification);
+
+    EXPECT_THAT(placement.capture_area.size.width, Eq(geom::Width{27}));
+    EXPECT_THAT(std::ceil(controls::visual_edge_clearance / magnification), Gt(27 / 2.0));
+    EXPECT_LT(bounds.left().as_value(), 0.5);
+    EXPECT_THAT(placement.capture_area.left(), Eq(geom::X{-13}));
+}
+
+TEST_P(OutputSelection, capture_size_matches_selected_output)
+{
+    auto const& [outputs, parameters] = GetParam();
+    auto const placement =
+        layout::place_following_cursor(parameters.desired_center, {1000.0, 1000.0}, outputs, 1.0);
+
+    EXPECT_THAT(placement.capture_area.size, Eq(parameters.expected_capture_size));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DesiredCenterSelectsContainingOutput,
+    OutputSelection,
+    Combine(
+        Values(geom::Rectangles{{{0, 0}, {800, 600}}, {{800, 0}, {400, 300}}}),
+        Values(
+            OutputSelectionParameters{
+                .desired_center = {799.0, 150.0},
+                .expected_capture_size = {640, 480}},
+            OutputSelectionParameters{
+                .desired_center = {801.0, 150.0},
+                .expected_capture_size = {320, 240}})));
+
+INSTANTIATE_TEST_SUITE_P(
+    DesiredCenterInGapSelectsNearestOutput,
+    OutputSelection,
+    Combine(
+        Values(geom::Rectangles{{{0, 0}, {800, 600}}, {{1000, 0}, {400, 300}}}),
+        Values(
+            OutputSelectionParameters{
+                .desired_center = {850.0, 150.0},
+                .expected_capture_size = {640, 480}},
+            OutputSelectionParameters{
+                .desired_center = {950.0, 150.0},
+                .expected_capture_size = {320, 240}})));
+
+TEST(MagnifierLayout, adjacent_output_straddling_is_not_confined)
+{
+    geom::Rectangles outputs{
+        {{0, 0}, {800, 600}},
+        {{800, 0}, {400, 600}}};
+
+    auto const placement = layout::place_freely({800.0, 300.0}, {200.0, 200.0}, outputs, 1.0);
+
+    EXPECT_THAT(visual_bounds(placement, 1.0).left().as_value(), DoubleEq(700.0));
+    expect_center_near(surface_center(placement), {800.0, 300.0}, 0.0);
+}
+
+TEST(MagnifierLayout, exactly_flush_far_edge_is_covered_without_confinement)
+{
+    auto const outputs = single_output();
+
+    auto const placement = layout::place_freely({700.0, 300.0}, {200.0, 200.0}, outputs, 1.25);
+
+    EXPECT_THAT(visual_bounds(placement, 1.25).right().as_value(), DoubleEq(800.0));
+    expect_center_near(surface_center(placement), {700.0, 300.0}, 0.0);
+}
+
+TEST(MagnifierLayout, gap_overhang_is_confined_with_rounding_toward_containment)
+{
+    auto const selected_output = geom::Rectangle{{0, 0}, {800, 600}};
+    geom::Rectangles outputs{
+        selected_output,
+        {{900, 0}, {400, 600}}};
+    auto const desired_center = geom::PointD{842.0, 300.0};
+    auto const magnification = 1.25;
+
+    auto const placement =
+        layout::place_freely(desired_center, {96.0, 200.0}, outputs, magnification);
+    auto const bounds = visual_bounds(placement, magnification);
+
+    EXPECT_LE(bounds.right().as_value(), selected_output.right().as_value());
+    EXPECT_GT(bounds.right().as_value(), selected_output.right().as_value() - 1.0);
+    EXPECT_LT(surface_center(placement).x.as_value(), desired_center.x.as_value());
+}
+
+TEST(MagnifierLayout, left_and_top_confinement_rounds_right_and_down_toward_containment)
+{
+    auto const output = geom::Rectangle{{0, 0}, {800, 600}};
+    auto const desired_center = geom::PointD{-42.0, -42.0};
+    auto const magnification = 1.25;
+
+    auto const placement =
+        layout::place_freely(desired_center, {96.0, 152.0}, single_output(output), magnification);
+    auto const bounds = visual_bounds(placement, magnification);
+
+    EXPECT_GE(bounds.left().as_value(), output.left().as_value());
+    EXPECT_GE(bounds.top().as_value(), output.top().as_value());
+    EXPECT_LT(bounds.left().as_value(), output.left().as_value() + 1.0);
+    EXPECT_LT(bounds.top().as_value(), output.top().as_value() + 1.0);
+    EXPECT_GT(surface_center(placement).x.as_value(), desired_center.x.as_value());
+    EXPECT_GT(surface_center(placement).y.as_value(), desired_center.y.as_value());
+}
+
+TEST(MagnifierLayout, output_removal_relocates_to_nearest_remaining_output)
+{
+    auto const outputs = single_output();
+
+    auto const placement = layout::place_freely({2100.0, 300.0}, {200.0, 200.0}, outputs, 1.0);
+    auto const bounds = visual_bounds(placement, 1.0);
+
+    EXPECT_THAT(bounds.right().as_value(), DoubleEq(800.0));
+    expect_center_near(surface_center(placement), {700.0, 300.0}, 0.0);
+}
+
+TEST(MagnifierLayout, capture_rounding_never_exceeds_strict_eighty_percent_cap)
+{
+    constexpr auto maximum_visual_fraction = 0.8;
+    auto const output = geom::Rectangle{{0, 0}, {201, 199}};
+    auto const magnification = 1.25;
+
+    auto const placement =
+        layout::place_following_cursor(
+            {50.0, 49.0},
+            {1000.0, 1000.0},
+            single_output(output),
+            magnification);
+    auto const bounds = visual_bounds(placement, magnification);
+
+    EXPECT_LE(
+        bounds.size.width.as_value(),
+        maximum_visual_fraction * output.size.width.as_value());
+    EXPECT_LE(
+        bounds.size.height.as_value(),
+        maximum_visual_fraction * output.size.height.as_value());
+    EXPECT_THAT(placement.capture_area.size, Eq(geom::Size{128, 127}));
+}
+
+TEST(MagnifierLayout, visual_size_is_clamped_to_the_control_minimum)
+{
+    auto const outputs = single_output();
+
+    auto const placement =
+        layout::place_freely({400.0, 300.0}, {1.0, 1.0}, outputs, 1.0);
+
+    EXPECT_THAT(placement.capture_area.size, Eq(controls::minimum_visual_size));
+}
+
+TEST(MagnifierLayout, requested_size_is_reclamped_for_each_output)
+{
+    auto const small_outputs = single_output({{0, 0}, {400, 300}});
+    auto const large_outputs = single_output({{0, 0}, {1600, 1200}});
+    auto const requested = geom::SizeD{1000.0, 900.0};
+    auto const magnification = 2.0;
+
+    auto const small =
+        layout::place_freely({200.0, 150.0}, requested, small_outputs, magnification);
+    auto const large =
+        layout::place_freely({800.0, 600.0}, requested, large_outputs, magnification);
+
+    // The request is output-limited on the small output and request-limited on the large output.
+    EXPECT_THAT(small.capture_area.size, Eq(geom::Size{160, 120}));
+    EXPECT_THAT(large.capture_area.size, Eq(geom::Size{500, 450}));
+}
+
+TEST_P(IntegralTranslation, has_bounded_quantization_error)
+{
+    auto const magnification = GetParam();
+    auto const translation = geom::Displacement{37, -41};
+    auto const requested_size = geom::SizeD{213.0, 271.0};
+
+    auto const original_output = geom::Rectangle{{-1000, -700}, {1800, 1300}};
+    auto const translated_output = geom::Rectangle{original_output.top_left + translation, original_output.size};
+
+    auto const original_center = geom::PointD{-123.5, 47.25};
+    auto const translated_center = original_center + geom::DisplacementD{translation};
+
+    auto const original = layout::place_freely(
+        original_center,
+        requested_size,
+        single_output(original_output),
+        magnification);
+
+    auto const translated = layout::place_freely(
+        translated_center,
+        requested_size,
+        single_output(translated_output),
+        magnification);
+
+    expect_center_near(surface_center(original), original_center);
+    expect_center_near(surface_center(translated), translated_center);
+
+    auto const surface_translation = translated.surface_top_left - original.surface_top_left;
+    auto const capture_translation = translated.capture_area.top_left - original.capture_area.top_left;
+
+    auto const expected_dx = translation.dx.as_value();
+    auto const expected_dy = translation.dy.as_value();
+
+    EXPECT_THAT(surface_translation.dx.as_value(), Eq(expected_dx));
+    EXPECT_THAT(capture_translation.dx.as_value(), Eq(expected_dx));
+
+    // Each integer position truncates toward zero, so the measured translation is
+    // trunc(y + dy) - trunc(y). At 3.5x, the surface positions are 8.75 and -32.25:
+    // trunc(-32.25) - trunc(8.75) = -32 - 8 = -40, one pixel less negative than -41.
+    // Mapping from those quantized surface positions gives capture positions 28.648... and
+    // -11.137...: trunc(-11.137...) - trunc(28.648...) = -11 - 28 = -39, two pixels less negative.
+    EXPECT_THAT(surface_translation.dy.as_value(), AllOf(Ge(expected_dy), Le(expected_dy + 1)));
+    EXPECT_THAT(capture_translation.dy.as_value(), AllOf(Ge(expected_dy), Le(expected_dy + 2)));
+
+    EXPECT_THAT(translated.capture_area.size, Eq(original.capture_area.size));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Magnifications,
+    IntegralTranslation,
+    ValuesIn(test_magnifications));
+
+TEST_P(PinnedResize, keeps_bottom_right_handle_position)
+{
+    auto const outputs = single_output();
+    auto const pinned_handle_corner = geom::Point{700, 550};
+    auto const pinned = geom::PointD{pinned_handle_corner};
+    auto const magnification = GetParam();
+
+    auto const placement = layout::resize_freely(
+        {460.0, 310.0},
+        pinned,
+        outputs,
+        magnification);
+    auto const bounds = visual_bounds(placement, magnification);
+    auto const handles = controls::positions_for(placement, magnification);
+    auto const actual_handle_corner =
+        handles.drag + geom::Displacement{controls::handle_diameter, controls::handle_diameter};
+
+    EXPECT_THAT(actual_handle_corner, Eq(pinned_handle_corner));
+    EXPECT_THAT(bounds.right().as_value(), DoubleNear(pinned.x.as_value(), 0.5));
+    EXPECT_THAT(bounds.bottom().as_value(), DoubleNear(pinned.y.as_value(), 0.5));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Magnifications,
+    PinnedResize,
+    ValuesIn(test_magnifications));
+
+TEST(MagnifierLayout, pinned_resize_clamps_to_output_cap_without_hidden_oversize)
+{
+    constexpr auto maximum_visual_fraction = 0.8;
+    auto const output = geom::Rectangle{{0, 0}, {800, 600}};
+    auto const outputs = single_output(output);
+    auto const pinned = geom::PointD{750.0, 550.0};
+    auto const magnification = 1.25;
+
+    auto const first = layout::resize_freely({0.0, 0.0}, pinned, outputs, magnification);
+    auto const farther = layout::resize_freely({-100.0, -100.0}, pinned, outputs, magnification);
+    auto const first_bounds = visual_bounds(first, magnification);
+
+    EXPECT_THAT(first.capture_area.size, Eq(geom::Size{512, 384}));
+    EXPECT_THAT(farther.capture_area.size, Eq(first.capture_area.size));
+    EXPECT_LE(
+        first_bounds.size.width.as_value(),
+        maximum_visual_fraction * output.size.width.as_value());
+    EXPECT_LE(
+        first_bounds.size.height.as_value(),
+        maximum_visual_fraction * output.size.height.as_value());
+}
+
+TEST(MagnifierControls, positions_are_derived_from_visual_bounds)
+{
+    auto const magnification = 1.25;
+    layout::FreePlacement const placement{
+        layout::Placement{{{0, 0}, {161, 121}}},
+        {100, 80}};
+    auto const bounds = visual_bounds(placement, magnification);
+
+    EXPECT_THAT(bounds.size.width.as_value(), DoubleEq(201.25));
+
+    auto const positions = controls::positions_for(placement, magnification);
+    EXPECT_THAT(positions.resize, Eq(geom::Point{79, 64}));
+    EXPECT_THAT(positions.drag, Eq(geom::Point{233, 168}));
+    EXPECT_THAT(positions.zoom_in, Eq(geom::Point{233, 64}));
+    EXPECT_THAT(positions.zoom_out, Eq(geom::Point{233, 120}));
+}
+
+TEST(MagnifierControls, content_hit_testing_includes_content_and_excludes_outside_bounds)
+{
+    auto const outputs = single_output();
+    auto const magnification = 1.0;
+    auto const placement =
+        layout::place_freely({400.0, 300.0}, {240.0, 200.0}, outputs, magnification);
+
+    EXPECT_TRUE(controls::contains_content(placement, magnification, {400.0f, 300.0f}));
+    EXPECT_FALSE(controls::contains_content(placement, magnification, {279.0f, 300.0f}));
+    EXPECT_FALSE(controls::contains_content(placement, magnification, {521.0f, 300.0f}));
+}
+
+TEST_P(ContentHitTestingForHandle, excludes_handles)
+{
+    auto const magnification = 1.0;
+    auto const placement =
+        layout::place_freely({400.0, 300.0}, {240.0, 200.0}, single_output(), magnification);
+    auto const positions = controls::positions_for(placement, magnification);
+    auto const handle = positions.for_kind(GetParam());
+    auto const handle_center = geom::PointD{
+        handle.x.as_value() + controls::handle_diameter / 2.0,
+        handle.y.as_value() + controls::handle_diameter / 2.0};
+
+    EXPECT_FALSE(controls::contains_content(placement, magnification, handle_center));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EveryControl,
+    ContentHitTestingForHandle,
+    Values(
+        controls::HandleKind::drag,
+        controls::HandleKind::resize,
+        controls::HandleKind::zoom_in,
+        controls::HandleKind::zoom_out));

--- a/tests/miral/magnifier_layout.cpp
+++ b/tests/miral/magnifier_layout.cpp
@@ -32,7 +32,7 @@ namespace controls = miral::magnifier_controls;
 namespace layout = miral::magnifier_layout;
 using namespace testing;
 
-namespace
+namespace expected_edges
 {
 enum class ExpectedEdge
 {
@@ -42,11 +42,12 @@ enum class ExpectedEdge
     bottom = 1 << 3,
 };
 
-constexpr auto mir_enable_enum_bit_operators(ExpectedEdge edge) -> ExpectedEdge
-{
-    return edge;
+auto mir_enable_enum_bit_operators(ExpectedEdge) -> ExpectedEdge;
 }
 
+namespace
+{
+using ExpectedEdge = expected_edges::ExpectedEdge;
 using ExpectedEdges = mir::Flags<ExpectedEdge>;
 
 constexpr std::array test_magnifications{1.25, 1.5, 2.0, 3.5, 8.0};


### PR DESCRIPTION
Related: #5071

Split out of #5071, which was too large to review as one change.

## What's new?

- Add `miral::MagnifierLayout`, which owns all of the magnifier's geometry: given a requested visual size, a magnification and the set of outputs, it derives the captured region and the surface position, clamps both to the outputs, and places the control handles around the resulting bounds.
- Supported placements: centred on a point (cursor-following), freely positioned from a desired top-left, freely positioned centred on a point, and resize from a pinned corner.
- `HandleKind` is defined here because the enumerator value doubles as the index into `MagnifierLayout::HandlePositions`.
- Nothing consumes this yet; `Magnifier` is ported to it separately. Isolating the arithmetic makes it testable without standing up a server.

## How to test

```sh
cmake --build build --target miral-test-internal
./build/bin/miral-test-internal --gtest_filter='MagnifierLayout*'
```

7 tests, all passing.

## Checklist

- [x] Tests added and pass
- [x] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
