### PR TITLE
Handle unmanaged surfaces in window_at safely

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -880,8 +880,12 @@ auto miral::BasicWindowManager::can_select_window(miral::Window const& window) c
 auto miral::BasicWindowManager::window_at(geometry::Point cursor) const
 -> Window
 {
-    auto surface_at = focus_controller->surface_at(cursor);
-    return surface_at ? info_for(surface_at).window() : Window{};
+    auto const surface_at = focus_controller->surface_at(cursor);
+    if (!surface_at)
+        return Window{};
+
+    auto const info = window_info.find(surface_at);
+    return info == window_info.end() ? Window{} : info->second.window();
 }
 
 auto miral::BasicWindowManager::active_output() -> geometry::Rectangle const

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -16,6 +16,7 @@ add_compile_definitions(MIRAL_ENABLE_DEPRECATIONS=0)
 
 mir_add_wrapped_executable(miral-test-internal NOINSTALL
     render_scene_into_surface.cpp
+    basic_window_manager.cpp
     mru_window_list.cpp
     active_outputs.cpp
     configuration_option.cpp

--- a/tests/miral/basic_window_manager.cpp
+++ b/tests/miral/basic_window_manager.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "test_window_manager_tools.h"
+
+namespace mt = mir::test;
+
+using namespace testing;
+
+struct BasicWindowManager : mt::TestWindowManagerTools
+{
+};
+
+TEST_F(BasicWindowManager, window_at_returns_empty_for_unmanaged_surface)
+{
+    ON_CALL(focus_controller, surface_at(_))
+        .WillByDefault([&](auto) { return create_surface(session, {}); });
+
+    EXPECT_EQ(basic_window_manager.window_at({}), miral::Window{});
+}

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -22,7 +22,6 @@
 #include <miral/output.h>
 
 #include <mir/shell/display_layout.h>
-#include <mir/shell/focus_controller.h>
 #include <mir/shell/persistent_surface_store.h>
 #include <mir/graphics/display_configuration_observer.h>
 #include <mir/wayland/weak.h>
@@ -40,36 +39,6 @@
 
 namespace
 {
-
-struct StubFocusController : mir::shell::FocusController
-{
-    void focus_next_session() override {}
-    void focus_prev_session() override {}
-
-    auto focused_session() const -> std::shared_ptr<mir::scene::Session> override { return {}; }
-
-    void set_popup_grab_tree(std::shared_ptr<mir::scene::Surface> const& /*surface*/) override {}
-
-    void set_focus_to(
-        std::shared_ptr<mir::scene::Session> const& /*focus_session*/,
-        std::shared_ptr<mir::scene::Surface> const& /*focus_surface*/) override {}
-
-    auto focused_surface() const -> std::shared_ptr<mir::scene::Surface> override { return {}; }
-
-    void raise(mir::shell::SurfaceSet const& /*windows*/) override {}
-
-    virtual auto surface_at(mir::geometry::Point /*cursor*/) const -> std::shared_ptr<mir::scene::Surface> override
-        { return {}; }
-
-    void swap_z_order(mir::shell::SurfaceSet const& /*first*/, mir::shell::SurfaceSet const& /*second*/) override {}
-
-    void send_to_back(mir::shell::SurfaceSet const& /*windows*/) override {}
-
-    auto is_above(std::weak_ptr<mir::scene::Surface> const& /*a*/, std::weak_ptr<mir::scene::Surface> const& /*b*/) const -> bool override
-    {
-        return false;
-    }
-};
 
 struct StubDisplayLayout : mir::shell::DisplayLayout
 {
@@ -254,7 +223,6 @@ namespace mt = mir::test;
 
 struct mt::TestWindowManagerTools::Self
 {
-    StubFocusController focus_controller;
     StubDisplayLayout display_layout;
     StubPersistentSurfaceStore persistent_surface_store;
     FakeDisplayConfigurationObserverRegistrar display_configuration_observer;
@@ -267,8 +235,9 @@ mt::TestWindowManagerTools::TestWindowManagerTools()
       session{std::make_shared<StubStubSession>()},
       window_manager_policy{nullptr},
       window_manager_tools{nullptr},
+      focus_controller{},
       basic_window_manager{
-        &self->focus_controller,
+        &focus_controller,
         mir::test::fake_shared(self->display_layout),
         mir::test::fake_shared(self->persistent_surface_store),
         self->display_configuration_observer,

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -22,6 +22,7 @@
 
 #include <miral/canonical_window_manager.h>
 #include <miral/window.h>
+#include <mir/shell/focus_controller.h>
 #include <mir/shell/surface_specification.h>
 #include <mir/scene/surface.h>
 
@@ -37,6 +38,35 @@ class DisplayConfiguration;
 
 namespace test
 {
+
+struct MockFocusController : mir::shell::FocusController
+{
+    void focus_next_session() override {}
+    void focus_prev_session() override {}
+
+    auto focused_session() const -> std::shared_ptr<mir::scene::Session> override { return {}; }
+
+    void set_popup_grab_tree(std::shared_ptr<mir::scene::Surface> const& /*surface*/) override {}
+
+    void set_focus_to(
+        std::shared_ptr<mir::scene::Session> const& /*focus_session*/,
+        std::shared_ptr<mir::scene::Surface> const& /*focus_surface*/) override {}
+
+    auto focused_surface() const -> std::shared_ptr<mir::scene::Surface> override { return {}; }
+
+    void raise(mir::shell::SurfaceSet const& /*windows*/) override {}
+
+    MOCK_METHOD(std::shared_ptr<mir::scene::Surface>, surface_at, (mir::geometry::Point point), (const override));
+
+    void swap_z_order(mir::shell::SurfaceSet const& /*first*/, mir::shell::SurfaceSet const& /*second*/) override {}
+
+    void send_to_back(mir::shell::SurfaceSet const& /*windows*/) override {}
+
+    auto is_above(std::weak_ptr<mir::scene::Surface> const& /*a*/, std::weak_ptr<mir::scene::Surface> const& /*b*/) const -> bool override
+    {
+        return false;
+    }
+};
 
 struct MockWindowManagerPolicy
     : miral::CanonicalWindowManagerPolicy
@@ -79,6 +109,7 @@ public:
     std::shared_ptr<mir::scene::Session> session;
     MockWindowManagerPolicy* window_manager_policy;
     miral::WindowManagerTools window_manager_tools;
+    MockFocusController focus_controller;
     miral::BasicWindowManager basic_window_manager;
 
     static auto create_surface(


### PR DESCRIPTION
## What's new?

- `window_at` now returns an empty Window when the focused surface is not present in window_info
-  Add a regression test covering that case.

## How to test

- Run the test with and without the patch applied.

## Checklist

- [x] Tests added and pass
- [ ] ~Adequate documentation added~
- [ ] ~(optional) Added Screenshots or videos~
