### PR TITLE
tools: sync rpm/mir.spec sover macros in update_package_abis.sh

### DIFF
--- a/.github/instructions/abi-symbols.instructions.md
+++ b/.github/instructions/abi-symbols.instructions.md
@@ -31,7 +31,7 @@ No `*_ABI` bump is required for additive changes.
 1. Bump `MIRAL_VERSION_MAJOR` in `src/CMakeLists.txt`, reset `MIRAL_VERSION_MINOR` and `MIRAL_VERSION_PATCH` to 0
 1. Bump `MIRAL_ABI` in `src/miral/CMakeLists.txt`
 1. Run `generate-miral-symbols-map` then `regenerate-miral-debian-symbols`
-1. Run `./tools/update_package_abis.sh` to update Debian package names (control file, `.install` file renames)
+1. Run `./tools/update_package_abis.sh` to update Debian package names (control file, `.install` file renames) and RPM soversion macros (`rpm/mir.spec`)
 
 ### mirserver — any symbol change (additive or breaking)
 
@@ -41,15 +41,15 @@ mirserver has no stable ABI promise. **Every** symbol change requires bumping `M
 1. Bump `MIRSERVER_ABI` in `src/server/CMakeLists.txt`
 1. Bump the minor number in `project(Mir VERSION X.Y.Z)` in the **top-level** `CMakeLists.txt` (the stanza name `MIR_SERVER_INTERNAL_X.Y` derives from this)
 1. `cmake --build <BUILD_DIR> --target generate-mirserver-symbols-map`
-1. Run `./tools/update_package_abis.sh` (handles `debian/control` and `.install` file renames)
+1. Run `./tools/update_package_abis.sh` (handles `debian/control` and `.install` file renames, and `rpm/mir.spec` soversion macros)
 
-**Note**: there is no `regenerate-mirserver-debian-symbols` target — mirserver debian packaging is managed by `update_package_abis.sh`.
+**Note**: there is no `regenerate-mirserver-debian-symbols` target — mirserver debian and RPM packaging is managed by `update_package_abis.sh`.
 
 ### General rules
 
 - All version bumps are once-per-release-cycle — check if someone already bumped before you do.
 - CI (`symbols-check.yml`) catches added/removed symbols but does **not** detect changed signatures — those must be moved to a new stanza manually.
-- `tools/update_package_abis.sh` handles `debian/control` and `.install` file renames for all libraries. It does not modify `symbols.map`, CMake variables, or RPM packaging.
+- `tools/update_package_abis.sh` handles `debian/control` and `.install` file renames, and keeps the `%global *_sover` macros in `rpm/mir.spec` in sync, for all libraries. It does not modify `symbols.map` or CMake variables.
 - ABI version variables are defined per-library as `set(LIB_ABI N)` (e.g., `MIRAL_ABI`, `MIRCORE_ABI`, `MIRWAYLAND_ABI`, `MIRSERVER_ABI`). Bump these when breaking ABI.
 
 See [How to Update Symbol Maps](../../doc/sphinx/contributing/how-to/update-symbols-map.md) and

--- a/tools/update_package_abis.sh
+++ b/tools/update_package_abis.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Script to check and update debian packaging to match current ABIs
+# Script to check and update debian and RPM packaging to match current ABIs
 
 set -e
 
@@ -37,12 +37,28 @@ package_abi_var()
     echo "${1##*:}"
 }
 
+# Maps each ABI variable to its corresponding soversion macro in rpm/mir.spec.
+rpm_sover_macro()
+{
+    case "$1" in
+        MIROIL_ABI) echo "miroil_sover" ;;
+        MIRAL_ABI) echo "miral_sover" ;;
+        MIRCORE_ABI) echo "mircore_sover" ;;
+        MIRCOMMON_ABI) echo "mircommon_sover" ;;
+        MIRPLATFORM_ABI) echo "mirplatform_sover" ;;
+        MIRSERVER_ABI) echo "mirserver_sover" ;;
+        MIR_SERVER_GRAPHICS_PLATFORM_ABI) echo "mirplatformgraphics_sover" ;;
+        MIR_SERVER_INPUT_PLATFORM_ABI) echo "mirplatforminput_sover" ;;
+        MIRWAYLAND_ABI) echo "mirwayland_sover" ;;
+    esac
+}
+
 print_help_and_exit()
 {
     local prog=$(basename $0)
 
     echo "Usage: $prog [OPTION]..."
-    echo "Update debian packaging to match current ABIs"
+    echo "Update debian and RPM packaging to match current ABIs"
     echo ""
     echo "      --no-vcs   do not register file changes (e.g., moves) with the detected VCS"
     echo "      --check    check for ABI mismatches without updating debian packaging"
@@ -157,6 +173,26 @@ update_install_files()
     done
 }
 
+update_spec_file()
+{
+    if [ ! -f rpm/mir.spec ];
+    then
+        return
+    fi
+
+    for p in $packages;
+    do
+        local abi_var=$(package_abi_var $p)
+        local sover_macro=$(rpm_sover_macro $abi_var)
+        if [ -z "$sover_macro" ];
+        then
+            continue
+        fi
+        local abi=$(eval "echo \$${abi_var}")
+        sed -i "s/^%global ${sover_macro} [[:digit:]]\+/%global ${sover_macro} ${abi}/" rpm/mir.spec
+    done
+}
+
 report_abi_mismatch()
 {
     log "ABI mismatch: $1"
@@ -198,6 +234,36 @@ check_install_files()
             then
                 report_abi_mismatch "$current_file contains $suffix, but $pkg ABI is $abi"
             fi
+        fi
+    done
+}
+
+check_spec_file()
+{
+    if [ ! -f rpm/mir.spec ];
+    then
+        return
+    fi
+
+    local seen_macros=""
+    for p in $packages;
+    do
+        local abi_var=$(package_abi_var $p)
+        local sover_macro=$(rpm_sover_macro $abi_var)
+        if [ -z "$sover_macro" ];
+        then
+            continue
+        fi
+        case " $seen_macros " in
+            *" $sover_macro "*) continue ;;
+        esac
+        seen_macros="$seen_macros $sover_macro"
+
+        local abi=$(eval "echo \$${abi_var}")
+        local current=$(grep -o "^%global ${sover_macro} [[:digit:]]\+" rpm/mir.spec | grep -o '[[:digit:]]\+$')
+        if [ -n "$current" ] && [ "$current" != "$abi" ];
+        then
+            report_abi_mismatch "rpm/mir.spec defines ${sover_macro} as ${current}, but ${abi_var} is ${abi}"
         fi
     done
 }
@@ -250,6 +316,7 @@ then
     check_for_unknown_packages
     check_control_file
     check_install_files
+    check_spec_file
     if [ "$has_check_error" = "yes" ];
     then
         log "Consider running tools/update_package_abis.sh to fix the mismatches."
@@ -259,4 +326,5 @@ else
     check_for_unknown_packages
     update_control_file
     update_install_files
+    update_spec_file
 fi

--- a/tools/update_package_abis.sh
+++ b/tools/update_package_abis.sh
@@ -177,15 +177,22 @@ update_spec_file()
 {
     if [ ! -f rpm/mir.spec ];
     then
+        echo "No rpm/mir.spec in this source tree: skipping RPM packaging" >&2
         return
     fi
 
+    local unmapped_vars=""
     for p in $packages;
     do
         local abi_var=$(package_abi_var $p)
         local sover_macro=$(rpm_sover_macro $abi_var)
         if [ -z "$sover_macro" ];
         then
+            case " $unmapped_vars " in
+                *" $abi_var "*) continue ;;
+            esac
+            unmapped_vars="$unmapped_vars $abi_var"
+            report_unmapped_sover $abi_var
             continue
         fi
         local abi=$(eval "echo \$${abi_var}")
@@ -197,6 +204,11 @@ report_abi_mismatch()
 {
     log "ABI mismatch: $1"
     has_check_error=yes
+}
+
+report_unmapped_sover()
+{
+    echo "rpm/mir.spec has no known soversion macro for $1: rpm_sover_macro() in this script needs to be updated" >&2
 }
 
 check_control_file()
@@ -242,16 +254,23 @@ check_spec_file()
 {
     if [ ! -f rpm/mir.spec ];
     then
+        echo "No rpm/mir.spec in this source tree: skipping RPM packaging" >&2
         return
     fi
 
     local seen_macros=""
+    local unmapped_vars=""
     for p in $packages;
     do
         local abi_var=$(package_abi_var $p)
         local sover_macro=$(rpm_sover_macro $abi_var)
         if [ -z "$sover_macro" ];
         then
+            case " $unmapped_vars " in
+                *" $abi_var "*) continue ;;
+            esac
+            unmapped_vars="$unmapped_vars $abi_var"
+            report_unmapped_sover $abi_var
             continue
         fi
         case " $seen_macros " in


### PR DESCRIPTION
## What this does

`tools/update_package_abis.sh` only ever wrote `debian/control` and `debian/*.install`. Since Fedora/RPM packaging (`rpm/mir.spec`) was added, the script was never extended to keep its `%global <lib>_sover N` macros in sync with the same CMake `*_ABI` variables, so `rpm/mir.spec` can silently drift after an ABI bump.

This adds RPM spec support alongside the existing debian handling:
- Maps each `*_ABI` variable to its corresponding `rpm/mir.spec` sover macro.
- Updates those macros in the default/update code path.
- Reports mismatches under `--check` (deduped, since several packages share one ABI variable).
- Corrects `.github/instructions/abi-symbols.instructions.md`, which explicitly (and now incorrectly) said the script "does not modify RPM packaging."

## Testing

- `./tools/update_package_abis.sh --check --verbose` on a clean tree: exit 0, all 9 ABI vars detected, no mismatches.
- Manually corrupted two sover macros in `rpm/mir.spec`, re-ran `--check`: correctly reported both mismatches (deduped where multiple packages share one ABI variable).
- Ran update mode: both macros restored; diff against the original `rpm/mir.spec` is identical, confirming a clean round-trip.
- `git status` confirms only `tools/update_package_abis.sh` and the one doc file are touched — `rpm/mir.spec`, `debian/control`, `debian/*.install` unchanged in the final diff.

## Related

#4981. A previous attempt (#5092) was self-closed by its author with no maintainer feedback.