### PR TITLE
feat: `DMABufBuffer::MappableFB::as_dmabuf`

### DIFF
--- a/include/platform/mir/graphics/cpu_addressable_fb.h
+++ b/include/platform/mir/graphics/cpu_addressable_fb.h
@@ -30,6 +30,8 @@ public:
     CPUAddressableFB(mir::Fd const& drm_fd, bool supports_modifiers, DRMFormat format, mir::geometry::Size const& size);
     ~CPUAddressableFB() override;
 
+    auto as_dmabuf() -> DMABufBuffer const* override;
+
     auto map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<std::byte>> override;
 
     auto format() const -> MirPixelFormat override;

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -55,6 +55,7 @@ class Display;
 class DisplaySink;
 class DisplayReport;
 class DisplayConfigurationPolicy;
+class DMABufBuffer;
 class GraphicBufferAllocator;
 class GLConfig;
 
@@ -372,6 +373,14 @@ public:
         MappableFB() = default;
         virtual ~MappableFB() override = default;
 
+        /**
+         * Return a DMABufBuffer of this framebuffer, if one exists.
+         *
+         * \return A pointer to a DMABufBuffer valid for the lifetime of this MappableFB,
+         *         or nullptr if this framebuffer cannot be exported as a DMA-Buf.
+         */
+        virtual auto as_dmabuf() -> DMABufBuffer const* = 0;
+
         using renderer::software::WriteMappable::size;
     };
 
@@ -449,8 +458,6 @@ public:
 
     virtual auto make_surface(DRMFormat format, std::span<uint64_t> modifiers) -> std::unique_ptr<GBMSurface> = 0;
 };
-
-class DMABufBuffer;
 
 class DmaBufDisplayAllocator : public DisplayAllocator
 {

--- a/src/platform/graphics/cpu_addressable_fb.cpp
+++ b/src/platform/graphics/cpu_addressable_fb.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <mir/graphics/cpu_addressable_fb.h>
+#include <mir/graphics/dmabuf_buffer.h>
 
 #include <mir/errno_utils.h>
 #include <mir/log.h>
@@ -24,6 +25,8 @@
 #include <xf86drmMode.h>
 #include <xf86drm.h>
 #include <drm_fourcc.h>
+#include <fcntl.h>
+#include <drm/drm.h>
 
 namespace mg = mir::graphics;
 
@@ -94,6 +97,56 @@ class mg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappable
         size_t const len_;
     };
 
+    class DMABuf: public mg::DMABufBuffer
+    {
+    public:
+        DMABuf(
+            mg::DRMFormat format,
+            std::optional<uint64_t> modifier,
+            std::vector<PlaneDescriptor> planes,
+            mg::gl::Texture::Layout layout,
+            mir::geometry::Size size)
+            : format_{format},
+              modifier_{std::move(modifier)},
+              planes_{std::move(planes)},
+              layout_{layout},
+              size_{size}
+        {
+        }
+
+        auto format() const -> mg::DRMFormat override
+        {
+            return format_;
+        }
+
+        auto modifier() const -> std::optional<uint64_t> override
+        {
+            return modifier_;
+        }
+
+        auto planes() const -> std::vector<PlaneDescriptor> const& override
+        {
+            return planes_;
+        }
+
+        auto layout() const -> mg::gl::Texture::Layout override
+        {
+            return layout_;
+        }
+
+        auto size() const -> mir::geometry::Size override
+        {
+            return size_;
+        }
+
+    private:
+        mg::DRMFormat const format_;
+        std::optional<uint64_t> const modifier_;
+        std::vector<PlaneDescriptor> const planes_;
+        mg::gl::Texture::Layout const layout_;
+        mir::geometry::Size const size_;
+    };
+
 public:
     ~Buffer()
     {
@@ -123,8 +176,39 @@ public:
                     "Failed to allocate CPU-accessible buffer"}));
         }
 
+        struct drm_prime_handle prime = {};
+        prime.handle = params.handle;
+        prime.flags = DRM_CLOEXEC | DRM_RDWR;
+
+        std::unique_ptr<DMABuf> dmabuf;
+        if (drmIoctl(drm_fd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &prime) == 0)
+        {
+            dmabuf = std::make_unique<DMABuf>(
+                format,
+                DRM_FORMAT_MOD_LINEAR,
+                std::vector<DMABuf::PlaneDescriptor>{
+                    DMABuf::PlaneDescriptor {
+                        .dma_buf = mir::Fd{prime.fd},
+                        .stride = params.pitch,
+                        .offset = 0,
+                    }
+                },
+                mg::gl::Texture::Layout::TopRowFirst,
+                size
+            );
+        }
+        else
+        {
+            log_error("Failed to export GEM handle to dma-buf: %s (%i)", mir::errno_to_cstr(errno), errno);
+        }
+
         return std::unique_ptr<Buffer>{
-            new Buffer{std::move(drm_fd), params, format}};
+            new Buffer{std::move(drm_fd), std::move(dmabuf), params, format}};
+    }
+
+    auto as_dmabuf() -> DMABufBuffer const*
+    {
+        return dmabuf_.get();
     }
 
     auto map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<std::byte>> override
@@ -187,9 +271,11 @@ public:
 private:
     Buffer(
         mir::Fd fd,
+        std::unique_ptr<DMABuf> dmabuf,
         struct drm_mode_create_dumb const& params,
         DRMFormat format)
         : drm_fd{std::move(fd)},
+          dmabuf_{std::move(dmabuf)},
           width_{params.width},
           height_{params.height},
           pitch_{params.pitch},
@@ -231,6 +317,7 @@ private:
     }
 
     mir::Fd const drm_fd;
+    std::unique_ptr<DMABuf> const dmabuf_;
     uint32_t const width_;
     uint32_t const height_;
     uint32_t const pitch_;
@@ -262,6 +349,11 @@ mg::CPUAddressableFB::CPUAddressableFB(
       fb_id{fb_id_for_buffer(this->drm_fd, supports_modifiers, format, *buffer)},
       buffer{std::move(buffer)}
 {
+}
+
+auto mg::CPUAddressableFB::as_dmabuf() -> DMABufBuffer const*
+{
+    return buffer->as_dmabuf();
 }
 
 auto mg::CPUAddressableFB::map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<std::byte>>

--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -50,6 +50,11 @@ public:
         {
         }
 
+        auto as_dmabuf() -> mg::DMABufBuffer const* override
+        {
+            return nullptr;
+        }
+
         auto map_writeable() -> std::unique_ptr<mrs::Mapping<std::byte>> override
         {
             return buffer->map_writeable();

--- a/tests/include/mir/test/doubles/stub_display_sink.h
+++ b/tests/include/mir/test/doubles/stub_display_sink.h
@@ -42,6 +42,11 @@ class DummyCPUAddressableDisplayAllocator : public graphics::CPUAddressableDispl
         {
         }
 
+        auto as_dmabuf() -> graphics::DMABufBuffer const* override
+        {
+            return nullptr;
+        }
+
         auto map_writeable() -> std::unique_ptr<renderer::software::Mapping<std::byte>> override
         {
             return buffer->map_writeable();


### PR DESCRIPTION
## What's new?

Implement 'Extension to `CPUAddressableDisplayAllocator::MappableFB`' from [MI096](https://docs.google.com/document/d/1wBC5ISc5NNj6y5ipwzvuxvw7WR6xW_pB-_RHoMXOwjY/edit?tab=t.0#heading=h.dm9j6xa112n2).

- `CPUAddressableDisplayAllocator::MappableFB::as_dmabuf() -> DMABufBuffer const*`

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
