### PR TITLE
(wayland-rs) encode C++ exceptions over the FFI boundary such that they always log something sensible

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -41,6 +41,7 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
         mod dispatch {
             use wayland_server::{Client, DataInit, Dispatch, GlobalDispatch, New, DisplayHandle, Resource};
             use wayland_server::backend::{ClientId, ObjectId};
+            use wayland_server::backend::protocol::Interface;
             use crate::protocols;
             use crate::wayland_server_core::ServerState;
             use crate::ffi;
@@ -83,6 +84,45 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
                 }
             }
 
+            /// Post `wl_display.error` with the `implementation` code against the
+            /// client's `wl_display`, mirroring libwayland's
+            /// `wl_client_post_implementation_error` (and Mir's C++
+            /// `mir::wayland::internal_error_processing_request`). This is the
+            /// correct protocol error for a compositor-side failure.
+            ///
+            /// `wayland-server` special-cases `wl_display` and never exposes it as a
+            /// `Resource`, so we resolve object id 1 (which is always the
+            /// `wl_display`) for this client through the backend handle. This relies
+            /// on the pure-Rust `wayland-backend` that `wayland_rs` uses, where
+            /// `object_for_protocol_id` matches interfaces by name.
+            fn post_implementation_error(resource: &impl Resource, message: &str) {
+                /// `wl_display.error.implementation`: the compositor hit an internal error.
+                const WL_DISPLAY_ERROR_IMPLEMENTATION: u32 = 3;
+
+                static WL_DISPLAY_INTERFACE: Interface = Interface {
+                    name: "wl_display",
+                    version: 1,
+                    requests: &[],
+                    events: &[],
+                    c_ptr: None,
+                };
+
+                let Some(handle) = resource.handle().upgrade() else {
+                    return;
+                };
+                let display = handle
+                    .get_client(resource.id())
+                    .and_then(|client| handle.object_for_protocol_id(client, &WL_DISPLAY_INTERFACE, 1));
+                match display {
+                    Ok(display) => handle.post_error(
+                        display,
+                        WL_DISPLAY_ERROR_IMPLEMENTATION,
+                        CString::new(message).expect("Error message contained null byte"),
+                    ),
+                    Err(_) => log::error!("Failed to resolve wl_display to post an implementation error"),
+                }
+            }
+
             /// Handle a C++ exception that crossed the FFI boundary during dispatch.
             ///
             /// `mir::wayland_rs::ProtocolError` encodes itself as
@@ -95,16 +135,12 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
                     post_protocol_error(resource, object_id, code, message);
                 } else {
                     log::error!("Internal error dispatching Wayland request on {}: {}", resource.id(), what);
-                    // No protocol-level error code fits an internal failure; what matters
-                    // is that the client sees an honest message rather than a garbled
-                    // pseudo-protocol-error, and the real cause is in the server log.
-                    if let Some(handle) = resource.handle().upgrade() {
-                        handle.post_error(
-                            resource.id(),
-                            0,
-                            CString::new("internal server error").expect("static string"),
-                        );
-                    }
+                    // An internal failure is a compositor-side error, so raise
+                    // wl_display.error with the `implementation` code against the
+                    // client's wl_display (as libwayland's
+                    // wl_client_post_implementation_error does). The client sees an
+                    // honest protocol error while the real cause stays in the log.
+                    post_implementation_error(resource, &format!("internal server error: {what}"));
                 }
             }
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -85,7 +85,7 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
 
             /// Handle a C++ exception that crossed the FFI boundary during dispatch.
             ///
-            /// `mir::wayland::ProtocolError` encodes itself as
+            /// `mir::wayland_rs::ProtocolError` encodes itself as
             /// "MIR_PROTOCOL_ERROR:<object_id>:<code>: <message>" (only what() survives
             /// the cxx boundary). Anything without that sentinel is an internal server
             /// error and must not be dressed up as a client protocol violation.

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -91,16 +91,7 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
             /// error and must not be dressed up as a client protocol violation.
             fn handle_dispatch_error(resource: &impl Resource, what: &str) {
                 if let Some(encoded) = what.strip_prefix("MIR_PROTOCOL_ERROR:") {
-                    let mut parts = encoded.splitn(3, ':');
-                    let object_id = parts.next()
-                        .and_then(|s| s.trim().parse::<u32>().ok())
-                        .unwrap_or(0);
-                    let code = parts.next()
-                        .and_then(|s| s.trim().parse::<u32>().ok())
-                        .unwrap_or(0);
-                    let message = parts.next()
-                        .map(|s| s.trim().to_string())
-                        .unwrap_or_else(|| encoded.to_string());
+                    let (object_id, code, message) = parse_post_error(encoded);
                     post_protocol_error(resource, object_id, code, message);
                 } else {
                     log::error!("Internal error dispatching Wayland request on {}: {}", resource.id(), what);

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -83,6 +83,40 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
                 }
             }
 
+            /// Handle a C++ exception that crossed the FFI boundary during dispatch.
+            ///
+            /// `mir::wayland::ProtocolError` encodes itself as
+            /// "MIR_PROTOCOL_ERROR:<object_id>:<code>: <message>" (only what() survives
+            /// the cxx boundary). Anything without that sentinel is an internal server
+            /// error and must not be dressed up as a client protocol violation.
+            fn handle_dispatch_error(resource: &impl Resource, what: &str) {
+                if let Some(encoded) = what.strip_prefix("MIR_PROTOCOL_ERROR:") {
+                    let mut parts = encoded.splitn(3, ':');
+                    let object_id = parts.next()
+                        .and_then(|s| s.trim().parse::<u32>().ok())
+                        .unwrap_or(0);
+                    let code = parts.next()
+                        .and_then(|s| s.trim().parse::<u32>().ok())
+                        .unwrap_or(0);
+                    let message = parts.next()
+                        .map(|s| s.trim().to_string())
+                        .unwrap_or_else(|| encoded.to_string());
+                    post_protocol_error(resource, object_id, code, message);
+                } else {
+                    log::error!("Internal error dispatching Wayland request on {}: {}", resource.id(), what);
+                    // No protocol-level error code fits an internal failure; what matters
+                    // is that the client sees an honest message rather than a garbled
+                    // pseudo-protocol-error, and the real cause is in the server log.
+                    if let Some(handle) = resource.handle().upgrade() {
+                        handle.post_error(
+                            resource.id(),
+                            0,
+                            CString::new("internal server error").expect("static string"),
+                        );
+                    }
+                }
+            }
+
             #(#generated_dispatch_implementations)*
 
             #server_side_factories
@@ -544,8 +578,7 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
                     child_wrapper.lock().unwrap().inner = Some(child);
                 }
                 Err(err) => {
-                    let (object_id, code, message) = parse_post_error(err.what());
-                    post_protocol_error(resource, object_id, code, message);
+                    handle_dispatch_error(resource, err.what());
                 }
             }
         }
@@ -561,8 +594,7 @@ fn generate_request_body(request: &WaylandRequest) -> TokenStream {
             // SAFETY: The mutex guard provides the only mutable access while the call is
             // in progress. The pinned reference is used only for this FFI call.
             if let Err(err) = unsafe { inner.pin_mut_unchecked().#snake_request_name(#( #call_arg_names ),*) } {
-                let (object_id, code, message) = parse_post_error(err.what());
-                post_protocol_error(resource, object_id, code, message);
+                handle_dispatch_error(resource, err.what());
             }
         }
     }

--- a/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/protocol_error.h
+++ b/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/protocol_error.h
@@ -30,10 +30,22 @@ class ProtocolError : public std::runtime_error
 {
 public:
     ProtocolError(uint32_t object_id, uint32_t error_code, char const* fmt, ...);
+
+    /// Encoded as "MIR_PROTOCOL_ERROR:<object_id>:<error_code>: <message>" so the
+    /// error survives the cxx FFI boundary (which only carries what()); the Rust
+    /// dispatch layer parses this back. Other exception types lack the sentinel
+    /// prefix and must not be parsed as protocol errors.
+    static constexpr char const* what_sentinel = "MIR_PROTOCOL_ERROR:";
     auto what() const noexcept -> char const* override;
+    auto object_id() const noexcept -> uint32_t;
+    auto code() const noexcept -> uint32_t;
+    auto message() const noexcept -> std::string const&;
 
 private:
+    uint32_t object_id_;
+    uint32_t code_;
     std::string message_;
+    std::string what_;
 };
 }
 }

--- a/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/protocol_error.h
+++ b/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/include/protocol_error.h
@@ -31,17 +31,18 @@ class ProtocolError : public std::runtime_error
 public:
     ProtocolError(uint32_t object_id, uint32_t error_code, char const* fmt, ...);
 
-    /// Encoded as "MIR_PROTOCOL_ERROR:<object_id>:<error_code>: <message>" so the
-    /// error survives the cxx FFI boundary (which only carries what()); the Rust
-    /// dispatch layer parses this back. Other exception types lack the sentinel
-    /// prefix and must not be parsed as protocol errors.
-    static constexpr char const* what_sentinel = "MIR_PROTOCOL_ERROR:";
     auto what() const noexcept -> char const* override;
     auto object_id() const noexcept -> uint32_t;
     auto code() const noexcept -> uint32_t;
     auto message() const noexcept -> std::string const&;
 
 private:
+    /// Encoded as "MIR_PROTOCOL_ERROR:<object_id>:<error_code>: <message>" so the
+    /// error survives the cxx FFI boundary (which only carries what()); the Rust
+    /// dispatch layer parses this back. Other exception types lack the sentinel
+    /// prefix and must not be parsed as protocol errors.
+    static constexpr char const* what_sentinel = "MIR_PROTOCOL_ERROR:";
+
     uint32_t object_id_;
     uint32_t code_;
     std::string message_;

--- a/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/src/protocol_error.cpp
+++ b/src/server/frontend_wayland/wayland_rs/wayland_rs_cpp/src/protocol_error.cpp
@@ -22,7 +22,7 @@
 
 namespace
 {
-auto format_message(uint32_t object_id, uint32_t error_code, char const* fmt, va_list args) -> std::string
+auto format_message(char const* fmt, va_list args) -> std::string
 {
     va_list args_copy;
     va_copy(args_copy, args);
@@ -31,26 +31,33 @@ auto format_message(uint32_t object_id, uint32_t error_code, char const* fmt, va
 
     if (len < 0)
     {
-        return std::to_string(object_id) + ":" + std::to_string(error_code) + ": formatting error";
+        return "formatting error";
     }
 
     std::vector<char> buf(len + 1);
     std::vsnprintf(buf.data(), buf.size(), fmt, args);
 
-    return std::to_string(object_id) + ":" + std::to_string(error_code) + ": " + buf.data();
+    return buf.data();
 }
 }
 
-mir::wayland_rs::ProtocolError::ProtocolError(uint32_t object_id, uint32_t error_code, char const* fmt, ...)
-    : std::runtime_error{"Client protocol error"}
+mir::wayland_rs::ProtocolError::ProtocolError(uint32_t object_id, uint32_t error_code, char const* fmt, ...) :
+    std::runtime_error{"Client protocol error"},
+    object_id_{object_id},
+    code_{error_code}
 {
     va_list args;
     va_start(args, fmt);
-    message_ = format_message(object_id, error_code, fmt, args);
+    message_ = format_message(fmt, args);
     va_end(args);
+
+    what_ = what_sentinel + std::to_string(object_id_) + ":" + std::to_string(code_) + ": " + message_;
 }
 
-auto mir::wayland_rs::ProtocolError::what() const noexcept -> char const*
-{
-    return message_.c_str();
-}
+auto mir::wayland_rs::ProtocolError::what() const noexcept -> char const* { return what_.c_str(); }
+
+auto mir::wayland_rs::ProtocolError::object_id() const noexcept -> uint32_t { return object_id_; }
+
+auto mir::wayland_rs::ProtocolError::code() const noexcept -> uint32_t { return code_; }
+
+auto mir::wayland_rs::ProtocolError::message() const noexcept -> std::string const& { return message_; }

--- a/tests/wayland_rs/CMakeLists.txt
+++ b/tests/wayland_rs/CMakeLists.txt
@@ -3,6 +3,7 @@ mir_add_wrapped_executable(mir_wayland_rs_tests NOINSTALL
   ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_client_registry.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_fd_ready_listener.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_client_injection.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_protocol_error.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_weak.cpp
   ${PROJECT_SOURCE_DIR}/tests/mir_test/signal.cpp
   ${PROJECT_SOURCE_DIR}/tests/mir_test_framework/temporary_environment_value.cpp

--- a/tests/wayland_rs/test_protocol_error.cpp
+++ b/tests/wayland_rs/test_protocol_error.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "protocol_error.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace mrs = mir::wayland_rs;
+
+using namespace testing;
+
+TEST(ProtocolError, accessors_return_constructor_values)
+{
+    mrs::ProtocolError const error{42, 7, "something went wrong"};
+
+    EXPECT_THAT(error.object_id(), Eq(42u));
+    EXPECT_THAT(error.code(), Eq(7u));
+    EXPECT_THAT(error.message(), Eq("something went wrong"));
+}
+
+TEST(ProtocolError, message_excludes_sentinel_and_id_and_code)
+{
+    mrs::ProtocolError const error{42, 7, "just the message"};
+    EXPECT_THAT(error.message(), Eq("just the message"));
+}
+
+TEST(ProtocolError, what_is_exact_encoded_wire_string)
+{
+    mrs::ProtocolError const error{42, 7, "something went wrong"};
+
+    EXPECT_THAT(std::string{error.what()}, Eq("MIR_PROTOCOL_ERROR:42:7: something went wrong"));
+}
+
+TEST(ProtocolError, what_starts_with_sentinel)
+{
+    mrs::ProtocolError const error{1, 2, "boom"};
+
+    EXPECT_THAT(std::string{error.what()}, StartsWith("MIR_PROTOCOL_ERROR:"));
+}
+
+TEST(ProtocolError, formats_printf_style_arguments)
+{
+    mrs::ProtocolError const error{3, 4, "bad value %d for %s", 99, "surface"};
+
+    EXPECT_THAT(error.message(), Eq("bad value 99 for surface"));
+    EXPECT_THAT(std::string{error.what()}, Eq("MIR_PROTOCOL_ERROR:3:4: bad value 99 for surface"));
+}
+
+TEST(ProtocolError, preserves_colons_in_message)
+{
+    mrs::ProtocolError const error{5, 6, "expected a:b:c format"};
+
+    EXPECT_THAT(error.message(), Eq("expected a:b:c format"));
+    EXPECT_THAT(std::string{error.what()}, Eq("MIR_PROTOCOL_ERROR:5:6: expected a:b:c format"));
+}
+
+TEST(ProtocolError, is_catchable_as_runtime_error)
+{
+    try
+    {
+        throw mrs::ProtocolError{8, 9, "thrown"};
+    }
+    catch (std::runtime_error const& error)
+    {
+        EXPECT_THAT(std::string{error.what()}, Eq("MIR_PROTOCOL_ERROR:8:9: thrown"));
+        return;
+    }
+
+    FAIL() << "ProtocolError was not caught as std::runtime_error";
+}


### PR DESCRIPTION
## What's new?
If the C++ side threw some unknown exception, then it ended up being unparseable garbage in the Rust side of things. A better solution is to throw an implementation error on the display object.

- Updated the `mir::wayland_rs::ProtocolError` class to be more verbose and more closely match the existing `mir::wayland::ProtocolError` class
- Added `handle_dispatch_error` which will ensure that errors not matching the sentinel are still reported and handle appropriately
- Added unit tests for the `mir::wayland_rs::ProtocolError` class, which were missing before.

## How to test
New tests pass!

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
