### PR TITLE
Fix compile error in PointerMovementEvent matcher: pass result_listener pointer not reference

### DIFF
--- a/include/test/mir/test/event_matchers.h
+++ b/include/test/mir/test/event_matchers.h
@@ -774,7 +774,7 @@ MATCHER(TouchMovementEvent, "")
 MATCHER(PointerMovementEvent, "")
 {
     auto pev = maybe_pointer_event(to_address(arg));
-    if (event_is_nullptr(pev, *result_listener))
+    if (event_is_nullptr(pev, result_listener))
         return false;
 
     if (!enums_match(mir_pointer_action_motion, mir_pointer_event_action(pev), result_listener))


### PR DESCRIPTION
This matcher is currently unused, which is why the typo hasn't been spotted