### PR TITLE
workshop: can do X11 now, and drop useless actions

### DIFF
--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -2,8 +2,8 @@ name: dev
 description: |
   A development environment for Mir.
   Provides a Ubuntu 26.04 base with VS Code Remote, GitHub Copilot, and the Mir project SDK.
-  Includes actions for configuring (cmake), building (build), and compiling with cache support (ccache),
-  as well as documentation generation (doc), exposed via a tunnel on `localhost:8000`.
+  Includes actions for configuring (cmake), building (build), and documentation generation (doc),
+  exposed via a tunnel on `localhost:8000`.
 
   Connect the `desktop` interface (`workshop connect dev/mir:desktop`) to run the built server with `workshop exec <executable>` displayed on the host.
 base: ubuntu@26.04

--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -69,20 +69,3 @@ actions:
     fi
 
     SPHINX_HOST=$( hostname -f ) cmake --build ~/build --target "doc-${target:-run}" "$@"
-
-  ccache: ccache "$@"
-
-  nest: |
-    if [ -z "$WAYLAND_DISPLAY" ]; then
-      echo "Error: Connect the "desktop" plug first:" >&2
-      echo "  workshop connect dev/mir:desktop" >&2
-      exit 1
-    fi
-
-    export MIR_SERVER_CURSOR=software
-    export MIR_SERVER_PLATFORM_DISPLAY_LIBS=mir:wayland
-    # TODO: uncomment once #5090 lands
-    # export MIR_SERVER_WAYLAND_OUTPUT=1280x1024
-    export MIR_SERVER_WAYLAND_HOST=$WAYLAND_DISPLAY
-    export WAYLAND_DISPLAY=mir-wayland-0
-    "$@"

--- a/.workshop/mir/hooks/setup-project
+++ b/.workshop/mir/hooks/setup-project
@@ -13,3 +13,8 @@ cmake \
   -B $HOME/build \
   -G Ninja \
   .
+
+cat <<'EOF' >> ~/.profile
+export WAYLAND_DISPLAY=wayland-99
+export MIR_SERVER_PLATFORM_DISPLAY_LIBS=mir:x11
+EOF


### PR DESCRIPTION
## What's new?

Simplify the workshop, no need for `run nest` any more, everything works with plain `exec`.

You need the `desktop` interface connected, though - and there's (yet) no way to warn if that's disconnected in `exec`.

Also can't use `mir-wayland-0` with strict snaps.

## How to test

```shell
workshop build
workshop exec miral-shell &
workshop exec glmark2-es2-wayland
```

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
