### PR TITLE
workshop: `coverage` and `doc` on the workshop host

### DIFF
--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -17,9 +17,19 @@ sdks:
       interface: tunnel
       endpoint: localhost:8000
 actions:
-  cmake: |
-    set -xeu
-    cmake ~/build "$@"
+  configure: |
+    cmake \
+      -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_INSTALL_PREFIX=$HOME/install \
+      -DCMAKE_C_COMPILER=clang \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      -DMIR_USE_LD=mold \
+      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      -B $HOME/build \
+      -G Ninja \
+      . \
+      "$@"
 
   build: |
     set -xeu

--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -14,6 +14,7 @@ sdks:
 - name: system
 actions:
   configure: |
+    set -xeu
     cmake \
       -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_INSTALL_PREFIX=$HOME/install \
@@ -33,7 +34,7 @@ actions:
 
   coverage: |
     set -xeu
-    cmake ~/build -DMIR_ENABLE_COVERAGE=ON
+    cmake -S . -B ~/build -DMIR_ENABLE_COVERAGE=ON
     cmake --build ~/build --target coverage-html "$@"
     echo
     echo "Coverage report available at http://$( hostname -f ):8001/"

--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -25,6 +25,13 @@ actions:
     set -xeu
     cmake --build ~/build "$@"
 
+  coverage: |
+    set -xeu
+    cmake ~/build -DMIR_ENABLE_COVERAGE=ON
+    cmake --build ~/build --target coverage-html "$@"
+    echo
+    echo "Coverage report available at http://$( hostname -f ):8001/"
+
   package: |
     set -xeu
     cd $HOME

--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -12,10 +12,6 @@ sdks:
 - name: copilot
 - name: project-mir
 - name: system
-  plugs:
-    doc:
-      interface: tunnel
-      endpoint: localhost:8000
 actions:
   configure: |
     cmake \
@@ -71,7 +67,7 @@ actions:
       shift
     fi
 
-    cmake --build ~/build --target "doc-${target:-run}" "$@"
+    SPHINX_HOST=$( hostname -f ) cmake --build ~/build --target "doc-${target:-run}" "$@"
 
   ccache: ccache "$@"
 

--- a/.workshop/mir/hooks/setup-base
+++ b/.workshop/mir/hooks/setup-base
@@ -11,6 +11,7 @@ apt-get --yes --no-install-recommends install \
   gcovr \
   glmark2-es2 \
   glmark2-es2-wayland \
+  inotify-tools \
   lcov \
   libclang-rt-dev \
   llvm \
@@ -35,29 +36,29 @@ exec llvm-cov gcov "$@"
 EOF
 chmod +x /usr/local/bin/gcov
 
-cat <<'EOF' > /etc/systemd/system/mir-coverage.path
-[Unit]
-Description=Watch for livereload directory existence
-
-[Path]
-# Triggers as soon as the target folder exists
-PathExists=/home/workshop/build/coverage-html
-Unit=mir-coverage.service
-
-[Install]
-WantedBy=default.target
-EOF
-
 cat <<'EOF' > /etc/systemd/system/mir-coverage.service
 [Unit]
-Description=LiveReload HTTP Server
+Description=Mir test coverage report
+After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/workshop/build/coverage-html
-# Adjust the path to 'livereload' executable if installed in a venv or ~/.local/bin/
-ExecStart=/usr/bin/livereload --host 0 --port 8001 /home/workshop/build/coverage-html
+ExecStartPre=/bin/bash -c 'until [ -d /home/workshop/build/coverage-html ]; do sleep 2; done'
+# Monitor livereload itself and the folder disappearing
+ExecStart=/bin/bash -c '\
+  /usr/bin/livereload --host 0 --port 8001 /home/workshop/build/coverage-html & \
+  LR_PID=$$!; \
+  inotifywait -qq -e delete_self -e move_self /home/workshop/build/coverage-html & \
+  IN_PID=$$!; \
+  wait -n; \
+  kill $$LR_PID $$IN_PID 2>/dev/null; \
+  exit 1'
+
 Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
 EOF
 
-systemctl enable --now mir-coverage.path
+systemctl enable --now --no-block mir-coverage.service

--- a/.workshop/mir/hooks/setup-base
+++ b/.workshop/mir/hooks/setup-base
@@ -8,12 +8,17 @@ apt-get --yes --no-install-recommends install \
   clang \
   dmz-cursor-theme \
   fonts-ubuntu \
+  gcovr \
   glmark2-es2 \
   glmark2-es2-wayland \
+  lcov \
+  libclang-rt-dev \
+  llvm \
   mesa-utils \
   mold \
   ninja-build \
   python3-venv \
+  python3-livereload \
   ripgrep \
   xterm \
   yq
@@ -23,3 +28,36 @@ cat <<'EOF' > /etc/profile.d/mir.sh
 export PATH="$HOME/build/bin:$PATH"
 export CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,modules,pch_defines,time_macros
 EOF
+
+cat <<'EOF' > /usr/local/bin/gcov
+#!/bin/sh
+exec llvm-cov gcov "$@"
+EOF
+chmod +x /usr/local/bin/gcov
+
+cat <<'EOF' > /etc/systemd/system/mir-coverage.path
+[Unit]
+Description=Watch for livereload directory existence
+
+[Path]
+# Triggers as soon as the target folder exists
+PathExists=/home/workshop/build/coverage-html
+Unit=mir-coverage.service
+
+[Install]
+WantedBy=default.target
+EOF
+
+cat <<'EOF' > /etc/systemd/system/mir-coverage.service
+[Unit]
+Description=LiveReload HTTP Server
+
+[Service]
+Type=simple
+WorkingDirectory=/home/workshop/build/coverage-html
+# Adjust the path to 'livereload' executable if installed in a venv or ~/.local/bin/
+ExecStart=/usr/bin/livereload --host 0 --port 8001 /home/workshop/build/coverage-html
+Restart=on-failure
+EOF
+
+systemctl enable --now mir-coverage.path

--- a/.workshop/mir/sdk.yaml
+++ b/.workshop/mir/sdk.yaml
@@ -10,7 +10,3 @@ plugs:
     workshop-target: /home/workshop/.cache/ccache
   gpu:
     interface: gpu
-slots:
-  doc:
-    interface: tunnel
-    endpoint: localhost:8000


### PR DESCRIPTION
## What's new?

```
$ workshop run coverage
# ...
Coverage report available at http://dev-….wp:8001/
```

(you will need `workshop run build` first, that needs fixing elsewhere)

```
$ workshop run doc
# ...
[sphinx-autobuild] Serving on http://dev-....wp:8000
```

```
$ workshop run configure
```

## How to test

:point_up: 

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
