### PR TITLE
Allow commits from a dirty workspace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     args: ["--", "-D", "warnings"]
   - id: cargo-clippy
     alias: clippy-fix
-    args: ["--fix", "--", "-D", "warnings"]
+    args: ["--fix", "--allow-dirty", "--allow-staged", "--", "-D", "warnings"]
   - id: cargo-fmt
 
 - repo: https://github.com/pre-commit/mirrors-clang-format


### PR DESCRIPTION
I often have files (debug log, incomplete work, notes, etc) in my workspace that I don't want to commit.

The pre-commit hook need not fail because of that.