### PR TITLE
(wayland-rs) drop shared_ptr C++ reference from Rust explicitly on resource destruction

### DIFF
--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -723,7 +723,11 @@ fn generate_dispatch_impl(
                 //
                 // This bidirectionality is necessary so that Rust can forward client
                 // requests to C++ and C++ can send server events to Rust.
-                data.lock().unwrap_or_else(|e| e.into_inner()).inner.take();
+                let taken_inner = {
+                    let mut guard = data.lock().unwrap_or_else(|e| e.into_inner());
+                    guard.inner.take()
+                };
+                drop(taken_inner);
             }
         }
     }

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -713,9 +713,17 @@ fn generate_dispatch_impl(
                 _state: &mut Self,
                 _client: ClientId,
                 resource: &#namespace_name::#interface_name::#protocol_struct_name,
-                _data: &Arc<Mutex<#wrapper_struct_name>>,
+                data: &Arc<Mutex<#wrapper_struct_name>>,
             ) {
                 unregister_resource(resource);
+
+                // The C++ object holds the middleware, whose resource handle holds
+                // `data`, whose `inner` holds the C++ object. Break the cycle here
+                // or the whole chain (and the client's session) leaks.
+                //
+                // This bidirectionality is necessary so that Rust can forward client
+                // requests to C++ and C++ can send server events to Rust.
+                data.lock().unwrap_or_else(|e| e.into_inner()).inner.take();
             }
         }
     }


### PR DESCRIPTION
## What's new?
This fixes a bug where Rust keeps the C++ shared ptr (and hence the client object underneath it) alive longer than it should.

The problem is:

- Wrapper owns the C++ shared ptr
- C++ objects owns the middleware which owns the resource handle, which keeps the arc alive.

This bidirectionality is important so that events and requests can be sent from both sides, but it is unfortunate as it causes us to have this explicit release of the shared ptr. This is the most pragmatic solution for this AFAICT.

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
