### PR TITLE
scene: drop wl_array from TextInputHub

### DIFF
--- a/src/include/server/mir/scene/text_input_hub.h
+++ b/src/include/server/mir/scene/text_input_hub.h
@@ -20,13 +20,12 @@
 #include <mir/observer_registrar.h>
 #include <mir/int_wrapper.h>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
-#include <wayland-server.h>
+#include <vector>
 #include <algorithm>
-
-struct wl_array;
 
 namespace mir
 {
@@ -99,39 +98,6 @@ struct TextInputState
     std::optional<TextInputContentPurpose> content_purpose;
 };
 
-class CopyableWlArray
-{
-public:
-    explicit CopyableWlArray(wl_array const* in_data)
-    {
-        wl_array_init(&data_);
-        wl_array_copy(&data_, const_cast<wl_array*>(in_data));
-    }
-
-    CopyableWlArray(CopyableWlArray const& other)
-        : CopyableWlArray{&other.data_}
-    {
-    }
-
-    CopyableWlArray& operator=(CopyableWlArray other)
-    {
-        std::swap(data_, other.data_);
-        return *this;
-    }
-
-    ~CopyableWlArray()
-    {
-        wl_array_release(&data_);
-    }
-
-    [[nodiscard]] wl_array* data() const
-    {
-        return const_cast<wl_array*>(&data_);
-    }
-private:
-    wl_array data_;
-};
-
 /// See text-input-unstable-v3.xml for details
 struct TextInputChange
 {
@@ -177,7 +143,7 @@ struct TextInputChange
     std::optional<TextInputKeySym> keysym;
 
     /// \remark Defined for text input v1 and v2, not v3.
-    std::optional<CopyableWlArray> modifier_map;
+    std::optional<std::vector<std::uint8_t>> modifier_map;
 
     /// \remark Defined for text input v1 and v2, not v3.
     std::optional<CursorPosition> cursor_position;

--- a/src/server/frontend_wayland/input_method_v1.cpp
+++ b/src/server/frontend_wayland/input_method_v1.cpp
@@ -328,7 +328,8 @@ private:
 
         void modifiers_map(struct wl_array *map) override
         {
-            change.pending_change.modifier_map = scene::CopyableWlArray(map);
+            auto const* const bytes = static_cast<std::uint8_t const*>(map->data);
+            change.pending_change.modifier_map = std::vector<std::uint8_t>(bytes, bytes + map->size);
             change.waiting_status = InputMethodV1ChangeWaitingStatus::none;
         }
 

--- a/src/server/frontend_wayland/text_input_v1.cpp
+++ b/src/server/frontend_wayland/text_input_v1.cpp
@@ -295,7 +295,9 @@ void TextInputV1::send_text_change(ms::TextInputChange const& change)
     }
     if (change.modifier_map)
     {
-        send_modifiers_map_event(change.modifier_map.value().data());
+        auto const& map = change.modifier_map.value();
+        wl_array array{map.size(), map.size(), const_cast<std::uint8_t*>(map.data())};
+        send_modifiers_map_event(&array);
     }
     if (change.direction)
     {

--- a/src/server/frontend_wayland/text_input_v2.cpp
+++ b/src/server/frontend_wayland/text_input_v2.cpp
@@ -304,7 +304,9 @@ void mf::TextInputV2::send_text_change(ms::TextInputChange const& change)
     }
     if (change.modifier_map)
     {
-        send_modifiers_map_event(change.modifier_map.value().data());
+        auto const& map = change.modifier_map.value();
+        wl_array array{map.size(), map.size(), const_cast<std::uint8_t*>(map.data())};
+        send_modifiers_map_event(&array);
     }
     if (change.direction)
     {

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -536,10 +536,6 @@ global:
     mir::scene::BasicSurface::window_size*;
     mir::scene::ClipboardObserver::?ClipboardObserver*;
     mir::scene::ClipboardObserver::ClipboardObserver*;
-    mir::scene::CopyableWlArray::?CopyableWlArray*;
-    mir::scene::CopyableWlArray::CopyableWlArray*;
-    mir::scene::CopyableWlArray::data*;
-    mir::scene::CopyableWlArray::operator*;
     mir::scene::DataExchangeSource::?DataExchangeSource*;
     mir::scene::DataExchangeSource::DataExchangeSource*;
     mir::scene::IdleHub::?IdleHub*;
@@ -1341,7 +1337,6 @@ global:
     typeinfo?for?mir::scene::BasicSurface;
     typeinfo?for?mir::scene::Clipboard;
     typeinfo?for?mir::scene::ClipboardObserver;
-    typeinfo?for?mir::scene::CopyableWlArray;
     typeinfo?for?mir::scene::DataExchangeSource;
     typeinfo?for?mir::scene::IdleHub;
     typeinfo?for?mir::scene::IdleStateObserver;


### PR DESCRIPTION
mir::scene::TextInputChange carried its modifier map as a CopyableWlArray,
which forced <wayland-server.h> into a scene header and leaked a protocol
detail into the scene layer.

Store the map as a plain std::vector<std::uint8_t> instead and convert to
and from wl_array at the protocol boundary, where it belongs. Remove
CopyableWlArray, along with its now-unused symbols.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Closes #???

<!-- Mention the issue this closes if applicable -->

Related: #???, https://..., ...

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

## What's new?

<!-- List the major changes of this PR -->

## How to test

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
