### PR TITLE
graphics: expose DMABufEGLProvider to the Wayland frontend

### DIFF
--- a/include/platform/mir/graphics/graphic_buffer_allocator.h
+++ b/include/platform/mir/graphics/graphic_buffer_allocator.h
@@ -35,6 +35,8 @@ namespace renderer::software { class RWMappable; }
 namespace graphics
 {
 
+class DMABufEGLProvider;
+
 /**
  * Interface to graphic buffer allocation.
  */
@@ -87,6 +89,16 @@ public:
         std::shared_ptr<renderer::software::RWMappable> shm_data,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<Buffer> = 0;
+
+    /**
+     * The linux-dmabuf import provider for this allocator, if any.
+     *
+     * The (Rust-backed) Wayland frontend uses this to implement the zwp_linux_dmabuf_v1
+     * protocol directly, rather than going through the old libwayland bind_display path.
+     *
+     * \return the provider, or nullptr if this allocator does not support dmabuf import.
+     */
+    virtual auto dma_buf_provider() -> std::shared_ptr<DMABufEGLProvider> = 0;
 
 protected:
     GraphicBufferAllocator() = default;

--- a/include/platform/mir/graphics/linux_dmabuf.h
+++ b/include/platform/mir/graphics/linux_dmabuf.h
@@ -21,8 +21,11 @@
 #include "linux-dmabuf-stable-v1_wrapper.h"
 
 #include <EGL/egl.h>
+#include <sys/types.h>
 #include <memory>
 #include <span>
+#include <utility>
+#include <vector>
 
 #include <mir/graphics/buffer.h>
 #include <mir/graphics/drm_formats.h>
@@ -55,12 +58,30 @@ public:
         std::shared_ptr<EGLExtensions> egl_extensions,
         EGLExtensions::EXTImageDmaBufImportModifiers const& dmabuf_ext,
         std::shared_ptr<common::EGLContextExecutor> egl_delegate,
+        std::unique_ptr<renderer::gl::Context> import_context,
         EGLImageAllocator allocate_importable_image);
 
     ~DMABufEGLProvider();
 
     auto devnum() const -> dev_t;
 
+    /**
+     * The EGL context used to import dma-bufs.
+     *
+     * Importing a dma-buf creates a GL texture, which requires a current EGL
+     * context. Callers of import_dma_buf() must make this context current on
+     * the calling thread first (see import_dma_buf()).
+     */
+    auto context() const -> renderer::gl::Context&;
+
+    /**
+     * Import a dma-buf into a graphics::Buffer.
+     *
+     * \note This must be called with a valid EGL context current on the
+     *       calling thread (for example, context() made current). Constructing
+     *       the buffer binds a GL texture to the imported EGLImage, which
+     *       requires a current context; without one the texture samples black.
+     */
     auto import_dma_buf(
         DMABufBuffer const& dma_buf,
         std::function<void()>&& on_consumed,
@@ -74,6 +95,22 @@ public:
      */
     void validate_import(DMABufBuffer const& dma_buf);
 
+    /**
+     * Whether the given format/modifier combination can be imported by this provider.
+     *
+     * Exposed for the (Rust-backed) Wayland frontend, which no longer has access to the
+     * internal EGL format descriptors.
+     */
+    auto is_importable(DRMFormat format, uint64_t modifier) const -> bool;
+
+    /**
+     * The formats (and their supported modifiers) this provider can import.
+     *
+     * Exposed for the Wayland frontend so it can advertise linux-dmabuf formats/modifiers
+     * without touching the internal EGL descriptor types.
+     */
+    auto supported_format_modifiers() const -> std::vector<std::pair<DRMFormat, std::vector<uint64_t>>>;
+
     auto as_texture(std::shared_ptr<NativeBufferBase> buffer) -> std::shared_ptr<gl::Texture>;
 
     auto supported_formats() const -> DmaBufFormatDescriptors const&;
@@ -85,6 +122,7 @@ private:
     dev_t const devnum_;
     std::unique_ptr<DmaBufFormatDescriptors> const formats;
     std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
+    std::unique_ptr<renderer::gl::Context> const import_context;
     EGLImageAllocator allocate_importable_image;
     std::unique_ptr<EGLBufferCopier> const blitter;
 };

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -34,6 +34,7 @@
 #include <mir/graphics/buffer_basic.h>
 #include <mir/graphics/dmabuf_buffer.h>
 #include <mir/graphics/egl_context_executor.h>
+#include <mir/renderer/gl/context.h>
 #include <mir/renderer/sw/pixel_source.h>
 
 #include <EGL/egl.h>
@@ -1479,6 +1480,7 @@ mg::DMABufEGLProvider::DMABufEGLProvider(
     std::shared_ptr<EGLExtensions> egl_extensions,
     mg::EGLExtensions::EXTImageDmaBufImportModifiers const& dmabuf_ext,
     std::shared_ptr<mgc::EGLContextExecutor> egl_delegate,
+    std::unique_ptr<renderer::gl::Context> import_context,
     EGLImageAllocator allocate_importable_image)
     : dpy{dpy},
       egl_extensions{std::move(egl_extensions)},
@@ -1486,12 +1488,18 @@ mg::DMABufEGLProvider::DMABufEGLProvider(
       devnum_{get_devnum(dpy)},
       formats{std::make_unique<DmaBufFormatDescriptors>(dpy, dmabuf_ext)},
       egl_delegate{std::move(egl_delegate)},
+      import_context{std::move(import_context)},
       allocate_importable_image{std::move(allocate_importable_image)},
       blitter{std::make_unique<mg::EGLBufferCopier>(this->egl_delegate)}
 {
 }
 
 mg::DMABufEGLProvider::~DMABufEGLProvider() = default;
+
+auto mg::DMABufEGLProvider::context() const -> mir::renderer::gl::Context&
+{
+    return *import_context;
+}
 
 auto mg::DMABufEGLProvider::devnum() const -> dev_t
 {
@@ -1501,6 +1509,26 @@ auto mg::DMABufEGLProvider::devnum() const -> dev_t
 auto mg::DMABufEGLProvider::supported_formats() const -> mg::DmaBufFormatDescriptors const&
 {
     return *formats;
+}
+
+auto mg::DMABufEGLProvider::is_importable(mg::DRMFormat format, uint64_t modifier) const -> bool
+{
+    return descriptor_for_format_and_modifiers(format, modifier, *this) != nullptr;
+}
+
+auto mg::DMABufEGLProvider::supported_format_modifiers() const
+    -> std::vector<std::pair<mg::DRMFormat, std::vector<uint64_t>>>
+{
+    std::vector<std::pair<mg::DRMFormat, std::vector<uint64_t>>> result;
+    auto const& descriptors = supported_formats();
+    for (auto i = 0u; i < descriptors.num_formats(); ++i)
+    {
+        auto const& [format, modifiers, external_only] = descriptors[i];
+        result.emplace_back(
+            mg::DRMFormat{static_cast<uint32_t>(format)},
+            std::vector<uint64_t>{modifiers.begin(), modifiers.end()});
+    }
+    return result;
 }
 
 auto mg::DMABufEGLProvider::import_dma_buf(
@@ -1513,6 +1541,13 @@ auto mg::DMABufEGLProvider::import_dma_buf(
         dma_buf.format(),
         dma_buf.modifier().value_or(DRM_FORMAT_MOD_INVALID),
         *this);
+
+    /* Constructing a DmabufTexBuffer creates a GL texture bound to the imported
+     * dma-buf's EGLImage, which requires a current EGL context. It is a precondition
+     * of this method that the caller has made a suitable context (for example,
+     * context()) current on the calling thread. Without a current context the texture
+     * is never bound to the EGLImage and samples as black.
+     */
     return std::make_shared<DmabufTexBuffer>(
         dpy,
         *egl_extensions,

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -14,6 +14,13 @@ MIR_PLATFORM_2.29 {
     mir::graphics::DMABufEGLProvider::?DMABufEGLProvider*;
     mir::graphics::DMABufEGLProvider::DMABufEGLProvider*;
     mir::graphics::DMABufEGLProvider::as_texture*;
+    mir::graphics::DMABufEGLProvider::context*;
+    mir::graphics::DMABufEGLProvider::devnum*;
+    mir::graphics::DMABufEGLProvider::import_dma_buf*;
+    mir::graphics::DMABufEGLProvider::is_importable*;
+    mir::graphics::DMABufEGLProvider::supported_format_modifiers*;
+    mir::graphics::DMABufEGLProvider::supported_formats*;
+    mir::graphics::DMABufEGLProvider::validate_import*;
     mir::graphics::DRMFormat::DRMFormat*;
     mir::graphics::DRMFormat::Info::alpha_equivalent*;
     mir::graphics::DRMFormat::Info::bytes_per_pixel*;

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -189,6 +189,11 @@ auto mgg::BufferAllocator::buffer_from_shm(
         std::move(on_release));
 }
 
+auto mgg::BufferAllocator::dma_buf_provider() -> std::shared_ptr<mg::DMABufEGLProvider>
+{
+    return dmabuf_provider;
+}
+
 auto mgg::BufferAllocator::shared_egl_context() -> EGLContext
 {
     return static_cast<EGLContext>(*ctx);

--- a/src/platforms/gbm-kms/server/buffer_allocator.h
+++ b/src/platforms/gbm-kms/server/buffer_allocator.h
@@ -75,6 +75,8 @@ public:
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<Buffer> override;
 
+    auto dma_buf_provider() -> std::shared_ptr<DMABufEGLProvider> override;
+
     auto shared_egl_context() -> EGLContext;
 private:
     std::unique_ptr<renderer::gl::Context> const ctx;

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -368,7 +368,8 @@ auto maybe_make_dmabuf_provider(
     std::shared_ptr<gbm_device> gbm,
     EGLDisplay dpy,
     std::shared_ptr<mg::EGLExtensions> egl_extensions,
-    std::shared_ptr<mg::common::EGLContextExecutor> egl_delegate)
+    std::shared_ptr<mg::common::EGLContextExecutor> egl_delegate,
+    std::unique_ptr<mir::renderer::gl::Context> import_context)
     -> std::shared_ptr<mg::DMABufEGLProvider>
 {
     try
@@ -379,6 +380,7 @@ auto maybe_make_dmabuf_provider(
             std::move(egl_extensions),
             modifier_ext,
             std::move(egl_delegate),
+            std::move(import_context),
             [gbm](mg::DRMFormat format, std::span<uint64_t const> modifiers, mir::geometry::Size size)
                 -> std::shared_ptr<mg::DMABufBuffer>
             {
@@ -415,7 +417,7 @@ mgg::RenderingPlatform::RenderingPlatform(
       bound_display{std::visit(display_provider_or_nothing{}, hw)},
       share_ctx{std::make_unique<SurfacelessEGLContext>(dpy)},
       egl_delegate{std::make_shared<mg::common::EGLContextExecutor>(share_ctx->make_share_context())},
-      dmabuf_provider{maybe_make_dmabuf_provider(device, share_ctx->egl_display(), std::make_shared<mg::EGLExtensions>(), egl_delegate)},
+      dmabuf_provider{maybe_make_dmabuf_provider(device, share_ctx->egl_display(), std::make_shared<mg::EGLExtensions>(), egl_delegate, share_ctx->make_share_context())},
       quirks{std::move(quirks)}
 {
 }

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -279,6 +279,11 @@ auto mge::BufferAllocator::buffer_from_shm(
         std::move(on_release));
 }
 
+auto mge::BufferAllocator::dma_buf_provider() -> std::shared_ptr<mg::DMABufEGLProvider>
+{
+    return dmabuf_provider;
+}
+
 auto mge::BufferAllocator::shared_egl_context() -> EGLContext
 {
     return static_cast<EGLContext>(*ctx);

--- a/src/platforms/renderer-generic-egl/buffer_allocator.h
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.h
@@ -70,6 +70,8 @@ public:
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<Buffer> override;
 
+    auto dma_buf_provider() -> std::shared_ptr<DMABufEGLProvider> override;
+
     auto shared_egl_context() -> EGLContext;
 private:
     std::unique_ptr<renderer::gl::Context> const ctx;

--- a/src/platforms/renderer-generic-egl/rendering_platform.cpp
+++ b/src/platforms/renderer-generic-egl/rendering_platform.cpp
@@ -166,7 +166,8 @@ private:
 auto maybe_make_dmabuf_provider(
     EGLDisplay dpy,
     std::shared_ptr<mg::EGLExtensions> egl_extensions,
-    std::shared_ptr<mgc::EGLContextExecutor> egl_delegate)
+    std::shared_ptr<mgc::EGLContextExecutor> egl_delegate,
+    std::unique_ptr<mir::renderer::gl::Context> import_context)
     -> std::shared_ptr<mg::DMABufEGLProvider>
 {
     try
@@ -177,6 +178,7 @@ auto maybe_make_dmabuf_provider(
             std::move(egl_extensions),
             modifier_ext,
             std::move(egl_delegate),
+            std::move(import_context),
             [](mg::DRMFormat, std::span<uint64_t const>, geom::Size) -> std::shared_ptr<mg::DMABufBuffer>
             {
                 return nullptr;    // We can't (portably) allocate dmabufs, but we also shouldn't need to
@@ -208,7 +210,8 @@ mge::RenderingPlatform::RenderingPlatform(std::tuple<EGLDisplay, bool> display)
           maybe_make_dmabuf_provider(
               dpy,
               std::make_shared<mg::EGLExtensions>(),
-              std::make_shared<mgc::EGLContextExecutor>(ctx->make_share_context()))},
+              std::make_shared<mgc::EGLContextExecutor>(ctx->make_share_context()),
+              ctx->make_share_context())},
       egl_delegate{std::make_shared<mg::common::EGLContextExecutor>(ctx->make_share_context())}
 {
 }

--- a/tests/include/mir/test/doubles/stub_buffer_allocator.h
+++ b/tests/include/mir/test/doubles/stub_buffer_allocator.h
@@ -45,6 +45,8 @@ public:
         std::shared_ptr<renderer::software::RWMappable> data,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release) -> std::shared_ptr<graphics::Buffer>;
+
+    auto dma_buf_provider() -> std::shared_ptr<graphics::DMABufEGLProvider> override;
 };
 
 }

--- a/tests/mir_test_doubles/stub_buffer_allocator.cpp
+++ b/tests/mir_test_doubles/stub_buffer_allocator.cpp
@@ -68,3 +68,8 @@ auto mtd::StubBufferAllocator::buffer_from_shm(
 
     return buffer;
 }
+
+auto mtd::StubBufferAllocator::dma_buf_provider() -> std::shared_ptr<mg::DMABufEGLProvider>
+{
+    return nullptr;
+}


### PR DESCRIPTION
Importing a linux-dmabuf buffer currently requires reaching into the
platform's internal EGL format descriptors, so the protocol implementation
has to live in the platform alongside them.

Give DMABufEGLProvider the vocabulary a frontend needs to do that work
itself:

  - own an EGL context for imports, exposed as context(). Importing binds a
    GL texture to the imported EGLImage, which needs a current context;
    without one the texture samples black.
  - is_importable(), to validate a format/modifier pair.
  - supported_format_modifiers(), to advertise formats without touching the
    internal descriptor types.

Also add GraphicBufferAllocator::dma_buf_provider() so a frontend can reach
the provider at all.

This is purely additive; graphics::LinuxDmaBuf and the existing
bind_display()/buffer_from_resource() import path are untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Closes #???

<!-- Mention the issue this closes if applicable -->

Related: #???, https://..., ...

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

## What's new?

<!-- List the major changes of this PR -->

## How to test

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
