### PR TITLE
Enable `cargo clippy` and `cargo check` in precommit hooks

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,6 +19,12 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+    - run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends --yes \
+          pkg-config \
+          libboost-dev \
+          libudev-dev
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,12 @@ repos:
 - repo: https://github.com/AndrejOrsula/pre-commit-cargo
   rev: 33ae92ed9b1a4392c8ac5fdef46887640d866e1e  # frozen: 0.5.0
   hooks:
+  - id: cargo-check
+  - id: cargo-clippy
+    args: ["--", "-D", "warnings"]
+  - id: cargo-clippy
+    alias: clippy-fix
+    args: ["--fix", "--", "-D", "warnings"]
   - id: cargo-fmt
 
 - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/src/platforms/evdev-rs/src/device.rs
+++ b/src/platforms/evdev-rs/src/device.rs
@@ -15,7 +15,6 @@
  */
 
 use cxx::SharedPtr;
-use input;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -101,7 +100,7 @@ impl LibinputDevice {
             .device
             .has_capability(input::DeviceCapability::Pointer)
         {
-            capabilities = capabilities | DeviceCapability::pointer.repr;
+            capabilities |= DeviceCapability::pointer.repr;
         }
         if device_info
             .device
@@ -110,7 +109,7 @@ impl LibinputDevice {
             capabilities |= DeviceCapability::touchpad.repr | DeviceCapability::pointer.repr;
         }
 
-        return Box::new(LibinputDeviceMetadata {
+        Box::new(LibinputDeviceMetadata {
             name: device_info.device.name().to_string(),
             unique_id: format!(
                 "{} {} {} {}",
@@ -119,9 +118,9 @@ impl LibinputDevice {
                 device_info.device.id_vendor(),
                 device_info.device.id_product()
             ),
-            capabilities: capabilities,
+            capabilities,
             valid: true,
-        });
+        })
     }
 
     pub fn get_pointer_settings(&self) -> Box<PointerSettings> {
@@ -168,17 +167,17 @@ impl LibinputDevice {
             }
         };
 
-        let acceleration_bias = device_info.device.config_accel_speed() as f64;
+        let acceleration_bias = device_info.device.config_accel_speed();
 
-        return Box::new(PointerSettings {
+        Box::new(PointerSettings {
             is_set: true,
-            handedness: handedness,
+            handedness,
             cursor_acceleration_bias: acceleration_bias,
-            acceleration: acceleration,
+            acceleration,
             horizontal_scroll_scale: guard.scroll_state.x_scroll_scale,
             vertical_scroll_scale: guard.scroll_state.y_scroll_scale,
             has_error: false,
-        });
+        })
     }
 
     pub fn set_pointer_settings(&self, settings: &SetPointerSettingsData) {
@@ -216,7 +215,7 @@ impl LibinputDevice {
         let _ = device_info.device.config_accel_set_profile(accel_profile);
         let _ = device_info
             .device
-            .config_accel_set_speed(settings.cursor_acceleration_bias as f64);
+            .config_accel_set_speed(settings.cursor_acceleration_bias);
         guard.scroll_state.x_scroll_scale = settings.horizontal_scroll_scale;
         guard.scroll_state.y_scroll_scale = settings.vertical_scroll_scale;
     }

--- a/src/platforms/evdev-rs/src/device.rs
+++ b/src/platforms/evdev-rs/src/device.rs
@@ -66,8 +66,9 @@ impl LibinputDevice {
             // # Safety
             //
             // Calling create_event_builder_wrapper with a raw pointer is unsafe.
-            device_info.event_builder =
-                Some(unsafe { self.bridge.create_event_builder_wrapper(event_builder) });
+            device_info.event_builder = Some(EventBuilderWrapperPtr(unsafe {
+                self.bridge.create_event_builder_wrapper(event_builder)
+            }));
         }
     }
 
@@ -246,10 +247,10 @@ pub struct LibinputDeviceInfo {
     /// The device node path (e.g. `/dev/input/event0`), stored so that
     /// `path_remove_device` can find this entry by devnode.
     pub devnode: String,
-    pub device: input::Device,
-    pub input_device: cxx::SharedPtr<InputDevice>,
+    pub device: LibinputDeviceHandle,
+    pub input_device: InputDevicePtr,
     pub input_sink: Option<InputSinkPtr>,
-    pub event_builder: Option<cxx::UniquePtr<EventBuilderWrapper>>,
+    pub event_builder: Option<EventBuilderWrapperPtr>,
     pub button_state: u32,
     pub pointer_x: f32,
     pub pointer_y: f32,
@@ -257,7 +258,7 @@ pub struct LibinputDeviceInfo {
     /// Input events that arrived before device registration completed (before
     /// `event_builder` was set). These are processed once `start()` is called.
     /// See: https://github.com/canonical/mir/pull/4780
-    pub deferred_events: Vec<input::Event>,
+    pub deferred_events: Vec<LibinputEventHandle>,
 }
 
 #[derive(Default, Copy, Clone)]
@@ -302,12 +303,11 @@ impl LibinputDeviceMetadata {
     }
 }
 
-// Because *mut InputSink and *mut EventBuilder are raw pointers, Rust assumes
-// that they are neither Send nor Sync. However, we know that the other side of
-// the pointer is actually a C++ object that is thread-safe, so we can assert
-// that these pointers are Send and Sync. We cannot define Send and Sync on the
-// raw types to fix the issue unfortunately, so we have to wrap them in a new type
-// and define Send and Sync on that.
+// cxx's SharedPtr and UniquePtr wrapping opaque C++ types do not automatically
+// implement Send or Sync, because Rust cannot verify thread-safety of the
+// underlying C++ objects. However, we know that the C++ side is thread-safe,
+// and all access is guarded by a Mutex. We therefore wrap the problematic types
+// in newtypes and assert Send + Sync on those.
 pub struct InputSinkPtr(pub std::ptr::NonNull<InputSink>);
 impl InputSinkPtr {
     pub fn handle_input(&mut self, event: &cxx::SharedPtr<MirEvent>) {
@@ -319,8 +319,69 @@ impl InputSinkPtr {
     }
 }
 
+pub struct InputDevicePtr(pub cxx::SharedPtr<InputDevice>);
+impl Clone for InputDevicePtr {
+    fn clone(&self) -> Self {
+        InputDevicePtr(self.0.clone())
+    }
+}
+impl std::ops::Deref for InputDevicePtr {
+    type Target = cxx::SharedPtr<InputDevice>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct EventBuilderWrapperPtr(pub cxx::UniquePtr<EventBuilderWrapper>);
+impl EventBuilderWrapperPtr {
+    pub fn pin_mut(&mut self) -> std::pin::Pin<&mut EventBuilderWrapper> {
+        self.0.pin_mut()
+    }
+}
+
+/// Newtype wrapper for [`input`] structures.
+pub struct LibinputHandle<T>(pub T);
+impl<T> LibinputHandle<T> {
+    /// Consume the wrapper, and produce the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+impl<T> std::ops::Deref for LibinputHandle<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<T> std::ops::DerefMut for LibinputHandle<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+impl<T> From<T> for LibinputHandle<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+/// Newtype wrapper around [`input::Device`] to allow asserting [`Send`] and [`Sync`].
+pub type LibinputDeviceHandle = LibinputHandle<input::Device>;
+
+/// Newtype wrapper around [`input::Event`] to allow asserting [`Send`] and [`Sync`].
+pub type LibinputEventHandle = LibinputHandle<input::Event>;
+
 // # Safety
 //
-// These needs to be unsafe because we are asserting that Send and Sync are valid on them.
+// These impls are unsafe because we are asserting that Send and Sync are valid.
+// This is sound because the underlying C++ objects are thread-safe, and all
+// access is serialised through the Mutex wrapping LibinputDeviceState.
 unsafe impl Send for InputSinkPtr {}
 unsafe impl Sync for InputSinkPtr {}
+unsafe impl Send for InputDevicePtr {}
+unsafe impl Sync for InputDevicePtr {}
+unsafe impl Send for EventBuilderWrapperPtr {}
+unsafe impl Sync for EventBuilderWrapperPtr {}
+unsafe impl Send for LibinputDeviceHandle {}
+unsafe impl Sync for LibinputDeviceHandle {}
+unsafe impl Send for LibinputEventHandle {}
+unsafe impl Sync for LibinputEventHandle {}

--- a/src/platforms/evdev-rs/src/device.rs
+++ b/src/platforms/evdev-rs/src/device.rs
@@ -128,9 +128,10 @@ impl LibinputDevice {
             eprintln!(
                 "LibinputDevice::get_pointer_settings: unable to acquire state lock; lock poisoned"
             );
-            let mut settings = PointerSettings::default();
-            settings.has_error = true;
-            return Box::new(settings);
+            return Box::new(PointerSettings {
+                has_error: true,
+                ..Default::default()
+            });
         };
 
         let Some(device_info) = guard.find_device_by_id(self.device_id) else {
@@ -236,7 +237,7 @@ pub struct LibinputDeviceState {
 }
 
 impl LibinputDeviceState {
-    pub fn find_device_by_id<'a>(&mut self, id: i32) -> Option<&'_ mut LibinputDeviceInfo> {
+    pub fn find_device_by_id(&mut self, id: i32) -> Option<&mut LibinputDeviceInfo> {
         self.known_devices.iter_mut().find(|d| d.id == id)
     }
 }

--- a/src/platforms/evdev-rs/src/device.rs
+++ b/src/platforms/evdev-rs/src/device.rs
@@ -230,7 +230,6 @@ pub struct ScrollState {
 }
 
 pub struct LibinputDeviceState {
-    pub libinput: input::Libinput,
     pub known_devices: Vec<LibinputDeviceInfo>,
     pub next_device_id: i32,
     pub scroll_state: ScrollState,

--- a/src/platforms/evdev-rs/src/event_processing.rs
+++ b/src/platforms/evdev-rs/src/event_processing.rs
@@ -14,13 +14,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::device::{
-    ContactData, InputSinkPtr, LibinputDeviceInfo, LibinputDeviceState, ScrollState,
-};
+use crate::device::{InputSinkPtr, LibinputDeviceInfo, LibinputDeviceState, ScrollState};
 use crate::ffi::PointerEventData;
 use crate::MirTouchAction;
 use cxx::{self, UniquePtr};
-use input;
 use input::event;
 use input::event::keyboard;
 use input::event::keyboard::KeyboardEventTrait;
@@ -395,7 +392,7 @@ fn handle_pointer_button(
         button_event.time_usec(),
         EV_KEY,
         mir_button.repr as i32,
-        action.repr as i32,
+        action.repr,
     );
 
     let pointer_event = PointerEventData {
@@ -567,7 +564,7 @@ fn handle_keyboard_event(
         key_event.time_usec(),
         EV_KEY,
         key_event.key() as i32,
-        keyboard_action.repr as i32,
+        keyboard_action.repr,
     );
 
     let created = event_builder.pin_mut().key_event(&key_event_data);
@@ -600,10 +597,7 @@ fn handle_touch_event(
 
             // We make sure that we only notify of "down" touch events once. Everything
             // after that is considered a simple "change".
-            let data = device_info
-                .touch_properties
-                .entry(slot)
-                .or_insert(ContactData::default());
+            let data = device_info.touch_properties.entry(slot).or_default();
             data.action = if data.down_notified {
                 MirTouchAction::mir_touch_action_change
             } else {
@@ -624,10 +618,7 @@ fn handle_touch_event(
                 return false;
             }
 
-            let data = device_info
-                .touch_properties
-                .entry(slot)
-                .or_insert(ContactData::default());
+            let data = device_info.touch_properties.entry(slot).or_default();
             data.action = MirTouchAction::mir_touch_action_change;
 
             // Set coordinates. In normal operation, bounding rectangle should always be valid.
@@ -741,20 +732,14 @@ fn handle_touch_frame(
 /// This is called when we already have the device_info reference (e.g., for deferred events).
 fn process_input_event_for_device(
     device_info: &mut LibinputDeviceInfo,
-    mut scroll_state: &mut ScrollState,
+    scroll_state: &mut ScrollState,
     bridge: &cxx::SharedPtr<crate::PlatformBridge>,
     event: input::Event,
     report: &crate::InputReport,
 ) {
     match event {
         input::Event::Pointer(pointer_event) => {
-            handle_pointer_event(
-                device_info,
-                &mut scroll_state,
-                bridge,
-                pointer_event,
-                report,
-            );
+            handle_pointer_event(device_info, scroll_state, bridge, pointer_event, report);
         }
 
         input::Event::Keyboard(keyboard_event) => {
@@ -824,7 +809,7 @@ pub fn process_libinput_events(
     }
 
     // Process newly arrived events.
-    while let Some(event) = state.libinput.next() {
+    for event in state.libinput.by_ref() {
         match event {
             input::Event::Device(device_event) => {
                 let libinput_device = device_event.device();

--- a/src/platforms/evdev-rs/src/event_processing.rs
+++ b/src/platforms/evdev-rs/src/event_processing.rs
@@ -14,7 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::device::{InputSinkPtr, LibinputDeviceInfo, LibinputDeviceState, ScrollState};
+use crate::device::{
+    InputDevicePtr, InputSinkPtr, LibinputDeviceInfo, LibinputDeviceState, ScrollState,
+};
 use crate::ffi::PointerEventData;
 use crate::MirTouchAction;
 use cxx::{self, UniquePtr};
@@ -129,8 +131,8 @@ fn handle_device_event(
             known_devices.push(LibinputDeviceInfo {
                 id: *next_device_id,
                 devnode,
-                device: libinput_device,
-                input_device: bridge.create_input_device(*next_device_id),
+                device: libinput_device.into(),
+                input_device: InputDevicePtr(bridge.create_input_device(*next_device_id)),
                 input_sink: None,
                 event_builder: None,
                 button_state: 0,
@@ -794,7 +796,7 @@ pub fn process_libinput_events(
                     device_info,
                     &mut state.scroll_state,
                     &bridge,
-                    event,
+                    event.into_inner(),
                     report,
                 );
             }
@@ -842,7 +844,7 @@ pub fn process_libinput_events(
                     );
                 } else {
                     // Device not yet registered, defer the event.
-                    device_info.deferred_events.push(other);
+                    device_info.deferred_events.push(other.into());
                 }
             }
         }

--- a/src/platforms/evdev-rs/src/event_processing.rs
+++ b/src/platforms/evdev-rs/src/event_processing.rs
@@ -778,6 +778,7 @@ fn process_input_event_for_device(
 /// because `event_builder` wasn't set yet when the KEY event arrived.
 /// See: https://github.com/canonical/mir/pull/4780
 pub fn process_libinput_events(
+    libinput: &mut input::Libinput,
     state: &mut LibinputDeviceState,
     device_registry: cxx::SharedPtr<crate::InputDeviceRegistry>,
     bridge: cxx::SharedPtr<crate::PlatformBridge>,
@@ -800,13 +801,13 @@ pub fn process_libinput_events(
         }
     }
 
-    if state.libinput.dispatch().is_err() {
+    if libinput.dispatch().is_err() {
         println!("Error dispatching libinput events");
         return;
     }
 
     // Process newly arrived events.
-    for event in state.libinput.by_ref() {
+    for event in libinput.by_ref() {
         match event {
             input::Event::Device(device_event) => {
                 let libinput_device = device_event.device();

--- a/src/platforms/evdev-rs/src/event_processing.rs
+++ b/src/platforms/evdev-rs/src/event_processing.rs
@@ -85,7 +85,7 @@ fn get_scroll_axis(value120: f64, value: f64, scale: f64, accum: &mut f64) -> Sc
 }
 
 fn get_device_info_from_libinput_device<'a>(
-    known_devices: &'a mut Vec<LibinputDeviceInfo>,
+    known_devices: &'a mut [LibinputDeviceInfo],
     libinput_device: &input::Device,
 ) -> Option<&'a mut LibinputDeviceInfo> {
     known_devices
@@ -161,12 +161,9 @@ fn handle_device_event(
         }
         event::DeviceEvent::Removed(removed_event) => {
             let dev = removed_event.device();
-            let Some(index) = known_devices
+            let index = known_devices
                 .iter()
-                .position(|x| x.device.as_raw() == dev.as_raw())
-            else {
-                return None;
-            };
+                .position(|x| x.device.as_raw() == dev.as_raw())?;
 
             // Remove from known_devices immediately (while holding the state lock), but
             // spawn a thread to call remove_device() on the registry.  Calling remove_device()

--- a/src/platforms/evdev-rs/src/lib.rs
+++ b/src/platforms/evdev-rs/src/lib.rs
@@ -350,7 +350,7 @@ pub fn evdev_rs_create(
     device_registry: cxx::SharedPtr<InputDeviceRegistry>,
     report: cxx::UniquePtr<InputReport>,
 ) -> Box<PlatformRs> {
-    return Box::new(PlatformRs::new(bridge, device_registry, report));
+    Box::new(PlatformRs::new(bridge, device_registry, report))
 }
 
 // # Safety

--- a/src/platforms/evdev-rs/src/lib.rs
+++ b/src/platforms/evdev-rs/src/lib.rs
@@ -292,9 +292,9 @@ mod ffi_bridge {
         /// Check whether a device is already pending or active.
         pub fn has_device(self: &PlatformBridge, devnum: u64) -> bool;
 
-        // # Safety
-        //
-        // This is unsafe because it receives a raw C++ pointer as an argument.
+        /// # Safety
+        ///
+        /// This is unsafe because it receives a raw C++ pointer as an argument.
         pub unsafe fn create_event_builder_wrapper(
             self: &PlatformBridge,
             event_builder: *mut EventBuilder,

--- a/src/platforms/evdev-rs/src/lib.rs
+++ b/src/platforms/evdev-rs/src/lib.rs
@@ -13,6 +13,10 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#![expect(
+    clippy::missing_safety_doc,
+    reason = "clippy struggles with `cxx` proc macro"
+)]
 
 // TODO: Report errors to Mir's logging facilities. We should do this following Mir's logging refactor.
 // TODO: Implement continue_after_config and pause_for_config

--- a/src/platforms/evdev-rs/src/libinput_interface.rs
+++ b/src/platforms/evdev-rs/src/libinput_interface.rs
@@ -15,8 +15,6 @@
  */
 
 use crate::fd_store::FdStore;
-use input;
-use libc;
 use std::os::unix::io;
 use std::sync::{Arc, Mutex};
 

--- a/src/platforms/evdev-rs/src/platform.rs
+++ b/src/platforms/evdev-rs/src/platform.rs
@@ -18,8 +18,6 @@ use crate::device::{LibinputDevice, LibinputDeviceState, ScrollState};
 use crate::event_processing::process_libinput_events;
 use crate::fd_store::FdStore;
 use crate::udev_monitor::{UdevEventType, UdevMonitor};
-use cxx;
-use input;
 use std::collections::HashSet;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -296,16 +294,13 @@ impl PlatformRs {
             return;
         }
 
-        match self.state.as_mut().unwrap().try_lock() {
-            Ok(mut state) => {
-                process_libinput_events(
-                    &mut *state,
-                    self.device_registry.clone(),
-                    self.bridge.clone(),
-                    &self.report,
-                );
-            }
-            _ => {}
+        if let Ok(mut state) = self.state.as_mut().unwrap().try_lock() {
+            process_libinput_events(
+                &mut state,
+                self.device_registry.clone(),
+                self.bridge.clone(),
+                &self.report,
+            );
         }
     }
 

--- a/src/platforms/evdev-rs/src/platform.rs
+++ b/src/platforms/evdev-rs/src/platform.rs
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::device::{LibinputDevice, LibinputDeviceState, ScrollState};
+use crate::device::{InputDevicePtr, LibinputDevice, LibinputDeviceState, ScrollState};
 use crate::event_processing::process_libinput_events;
 use crate::fd_store::FdStore;
 use crate::udev_monitor::{UdevEventType, UdevMonitor};
@@ -162,7 +162,7 @@ impl PlatformRs {
                     devnode
                 );
                 let device_info = state.known_devices.swap_remove(index);
-                libinput.path_remove_device(device_info.device);
+                libinput.path_remove_device(device_info.device.into_inner());
 
                 let input_device = device_info.input_device.clone();
                 let registry = self.device_registry.clone();
@@ -211,7 +211,7 @@ impl PlatformRs {
         //   - This thread: holds Rust state mutex, waiting for InputDeviceHub mutex (in remove_device)
         //   - A spawned add_device thread: holds InputDeviceHub mutex, waiting for Rust state mutex
         //     (in LibinputDevice::start)
-        let devices_to_remove: Vec<cxx::SharedPtr<crate::InputDevice>> = {
+        let devices_to_remove: Vec<InputDevicePtr> = {
             match state_arc.lock() {
                 Ok(mut state_guard) => state_guard
                     .known_devices

--- a/src/platforms/evdev-rs/src/platform.rs
+++ b/src/platforms/evdev-rs/src/platform.rs
@@ -33,6 +33,8 @@ pub struct PlatformRs {
 
     report: cxx::UniquePtr<crate::InputReport>,
 
+    libinput: Option<input::Libinput>,
+
     state: Option<Arc<Mutex<LibinputDeviceState>>>,
 
     /// Whether the platform is currently running. Owned by Rust, queried by C++.
@@ -58,6 +60,7 @@ impl PlatformRs {
             bridge,
             device_registry,
             report,
+            libinput: None,
             state: None,
             running: Arc::new(AtomicBool::new(false)),
             known_devnums: HashSet::new(),
@@ -77,19 +80,19 @@ impl PlatformRs {
     /// Returns `true` if a fresh context was created, `false` if the platform
     /// was already started.
     pub fn start(&mut self) -> bool {
-        if self.state.is_some() {
+        if self.state.is_some() || self.libinput.is_some() {
             return false;
         }
 
         println!("Starting the evdev-rs platform");
 
-        let libinput =
-            input::Libinput::new_from_path(crate::libinput_interface::LibinputInterfaceImpl {
+        self.libinput = Some(input::Libinput::new_from_path(
+            crate::libinput_interface::LibinputInterfaceImpl {
                 fd_store: self.fd_store.clone(),
-            });
+            },
+        ));
 
         self.state = Some(Arc::new(Mutex::new(LibinputDeviceState {
-            libinput,
             known_devices: Vec::new(),
             next_device_id: 0,
             scroll_state: ScrollState {
@@ -123,19 +126,11 @@ impl PlatformRs {
     /// the bridge's pending-fd map. libinput will call `open_restricted()`,
     /// which retrieves the pre-acquired fd non-blockingly via `claim_pending_fd`.
     pub fn path_add_device(&mut self, devnode: &str) {
-        let Some(state_arc) = self.state.as_mut() else {
-            println!("PlatformRs::path_add_device: platform not started");
+        let Some(libinput) = self.libinput.as_mut() else {
             return;
         };
-        match state_arc.lock() {
-            Ok(mut state) => {
-                println!("evdev-rs: libinput path_add_device({})", devnode);
-                state.libinput.path_add_device(devnode);
-            }
-            Err(_) => {
-                println!("PlatformRs::path_add_device: state mutex poisoned");
-            }
-        }
+        println!("evdev-rs: libinput path_add_device({})", devnode);
+        libinput.path_add_device(devnode);
     }
 
     /// Remove a device from the libinput context by path.
@@ -144,6 +139,9 @@ impl PlatformRs {
     /// removed (hotplug disconnect).
     pub fn path_remove_device(&mut self, devnode: &str) {
         let Some(state_arc) = self.state.as_mut() else {
+            return;
+        };
+        let Some(libinput) = self.libinput.as_mut() else {
             return;
         };
         match state_arc.lock() {
@@ -164,7 +162,7 @@ impl PlatformRs {
                     devnode
                 );
                 let device_info = state.known_devices.swap_remove(index);
-                state.libinput.path_remove_device(device_info.device);
+                libinput.path_remove_device(device_info.device);
 
                 let input_device = device_info.input_device.clone();
                 let registry = self.device_registry.clone();
@@ -182,13 +180,9 @@ impl PlatformRs {
     }
 
     pub unsafe fn libinput_fd(&mut self) -> i32 {
-        match self.state.as_mut() {
-            Some(state_arc) => match state_arc.lock() {
-                Ok(state) => state.libinput.as_raw_fd(),
-                Err(_) => -1,
-            },
-            None => -1,
-        }
+        self.libinput
+            .as_mut()
+            .map_or(-1, |libinput| libinput.as_raw_fd())
     }
 
     pub fn continue_after_config(&self) {}
@@ -207,6 +201,7 @@ impl PlatformRs {
         // code at that point. This results in a segfault.
         let Some(state_arc) = self.state.take() else {
             // Platform not started or already stopped.
+            self.libinput.take();
             return;
         };
 
@@ -249,6 +244,8 @@ impl PlatformRs {
                     .remove_device(input_device);
             }
         }
+
+        self.libinput.take();
     }
 
     pub fn create_input_device(&mut self, device_id: i32) -> Box<LibinputDevice> {
@@ -263,11 +260,6 @@ impl PlatformRs {
                 return Box::new(LibinputDevice {
                     device_id,
                     state: Arc::new(Mutex::new(LibinputDeviceState {
-                        libinput: input::Libinput::new_from_path(
-                            crate::libinput_interface::LibinputInterfaceImpl {
-                                fd_store: self.fd_store.clone(),
-                            },
-                        ),
                         known_devices: Vec::new(),
                         next_device_id: 0,
                         scroll_state: ScrollState {
@@ -290,12 +282,16 @@ impl PlatformRs {
     }
 
     pub fn process(&mut self) {
-        if self.state.is_none() {
+        let Some(libinput) = self.libinput.as_mut() else {
             return;
-        }
+        };
+        let Some(state_arc) = self.state.as_mut() else {
+            return;
+        };
 
-        if let Ok(mut state) = self.state.as_mut().unwrap().try_lock() {
+        if let Ok(mut state) = state_arc.try_lock() {
             process_libinput_events(
+                libinput,
                 &mut state,
                 self.device_registry.clone(),
                 self.bridge.clone(),

--- a/src/platforms/evdev-rs/src/udev_monitor.rs
+++ b/src/platforms/evdev-rs/src/udev_monitor.rs
@@ -15,7 +15,6 @@
  */
 
 use std::os::fd::AsRawFd;
-use udev;
 
 /// Type of udev device event.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_builder.rs
@@ -123,7 +123,7 @@ impl CppBuilder {
                         ));
                     }
                     result.push_str("    };\n");
-                    result.push_str("\n");
+                    result.push('\n');
                 }
 
                 // Virtual destructor
@@ -200,7 +200,7 @@ impl CppBuilder {
                             ctor_args_str.join(", "),
                             initialiser_list.join(", ")
                         ));
-                        result.push_str("\n");
+                        result.push('\n');
                     }
 
                     for member in &class.protected_members {
@@ -213,7 +213,7 @@ impl CppBuilder {
                         ));
                     }
 
-                    result.push_str("\n");
+                    result.push('\n');
                 }
 
                 result.push_str("private:\n");
@@ -362,17 +362,15 @@ impl CppBuilder {
                         Some(quote! {
                             pub fn #method_name(self: Pin<&mut #class_name>, #(#args),*) -> #retval;
                         })
-                    } else {
-                        if method.throws {
-                            Some(quote! {
-                                pub fn #method_name(self: Pin<&mut #class_name>, #(#args),*) -> Result<()>;
-                            })
-                        }
-                        else {
-                            Some(quote! {
-                                pub fn #method_name(self: Pin<&mut #class_name>, #(#args),*);
-                            })
-                        }
+                    } else if method.throws {
+                        Some(quote! {
+                            pub fn #method_name(self: Pin<&mut #class_name>, #(#args),*) -> Result<()>;
+                        })
+                    }
+                    else {
+                        Some(quote! {
+                            pub fn #method_name(self: Pin<&mut #class_name>, #(#args),*);
+                        })
                     }
                 });
                 tokens.push(quote! {
@@ -548,7 +546,7 @@ impl CppEnumOption {
     pub fn new(name: impl Into<String>, value: u32) -> CppEnumOption {
         CppEnumOption {
             name: sanitize_identifier(&name.into()),
-            value: value,
+            value,
         }
     }
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -334,7 +334,7 @@ fn create_cpp_builder(
         .interfaces
         .iter()
         .filter(|interface| interface.name != "wl_registry" && interface.name != "wl_display")
-        .map(|interface| wayland_interface_to_cpp_class(interface));
+        .map(wayland_interface_to_cpp_class);
 
     for class in classes {
         namespace.add_class(class);
@@ -719,7 +719,7 @@ fn wayland_request_to_cpp_method(method: &WaylandRequest) -> Vec<CppMethod> {
     let return_prefix = if has_retval { "return " } else { "" };
     let mut all_delegation_args: Vec<String> = cpp_args
         .iter()
-        .map(|arg| delegation_argument_expression(arg))
+        .map(delegation_argument_expression)
         .collect();
 
     // Forward child_instance and child_object_id to the virtual method

--- a/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/cpp_protocol_generation.rs
@@ -47,7 +47,7 @@ pub struct CppProtocolGenerationOutput {
 /// - An output global binder builder
 /// - An FFI forward-declaration builder
 pub fn generate_cpp_protocol_builders(
-    protocols: &Vec<WaylandProtocol>,
+    protocols: &[WaylandProtocol],
 ) -> CppProtocolGenerationOutput {
     let global_builder = create_global_factory(protocols);
     let wayland_server_notification_handler_builder = create_wayland_server_notification_handler();
@@ -78,7 +78,7 @@ pub fn generate_cpp_protocol_builders(
     }
 }
 
-fn create_global_factory(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
+fn create_global_factory(protocols: &[WaylandProtocol]) -> CppBuilder {
     let mut builder: CppBuilder = CppBuilder::new("MIR_WAYLANDRS_GLOBALS", "global_factory");
     builder.add_header_include("<memory>");
     builder.add_header_include("<rust/cxx.h>");
@@ -288,7 +288,7 @@ fn create_output_global_binder() -> CppBuilder {
 /// Plain `struct Foo;` forward declarations are sufficient because rust::Box<T>
 /// only stores a T* internally and does not require T to be a complete type at
 /// the point of a virtual function declaration.
-fn create_ffi_fwd_builder(protocols: &Vec<WaylandProtocol>) -> CppBuilder {
+fn create_ffi_fwd_builder(protocols: &[WaylandProtocol]) -> CppBuilder {
     let mut builder = CppBuilder::new("MIR_WAYLANDRS_FFI_FWD", "ffi_fwd");
     // <rust/cxx.h> is included here so that protocol headers pulling in ffi_fwd.h
     // have access to rust::Box, rust::String, etc. without a direct dependency on ffi.rs.h.
@@ -386,7 +386,7 @@ fn create_cpp_builder(
 /// Collect the names of interfaces that are created server-side and returned to the client
 /// through an event carrying a `new_id` argument (e.g. `wl_buffer`). `wl_display` and
 /// `wl_registry` are excluded as they are never created this way.
-fn collect_event_created_interfaces(protocols: &Vec<WaylandProtocol>) -> Vec<String> {
+fn collect_event_created_interfaces(protocols: &[WaylandProtocol]) -> Vec<String> {
     let mut seen: Vec<String> = Vec::new();
     for protocol in protocols {
         for interface in &protocol.interfaces {

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -36,7 +36,7 @@ pub fn generate_dispatch_rs(protocols: &[WaylandProtocol]) -> TokenStream {
     let output_dynamic_global = generate_output_dynamic_global(protocols);
 
     quote! {
-        #[allow(dead_code, unused_imports)]
+        #[allow(dead_code, unused_imports, clippy::all)]
         mod dispatch {
             use wayland_server::{Client, DataInit, Dispatch, GlobalDispatch, New, DisplayHandle, Resource};
             use wayland_server::backend::{ClientId, ObjectId};

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -719,10 +719,10 @@ fn generate_dispatch_impl(
 
     // This snippet checks if the interface has any requests at all. If not, then data
     // will be prefixed with an underscore.
-    let interface_has_requests = interface.items.iter().any(|item| match item {
-        InterfaceItem::Request(_) => true,
-        _ => false,
-    });
+    let interface_has_requests = interface
+        .items
+        .iter()
+        .any(|item| matches!(item, InterfaceItem::Request(_)));
 
     let data_name = format_ident!(
         "{}",

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -27,7 +27,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::Ident;
 
-pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
+pub fn generate_dispatch_rs(protocols: &[WaylandProtocol]) -> TokenStream {
     let generated_dispatch_implementations =
         protocols.iter().map(generate_dispatch_implementations);
 
@@ -165,7 +165,7 @@ pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
 /// The binder is stored behind a `Mutex` because `GlobalDispatch::bind` and
 /// `can_view` only receive a shared reference to the global data, yet the C++
 /// binder methods (like the factory's) require a `Pin<&mut _>` to be invoked.
-fn generate_output_dynamic_global(protocols: &Vec<WaylandProtocol>) -> TokenStream {
+fn generate_output_dynamic_global(protocols: &[WaylandProtocol]) -> TokenStream {
     let (protocol, interface) = protocols
         .iter()
         .find_map(|protocol| {
@@ -223,7 +223,7 @@ fn generate_output_dynamic_global(protocols: &Vec<WaylandProtocol>) -> TokenStre
 /// * `set_<interface>_inner` — stores the fully constructed C++ object into the
 ///   resource's wrapper so subsequent requests route to it (and its lifetime is
 ///   tied to the resource), mirroring the request-driven `new_id` path.
-fn generate_server_side_factories(protocols: &Vec<WaylandProtocol>) -> TokenStream {
+fn generate_server_side_factories(protocols: &[WaylandProtocol]) -> TokenStream {
     let mut seen: Vec<String> = Vec::new();
     let mut factories: Vec<TokenStream> = Vec::new();
 
@@ -259,7 +259,7 @@ fn generate_server_side_factories(protocols: &Vec<WaylandProtocol>) -> TokenStre
 }
 
 /// Resolve the fully-qualified Rust path of the resource type for `interface_name`.
-fn resolve_resource_path(protocols: &Vec<WaylandProtocol>, interface_name: &str) -> TokenStream {
+fn resolve_resource_path(protocols: &[WaylandProtocol], interface_name: &str) -> TokenStream {
     let namespace = protocols
         .iter()
         .find(|protocol| {
@@ -279,7 +279,7 @@ fn resolve_resource_path(protocols: &Vec<WaylandProtocol>, interface_name: &str)
 /// Generate the `create_<interface>` / `set_<interface>_inner` helper pair for a
 /// single server-created interface.
 fn generate_server_side_factory(
-    protocols: &Vec<WaylandProtocol>,
+    protocols: &[WaylandProtocol],
     interface_name: &str,
 ) -> TokenStream {
     let create_fn = format_ident!("allocate_{}", dash_to_snake(interface_name));

--- a/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/dispatch_generator.rs
@@ -28,9 +28,8 @@ use quote::{format_ident, quote};
 use syn::Ident;
 
 pub fn generate_dispatch_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
-    let generated_dispatch_implementations = protocols
-        .iter()
-        .map(|protocol| generate_dispatch_implementations(protocol));
+    let generated_dispatch_implementations =
+        protocols.iter().map(generate_dispatch_implementations);
 
     let server_side_factories = generate_server_side_factories(protocols);
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -34,7 +34,7 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
 
     // Next, generate the Rust -> C++ side.
     let cpp_tokens: Vec<TokenStream> = builders
-        .into_iter()
+        .iter()
         .flat_map(|builder: &CppBuilder| builder.to_rust_cpp_bindings())
         .collect();
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -46,7 +46,7 @@ pub fn generate_ffi(protocols: &[WaylandProtocol], builders: &[CppBuilder]) -> T
         use crate::dispatch::*;
 
         #[cxx::bridge(namespace = "mir::wayland_rs")]
-        #[allow(dead_code, unused_imports)]
+        #[allow(dead_code, unused_imports, clippy::all)]
         mod ffi {
             extern "Rust" {
                 type WaylandServer;

--- a/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/ffi_generation.rs
@@ -24,7 +24,7 @@ use quote::{format_ident, quote};
 //
 // This includes Rust -> C++ with the help of the provided builders
 // and C++ -> Rust.
-pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>) -> TokenStream {
+pub fn generate_ffi(protocols: &[WaylandProtocol], builders: &[CppBuilder]) -> TokenStream {
     // First, generate the C++ -> Rust FFI code.
     let rust_tokens = protocols.iter().flat_map(generate_ffi_for_protocol);
 
@@ -91,7 +91,7 @@ pub fn generate_ffi(protocols: &Vec<WaylandProtocol>, builders: &Vec<CppBuilder>
 /// For every interface used as the `new_id` of an event we expose:
 /// * `allocate_<interface>(client, version) -> Box<Middleware>` and
 /// * `set_<interface>_inner(instance, object)`.
-fn generate_server_side_factory_ffi_decls(protocols: &Vec<WaylandProtocol>) -> Vec<TokenStream> {
+fn generate_server_side_factory_ffi_decls(protocols: &[WaylandProtocol]) -> Vec<TokenStream> {
     let mut seen: Vec<String> = Vec::new();
     let mut decls: Vec<TokenStream> = Vec::new();
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/helpers.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/helpers.rs
@@ -24,7 +24,7 @@ pub fn write_generated_rust_file(tokens: TokenStream, filename: &str) {
 pub fn write_generated_cpp_file(content: &str, out_dir: &str, filename: &str) {
     let dest_path = std::path::Path::new(&out_dir).join(filename);
 
-    fs::create_dir_all(&out_dir).unwrap();
+    fs::create_dir_all(out_dir).unwrap();
     fs::write(dest_path, content).unwrap();
 }
 
@@ -84,7 +84,7 @@ fn strip_wayland_interface_prefix(s: &str) -> &str {
 /// provides its C++ implementation.
 pub fn format_wayland_interface_to_cpp_class(s: &str) -> String {
     let s = strip_wayland_interface_prefix(s);
-    format!("{}", snake_to_pascal(s))
+    snake_to_pascal(s).to_string()
 }
 
 /// Formats the Wayland interface name to the name of the struct that

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -101,11 +101,11 @@ fn write_cpp_protocol_implementations(protocols: &Vec<WaylandProtocol>) {
 
     // Write the protocol headers
     for builder in &output.builders {
-        write_cpp_header(&builder);
-        write_cpp_source(&builder);
+        write_cpp_header(builder);
+        write_cpp_source(builder);
     }
 
-    let ffi = generate_ffi(&protocols, &output.builders);
+    let ffi = generate_ffi(protocols, &output.builders);
     write_generated_rust_file(ffi, "ffi.rs");
 }
 
@@ -130,6 +130,6 @@ fn write_cpp_source(builder: &CppBuilder) {
 }
 
 fn write_wayland_server_generated(protocols: &Vec<WaylandProtocol>) {
-    let tokens = generate_wayland_server_generated_rs(&protocols);
+    let tokens = generate_wayland_server_generated_rs(protocols);
     write_generated_rust_file(tokens, "wayland_server_generated.rs");
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -76,23 +76,23 @@ fn main() {
         .compile("wayland_rs");
 }
 
-fn write_protocols_rs(protocols: &Vec<WaylandProtocol>) {
+fn write_protocols_rs(protocols: &[WaylandProtocol]) {
     let tokens = generate_protocols_rs(protocols);
     write_generated_rust_file(tokens, "protocols.rs");
 }
 
-fn write_dispatch_rs(protocols: &Vec<WaylandProtocol>) {
+fn write_dispatch_rs(protocols: &[WaylandProtocol]) {
     let tokens = generate_dispatch_rs(protocols);
     write_generated_rust_file(tokens, "dispatch.rs");
 }
 
-fn write_protocol_middleware(protocols: &Vec<WaylandProtocol>) {
+fn write_protocol_middleware(protocols: &[WaylandProtocol]) {
     let middleware = generate_wayland_interface_middleware(protocols);
     write_generated_rust_file(middleware, "middleware.rs");
 }
 
 /// Write a header file for each protocol containing abstract classes per-interface.
-fn write_cpp_protocol_implementations(protocols: &Vec<WaylandProtocol>) {
+fn write_cpp_protocol_implementations(protocols: &[WaylandProtocol]) {
     let output = generate_cpp_protocol_builders(protocols);
 
     // Generate ffi_fwd.h first so that protocol headers can include it without
@@ -129,7 +129,7 @@ fn write_cpp_source(builder: &CppBuilder) {
     );
 }
 
-fn write_wayland_server_generated(protocols: &Vec<WaylandProtocol>) {
+fn write_wayland_server_generated(protocols: &[WaylandProtocol]) {
     let tokens = generate_wayland_server_generated_rs(protocols);
     write_generated_rust_file(tokens, "wayland_server_generated.rs");
 }

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_generator.rs
@@ -19,7 +19,7 @@ use crate::protocol_parser::WaylandProtocol;
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn generate_protocols_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
+pub fn generate_protocols_rs(protocols: &[WaylandProtocol]) -> TokenStream {
     let generated_protocols = protocols.iter().map(|protocol| {
         // We rely on the wayland_server crate for the core Wayland protocol.
         if protocol.name == "wayland" {

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_generator.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_generator.rs
@@ -112,7 +112,7 @@ pub fn generate_protocols_rs(protocols: &[WaylandProtocol]) -> TokenStream {
     });
 
     quote! {
-        #[allow(dead_code, unused_imports)]
+        #[allow(dead_code, unused_imports, clippy::all)]
         mod protocols {
             use wayland_server;
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
@@ -107,7 +107,7 @@ fn generate_enum_fallback_impls(protocols: &[WaylandProtocol]) -> TokenStream {
     }
 }
 
-pub fn generate_wayland_interface_middleware(protocols: &Vec<WaylandProtocol>) -> TokenStream {
+pub fn generate_wayland_interface_middleware(protocols: &[WaylandProtocol]) -> TokenStream {
     // First, generate the imports.
     let use_imports: Vec<TokenStream> = protocols
         .iter()

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_middleware_generation.rs
@@ -125,7 +125,7 @@ pub fn generate_wayland_interface_middleware(protocols: &[WaylandProtocol]) -> T
     let extensions = protocols.iter().flat_map(generate_extensions_for_protocol);
 
     quote! {
-        #[allow(dead_code, unused_imports)]
+        #[allow(dead_code, unused_imports, clippy::all)]
         mod middleware {
             use crate::wayland_server_core::*;
             use wayland_server::protocol::*;

--- a/src/server/frontend_wayland/wayland_rs/build_script/protocol_parser.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/protocol_parser.rs
@@ -279,23 +279,20 @@ pub fn parse_protocols() -> Vec<WaylandProtocol> {
                 let mut is_global = true;
                 for other_interface in &protocol.interfaces {
                     for item in &other_interface.items {
-                        match item {
-                            InterfaceItem::Request(req) => {
-                                for arg in &req.args {
-                                    if let Some(interface_name) = &arg.interface {
-                                        if interface_name == &interface.name
-                                            && arg.type_ == WaylandArgType::NewId
-                                        {
-                                            is_global = false;
-                                            break;
-                                        }
+                        if let InterfaceItem::Request(req) = item {
+                            for arg in &req.args {
+                                if let Some(interface_name) = &arg.interface {
+                                    if interface_name == &interface.name
+                                        && arg.type_ == WaylandArgType::NewId
+                                    {
+                                        is_global = false;
+                                        break;
                                     }
                                 }
                             }
-                            _ => {}
                         }
 
-                        if is_global == false {
+                        if !is_global {
                             break;
                         }
                     }

--- a/src/server/frontend_wayland/wayland_rs/build_script/wayland_server_generation.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/wayland_server_generation.rs
@@ -12,7 +12,7 @@ use quote::{format_ident, quote};
 /// At the moment this includes:
 ///
 /// - The global registration method.
-pub fn generate_wayland_server_generated_rs(protocols: &Vec<WaylandProtocol>) -> TokenStream {
+pub fn generate_wayland_server_generated_rs(protocols: &[WaylandProtocol]) -> TokenStream {
     let registration_impls = protocols.iter().flat_map(generate_register_globals_impl);
 
     quote! {

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_client.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_client.rs
@@ -119,7 +119,7 @@ impl WaylandClientId {
     }
 
     /// Check if this id is the same as the other id.
-    pub fn equals(&self, id: &Box<WaylandClientId>) -> bool {
+    pub fn equals(&self, id: &WaylandClientId) -> bool {
         self.id == id.id
     }
 }

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_client.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_client.rs
@@ -119,7 +119,8 @@ impl WaylandClientId {
     }
 
     /// Check if this id is the same as the other id.
-    pub fn equals(&self, id: &WaylandClientId) -> bool {
+    #[expect(clippy::borrowed_box, reason = "opaque type for FFI")]
+    pub fn equals(&self, id: &Box<WaylandClientId>) -> bool {
         self.id == id.id
     }
 }

--- a/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
+++ b/src/server/frontend_wayland/wayland_rs/src/wayland_server_core.rs
@@ -22,7 +22,6 @@ use calloop::{
     EventLoop, Interest, LoopHandle, Mode, PostAction, RegistrationToken,
 };
 use cxx::UniquePtr;
-use log;
 use std::error;
 use std::option::Option;
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
@@ -157,12 +156,10 @@ impl WaylandServer {
         loop_handle.insert_source(
             Generic::new(listener, Interest::READ, Mode::Level),
             move |_, listener, state: &mut ServerState| {
-                if let Ok(stream) = listener.accept() {
-                    if let Some(stream) = stream {
-                        // Insert the client into the display. This registers the
-                        // client's socket with the Display's internal backend.
-                        WaylandServer::insert_stream_client(state, &listener_disconnect_tx, stream);
-                    }
+                if let Ok(Some(stream)) = listener.accept() {
+                    // Insert the client into the display. This registers the
+                    // client's socket with the Display's internal backend.
+                    WaylandServer::insert_stream_client(state, &listener_disconnect_tx, stream);
                 }
                 Ok(PostAction::Continue)
             },


### PR DESCRIPTION
Closes #4947 (pre-commit configuration taken from here)

## What's new?

- Pull in changes from f37eb3b (pulling `input::Libinput` out of `LibinputDeviceState` so that it's `Send + Sync`
- Inspired changes from c054a63 (creation of `LibinputHandle<T>` to wrap `input::Event` and `input::Device` in order to assert that they're `Sync + Sync`
- `#[allow(clippy::all)]` in generated code

## How to test

CI passes

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
