### PR TITLE
server: decouple the server-facing Wayland API from libwayland types

### DIFF
--- a/src/include/server/mir/server.h
+++ b/src/include/server/mir/server.h
@@ -21,6 +21,7 @@
 #include <mir/shell/window_manager_builder.h>
 #include <mir_toolkit/common.h>
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -32,6 +33,7 @@ namespace mir::wayland { class Client; }
 
 namespace mir
 {
+class Executor;
 template<class Observer>
 class ObserverRegistrar;
 
@@ -67,6 +69,7 @@ class SurfaceFactory;
 class Session;
 class SessionLock;
 class SceneReport;
+class Surface;
 }
 namespace input
 {
@@ -470,7 +473,16 @@ public:
     /// It can be passed to another process, or used with wl_display_connect_to_fd()
     auto open_wayland_client_socket() -> Fd;
 
-    void run_on_wayland_display(std::function<void(wl_display*)> const& functor);
+    /// Run the supplied functor on the Wayland event-loop thread, passing the
+    /// executor that dispatches work onto that loop. Used by test/integration
+    /// tooling that needs to interact with the running Wayland backend.
+    void run_on_wayland_display(std::function<void(Executor&)> const& functor);
+
+    /// Resolve the `scene::Surface` for the Wayland surface identified by
+    /// (`session`, protocol object `id`), or nullptr if unknown. Used by
+    /// test/integration tooling to map a client-side surface to its Mir surface.
+    auto scene_surface_for_wayland_surface(scene::Session const& session, uint32_t id) const
+        -> std::shared_ptr<scene::Surface>;
     void add_wayland_extension(
         std::string const& name,
         std::function<std::shared_ptr<void>(

--- a/src/server/frontend_wayland/surface_registry.cpp
+++ b/src/server/frontend_wayland/surface_registry.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "surface_registry.h"
+#include "wl_surface.h"
 
 #include <mir/wayland/weak.h>
 
@@ -25,11 +26,26 @@ void mf::SurfaceRegistry::add_surface(
     std::shared_ptr<input::Surface const> const& surf, mw::Weak<mf::WlSurface> const& wl_surf)
 {
     scene_surface_to_wayland_surface.insert({surf, wl_surf});
+
+    if (wl_surf)
+    {
+        auto& surface = wl_surf.value();
+        ObjectKey const key{surface.session.get(), wl_resource_get_id(surface.raw_resource())};
+        wayland_surface_by_object[key] = wl_surf;
+        object_key_by_scene_surface[surf.get()] = key;
+    }
 }
 
 void mf::SurfaceRegistry::remove_surface(std::shared_ptr<input::Surface const> const& surf)
 {
     scene_surface_to_wayland_surface.erase(surf);
+
+    if (auto const iter = object_key_by_scene_surface.find(surf.get());
+        iter != object_key_by_scene_surface.end())
+    {
+        wayland_surface_by_object.erase(iter->second);
+        object_key_by_scene_surface.erase(iter);
+    }
 }
 
 auto mf::SurfaceRegistry::lookup_wayland_surface(std::shared_ptr<input::Surface const> const& surf)
@@ -41,4 +57,17 @@ auto mf::SurfaceRegistry::lookup_wayland_surface(std::shared_ptr<input::Surface 
     }
 
     return std::nullopt;
+}
+
+auto mf::SurfaceRegistry::scene_surface_for(scene::Session const& session, uint32_t id) const
+    -> std::shared_ptr<scene::Surface>
+{
+    if (auto const iter = wayland_surface_by_object.find({&session, id});
+        iter != wayland_surface_by_object.end())
+    {
+        if (auto const& wl_surf = iter->second)
+            return wl_surf.value().scene_surface().value_or(nullptr);
+    }
+
+    return nullptr;
 }

--- a/src/server/frontend_wayland/surface_registry.h
+++ b/src/server/frontend_wayland/surface_registry.h
@@ -17,12 +17,20 @@
 #ifndef MIR_FRONTEND_WAYLAND_SURFACE_REGISTRY_H_
 #define MIR_FRONTEND_WAYLAND_SURFACE_REGISTRY_H_
 
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <utility>
 
 namespace mir
 {
+namespace scene
+{
+class Session;
+class Surface;
+}
 namespace input
 {
 class Surface;
@@ -44,9 +52,20 @@ public:
     auto lookup_wayland_surface(std::shared_ptr<input::Surface const> const& surf)
         -> std::optional<wayland::Weak<frontend::WlSurface>>;
 
+    /// Resolve the `scene::Surface` for the Wayland surface identified by
+    /// (`session`, protocol object `id`), or nullptr if unknown. Intended for
+    /// test/integration tooling that needs to map a client-side surface to its
+    /// Mir scene surface.
+    auto scene_surface_for(scene::Session const& session, uint32_t id) const
+        -> std::shared_ptr<scene::Surface>;
+
 private:
     std::unordered_map<std::shared_ptr<input::Surface const>, wayland::Weak<frontend::WlSurface> const>
         scene_surface_to_wayland_surface;
+
+    using ObjectKey = std::pair<scene::Session const*, uint32_t>;
+    std::map<ObjectKey, wayland::Weak<frontend::WlSurface>> wayland_surface_by_object;
+    std::unordered_map<input::Surface const*, ObjectKey> object_key_by_scene_surface;
 };
 
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -299,7 +299,7 @@ mf::WaylandConnector::WaylandConnector(
         std::make_shared<FrameExecutor>(*main_loop),
         this->allocator);
     subcompositor_global = std::make_unique<mf::WlSubcompositor>(display.get());
-    auto const surface_registry = std::make_shared<mf::SurfaceRegistry>();
+    surface_registry = std::make_shared<mf::SurfaceRegistry>();
 
     auto const action_group_manager =
         std::make_shared<InputTriggerRegistry::ActionGroupManager>(token_authority, *executor);
@@ -575,9 +575,26 @@ int mf::WaylandConnector::client_socket_fd(
     return socket_fd[client];
 }
 
-void mf::WaylandConnector::run_on_wayland_display(std::function<void(wl_display*)> const& functor)
+void mf::WaylandConnector::run_on_wayland_display(std::function<void(Executor&)> const& functor)
 {
-    executor->spawn([display_ref = display.get(), functor]() { functor(display_ref); });
+    executor->spawn([executor = executor, functor]() { functor(*executor); });
+}
+
+void mf::WaylandConnector::create_wayland_client(
+    Fd const& client_fd,
+    std::function<void(wl_client*)> const& callback)
+{
+    executor->spawn(
+        [display_ref = display.get(), client_fd, callback]()
+        {
+            callback(wl_client_create(display_ref, client_fd));
+        });
+}
+
+auto mf::WaylandConnector::scene_surface_for(scene::Session const& session, uint32_t id) const
+    -> std::shared_ptr<scene::Surface>
+{
+    return surface_registry->scene_surface_for(session, id);
 }
 
 void mf::WaylandConnector::on_surface_created(

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -201,7 +201,17 @@ public:
     int client_socket_fd(
         std::function<void(std::shared_ptr<scene::Session> const& session)> const& connect_handler) const override;
 
-    void run_on_wayland_display(std::function<void(wl_display*)> const& functor);
+    void run_on_wayland_display(std::function<void(Executor&)> const& functor);
+
+    /// Create a Wayland client for `client_fd` on the Wayland event loop and
+    /// pass it to `callback`. The wl_display is owned by this connector, so
+    /// client creation happens here rather than handing the display out.
+    void create_wayland_client(Fd const& client_fd, std::function<void(wl_client*)> const& callback);
+
+    /// Resolve the `scene::Surface` for the Wayland surface identified by
+    /// (`session`, protocol object `id`), or nullptr if unknown.
+    auto scene_surface_for(scene::Session const& session, uint32_t id) const
+        -> std::shared_ptr<scene::Surface>;
 
     /// Runs callback the first time a wl_surface with the given id is created, or immediately if one currently exists
     /// Callback is never called if a wl_surface with the id is never created
@@ -243,6 +253,7 @@ private:
     std::unique_ptr<WpViewporter> viewporter;
     std::unique_ptr<LinuxDRMSyncobjManager> drm_syncobj;
     std::shared_ptr<Executor> const executor;
+    std::shared_ptr<SurfaceRegistry> surface_registry;
     std::shared_ptr<graphics::GraphicBufferAllocator> const allocator;
     std::shared_ptr<shell::Shell> const shell;
     std::unique_ptr<WaylandExtensions> const extensions;

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -140,13 +140,15 @@ auto connect_xwayland_wl_client(
 
     auto const ctx = std::make_shared<CreateClientContext>();
 
-    wayland_connector->run_on_wayland_display(
-        [ctx, wayland_fd, scale](wl_display* display)
+    wayland_connector->create_wayland_client(
+        wayland_fd,
+        [ctx, scale](wl_client* client)
         {
             {
                 std::lock_guard lock{ctx->mutex};
-                ctx->client = wl_client_create(display, wayland_fd);
-                mw::Client::from(ctx->client).set_output_geometry_scale(scale);
+                ctx->client = client;
+                if (client)
+                    mw::Client::from(client).set_output_geometry_scale(scale);
                 ctx->ready = true;
             }
             ctx->condition_variable.notify_one();

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -505,13 +505,25 @@ auto mir::Server::get_activation_token() const -> std::string
     BOOST_THROW_EXCEPTION(std::logic_error("Cannot open connection when not running"));
 }
 
-void mir::Server::run_on_wayland_display(std::function<void(wl_display*)> const& functor)
+void mir::Server::run_on_wayland_display(std::function<void(Executor&)> const& functor)
 {
     if (auto const config = self->server_config)
     {
         std::dynamic_pointer_cast<mir::frontend::WaylandConnector>(config->the_wayland_connector())
             ->run_on_wayland_display(functor);
     }
+}
+
+auto mir::Server::scene_surface_for_wayland_surface(scene::Session const& session, uint32_t id) const
+    -> std::shared_ptr<scene::Surface>
+{
+    if (auto const config = self->server_config)
+    {
+        return std::dynamic_pointer_cast<mir::frontend::WaylandConnector>(config->the_wayland_connector())
+            ->scene_surface_for(session, id);
+    }
+
+    return nullptr;
 }
 
 void mir::Server::add_wayland_extension(

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -181,6 +181,7 @@ global:
     mir::Server::override_the_window_manager_builder*;
     mir::Server::run*;
     mir::Server::run_on_wayland_display*;
+    mir::Server::scene_surface_for_wayland_surface*;
     mir::Server::set_command_line*;
     mir::Server::set_command_line_handler*;
     mir::Server::set_config_filename*;

--- a/tests/mir_test_framework/test_wlcs_display_server.cpp
+++ b/tests/mir_test_framework/test_wlcs_display_server.cpp
@@ -30,7 +30,6 @@
 #include <mir/executor.h>
 #include <mir/errno_utils.h>
 #include <mir/fd.h>
-#include <mir/compositor/buffer_stream.h>
 #include <mir/input/cursor_observer.h>
 #include <mir/input/cursor_observer_multiplexer.h>
 #include <mir/input/device.h>
@@ -40,17 +39,18 @@
 #include <mir/input/seat_observer.h>
 #include <mir/log.h>
 #include <mir/observer_registrar.h>
-#include <mir/scene/session_listener.h>
+#include <mir/scene/session.h>
 #include <mir/scene/surface.h>
 #include <mir/server.h>
 
-#include <wayland-server.h>
+#include <wayland-client.h>
 
 #include <fcntl.h>
 #include <sys/eventfd.h>
 
 #include <cstring>
 #include <deque>
+#include <mutex>
 #include <format>
 #include <optional>
 #include <unordered_map>
@@ -194,146 +194,6 @@ private:
 };
 
 
-using ClientFd = int;
-
-class WaylandExecutor : public mir::Executor
-{
-public:
-    void spawn (std::function<void()>&& work) override
-    {
-        {
-            std::lock_guard lock{mutex};
-            workqueue.emplace_back(std::move(work));
-        }
-        if (auto err = eventfd_write(notify_fd, 1))
-        {
-            BOOST_THROW_EXCEPTION((std::system_error{err, std::system_category(), "eventfd_write failed to notify event loop"}));
-        }
-    }
-
-    /**
-     * Get an Executor which dispatches onto a wl_event_loop
-     *
-     * \note    The executor may outlive the wl_event_loop, but no tasks will be dispatched
-     *          after the wl_event_loop is destroyed.
-     *
-     * \param [in]  loop    The event loop to dispatch on
-     * \return              An Executor that queues onto the wl_event_loop
-     */
-    static std::shared_ptr<mir::Executor> executor_for_event_loop(wl_event_loop* loop)
-    {
-        if (auto notifier = wl_event_loop_get_destroy_listener(loop, &on_display_destruction))
-        {
-            DestructionShim* shim;
-            shim = wl_container_of(notifier, shim, destruction_listener);
-
-            return shim->executor;
-        }
-        else
-        {
-            auto const executor = std::shared_ptr<WaylandExecutor>{new WaylandExecutor{loop}};
-            auto shim = std::make_unique<DestructionShim>(executor);
-
-            shim->destruction_listener.notify = &on_display_destruction;
-            wl_event_loop_add_destroy_listener(loop, &(shim.release())->destruction_listener);
-
-            return executor;
-        }
-    }
-
-private:
-    WaylandExecutor(wl_event_loop* loop)
-        : notify_fd{eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE | EFD_NONBLOCK)},
-        notify_source{wl_event_loop_add_fd(loop, notify_fd, WL_EVENT_READABLE, &on_notify, this)}
-    {
-        if (notify_fd == mir::Fd::invalid)
-        {
-            BOOST_THROW_EXCEPTION((std::system_error{
-                errno,
-                std::system_category(),
-                "Failed to create IPC pause notification eventfd"}));
-        }
-    }
-
-    std::function<void()> get_work()
-    {
-        std::lock_guard lock{mutex};
-        if (!workqueue.empty())
-        {
-            auto const work = std::move(workqueue.front());
-            workqueue.pop_front();
-            return work;
-        }
-
-        return {};
-    }
-
-    static int on_notify(int fd, uint32_t, void* data)
-    {
-        auto executor = static_cast<WaylandExecutor*>(data);
-
-        eventfd_t unused;
-        if (auto err = eventfd_read(fd, &unused))
-        {
-            mir::log(
-                mir::logging::Severity::error,
-                "wlcs-integration",
-                "eventfd_read failed to consume wakeup notification: %s (%i)",
-                mir::errno_to_cstr(err),
-                err);
-        }
-
-        while (auto work = executor->get_work())
-        {
-            try
-            {
-                work();
-            }
-            catch(...)
-            {
-                mir::log(
-                    mir::logging::Severity::critical,
-                    "wlcs-integration",
-                    std::current_exception(),
-                    "Exception processing Wayland event loop work item");
-            }
-        }
-
-        return 0;
-    }
-
-    static void on_display_destruction(wl_listener* listener, void*)
-    {
-        DestructionShim* shim;
-        shim = wl_container_of(listener, shim, destruction_listener);
-
-        {
-            std::lock_guard lock{shim->executor->mutex};
-            wl_event_source_remove(shim->executor->notify_source);
-        }
-        delete shim;
-    }
-
-    std::mutex mutex;
-    mir::Fd const notify_fd;
-    std::deque<std::function<void()>> workqueue;
-
-    wl_event_source* const notify_source;
-
-    struct DestructionShim
-    {
-        explicit DestructionShim(std::shared_ptr<WaylandExecutor> const& executor)
-            : executor{executor}
-        {
-        }
-
-        std::shared_ptr<WaylandExecutor> const executor;
-        wl_listener destruction_listener;
-    };
-    static_assert(
-        std::is_standard_layout<DestructionShim>::value,
-        "DestructionShim must be Standard Layout for wl_container_of to be defined behaviour");
-};
 }
 
 
@@ -369,212 +229,29 @@ private:
     TestWlcsDisplayServer* const runner;
 };
 
-class miral::TestWlcsDisplayServer::ResourceMapper : public mir::scene::SessionListener
+class miral::TestWlcsDisplayServer::ResourceMapper
 {
 public:
-    ResourceMapper()
-        : listeners{&this->state}
+    /// Record the association between the client socket `client_fd` (as returned
+    /// to WLCS) and the Mir `session` created for that connection.
+    void associate_client_socket(int client_fd, std::shared_ptr<mir::scene::Session> const& session)
     {
+        std::lock_guard lock{mutex};
+        session_for_fd_[client_fd] = session;
     }
 
-    void starting(std::shared_ptr<mir::scene::Session> const&) override
+    /// Look up the Mir session for a client socket, or nullptr if unknown.
+    auto session_for_fd(int client_fd) -> std::shared_ptr<mir::scene::Session>
     {
-    }
-
-    void stopping(std::shared_ptr<mir::scene::Session> const&) override
-    {
-    }
-
-    void focused(std::shared_ptr<mir::scene::Session> const&) override
-    {
-    }
-
-    void unfocused() override
-    {
-    }
-
-    void surface_created(
-        mir::scene::Session&,
-        std::shared_ptr<mir::scene::Surface> const& surface) override
-    {
-        auto state_accessor = state.lock();
-        if (std::this_thread::get_id() == state_accessor->wayland_thread)
-        {
-            if (listeners.last_wl_window == nullptr)
-            {
-                auto message =
-                    "miral::TestWlcsDisplayServer::ResourceMapper::resource_created()"
-                    " did not detect the shell surface used for a wl_surface."
-                    " You might need to add a new protocol to the `is_window` list.";
-                // We printf because Mir logging is suppressed, the exception is not surfaced, and it's a pain to track this down
-                printf("\x1b[31;1mERROR:\x1b[0m %s\n", message);
-                fflush(stdout);
-                BOOST_THROW_EXCEPTION((std::runtime_error{message}));
-            }
-
-            auto const streams = surface->get_streams();
-            if (streams.empty())
-                BOOST_THROW_EXCEPTION(
-                    std::runtime_error{"Surface::get_streams() returned empty list"});
-
-            auto wl_surface = state_accessor->stream_map.at(streams.front().stream);
-
-            state_accessor->surface_map[wl_surface] = surface;
-        }
-    }
-
-    void destroying_surface(
-        mir::scene::Session&,
-        std::shared_ptr<mir::scene::Surface> const&) override
-    {
-        // TODO: Maybe delete from map?
-    }
-
-    void buffer_stream_created(
-        mir::scene::Session&,
-        std::shared_ptr<mir::frontend::BufferStream> const& stream) override
-    {
-        auto state_accessor = state.lock();
-        if (std::this_thread::get_id() == state_accessor->wayland_thread)
-        {
-            if (listeners.last_wl_surface == nullptr)
-            {
-                BOOST_THROW_EXCEPTION((
-                    std::runtime_error{"BufferStream created without first constructing a wl_surface?"}));
-            }
-
-            state_accessor->stream_map[stream] = listeners.last_wl_surface;
-            listeners.last_wl_surface = nullptr;
-        }
-    }
-
-    void buffer_stream_destroyed(
-        mir::scene::Session&,
-        std::shared_ptr<mir::frontend::BufferStream> const& stream) override
-    {
-        state.lock()->stream_map.erase(stream);
-    }
-
-    void init(wl_display* display)
-    {
-        state.lock()->wayland_thread = std::this_thread::get_id();
-
-        listeners.client_listener.notify = &client_created;
-
-        wl_display_add_client_created_listener(display, &listeners.client_listener);
-    }
-
-    std::weak_ptr<mir::scene::Surface> surface_for_resource(wl_resource* surface)
-    {
-        if (std::strcmp(wl_resource_get_class(surface), "wl_surface") != 0)
-        {
-            BOOST_THROW_EXCEPTION((
-                std::logic_error{
-                    std::string{"Expected a wl_surface, got: "} +
-                    wl_resource_get_class(surface)
-                }));
-        }
-
-        auto state_accessor = state.lock();
-        return state_accessor->surface_map.at(surface);
-    }
-
-    wl_client* client_for_fd(int client_socket)
-    {
-        return listeners.state->lock()->client_session_map.at(client_socket);
-    }
-
-    void associate_client_socket(int client_socket)
-    {
-        auto state_accessor = state.wait_for(
-            [](State& state) { return static_cast<bool>(state.latest_client); },
-            std::chrono::seconds{30});
-        state_accessor->client_session_map[client_socket] = state_accessor->latest_client.value();
-        state_accessor->latest_client = {};
+        std::lock_guard lock{mutex};
+        if (auto const iter = session_for_fd_.find(client_fd); iter != session_for_fd_.end())
+            return iter->second;
+        return nullptr;
     }
 
 private:
-    struct Listeners;
-    struct ResourceListener
-    {
-        ResourceListener(Listeners* const listeners)
-            : listeners{listeners}
-        {
-        }
-
-        wl_listener resource_listener;
-        Listeners* const listeners;
-    };
-    struct State
-    {
-        std::thread::id wayland_thread;
-        std::unordered_map<wl_resource*, std::weak_ptr<mir::scene::Surface>> surface_map;
-        std::unordered_map<std::shared_ptr<mir::frontend::BufferStream>, wl_resource*> stream_map;
-
-        std::optional<wl_client*> latest_client;
-        std::unordered_map<ClientFd, wl_client*> client_session_map;
-        std::unordered_map<wl_client*, ResourceListener> resource_listener;
-    };
-    WaitableMutex<State> state;
-
-    struct Listeners
-    {
-        Listeners(WaitableMutex<State>* const state)
-            : state{state}
-        {
-        }
-
-        wl_listener client_listener;
-
-        wl_resource* last_wl_surface{nullptr};
-        wl_resource* last_wl_window{nullptr};
-
-        WaitableMutex<State>* const state;
-    } listeners;
-
-    static void resource_created(wl_listener* listener, void* ctx)
-    {
-        auto resource = static_cast<wl_resource*>(ctx);
-        ResourceListener* resource_listener;
-        resource_listener =
-            wl_container_of(listener, resource_listener, resource_listener);
-
-        bool const is_surface = std::strcmp(wl_resource_get_class(resource), "wl_surface") == 0;
-
-        bool const is_window = std::strcmp(wl_resource_get_class(resource), "wl_shell_surface") == 0 ||
-                               std::strcmp(wl_resource_get_class(resource), "zxdg_surface_v6") == 0 ||
-                               std::strcmp(wl_resource_get_class(resource), "xdg_surface") == 0 ||
-                               std::strcmp(wl_resource_get_class(resource), "zwlr_layer_surface_v1") == 0;
-
-        if (is_surface)
-        {
-            resource_listener->listeners->last_wl_surface = resource;
-        }
-        else if (is_window)
-        {
-            resource_listener->listeners->last_wl_window = resource;
-        }
-    }
-
-    static void client_created(wl_listener* listener, void* ctx)
-    {
-        auto client = static_cast<wl_client*>(ctx);
-        Listeners* listeners;
-        listeners =
-            wl_container_of(listener, listeners, client_listener);
-
-        wl_listener* resource_listener;
-        {
-            auto state_accessor = listeners->state->lock();
-            state_accessor->latest_client = client;
-            auto rl = state_accessor->resource_listener.emplace(client, listeners);
-            rl.first->second.resource_listener.notify = &resource_created;
-            resource_listener = &rl.first->second.resource_listener;
-        }
-        listeners->state->notify_all();
-
-        wl_client_add_resource_created_listener(client, resource_listener);
-    }
+    std::mutex mutex;
+    std::unordered_map<int, std::shared_ptr<mir::scene::Session>> session_for_fd_;
 };
 
 class miral::TestWlcsDisplayServer::InputEventListener : public mir::input::SeatObserver
@@ -854,11 +531,6 @@ miral::TestWlcsDisplayServer::TestWlcsDisplayServer(int argc, char const** argv)
 
     add_server_init([this](mir::Server& server)
         {
-            server.override_the_session_listener([this]()
-                {
-                    return resource_mapper;
-                });
-
             server.add_init_callback([this, &server]()
                 {
                     cursor_observer = std::make_shared<RunnerCursorObserver>(this);
@@ -877,11 +549,11 @@ void miral::TestWlcsDisplayServer::start_server()
     mir::test::Signal started;
 
     mir_server->run_on_wayland_display(
-        [this, &started](auto wayland_display)
+        [this, &started](mir::Executor& wayland_executor)
             {
-                resource_mapper->init(wayland_display);
-                executor = WaylandExecutor::executor_for_event_loop(
-                    wl_display_get_event_loop(wayland_display));
+                // The executor is owned by the running Wayland backend and
+                // outlives our use of it, so wrap it in a non-owning shared_ptr.
+                executor = std::shared_ptr<mir::Executor>(std::shared_ptr<void>{}, &wayland_executor);
 
                 // Execute all observations on the Wayland event loop…
                 mir_server->the_seat_observer_registrar()->register_interest(event_listener, *executor);
@@ -896,9 +568,23 @@ int miral::TestWlcsDisplayServer::create_client_socket()
 {
     try
     {
-        auto client_fd = fcntl(mir_server->open_wayland_client_socket(), F_DUPFD_CLOEXEC, 3);
+        auto const session_ready = std::make_shared<mir::test::Signal>();
+        auto const session_holder = std::make_shared<std::shared_ptr<mir::scene::Session>>();
 
-        resource_mapper->associate_client_socket(client_fd);
+        auto const raw_fd = mir_server->open_client_wayland(
+            [session_ready, session_holder](std::shared_ptr<mir::scene::Session> const& session)
+            {
+                *session_holder = session;
+                session_ready->raise();
+            });
+
+        auto const client_fd = fcntl(raw_fd, F_DUPFD_CLOEXEC, 3);
+        ::close(raw_fd);
+
+        if (!session_ready->wait_for(a_long_time))
+            BOOST_THROW_EXCEPTION((std::runtime_error{"Timeout waiting for client session"}));
+
+        resource_mapper->associate_client_socket(client_fd, *session_holder);
 
         return client_fd;
     }
@@ -917,16 +603,15 @@ int miral::TestWlcsDisplayServer::create_client_socket()
 void miral::TestWlcsDisplayServer::position_window(wl_display* client_, wl_surface* surface, mir::geometry::Point point)
 {
     auto const fd = wl_display_get_fd(client_);
-    auto const client = resource_mapper->client_for_fd(fd);
+    auto const session = resource_mapper->session_for_fd(fd);
     auto const id = wl_proxy_get_id(reinterpret_cast<wl_proxy*>(surface));
 
-    auto resource = wl_client_get_object(client, id);
+    if (!session)
+        BOOST_THROW_EXCEPTION((std::out_of_range{"No session for client socket"}));
 
-    auto mir_surface = resource_mapper->surface_for_resource(resource);
-
-    if (auto live_surface = mir_surface.lock())
+    if (auto const scene_surface = mir_server->scene_surface_for_wayland_surface(*session, id))
     {
-        live_surface->move_to(point);
+        scene_surface->move_to(point);
     }
     else
     {


### PR DESCRIPTION
The Wayland connector owns the wl_display and is the only thing that
should need to touch it. Rework the server-facing API accordingly:

  * run_on_wayland_display() now hands out an Executor& rather than a
    raw wl_display*, so callers can schedule work on the Wayland thread
    without being handed the display itself.

  * XWayland client creation moves into the connector as
    create_wayland_client(), replacing the previous
    run_on_wayland_display() + wl_client_create() dance in
    xwayland_server.cpp.

  * SurfaceRegistry gains scene_surface_for(session, id), backed by two
    new lookup maps, and mir::Server exposes it as
    scene_surface_for_wayland_surface(). This lets the WLCS test harness
    resolve a protocol object id to a scene::Surface directly, so the
    harness can drop its SessionListener-based ResourceMapper and its
    local WaylandExecutor (-357/+42).

add_wayland_extension() deliberately keeps its wl_display* parameter
here: dropping it would break real extensions while the libwayland
frontend is still live. That change belongs with the frontend migration.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Closes #???

<!-- Mention the issue this closes if applicable -->

Related: #???, https://..., ...

<!-- List any PRs, issues, and links that might benefit reviewers build context around your work -->

## What's new?

<!-- List the major changes of this PR -->

## How to test

<!-- List how reviewers can poke at the addition in this PR -->

## Checklist

- [ ] Tests added and pass
- [ ] Adequate documentation added
- [ ] (optional) Added Screenshots or videos
