### PR TITLE
(wayland-rs) Add concrete implementation of wayland_rs::Client to frontend wayland

### DIFF
--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -133,6 +133,11 @@ target_link_libraries(mirfrontend-wayland
 )
 
 if (MIR_ENABLE_RUST)
+  target_sources(mirfrontend-wayland
+    PRIVATE
+      wayland_client.cpp         wayland_client.h
+  )
+
   target_link_libraries(mirfrontend-wayland
     PUBLIC
       mirwayland_rs

--- a/src/server/frontend_wayland/wayland_client.cpp
+++ b/src/server/frontend_wayland/wayland_client.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "wayland_client.h"
+
+#include <mir/scene/session.h>
+#include <mir/shell/shell.h>
+
+namespace mf = mir::frontend;
+namespace ms = mir::scene;
+namespace msh = mir::shell;
+
+namespace { int const max_serial_event_pairs = 100; }
+
+mf::WaylandClient::WaylandClient(
+    wayland_rs::RawWlClient raw_client,
+    std::shared_ptr<ms::Session> session,
+    std::shared_ptr<msh::Shell> shell,
+    WaylandSerialSource serial_source) :
+    raw{std::move(raw_client)},
+    session{std::move(session)},
+    shell{std::move(shell)},
+    serial_source{std::move(serial_source)}
+{}
+
+mf::WaylandClient::~WaylandClient() { mark_being_destroyed(); }
+
+auto mf::WaylandClient::raw_client() const -> wayland_rs::RawWlClient const& { return raw; }
+
+auto mf::WaylandClient::is_being_destroyed() const -> bool { return being_destroyed; }
+
+auto mf::WaylandClient::client_session() const -> std::shared_ptr<ms::Session> { return session; }
+
+auto mf::WaylandClient::next_serial(std::shared_ptr<MirEvent const> event) -> uint32_t
+{
+    auto const serial = ++(*serial_source);
+    serial_event_pairs.push_front({serial, std::move(event)});
+    while (serial_event_pairs.size() > max_serial_event_pairs)
+    {
+        serial_event_pairs.pop_back();
+    }
+    return serial;
+}
+
+auto mf::WaylandClient::event_for(uint32_t serial) -> std::optional<std::shared_ptr<MirEvent const>>
+{
+    for (auto const& pair : serial_event_pairs)
+    {
+        if (pair.first == serial)
+        {
+            return pair.second;
+        }
+    }
+    return std::nullopt;
+}
+
+void mf::WaylandClient::set_output_geometry_scale(float scale) { output_geometry_scale_ = scale; }
+
+auto mf::WaylandClient::output_geometry_scale() -> float { return output_geometry_scale_; }
+
+void mf::WaylandClient::mark_being_destroyed()
+{
+    if (being_destroyed)
+    {
+        return;
+    }
+
+    being_destroyed = true;
+    if (session)
+    {
+        shell->close_session(session);
+    }
+}

--- a/src/server/frontend_wayland/wayland_client.h
+++ b/src/server/frontend_wayland/wayland_client.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_FRONTEND_WAYLAND_CLIENT_H_
+#define MIR_FRONTEND_WAYLAND_CLIENT_H_
+
+#include "client.h"
+
+#include <atomic>
+#include <deque>
+#include <memory>
+#include <utility>
+
+struct MirEvent;
+
+namespace mir
+{
+namespace scene { class Session; }
+namespace shell { class Shell; }
+
+namespace frontend
+{
+/// A monotonic serial source shared by all clients.
+///
+/// libwayland assigns serials from a single display-global counter
+/// (`wl_display_next_serial`). The wayland-rs reproduces that here
+/// so that serials stay unique across the whole frontend.
+using WaylandSerialSource = std::shared_ptr<std::atomic<uint32_t>>;
+
+/// A concrete `mir::wayland_rs::Client` backed by a Mir session.
+///
+/// A `mir::wayland_rs::RawWlClient` gets created by the rust side whenever
+/// a new Wayland client connects. C++ is notified via
+/// `mir::wayland_rs::WaylandServerNotificationHandler` when this happens.
+/// The concrete implementation of the notification handler registers a
+/// concrete implementation of `mir::wayland_rs::Client` in the
+/// `mir::wayland_rs::WaylandClientRegistry` whenever that happens.
+/// Afterward, the client instance is provided to every Wayland object that is
+/// associated with it.
+class WaylandClient : public wayland_rs::Client
+{
+public:
+    WaylandClient(
+        wayland_rs::RawWlClient raw_client,
+        std::shared_ptr<scene::Session> session,
+        std::shared_ptr<shell::Shell> shell,
+        WaylandSerialSource serial_source);
+
+    ~WaylandClient() override;
+
+    auto raw_client() const -> wayland_rs::RawWlClient const& override;
+    auto is_being_destroyed() const -> bool override;
+    auto client_session() const -> std::shared_ptr<scene::Session> override;
+    auto next_serial(std::shared_ptr<MirEvent const> event) -> uint32_t override;
+    auto event_for(uint32_t serial) -> std::optional<std::shared_ptr<MirEvent const>> override;
+    void set_output_geometry_scale(float scale) override;
+    auto output_geometry_scale() -> float override;
+
+    /// Called when the Rust client's destroy listener has fired. Flags the
+    /// client as being destroyed and closes the associated Mir session. The
+    /// object itself may outlive this call while its resources are torn down.
+    void mark_being_destroyed();
+
+private:
+    wayland_rs::RawWlClient const raw;
+    std::shared_ptr<scene::Session> const session;
+    std::shared_ptr<shell::Shell> const shell;
+    WaylandSerialSource const serial_source;
+
+    bool being_destroyed{false};
+    std::deque<std::pair<uint32_t, std::shared_ptr<MirEvent const>>> serial_event_pairs;
+    float output_geometry_scale_{1.0f};
+};
+}
+}
+
+#endif // MIR_FRONTEND_WAYLAND_CLIENT_H_

--- a/src/server/frontend_wayland/wayland_client.h
+++ b/src/server/frontend_wayland/wayland_client.h
@@ -20,8 +20,10 @@
 #include "client.h"
 
 #include <atomic>
+#include <cstdint>
 #include <deque>
 #include <memory>
+#include <optional>
 #include <utility>
 
 struct MirEvent;

--- a/tests/unit-tests/frontend_wayland/CMakeLists.txt
+++ b/tests/unit-tests/frontend_wayland/CMakeLists.txt
@@ -10,4 +10,11 @@ list(
   ${CMAKE_CURRENT_SOURCE_DIR}/test_recent_tokens.cpp
 )
 
+if (MIR_ENABLE_RUST)
+  list(
+    APPEND UNIT_TEST_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_client.cpp
+  )
+endif()
+
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/frontend_wayland/test_wayland_client.cpp
+++ b/tests/unit-tests/frontend_wayland/test_wayland_client.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "src/server/frontend_wayland/wayland_client.h"
+#include "client.h"
+
+#include <mir/events/event_builders.h>
+#include <mir/scene/session.h>
+#include <mir/shell/shell.h>
+#include <mir/test/doubles/stub_session.h>
+#include <mir/test/doubles/stub_shell.h>
+
+#include <rust/cxx.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+namespace mf = mir::frontend;
+namespace mrs = mir::wayland_rs;
+namespace ms = mir::scene;
+namespace mev = mir::events;
+namespace mtd = mir::test::doubles;
+
+using namespace testing;
+
+namespace
+{
+/// `mf::WaylandClient` only stores the raw client and hands it back from
+/// `raw_client()`, so it is fine to back it with a `nullptr`.
+auto empty_raw_client() -> mrs::RawWlClient { return rust::Box<mrs::WaylandClient>::from_raw(nullptr); }
+
+auto make_event() -> std::shared_ptr<MirEvent const>
+{
+    return mev::make_key_event(
+        MirInputDeviceId{0},
+        std::chrono::nanoseconds{0},
+        mir_keyboard_action_down,
+        0,
+        7,
+        mir_input_event_modifier_none);
+}
+
+struct MockShell : mtd::StubShell
+{
+    MOCK_METHOD(void, close_session, (std::shared_ptr<ms::Session> const&), (override));
+};
+
+struct WaylandClientTest : Test
+{
+    std::shared_ptr<NiceMock<MockShell>> const shell = std::make_shared<NiceMock<MockShell>>();
+    std::shared_ptr<ms::Session> const session = std::make_shared<mtd::StubSession>();
+    mf::WaylandSerialSource const serial_source = std::make_shared<std::atomic<uint32_t>>(0);
+
+    auto make_client(std::shared_ptr<ms::Session> client_session) -> std::unique_ptr<mf::WaylandClient>
+    {
+        return std::make_unique<mf::WaylandClient>(empty_raw_client(), std::move(client_session), shell, serial_source);
+    }
+
+    auto make_client() -> std::unique_ptr<mf::WaylandClient> { return make_client(session); }
+};
+}
+
+TEST_F(WaylandClientTest, client_session_returns_constructed_session)
+{
+    auto const client = make_client();
+    EXPECT_EQ(client->client_session(), session);
+}
+
+TEST_F(WaylandClientTest, is_not_being_destroyed_initially)
+{
+    auto const client = make_client();
+    EXPECT_FALSE(client->is_being_destroyed());
+}
+
+TEST_F(WaylandClientTest, output_geometry_scale_defaults_to_one)
+{
+    auto const client = make_client();
+    EXPECT_FLOAT_EQ(client->output_geometry_scale(), 1.0f);
+}
+
+TEST_F(WaylandClientTest, output_geometry_scale_returns_set_value)
+{
+    auto const client = make_client();
+    client->set_output_geometry_scale(2.5f);
+    EXPECT_FLOAT_EQ(client->output_geometry_scale(), 2.5f);
+}
+
+TEST_F(WaylandClientTest, next_serial_increments_shared_source)
+{
+    auto const client = make_client();
+    EXPECT_EQ(client->next_serial(nullptr), 1u);
+    EXPECT_EQ(client->next_serial(nullptr), 2u);
+    EXPECT_EQ(client->next_serial(nullptr), 3u);
+}
+
+TEST_F(WaylandClientTest, serials_are_shared_across_clients)
+{
+    auto const client_a = make_client();
+    auto const client_b = make_client();
+
+    EXPECT_EQ(client_a->next_serial(nullptr), 1u);
+    EXPECT_EQ(client_b->next_serial(nullptr), 2u);
+    EXPECT_EQ(client_a->next_serial(nullptr), 3u);
+}
+
+TEST_F(WaylandClientTest, event_for_returns_event_for_known_serial)
+{
+    auto const client = make_client();
+    auto const event = make_event();
+
+    auto const serial = client->next_serial(event);
+
+    auto const retrieved = client->event_for(serial);
+    EXPECT_EQ(*retrieved, event);
+}
+
+TEST_F(WaylandClientTest, event_for_returns_null_event_for_serial_recorded_with_null)
+{
+    auto const client = make_client();
+
+    auto const serial = client->next_serial(nullptr);
+
+    auto const retrieved = client->event_for(serial);
+    EXPECT_EQ(*retrieved, nullptr);
+}
+
+TEST_F(WaylandClientTest, event_for_returns_nullopt_for_unknown_serial)
+{
+    auto const client = make_client();
+    auto const serial = client->next_serial(make_event());
+
+    EXPECT_FALSE(client->event_for(serial + 1));
+}
+
+TEST_F(WaylandClientTest, event_for_evicts_oldest_beyond_capacity)
+{
+    auto const client = make_client();
+
+    int const capacity = 100;
+
+    auto const first_serial = client->next_serial(make_event());
+    for (int i = 1; i < capacity; ++i)
+        client->next_serial(make_event());
+
+    // The buffer is now exactly full; the oldest entry is still present.
+    ASSERT_TRUE(client->event_for(first_serial));
+
+    // One more issuance pushes the oldest out.
+    auto const newest_serial = client->next_serial(make_event());
+
+    EXPECT_FALSE(client->event_for(first_serial));
+    EXPECT_TRUE(client->event_for(newest_serial));
+}
+
+TEST_F(WaylandClientTest, mark_being_destroyed_flags_and_closes_session)
+{
+    auto const client = make_client();
+
+    EXPECT_CALL(*shell, close_session(session)).Times(1);
+
+    client->mark_being_destroyed();
+
+    EXPECT_TRUE(client->is_being_destroyed());
+}
+
+TEST_F(WaylandClientTest, mark_being_destroyed_is_idempotent)
+{
+    auto const client = make_client();
+
+    EXPECT_CALL(*shell, close_session(session)).Times(1);
+
+    client->mark_being_destroyed();
+    client->mark_being_destroyed();
+}
+
+TEST_F(WaylandClientTest, mark_being_destroyed_with_null_session_does_not_close)
+{
+    auto const client = make_client(nullptr);
+
+    EXPECT_CALL(*shell, close_session(_)).Times(0);
+
+    client->mark_being_destroyed();
+
+    EXPECT_TRUE(client->is_being_destroyed());
+}
+
+TEST_F(WaylandClientTest, destructor_closes_session)
+{
+    auto client = make_client();
+
+    EXPECT_CALL(*shell, close_session(session)).Times(1);
+
+    client.reset();
+}
+
+TEST_F(WaylandClientTest, destructor_does_not_close_session_already_marked)
+{
+    auto client = make_client();
+
+    EXPECT_CALL(*shell, close_session(session)).Times(1);
+
+    client->mark_being_destroyed();
+    client.reset();
+}


### PR DESCRIPTION
## What's new?
This loosely matches the existing `WlClient` interface from the C++ Wayland frontend.

- Added `WaylandClient`, which implements the `wayland_rs::Client` interface
- Wrote unit tests for it

A pull request implementing `mir::wayland_rs::WaylandServerNotificationHandler` will follow afterward!

## How to test
Run the unit tests :)

## Checklist

- [x] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
