### PR TITLE
(wayland-rs) Add `WaylandServer::insert_client` so that C++ can construct Wayland clients internally and inject them into the list of clients

### DIFF
--- a/include/core/mir/synchronised.h
+++ b/include/core/mir/synchronised.h
@@ -84,6 +84,17 @@ public:
         void wait(Cv& cv, Predicate stop_waiting)
         { cv.wait(lock, stop_waiting); }
 
+        /**
+         * Allows waiting for a condition variable with a timeout
+         *
+         * The protected data may be accessed both in the predicate and after this method completes.
+         *
+         * \return true if the predicate was satisfied, false if the timeout elapsed.
+         */
+        template<typename Cv, typename Duration, typename Predicate>
+        auto wait_for(Cv& cv, Duration const& timeout, Predicate stop_waiting) -> bool
+        { return cv.wait_for(lock, timeout, stop_waiting); }
+
     private:
         friend class Synchronised;
         LockedImpl(std::unique_lock<std::mutex>&& lock, U& value) : value{&value}, lock{std::move(lock)} {}

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -55,6 +55,7 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
                 fn stop(self: &WaylandServer);
                 fn drain_queue(self: &WaylandServer) -> bool;
                 fn register_fd_ready_listener(self: &WaylandServer, fd: i32, callback: UniquePtr<FdReadyCallback>);
+                fn insert_client(self: &WaylandServer, fd: i32);
 
                 type OutputGlobal;
                 fn create_output_global(self: &WaylandServer, binder: UniquePtr<OutputGlobalBinder>) -> Result<Box<OutputGlobal>>;

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
@@ -44,7 +44,7 @@ pub struct WaylandServer {
     fd_listener_signal: Mutex<Option<Ping>>,
     pending_fd_listeners: Mutex<Vec<PendingFdListener>>,
     client_signal: Mutex<Option<Ping>>,
-    pending_clients: Mutex<Vec<RawFd>>,
+    pending_clients: Mutex<Vec<UnixStream>>,
     /// A clone of the running display's handle, populated for the duration of
     /// [WaylandServer::run].
     display_handle: Mutex<Option<DisplayHandle>>,
@@ -444,10 +444,18 @@ impl WaylandServer {
             return;
         }
 
+        // SAFETY: `fd` is the server end of a socket pair whose ownership was
+        // transferred to us by the C++ caller; nothing else touches it, so we may
+        // take ownership here. Wrapping it in a `UnixStream` immediately upholds
+        // the ownership transfer in all lifecycle paths: if the server is dropped
+        // (or `run` never starts) before the queue is drained, the fd is closed
+        // by RAII rather than leaked.
+        let stream = unsafe { UnixStream::from_raw_fd(fd) };
+
         self.pending_clients
             .lock()
             .expect("No recovery from lock poisoning")
-            .push(fd);
+            .push(stream);
 
         if let Some(signal) = self
             .client_signal
@@ -492,19 +500,15 @@ impl WaylandServer {
     /// Drain `queue` of pending injected client fds, adopting a client for each.
     /// Runs on the event-loop thread.
     fn drain_pending_clients(
-        queue: &Mutex<Vec<RawFd>>,
+        queue: &Mutex<Vec<UnixStream>>,
         disconnect_tx: &mpsc::Sender<(ClientId, DisconnectReason)>,
         state: &mut ServerState,
     ) {
-        let pending: Vec<RawFd> = {
+        let pending: Vec<UnixStream> = {
             let mut queue = queue.lock().expect("No recovery from lock poisoning");
             std::mem::take(&mut *queue)
         };
-        for fd in pending {
-            // SAFETY: `fd` is the server end of a socket pair whose ownership was
-            // transferred to us by the C++ caller via `insert_client`; nothing
-            // else touches it, so we may take ownership here.
-            let stream = unsafe { UnixStream::from_raw_fd(fd) };
+        for stream in pending {
             Self::insert_stream_client(state, disconnect_tx, stream);
         }
     }

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
@@ -437,20 +437,27 @@ impl WaylandServer {
     /// is running. Injections queued before the server starts are applied when
     /// `run` begins; injections made while it is running wake the loop so they
     /// are applied promptly. Injections coalesce onto a single wake.
-    pub fn insert_client(&self, fd: i32) {
-        self.pending_clients
-            .lock()
-            .expect("No recovery from lock poisoning")
-            .push(fd as RawFd);
-        if let Some(signal) = self
-            .client_signal
-            .lock()
-            .expect("No recovery from lock poisoning")
-            .as_ref()
-        {
-            signal.ping();
-        }
+pub fn insert_client(&self, fd: i32) {
+    let fd: RawFd = fd;
+    if fd < 0 {
+        log::error!("insert_client called with invalid fd {}", fd);
+        return;
     }
+
+    self.pending_clients
+        .lock()
+        .expect("No recovery from lock poisoning")
+        .push(fd);
+
+    if let Some(signal) = self
+        .client_signal
+        .lock()
+        .expect("No recovery from lock poisoning")
+        .as_ref()
+    {
+        signal.ping();
+    }
+}
 
     /// Adopt `stream` as a Wayland client: register it with the display's
     /// backend and notify C++ of the new client. Shared by the listening-socket

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
@@ -437,27 +437,27 @@ impl WaylandServer {
     /// is running. Injections queued before the server starts are applied when
     /// `run` begins; injections made while it is running wake the loop so they
     /// are applied promptly. Injections coalesce onto a single wake.
-pub fn insert_client(&self, fd: i32) {
-    let fd: RawFd = fd;
-    if fd < 0 {
-        log::error!("insert_client called with invalid fd {}", fd);
-        return;
-    }
+    pub fn insert_client(&self, fd: i32) {
+        let fd: RawFd = fd;
+        if fd < 0 {
+            log::error!("insert_client called with invalid fd {}", fd);
+            return;
+        }
 
-    self.pending_clients
-        .lock()
-        .expect("No recovery from lock poisoning")
-        .push(fd);
+        self.pending_clients
+            .lock()
+            .expect("No recovery from lock poisoning")
+            .push(fd);
 
-    if let Some(signal) = self
-        .client_signal
-        .lock()
-        .expect("No recovery from lock poisoning")
-        .as_ref()
-    {
-        signal.ping();
+        if let Some(signal) = self
+            .client_signal
+            .lock()
+            .expect("No recovery from lock poisoning")
+            .as_ref()
+        {
+            signal.ping();
+        }
     }
-}
 
     /// Adopt `stream` as a Wayland client: register it with the display's
     /// backend and notify C++ of the new client. Shared by the listening-socket

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
@@ -25,7 +25,8 @@ use cxx::UniquePtr;
 use log;
 use std::error;
 use std::option::Option;
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::net::UnixStream;
 use std::sync::{mpsc, Arc, Mutex};
 use wayland_server::{
     backend::{ClientData, ClientId, DisconnectReason},
@@ -42,6 +43,8 @@ pub struct WaylandServer {
     work_signal: Mutex<Option<Ping>>,
     fd_listener_signal: Mutex<Option<Ping>>,
     pending_fd_listeners: Mutex<Vec<PendingFdListener>>,
+    client_signal: Mutex<Option<Ping>>,
+    pending_clients: Mutex<Vec<RawFd>>,
     /// A clone of the running display's handle, populated for the duration of
     /// [WaylandServer::run].
     display_handle: Mutex<Option<DisplayHandle>>,
@@ -54,6 +57,8 @@ impl WaylandServer {
             stop_signal: Mutex::new(None),
             work_signal: Mutex::new(None),
             fd_listener_signal: Mutex::new(None),
+            client_signal: Mutex::new(None),
+            pending_clients: Mutex::new(Vec::new()),
             pending_fd_listeners: Mutex::new(Vec::new()),
             display_handle: Mutex::new(None),
         }
@@ -148,42 +153,15 @@ impl WaylandServer {
 
         // First, add the listener to the event loop.
         let listener = ListeningSocket::bind(socket)?;
+        let listener_disconnect_tx = disconnect_tx.clone();
         loop_handle.insert_source(
             Generic::new(listener, Interest::READ, Mode::Level),
             move |_, listener, state: &mut ServerState| {
                 if let Ok(stream) = listener.accept() {
                     if let Some(stream) = stream {
-                        // Insert the client into the display.
-                        // This registers the client's socket with the Display's internal backend.
-                        let disconnect_tx = disconnect_tx.clone();
-                        let client_state = ClientState {
-                            on_disconnect: Box::new(move |client_id, reason| {
-                                log::info!(
-                                    "Client disconnected: {:?}, reason: {:?}",
-                                    client_id,
-                                    reason
-                                );
-                                // We publish the notification about the disconnected client onto the channel
-                                // so that the WaylandServerNotificationHandler is guaranteed to only be
-                                // spoken to on a single thread.
-                                let _ = disconnect_tx.send((client_id, reason));
-                            }),
-                            socket_fd: stream.as_raw_fd(),
-                        };
-                        match state.handle.insert_client(stream, Arc::new(client_state)) {
-                            Err(e) => log::error!("Failed to add client: {}", e),
-                            Ok(client) => {
-                                // Notify C++ that we have a new WaylandClient available to us.
-                                // The C++ side of things can choose to hold onto this Box if they
-                                // choose to.
-                                let wayland_client =
-                                    WaylandClient::new(client.clone(), state.handle.clone());
-                                state
-                                    .notification_handler
-                                    .pin_mut()
-                                    .client_added(Box::new(wayland_client));
-                            }
-                        }
+                        // Insert the client into the display. This registers the
+                        // client's socket with the Display's internal backend.
+                        WaylandServer::insert_stream_client(state, &listener_disconnect_tx, stream);
                     }
                 }
                 Ok(PostAction::Continue)
@@ -239,6 +217,24 @@ impl WaylandServer {
             })
             .map_err(|_| "Failed to insert work signal into event loop")?;
 
+        // Add a client-injection signal so that C++ can ask (from any thread) for
+        // a pre-connected socket fd to be adopted as a Wayland client (used for
+        // MirAL internal clients and the WLCS test harness).
+        let (client_pinger, client_ping_source) = calloop::ping::make_ping()?;
+
+        *self
+            .client_signal
+            .lock()
+            .expect("No recovery from lock poisoning") = Some(client_pinger);
+
+        let client_disconnect_tx = disconnect_tx.clone();
+        let client_queue = &self.pending_clients;
+        loop_handle
+            .insert_source(client_ping_source, move |_, _, state: &mut ServerState| {
+                WaylandServer::drain_pending_clients(client_queue, &client_disconnect_tx, state);
+            })
+            .map_err(|_| "Failed to insert client signal into event loop")?;
+
         // Add an fd-listener signal so that C++ can ask (from any thread) for the
         // file descriptors it registered to be inserted into the event loop. The
         // ping coalesces multiple requests into a single wake; when it fires we
@@ -273,6 +269,11 @@ impl WaylandServer {
         // signal was ready; their signal would have been dropped. Registrations
         // queued from here on raise their own signal and are handled by the loop.
         Self::drain_pending_fd_listeners(&loop_handle, &self.pending_fd_listeners);
+
+        // Likewise, adopt any clients injected before the client signal was
+        // ready; their signal would have been dropped. Injections queued from
+        // here on raise their own signal and are handled by the loop.
+        Self::drain_pending_clients(&self.pending_clients, &disconnect_tx, &mut state);
 
         while !state.stop_requested {
             // 1. Dispatch events
@@ -422,6 +423,82 @@ impl WaylandServer {
             if let Err(e) = Self::register_fd_ready_source(handle, fd, listener) {
                 log::error!("Failed to register fd ready listener: {}", e);
             }
+        }
+    }
+
+    /// Adopt a pre-connected socket `fd` as a Wayland client.
+    ///
+    /// This is how Mir injects clients that connect over a socket pair rather
+    /// than the listening socket: MirAL internal clients and the WLCS test harness.
+    /// The server end of the pair is handed here; ownership of `fd` is transferred
+    /// to the server, which closes it when the client disconnects.
+    ///
+    /// This may be called from any thread, and either before or while the server
+    /// is running. Injections queued before the server starts are applied when
+    /// `run` begins; injections made while it is running wake the loop so they
+    /// are applied promptly. Injections coalesce onto a single wake.
+    pub fn insert_client(&self, fd: i32) {
+        self.pending_clients
+            .lock()
+            .expect("No recovery from lock poisoning")
+            .push(fd as RawFd);
+        if let Some(signal) = self
+            .client_signal
+            .lock()
+            .expect("No recovery from lock poisoning")
+            .as_ref()
+        {
+            signal.ping();
+        }
+    }
+
+    /// Adopt `stream` as a Wayland client: register it with the display's
+    /// backend and notify C++ of the new client. Shared by the listening-socket
+    /// accept path and the injected-fd path so both behave identically. Runs on
+    /// the event-loop thread.
+    fn insert_stream_client(
+        state: &mut ServerState,
+        disconnect_tx: &mpsc::Sender<(ClientId, DisconnectReason)>,
+        stream: UnixStream,
+    ) {
+        let disconnect_tx = disconnect_tx.clone();
+        let client_state = ClientState {
+            on_disconnect: Box::new(move |client_id, reason| {
+                log::info!("Client disconnected: {:?}, reason: {:?}", client_id, reason);
+                let _ = disconnect_tx.send((client_id, reason));
+            }),
+            socket_fd: stream.as_raw_fd(),
+        };
+
+        match state.handle.insert_client(stream, Arc::new(client_state)) {
+            Err(e) => log::error!("Failed to add client: {}", e),
+            Ok(client) => {
+                let wayland_client = WaylandClient::new(client.clone(), state.handle.clone());
+                state
+                    .notification_handler
+                    .pin_mut()
+                    .client_added(Box::new(wayland_client));
+            }
+        }
+    }
+
+    /// Drain `queue` of pending injected client fds, adopting a client for each.
+    /// Runs on the event-loop thread.
+    fn drain_pending_clients(
+        queue: &Mutex<Vec<RawFd>>,
+        disconnect_tx: &mpsc::Sender<(ClientId, DisconnectReason)>,
+        state: &mut ServerState,
+    ) {
+        let pending: Vec<RawFd> = {
+            let mut queue = queue.lock().expect("No recovery from lock poisoning");
+            std::mem::take(&mut *queue)
+        };
+        for fd in pending {
+            // SAFETY: `fd` is the server end of a socket pair whose ownership was
+            // transferred to us by the C++ caller via `insert_client`; nothing
+            // else touches it, so we may take ownership here.
+            let stream = unsafe { UnixStream::from_raw_fd(fd) };
+            Self::insert_stream_client(state, disconnect_tx, stream);
         }
     }
 }

--- a/tests/wayland_rs/CMakeLists.txt
+++ b/tests/wayland_rs/CMakeLists.txt
@@ -12,6 +12,7 @@ add_dependencies(mir_wayland_rs_tests GMock)
 
 target_link_libraries(mir_wayland_rs_tests
   mirwayland_rs
+  mircore
 
   PkgConfig::WAYLAND_CLIENT
 

--- a/tests/wayland_rs/CMakeLists.txt
+++ b/tests/wayland_rs/CMakeLists.txt
@@ -2,6 +2,7 @@ mir_add_wrapped_executable(mir_wayland_rs_tests NOINSTALL
   ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_executor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_client_registry.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_fd_ready_listener.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_client_injection.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_weak.cpp
   ${PROJECT_SOURCE_DIR}/tests/mir_test/signal.cpp
   ${PROJECT_SOURCE_DIR}/tests/mir_test_framework/temporary_environment_value.cpp

--- a/tests/wayland_rs/test_client_injection.cpp
+++ b/tests/wayland_rs/test_client_injection.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "wayland_rs_server_test.h"
+
+#include <mir_test_framework/temporary_environment_value.h>
+
+#include <gtest/gtest.h>
+
+#include <wayland-client.h>
+
+#include <sys/socket.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+namespace mrs = mir::wayland_rs;
+
+namespace
+{
+class CountingNotificationHandler : public mrs::WaylandServerNotificationHandler
+{
+public:
+    void client_added(rust::Box<mrs::WaylandClient>) override
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        ++count;
+        cv.notify_all();
+    }
+
+    void client_removed(rust::Box<mrs::WaylandClientId>) override {}
+
+    /// Wait until at least `n` clients have been adopted, or the timeout elapses.
+    auto wait_for_clients(std::size_t n) -> bool
+    {
+        using namespace std::chrono_literals;
+        std::unique_lock<std::mutex> lock{mutex};
+        auto constexpr timeout = 5s;
+        return cv.wait_for(lock, timeout, [&] { return count >= n; });
+    }
+
+    auto client_count() -> std::size_t
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        return count;
+    }
+
+private:
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::size_t count{0};
+};
+
+auto make_socket_pair() -> std::pair<int, int>
+{
+    int fds[2]{-1, -1};
+    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != 0)
+        throw std::runtime_error{"Failed to create socket pair"};
+
+    return {fds[0], fds[1]};
+}
+
+class ClientInjectionTest : public mrs::test::RunningWaylandServerTest
+{
+public:
+    auto make_notification_handler() -> std::unique_ptr<mrs::WaylandServerNotificationHandler> override
+    {
+        auto handler_owned = std::make_unique<CountingNotificationHandler>();
+        handler = handler_owned.get();
+        return handler_owned;
+    }
+
+    void TearDown() override
+    {
+        for (auto* display : displays)
+            wl_display_disconnect(display);
+
+        RunningWaylandServerTest::TearDown();
+    }
+
+    /// Adopt the server end of a fresh socket pair via `insert_client` and drive
+    /// the client end with a `wl_display`. Returns the connected display, which
+    /// this fixture disconnects in `TearDown`.
+    auto inject_client() -> wl_display*
+    {
+        auto const [server_fd, client_fd] = make_socket_pair();
+
+        // Ownership of the client end transfers to the wl_display, which closes
+        // it on disconnect (and on failure here). This is the only step that can
+        // fail, so on that early exit we close the server end we have not yet
+        // handed off; on success it transfers to the server via insert_client.
+        auto* display = wl_display_connect_to_fd(client_fd);
+        if (!display)
+        {
+            ::close(server_fd);
+            throw std::runtime_error{"Failed to connect Wayland client to injected fd"};
+        }
+
+        (*server)->insert_client(server_fd);
+
+        displays.push_back(display);
+        return display;
+    }
+
+    CountingNotificationHandler* handler{nullptr};
+    std::vector<wl_display*> displays;
+};
+}
+
+TEST_F(ClientInjectionTest, injected_socket_fd_is_adopted_as_a_client)
+{
+    auto* const display = inject_client();
+    wl_display_roundtrip(display);
+
+    EXPECT_TRUE(handler->wait_for_clients(1)) << "The server did not adopt the injected socket as a client";
+}
+
+TEST_F(ClientInjectionTest, injected_client_can_complete_a_roundtrip)
+{
+    auto* const display = inject_client();
+
+    // A successful roundtrip proves the adopted socket is a fully-functional
+    // client connection the server dispatches, not merely a registered fd.
+    EXPECT_NE(wl_display_roundtrip(display), -1) << "Roundtrip over the injected client connection failed";
+    EXPECT_EQ(wl_display_get_error(display), 0) << "The injected client connection reported a protocol error";
+}
+
+TEST_F(ClientInjectionTest, multiple_injected_clients_are_all_adopted)
+{
+    std::size_t const client_count = 3;
+    for (std::size_t i = 0; i < client_count; ++i)
+        wl_display_roundtrip(inject_client());
+
+    EXPECT_TRUE(handler->wait_for_clients(client_count)) << "Not every injected socket was adopted as a client";
+    EXPECT_EQ(handler->client_count(), client_count);
+}
+
+TEST(ClientInjectionBeforeRunTest, client_injected_before_run_is_adopted)
+{
+    auto const runtime_dir = mrs::test::make_temp_runtime_dir();
+    mir_test_framework::TemporaryEnvironmentValue const xdg_runtime_dir{"XDG_RUNTIME_DIR", runtime_dir.c_str()};
+
+    auto server = mrs::create_wayland_server();
+    auto handler_owned = std::make_unique<CountingNotificationHandler>();
+    auto* const handler = handler_owned.get();
+    auto executor = std::make_unique<mrs::WaylandExecutor>(*server);
+
+    auto const [server_fd, client_fd] = make_socket_pair();
+
+    // Inject before the server is running: the client signal does not yet exist,
+    // so this must be queued and drained when `run` begins.
+    server->insert_client(server_fd);
+
+    std::string const socket = "mir-wayland-rs-test-prerun-" + std::to_string(::getpid());
+    std::thread server_thread{[&, notification_handler = std::move(handler_owned), work = std::move(executor)]() mutable
+                              { server->run(socket, nullptr, std::move(notification_handler), std::move(work)); }};
+
+    auto* display = wl_display_connect_to_fd(client_fd);
+    ASSERT_TRUE(display) << "Failed to connect Wayland client to injected fd";
+    wl_display_roundtrip(display);
+
+    EXPECT_TRUE(handler->wait_for_clients(1)) << "A client injected before the server started was not adopted";
+
+    wl_display_disconnect(display);
+    server->stop();
+    server_thread.join();
+
+    std::error_code ec;
+    std::filesystem::remove_all(runtime_dir, ec);
+}

--- a/tests/wayland_rs/test_client_injection.cpp
+++ b/tests/wayland_rs/test_client_injection.cpp
@@ -16,6 +16,8 @@
 
 #include "wayland_rs_server_test.h"
 
+#include <mir/synchronised.h>
+
 #include <mir_test_framework/temporary_environment_value.h>
 
 #include <gtest/gtest.h>
@@ -29,7 +31,6 @@
 #include <cstddef>
 #include <filesystem>
 #include <memory>
-#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <system_error>
@@ -47,8 +48,7 @@ class CountingNotificationHandler : public mrs::WaylandServerNotificationHandler
 public:
     void client_added(rust::Box<mrs::WaylandClient>) override
     {
-        std::lock_guard<std::mutex> lock{mutex};
-        ++count;
+        ++*count.lock();
         cv.notify_all();
     }
 
@@ -58,21 +58,19 @@ public:
     auto wait_for_clients(std::size_t n) -> bool
     {
         using namespace std::chrono_literals;
-        std::unique_lock<std::mutex> lock{mutex};
         auto constexpr timeout = 5s;
-        return cv.wait_for(lock, timeout, [&] { return count >= n; });
+        auto locked = count.lock();
+        return locked.wait_for(cv, timeout, [&] { return *locked >= n; });
     }
 
     auto client_count() -> std::size_t
     {
-        std::lock_guard<std::mutex> lock{mutex};
-        return count;
+        return *count.lock();
     }
 
 private:
-    std::mutex mutex;
+    mir::Synchronised<std::size_t> count{0};
     std::condition_variable cv;
-    std::size_t count{0};
 };
 
 auto make_socket_pair() -> std::pair<int, int>


### PR DESCRIPTION
## What's new?
WLCS and `miral::InternalClientLauncher` required a way to insert clients directly into the running Wayland server.

We added:
- `WaylandServer::insert_client` which can be called from any C++ thread
- Exhaustive tests in C++

We coalesced some implementation details in the meantime.

## How to test
1. Build the project
2. Run `bin/mir_wayland_rs_tests`

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
