### PR TITLE
miral: Clean up and integrate magnifier code with layout API

### DIFF
--- a/include/miral/miral/magnifier.h
+++ b/include/miral/miral/magnifier.h
@@ -27,8 +27,9 @@ namespace miral
 namespace live_config { class Store; }
 
 /// Renders a magnified region of the scene at the cursor position.
-/// By default, the magnifier will magnify a 400x300 region below
-/// the cursor by a 2x magnitude.
+/// By default, the magnifier captures a 300x300 region centred on the cursor
+/// and displays it at 1.5x, producing a 450x450 visual area. Changing the
+/// magnification preserves the visual area and adjusts the captured region.
 /// \remark Since MirAL 5.5
 class Magnifier
 {

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -17,9 +17,6 @@
 #include "render_scene_into_surface.h"
 #include <miral/magnifier.h>
 
-#include <input-method-unstable-v2_wrapper.h>
-#include <wayland_wrapper.h>
-
 #include <miral/live_config.h>
 #include <mir/log.h>
 #include <mir/server.h>

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -53,17 +53,6 @@ auto const max_magnification = 8.0f;
 
 struct State
 {
-    void apply_geometry(mml::Placement const& new_placement)
-    {
-        render_scene_into_surface.capture_area(new_placement.capture_area);
-
-        if (auto const surf = surface.lock())
-        {
-            surf->move_to(new_placement.capture_area.top_left);
-            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
-        }
-    }
-
     auto has_outputs() const -> bool { return screen_bounds.size() != 0; }
 
     std::weak_ptr<ms::Surface> surface;
@@ -74,7 +63,6 @@ struct State
         default_capture_width * static_cast<double>(default_magnification),
         default_capture_height * static_cast<double>(default_magnification)};
     bool default_enabled{false};
-    miral::RenderSceneIntoSurface render_scene_into_surface;
 };
 }
 
@@ -83,16 +71,14 @@ class miral::Magnifier::Self
 public:
     Self()
     {
-        state.lock()
-            ->render_scene_into_surface
+        render_scene_into_surface
             .capture_area(geom::Rectangle{{300, 300}, geom::Size(default_capture_width, default_capture_height)})
             .overlay_cursor(false);
     }
 
     void init(mir::Server& server)
     {
-        auto const s = state.lock();
-        s->render_scene_into_surface.on_surface_ready(
+        render_scene_into_surface.on_surface_ready(
             [this](auto const& surf)
             {
                 auto s = state.lock();
@@ -109,7 +95,7 @@ public:
                 s->surface = surf;
             });
 
-        s->render_scene_into_surface(server);
+        render_scene_into_surface(server);
 
         server.add_init_callback(
             [&]
@@ -170,8 +156,8 @@ public:
     {
         auto s = state.lock();
         s->requested_visual_size = geom::SizeD{size} * s->magnification;
-        auto const capture_top_left = s->render_scene_into_surface.capture_area().top_left;
-        s->render_scene_into_surface.capture_area({capture_top_left, size});
+        auto const capture_top_left = render_scene_into_surface.capture_area().top_left;
+        render_scene_into_surface.capture_area({capture_top_left, size});
 
         if (!s->surface.lock())
             return;
@@ -179,7 +165,7 @@ public:
         place_at_cursor(*s);
     }
 
-    geom::Size current_size() const { return state.lock()->render_scene_into_surface.capture_area().size; }
+    geom::Size current_size() const { return render_scene_into_surface.capture_area().size; }
 
 private:
     class DisplayConfigObserver : public mg::NullDisplayConfigurationObserver
@@ -198,6 +184,20 @@ private:
         Self& self;
     };
 
+    void apply_geometry(
+        mml::Placement const& new_placement,
+        miral::RenderSceneIntoSurface& render_scene_into_surface,
+        State& state)
+    {
+        render_scene_into_surface.capture_area(new_placement.capture_area);
+
+        if (auto const surf = state.surface.lock())
+        {
+            surf->move_to(new_placement.capture_area.top_left);
+            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(state.magnification, state.magnification, 1)));
+        }
+    }
+
     /// Applies visual geometry with the magnifier's logical top-left computed
     /// from its current visual size so the surface is centred on the cursor.
     void place_at_cursor(State& s)
@@ -205,12 +205,13 @@ private:
         if (!s.has_outputs())
             return;
 
-        s.apply_geometry(
-            mml::place_following_cursor(
-                geom::PointD{s.cursor_pos},
-                s.requested_visual_size,
-                s.screen_bounds,
-                s.magnification));
+        auto const new_placement = mml::place_following_cursor(
+            geom::PointD{s.cursor_pos}, s.requested_visual_size, s.screen_bounds, s.magnification);
+
+        apply_geometry(
+            new_placement,
+            render_scene_into_surface,
+            s);
     }
 
     class CursorObserver : public mi::CursorObserver
@@ -239,6 +240,7 @@ private:
     };
 
     mir::Synchronised<State> state;
+    miral::RenderSceneIntoSurface render_scene_into_surface;
     std::shared_ptr<CursorObserver> cursor_observer;
     std::shared_ptr<DisplayConfigObserver> display_config_observer;
 };

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -100,7 +100,16 @@ public:
         server.add_init_callback(
             [&]
             {
-                server.the_main_loop()->spawn([=, this, &server] { this->post_init(server); });
+                cursor_observer = std::make_shared<CursorObserver>(this);
+                server.the_cursor_observer_multiplexer()->register_interest(cursor_observer);
+
+                display_config_observer = std::make_shared<DisplayConfigObserver>(*this);
+                server.the_display_configuration_observer_registrar()->register_interest(display_config_observer);
+
+                auto s = state.lock();
+
+                if (auto const surf = s->surface.lock(); surf && s->default_enabled)
+                    place_at_cursor(*s);
             });
 
         server.add_stop_callback(
@@ -115,19 +124,6 @@ public:
             });
     }
 
-    void post_init(mir::Server& server)
-    {
-        cursor_observer = std::make_shared<CursorObserver>(this);
-        server.the_cursor_observer_multiplexer()->register_interest(cursor_observer);
-
-        display_config_observer = std::make_shared<DisplayConfigObserver>(*this);
-        server.the_display_configuration_observer_registrar()->register_interest(display_config_observer);
-
-        auto s = state.lock();
-
-        if (auto const surf = s->surface.lock(); surf && s->default_enabled)
-            place_at_cursor(*s);
-    }
 
     void set_enable(bool enable)
     {

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -14,16 +14,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "render_scene_into_surface.h"
 #include <miral/magnifier.h>
 
+#include "magnifier_layout.h"
+#include "render_scene_into_surface.h"
 #include <miral/live_config.h>
 #include <mir/log.h>
 #include <mir/server.h>
 #include <mir/synchronised.h>
+#include <mir/graphics/display_configuration.h>
+#include <mir/graphics/display_configuration_observer.h>
+#include <mir/graphics/null_display_configuration_observer.h>
+#include <mir/geometry/rectangles.h>
 #include <mir/input/cursor_observer.h>
 #include <mir/input/cursor_observer_multiplexer.h>
 #include <mir/scene/surface.h>
+#include <mir/observer_registrar.h>
+#include <mir/main_loop.h>
 
 #include <algorithm>
 #include <glm/gtc/matrix_transform.hpp>
@@ -32,6 +39,7 @@ namespace mi = mir::input;
 namespace ms = mir::scene;
 namespace geom = mir::geometry;
 namespace mg = mir::graphics;
+namespace mml = miral::magnifier_layout;
 
 namespace
 {
@@ -45,9 +53,26 @@ auto const max_magnification = 8.0f;
 
 struct State
 {
+    void apply_geometry(mml::Placement const& new_placement)
+    {
+        render_scene_into_surface.capture_area(new_placement.capture_area);
+
+        if (auto const surf = surface.lock())
+        {
+            surf->move_to(new_placement.capture_area.top_left);
+            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
+        }
+    }
+
+    auto has_outputs() const -> bool { return screen_bounds.size() != 0; }
+
     std::weak_ptr<ms::Surface> surface;
     geom::Point cursor_pos;
+    geom::Rectangles screen_bounds;
     float magnification{default_magnification};
+    geom::SizeD requested_visual_size{
+        default_capture_width * static_cast<double>(default_magnification),
+        default_capture_height * static_cast<double>(default_magnification)};
     bool default_enabled{false};
     miral::RenderSceneIntoSurface render_scene_into_surface;
 };
@@ -89,17 +114,33 @@ public:
         server.add_init_callback(
             [&]
             {
-                cursor_observer = std::make_shared<CursorObserver>(this);
-                server.the_cursor_observer_multiplexer()->register_interest(cursor_observer);
-                cursor_multiplexer = server.the_cursor_observer_multiplexer();
+                server.the_main_loop()->spawn([=, this, &server] { this->post_init(server); });
             });
 
         server.add_stop_callback(
             [&]
             {
-                if (auto const locked = cursor_multiplexer.lock())
-                    locked->unregister_interest(*cursor_observer);
+                if (cursor_observer)
+                    server.the_cursor_observer_multiplexer()->unregister_interest(*cursor_observer);
+
+                if (display_config_observer)
+                    server.the_display_configuration_observer_registrar()->unregister_interest(
+                        *display_config_observer);
             });
+    }
+
+    void post_init(mir::Server& server)
+    {
+        cursor_observer = std::make_shared<CursorObserver>(this);
+        server.the_cursor_observer_multiplexer()->register_interest(cursor_observer);
+
+        display_config_observer = std::make_shared<DisplayConfigObserver>(*this);
+        server.the_display_configuration_observer_registrar()->register_interest(display_config_observer);
+
+        auto s = state.lock();
+
+        if (auto const surf = s->surface.lock(); surf && s->default_enabled)
+            place_at_cursor(*s);
     }
 
     void set_enable(bool enable)
@@ -117,22 +158,59 @@ public:
 
     void set_magnification(float new_magnification)
     {
-        auto s = state.lock();
+        auto const s = state.lock();
         s->magnification = new_magnification;
-        if (auto const surf = s->surface.lock())
-            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(s->magnification, s->magnification, 1)));
+        if (!s->surface.lock() || !s->has_outputs())
+            return;
+
+        place_at_cursor(*s);
     }
 
     void set_capture_size(geom::Size const& size)
     {
         auto s = state.lock();
-        auto const capture_position = CursorObserver::cursor_position_to_capture_position(size, s->cursor_pos);
-        s->render_scene_into_surface.capture_area({capture_position, size});
+        s->requested_visual_size = geom::SizeD{size} * s->magnification;
+        auto const capture_top_left = s->render_scene_into_surface.capture_area().top_left;
+        s->render_scene_into_surface.capture_area({capture_top_left, size});
+
+        if (s->surface.lock() && s->has_outputs())
+            place_at_cursor(*s);
     }
 
     geom::Size current_size() const { return state.lock()->render_scene_into_surface.capture_area().size; }
 
 private:
+    class DisplayConfigObserver : public mg::NullDisplayConfigurationObserver
+    {
+    public:
+        DisplayConfigObserver(Self& self) : self{self} {}
+
+        void initial_configuration(std::shared_ptr<mg::DisplayConfiguration const> const& config) override
+        { update_bounds(config); }
+
+        void configuration_applied(std::shared_ptr<mg::DisplayConfiguration const> const& config) override
+        { update_bounds(config); }
+
+    private:
+        void update_bounds(std::shared_ptr<mg::DisplayConfiguration const> const& config);
+        Self& self;
+    };
+
+    /// Applies visual geometry with the magnifier's logical top-left computed
+    /// from its current visual size so the surface is centred on the cursor.
+    void place_at_cursor(State& s)
+    {
+        if (!s.has_outputs())
+            return;
+
+        s.apply_geometry(
+            mml::place_following_cursor(
+                geom::PointD{s.cursor_pos},
+                s.requested_visual_size,
+                s.screen_bounds,
+                s.magnification));
+    }
+
     class CursorObserver : public mi::CursorObserver
     {
     public:
@@ -142,41 +220,46 @@ private:
         {
             auto s = self->state.lock();
             s->cursor_pos = geom::Point{abs_x, abs_y};
+
             auto const surf = s->surface.lock();
             if (!surf)
                 return;
 
-            auto const capture_position = cursor_position_to_capture_position(
-                surf->window_size(),
-                s->cursor_pos);
-            surf->move_to(capture_position);
-            s->render_scene_into_surface.capture_area(
-                geom::Rectangle{capture_position, surf->window_size()});
+            self->place_at_cursor(*s);
         }
 
         void pointer_usable() override {}
         void pointer_unusable() override {}
         void image_set_to(std::shared_ptr<mg::CursorImage>) override {}
 
-        static geom::Point cursor_position_to_capture_position(
-            geom::Size const& window_size,
-            geom::Point const& cursor_pos)
-        {
-            return geom::Point{
-                cursor_pos.x.as_value() - window_size.width.as_value() / 2,
-                cursor_pos.y.as_value() - window_size.height.as_value() / 2
-            };
-        }
-
     private:
         Self* self;
     };
 
     mir::Synchronised<State> state;
-
     std::shared_ptr<CursorObserver> cursor_observer;
-    std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
+    std::shared_ptr<DisplayConfigObserver> display_config_observer;
 };
+
+void miral::Magnifier::Self::DisplayConfigObserver::update_bounds(
+    std::shared_ptr<mg::DisplayConfiguration const> const& config)
+{
+    geom::Rectangles rects;
+    config->for_each_output(
+        [&rects](mg::DisplayConfigurationOutput const& output)
+        {
+            if (output.used && output.connected)
+                rects.add(output.extents());
+        });
+
+    auto s = self.state.lock();
+    s->screen_bounds = rects;
+    if (!s->has_outputs())
+        return;
+
+    if (s->surface.lock())
+        self.place_at_cursor(*s);
+}
 
 miral::Magnifier::Magnifier()
     : self(std::make_shared<Self>())

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -24,6 +24,7 @@
 #include <mir/input/cursor_observer_multiplexer.h>
 #include <mir/scene/surface.h>
 
+#include <algorithm>
 #include <glm/gtc/matrix_transform.hpp>
 
 namespace mi = mir::input;
@@ -35,7 +36,11 @@ namespace
 {
 auto const default_capture_width = 300;
 auto const default_capture_height = 300;
+/// The lowest magnification that still reads as visibly magnified; below
+/// this the magnifier is hard to distinguish from the unmagnified scene.
+auto const min_magnification = 1.25f;
 auto const default_magnification = 1.5f;
+auto const max_magnification = 8.0f;
 }
 
 class miral::Magnifier::Self
@@ -189,18 +194,8 @@ miral::Magnifier::Magnifier(live_config::Store& config_store)
         {"magnifier", "magnification"},
         "The magnification scale ",
         default_magnification,
-        [this](live_config::Key const& key, std::optional<float> val)
-        {
-            if (val.has_value() && *val <= 1.f)
-            {
-                mir::log_warning(
-                    "Config key '%s' should be greater than or equal to 1",
-                    key.to_string().c_str());
-                return;
-            }
-
-            magnification(val.value_or(default_magnification));
-        });
+        [this](live_config::Key const&, std::optional<float> val)
+        { magnification(val.value_or(default_magnification)); });
     config_store.add_int_attribute(
         {"magnifier", "capture_size", "width"},
         "The width of the rectangular region that will be magnified",
@@ -253,14 +248,15 @@ miral::Magnifier& miral::Magnifier::enable(bool enabled)
 
 miral::Magnifier& miral::Magnifier::magnification(float magnification)
 {
-    if (magnification <= 1.f)
+    auto const clamped_magnification = std::clamp(magnification, min_magnification, max_magnification);
+    if (magnification != clamped_magnification)
     {
-        mir::log_warning(
-            "Magnification should be greater than or equal to 1");
+        mir::log_warning("Magnification should be between %.2f and %.2f", min_magnification, max_magnification);
+
         return *this;
     }
 
-    self->set_magnification(magnification);
+    self->set_magnification(clamped_magnification);
     return *this;
 }
 

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -20,6 +20,7 @@
 #include <miral/live_config.h>
 #include <mir/log.h>
 #include <mir/server.h>
+#include <mir/synchronised.h>
 #include <mir/input/cursor_observer.h>
 #include <mir/input/cursor_observer_multiplexer.h>
 #include <mir/scene/surface.h>
@@ -41,6 +42,15 @@ auto const default_capture_height = 300;
 auto const min_magnification = 1.25f;
 auto const default_magnification = 1.5f;
 auto const max_magnification = 8.0f;
+
+struct State
+{
+    std::weak_ptr<ms::Surface> surface;
+    geom::Point cursor_pos;
+    float magnification{default_magnification};
+    bool default_enabled{false};
+    miral::RenderSceneIntoSurface render_scene_into_surface;
+};
 }
 
 class miral::Magnifier::Self
@@ -48,50 +58,55 @@ class miral::Magnifier::Self
 public:
     Self()
     {
-        render_scene_into_surface
+        state.lock()
+            ->render_scene_into_surface
             .capture_area(geom::Rectangle{{300, 300}, geom::Size(default_capture_width, default_capture_height)})
             .overlay_cursor(false);
     }
 
     void init(mir::Server& server)
     {
-        render_scene_into_surface.on_surface_ready([this](auto const& surf)
-        {
-            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
-            surf->set_depth_layer(mir_depth_layer_always_on_top);
-            surf->set_focus_mode(mir_focus_mode_disabled);
+        auto const s = state.lock();
+        s->render_scene_into_surface.on_surface_ready(
+            [this](auto const& surf)
+            {
+                auto s = state.lock();
+                surf->set_transformation(
+                    glm::scale(glm::mat4(1.0), glm::vec3(s->magnification, s->magnification, 1)));
+                surf->set_depth_layer(mir_depth_layer_always_on_top);
+                surf->set_focus_mode(mir_focus_mode_disabled);
 
-            if (default_enabled)
-                surf->show();
-            else
-                surf->hide();
+                if (s->default_enabled)
+                    surf->show();
+                else
+                    surf->hide();
 
-            std::lock_guard lock(mutex);
-            surface = surf;
-        });
+                s->surface = surf;
+            });
 
-        render_scene_into_surface(server);
+        s->render_scene_into_surface(server);
 
-        server.add_init_callback([&]
-        {
-            observer = std::make_shared<Observer>(this);
-            server.the_cursor_observer_multiplexer()->register_interest(observer);
-            cursor_multiplexer = server.the_cursor_observer_multiplexer();
-        });
+        server.add_init_callback(
+            [&]
+            {
+                cursor_observer = std::make_shared<CursorObserver>(this);
+                server.the_cursor_observer_multiplexer()->register_interest(cursor_observer);
+                cursor_multiplexer = server.the_cursor_observer_multiplexer();
+            });
 
-        server.add_stop_callback([&]
-        {
-            std::lock_guard lock(mutex);
-            if (auto const locked = cursor_multiplexer.lock())
-                locked->unregister_interest(*observer);
-        });
+        server.add_stop_callback(
+            [&]
+            {
+                if (auto const locked = cursor_multiplexer.lock())
+                    locked->unregister_interest(*cursor_observer);
+            });
     }
 
     void set_enable(bool enable)
     {
-        std::lock_guard lock(mutex);
-        default_enabled = enable;
-        if (auto const surf = surface.lock())
+        auto s = state.lock();
+        s->default_enabled = enable;
+        if (auto const surf = s->surface.lock())
         {
             if (enable)
                 surf->show();
@@ -102,43 +117,40 @@ public:
 
     void set_magnification(float new_magnification)
     {
-        std::lock_guard lock(mutex);
-        magnification = new_magnification;
-        if (auto const surf = surface.lock())
-            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(magnification, magnification, 1)));
+        auto s = state.lock();
+        s->magnification = new_magnification;
+        if (auto const surf = s->surface.lock())
+            surf->set_transformation(glm::scale(glm::mat4(1.0), glm::vec3(s->magnification, s->magnification, 1)));
     }
 
     void set_capture_size(geom::Size const& size)
     {
-        std::lock_guard lock(mutex);
-        auto const capture_position = Observer::cursor_position_to_capture_position(size, cursor_pos);
-        render_scene_into_surface.capture_area({ capture_position, size });
+        auto s = state.lock();
+        auto const capture_position = CursorObserver::cursor_position_to_capture_position(size, s->cursor_pos);
+        s->render_scene_into_surface.capture_area({capture_position, size});
     }
 
-    geom::Size current_size() const
-    {
-        return render_scene_into_surface.capture_area().size;
-    }
+    geom::Size current_size() const { return state.lock()->render_scene_into_surface.capture_area().size; }
 
 private:
-    class Observer : public mi::CursorObserver
+    class CursorObserver : public mi::CursorObserver
     {
     public:
-        explicit Observer(Self* self) : self(self) {}
+        explicit CursorObserver(Self* self) : self(self) {}
 
         void cursor_moved_to(float abs_x, float abs_y) override
         {
-            std::lock_guard lock(self->mutex);
-            self->cursor_pos = geom::Point{abs_x, abs_y};
-            auto const surf = self->surface.lock();
+            auto s = self->state.lock();
+            s->cursor_pos = geom::Point{abs_x, abs_y};
+            auto const surf = s->surface.lock();
             if (!surf)
                 return;
 
             auto const capture_position = cursor_position_to_capture_position(
                 surf->window_size(),
-                self->cursor_pos);
+                s->cursor_pos);
             surf->move_to(capture_position);
-            self->render_scene_into_surface.capture_area(
+            s->render_scene_into_surface.capture_area(
                 geom::Rectangle{capture_position, surf->window_size()});
         }
 
@@ -160,16 +172,10 @@ private:
         Self* self;
     };
 
-    friend Observer;
+    mir::Synchronised<State> state;
 
-    std::mutex mutex;
-    RenderSceneIntoSurface render_scene_into_surface;
+    std::shared_ptr<CursorObserver> cursor_observer;
     std::weak_ptr<mi::CursorObserverMultiplexer> cursor_multiplexer;
-    std::shared_ptr<Observer> observer;
-    std::weak_ptr<ms::Surface> surface;
-    geom::Point cursor_pos;
-    float magnification = default_magnification;
-    bool default_enabled = false;
 };
 
 miral::Magnifier::Magnifier()

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -33,8 +33,8 @@ namespace mg = mir::graphics;
 
 namespace
 {
-auto const default_capture_width = 150;
-auto const default_capture_height = 150;
+auto const default_capture_width = 300;
+auto const default_capture_height = 300;
 auto const default_magnification = 1.5f;
 }
 

--- a/src/miral/magnifier.cpp
+++ b/src/miral/magnifier.cpp
@@ -160,7 +160,7 @@ public:
     {
         auto const s = state.lock();
         s->magnification = new_magnification;
-        if (!s->surface.lock() || !s->has_outputs())
+        if (!s->surface.lock())
             return;
 
         place_at_cursor(*s);
@@ -173,8 +173,10 @@ public:
         auto const capture_top_left = s->render_scene_into_surface.capture_area().top_left;
         s->render_scene_into_surface.capture_area({capture_top_left, size});
 
-        if (s->surface.lock() && s->has_outputs())
-            place_at_cursor(*s);
+        if (!s->surface.lock())
+            return;
+
+        place_at_cursor(*s);
     }
 
     geom::Size current_size() const { return state.lock()->render_scene_into_surface.capture_area().size; }

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -42,22 +42,6 @@ using namespace testing;
 using namespace miral;
 using namespace std::chrono_literals;
 
-namespace
-{
-/// Raises a signal each time cursor_moved_to() fires. Used by cursor-tracking
-/// tests to wait for cursor events to propagate through the main loop before
-/// inspecting surface state.
-struct SentinelCursorObserver : public mi::CursorObserver
-{
-    void cursor_moved_to(float, float) override { signal.raise(); }
-    void pointer_usable() override {}
-    void pointer_unusable() override {}
-    void image_set_to(std::shared_ptr<mir::graphics::CursorImage>) override {}
-    mir::test::Signal signal;
-};
-
-}
-
 class MagnifierTest : public TestServer
 {
 public:
@@ -99,8 +83,20 @@ ASSERT_TRUE(flushed->wait_for(2s)) << "timed out waiting for " << context;
     /// has settled.
     void wait_for_initial_cursor_state()
     {
+        /// Raises a signal each time cursor_moved_to() fires. Used by cursor-tracking
+        /// tests to wait for cursor events to propagate through the main loop before
+        /// inspecting surface state.
+        struct CursorMovementObserver : public mi::CursorObserver
+        {
+            void cursor_moved_to(float, float) override { signal.raise(); }
+            void pointer_usable() override {}
+            void pointer_unusable() override {}
+            void image_set_to(std::shared_ptr<mir::graphics::CursorImage>) override {}
+            mir::test::Signal signal;
+        };
+
         auto const mux = server().the_cursor_observer_multiplexer();
-        auto const sentinel = std::make_shared<SentinelCursorObserver>();
+        auto const sentinel = std::make_shared<CursorMovementObserver>();
         mux->register_interest(sentinel);
         ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for initial cursor state";
         mux->unregister_interest(*sentinel);

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -31,6 +31,9 @@
 #include <gmock/gmock.h>
 #include <glm/gtc/matrix_transform.hpp>
 
+#include <limits>
+#include <string>
+
 namespace geom = mir::geometry;
 namespace mi = mir::input;
 namespace mtd = mir::test::doubles;
@@ -107,6 +110,19 @@ ASSERT_TRUE(flushed->wait_for(2s)) << "timed out waiting for " << context;
     Magnifier magnifier;
 };
 
+struct MagnificationTestCase
+{
+    char const* name;
+    float requested;
+    float expected;
+};
+
+class MagnificationTest :
+    public MagnifierTest,
+    public WithParamInterface<MagnificationTestCase>
+{
+};
+
 TEST_F(MagnifierTest, magnifier_disabled_by_default)
 {
     add_start_callback([&]
@@ -138,6 +154,38 @@ TEST_F(MagnifierTest, changing_magnification_preserves_visual_size)
     EXPECT_THAT(magnifier_renderable()->transformation(), Eq(expected));
     EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(225, 225)));
 }
+
+TEST_P(MagnificationTest, accepts_supported_and_rejects_unsupported_magnifications)
+{
+    magnifier.magnification(2.0f);
+    magnifier.enable(true);
+    start_server();
+    wait_for_magnifier_initialization();
+    wait_for_initial_cursor_state();
+
+    auto const& test_case = GetParam();
+    magnifier.magnification(test_case.requested);
+
+    auto const expected =
+        glm::scale(glm::mat4(1.0), glm::vec3(test_case.expected, test_case.expected, 1));
+    EXPECT_THAT(magnifier_renderable()->transformation(), Eq(expected));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SupportedRange,
+    MagnificationTest,
+    Values(
+        MagnificationTestCase{"minimum", 1.25f, 1.25f},
+        MagnificationTestCase{"maximum", 8.0f, 8.0f},
+        MagnificationTestCase{"below_minimum", 1.0f, 2.0f},
+        MagnificationTestCase{"above_maximum", 8.25f, 2.0f},
+        MagnificationTestCase{"negative_infinity", -std::numeric_limits<float>::infinity(), 2.0f},
+        MagnificationTestCase{"positive_infinity", std::numeric_limits<float>::infinity(), 2.0f},
+        MagnificationTestCase{"nan", std::numeric_limits<float>::quiet_NaN(), 2.0f}),
+    [](TestParamInfo<MagnificationTestCase> const& info)
+    {
+        return std::string{info.param.name};
+    });
 
 TEST_F(MagnifierTest, can_set_capture_size)
 {

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -66,7 +66,7 @@ public:
     /// Waits for work already queued on the main loop to complete. The display
     /// configuration observer multiplexer dispatches on the main loop, so this
     /// is what synchronises with the magnifier's DisplayConfigObserver.
-    void flush_main_loop(char const* context)
+    void flush_main_loop(std::string_view context)
     {
         auto flushed = std::make_shared<mir::test::Signal>();
         server().the_main_loop()->spawn([flushed] { flushed->raise(); });
@@ -108,7 +108,7 @@ public:
 
 struct MagnificationTestCase
 {
-    char const* name;
+    std::string_view name;
     float requested;
     float expected;
 };

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -223,8 +223,13 @@ TEST_F(MagnifierTest, reapplies_layout_after_outputs_are_restored)
     server().the_display_configuration_observer()->configuration_applied(no_outputs);
     flush_main_loop("display removal");
 
+    // Resize while no outputs are available, the requested size is saved, and
+    // the code exits early because placement cannot be done without any
+    // outputs. When an output is restored, the size previously saved is
+    // constrained.
     magnifier.capture_size(Size(1200, 1200));
     magnifier_renderable()->buffer();
+    EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(1200, 1200)));
 
     auto const restored_output = std::make_shared<mtd::StubDisplayConfig>(
         std::vector<geom::Rectangle>{{{0, 0}, {800, 600}}});

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -18,17 +18,42 @@
 #include <mir/server.h>
 #include <mir/compositor/scene.h>
 #include <mir/compositor/scene_element.h>
+#include <mir/graphics/display_configuration_observer.h>
 #include <mir/graphics/renderable.h>
+#include <mir/input/cursor_observer.h>
+#include <mir/input/cursor_observer_multiplexer.h>
+#include <mir/main_loop.h>
+#include <mir/test/doubles/stub_display_configuration.h>
+#include <mir/test/signal.h>
 
 #include <miral/test_server.h>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <glm/gtc/matrix_transform.hpp>
 
-namespace mtf = mir_test_framework;
+namespace geom = mir::geometry;
+namespace mi = mir::input;
+namespace mtd = mir::test::doubles;
 
 using namespace testing;
 using namespace miral;
+using namespace std::chrono_literals;
+
+namespace
+{
+/// Raises a signal each time cursor_moved_to() fires. Used by cursor-tracking
+/// tests to wait for cursor events to propagate through the main loop before
+/// inspecting surface state.
+struct SentinelCursorObserver : public mi::CursorObserver
+{
+    void cursor_moved_to(float, float) override { signal.raise(); }
+    void pointer_usable() override {}
+    void pointer_unusable() override {}
+    void image_set_to(std::shared_ptr<mir::graphics::CursorImage>) override {}
+    mir::test::Signal signal;
+};
+
+}
 
 class MagnifierTest : public TestServer
 {
@@ -46,6 +71,39 @@ public:
         add_server_init(magnifier);
     }
 
+    auto magnifier_renderable() const -> std::shared_ptr<mir::graphics::Renderable>
+    { return server().the_scene()->scene_elements_for(this).at(magnifier_index)->renderable(); }
+
+    auto scene_element_count() const -> size_t { return server().the_scene()->scene_elements_for(this).size(); }
+
+    /// Waits for work already queued on the main loop to complete. The display
+    /// configuration observer multiplexer dispatches on the main loop, so this
+    /// is what synchronises with the magnifier's DisplayConfigObserver.
+    void flush_main_loop(char const* context)
+    {
+        mir::test::Signal flushed;
+        server().the_main_loop()->spawn([&flushed] { flushed.raise(); });
+        ASSERT_TRUE(flushed.wait_for(2s)) << "timed out waiting for " << context;
+    }
+
+    void wait_for_magnifier_initialization()
+    {
+        flush_main_loop("magnifier initialization");
+    }
+
+    /// Registering interest replays the current cursor state, so waiting for
+    /// the sentinel's first signal is how a test knows the initial placement
+    /// has settled.
+    void wait_for_initial_cursor_state()
+    {
+        auto const mux = server().the_cursor_observer_multiplexer();
+        auto const sentinel = std::make_shared<SentinelCursorObserver>();
+        mux->register_interest(sentinel);
+        ASSERT_TRUE(sentinel->signal.wait_for(2s)) << "timed out waiting for initial cursor state";
+        mux->unregister_interest(*sentinel);
+    }
+
+    static constexpr auto magnifier_index = 0;
     Magnifier magnifier;
 };
 
@@ -53,9 +111,7 @@ TEST_F(MagnifierTest, magnifier_disabled_by_default)
 {
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(0));
+        EXPECT_THAT(scene_element_count(), Eq(0));
     });
     start_server();
 }
@@ -65,39 +121,70 @@ TEST_F(MagnifierTest, can_start_enabled)
     magnifier.enable(true);
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(1));
+        EXPECT_THAT(scene_element_count(), Eq(1));
     });
     start_server();
 }
 
-TEST_F(MagnifierTest, magnification_results_in_scaled_transform)
+TEST_F(MagnifierTest, changing_magnification_preserves_visual_size)
 {
     magnifier.magnification(2.f);
     magnifier.enable(true);
-    add_start_callback([&]
-    {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(1));
-        auto const expected = glm::scale(glm::mat4(1.0), glm::vec3(2, 2, 1));
-
-        EXPECT_THAT(elements.at(0)->renderable()->transformation(), Eq(expected));
-    });
     start_server();
+    wait_for_magnifier_initialization();
+    wait_for_initial_cursor_state();
+
+    auto const expected = glm::scale(glm::mat4(1.0), glm::vec3(2, 2, 1));
+    EXPECT_THAT(magnifier_renderable()->transformation(), Eq(expected));
+    EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(225, 225)));
 }
 
 TEST_F(MagnifierTest, can_set_capture_size)
 {
-    magnifier.capture_size(Size(500, 500));
+    magnifier.capture_size(Size(200, 200));
     magnifier.enable(true);
     add_start_callback([&]
     {
-        auto const scene = server().the_scene();
-        auto const elements = scene->scene_elements_for(this);
-        EXPECT_THAT(elements.size(), Eq(1));
-        EXPECT_THAT(elements.at(0)->renderable()->screen_position().size, Eq(Size(500, 500)));
+        EXPECT_THAT(scene_element_count(), Eq(1));
+        EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(200, 200)));
     });
     start_server();
+}
+
+TEST_F(MagnifierTest, capture_size_is_limited_to_80_percent_of_the_output)
+{
+    magnifier.enable(true);
+    start_server();
+
+    wait_for_initial_cursor_state();
+
+    magnifier.capture_size(Size(1000, 1000));
+    magnifier_renderable()->buffer();
+
+    auto const capture_size = magnifier_renderable()->screen_position().size;
+    EXPECT_THAT(capture_size.width, Lt(Width{1000}));
+    EXPECT_THAT(capture_size.height, Lt(Height{1000}));
+}
+
+TEST_F(MagnifierTest, reapplies_layout_after_outputs_are_restored)
+{
+    magnifier.capture_size(Size(1000, 1000)).enable(true);
+    start_server();
+    wait_for_magnifier_initialization();
+    wait_for_initial_cursor_state();
+
+    auto const no_outputs = std::make_shared<mtd::StubDisplayConfig>(std::vector<geom::Rectangle>{});
+    server().the_display_configuration_observer()->configuration_applied(no_outputs);
+    flush_main_loop("display removal");
+
+    magnifier.capture_size(Size(1200, 1200));
+    magnifier_renderable()->buffer();
+
+    auto const restored_output = std::make_shared<mtd::StubDisplayConfig>(
+        std::vector<geom::Rectangle>{{{0, 0}, {800, 600}}});
+    server().the_display_configuration_observer()->configuration_applied(restored_output);
+    flush_main_loop("display restoration");
+    magnifier_renderable()->buffer();
+
+    EXPECT_THAT(magnifier_renderable()->screen_position().size, Eq(Size(426, 320)));
 }

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -81,9 +81,9 @@ public:
     /// is what synchronises with the magnifier's DisplayConfigObserver.
     void flush_main_loop(char const* context)
     {
-        mir::test::Signal flushed;
-        server().the_main_loop()->spawn([&flushed] { flushed.raise(); });
-        ASSERT_TRUE(flushed.wait_for(2s)) << "timed out waiting for " << context;
+auto flushed = std::make_shared<mir::test::Signal>();
+server().the_main_loop()->spawn([flushed] { flushed->raise(); });
+ASSERT_TRUE(flushed->wait_for(2s)) << "timed out waiting for " << context;
     }
 
     void wait_for_magnifier_initialization()

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -68,9 +68,9 @@ public:
     /// is what synchronises with the magnifier's DisplayConfigObserver.
     void flush_main_loop(char const* context)
     {
-auto flushed = std::make_shared<mir::test::Signal>();
-server().the_main_loop()->spawn([flushed] { flushed->raise(); });
-ASSERT_TRUE(flushed->wait_for(2s)) << "timed out waiting for " << context;
+        auto flushed = std::make_shared<mir::test::Signal>();
+        server().the_main_loop()->spawn([flushed] { flushed->raise(); });
+        ASSERT_TRUE(flushed->wait_for(2s)) << "timed out waiting for " << context;
     }
 
     void wait_for_magnifier_initialization()

--- a/tests/miral/magnifier.cpp
+++ b/tests/miral/magnifier.cpp
@@ -206,8 +206,10 @@ TEST_F(MagnifierTest, capture_size_is_limited_to_80_percent_of_the_output)
     magnifier_renderable()->buffer();
 
     auto const capture_size = magnifier_renderable()->screen_position().size;
-    EXPECT_THAT(capture_size.width, Lt(Width{1000}));
-    EXPECT_THAT(capture_size.height, Lt(Height{1000}));
+    // The output cap is a visual size of 640x480. The capture surface is
+    // rendered at 1.5x, so its width is floor(640 / 1.5) = 426 pixels.
+    EXPECT_THAT(capture_size.width, Eq(Width{426}));
+    EXPECT_THAT(capture_size.height, Eq(Height{320}));
 }
 
 TEST_F(MagnifierTest, reapplies_layout_after_outputs_are_restored)


### PR DESCRIPTION
Related: #5071

Split from #5135 to keep the existing cursor-following magnifier changes separate from freely positioned controls.

## What's new?

- Route cursor-following placement through `MagnifierLayout` so the requested visual area and captured source region remain consistent across magnification changes.
- Constrain the magnifier to usable output bounds and reapply layout after display configuration changes.
- Retune the default capture to 300x300 at 1.5x, producing a 450x450 visual area, and document the capture-versus-visual-size behavior.
- Validate magnification against the supported range and make magnifier state thread-safer with `mir::Synchronised` instead of `std::mutex`

## How to test

```sh
cmake --build build --target miral-test
LD_LIBRARY_PATH=build/lib ./build/bin/miral-test --gtest_filter='Magnifier*'
```

6 tests pass.

## Checklist

- [x] Tests added and pass
- [x] Documentation updated
