### PR TITLE
get tics clippy working

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -102,7 +102,8 @@ jobs:
           ninja-build \
           pylint \
           rust-clippy \
-          xwayland
+          xwayland \
+          libudev-dev
 
         sudo --preserve-env apt-get build-dep --yes ./
 

--- a/src/server/frontend_wayland/wayland_rs/build_script/main.rs
+++ b/src/server/frontend_wayland/wayland_rs/build_script/main.rs
@@ -38,6 +38,7 @@ use crate::wayland_server_generation::generate_wayland_server_generated_rs;
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    #[cfg_attr(clippy, expect(unused_variables))]
     let include_path = Path::new(&manifest_dir).join(".");
 
     println!("cargo:rerun-if-changed=src/lib.rs");
@@ -71,6 +72,7 @@ fn main() {
     // Finally, declare the bridges.
     // This must happen last because `src/ffi.rs` is built by this script and
     // it may not exist before the build is run.
+    #[cfg(not(clippy))]
     cxx_build::bridges(vec!["src/ffi.rs"])
         .include(&include_path)
         .compile("wayland_rs");


### PR DESCRIPTION
TICs seems to be dying in some of my PRs (#5193, #5199), seemingly as a result of switching to workshop for tics in #5162.

It was initially failing due to missing `libudev-dev` in the action, and afterwards the `wayland_rs` build script was failing when invoking the `cxx::build` stage.

This all occurs as clippy still has to build the project (and all dependencies) to perform linting (as some lints rely on the AST, type checking, etc). This means that all build scripts are executed, and since clippy (via the TICs runner) is executed outside the workshop, all of the dev dependencies are missing.

For this fix, I just installed `libudev-dev` in the action, and conditionally compile the `cxx::build` call in the build script if it's being driven by clippy. An alternate option would be to get tics to execute clippy within workshop, not sure if this is possible however.

## How to test

tics green

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
